### PR TITLE
Only show 'go to breakglass' hint when the user has Escalations to perform

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,10 +45,12 @@ func main() {
 		return
 	}
 
+	whctrl := webhook.NewWebhookController(log, config, &sessionManager, &escalationManager)
+
 	err = server.RegisterAll([]api.APIController{
 		breakglass.NewBreakglassSessionController(log, config, &sessionManager, &escalationManager, auth.Middleware()),
 		breakglass.NewBreakglassEscalationController(log, &escalationManager, auth.Middleware()),
-		webhook.NewWebhookController(log, config, &sessionManager),
+		&whctrl,
 	})
 	if err != nil {
 		log.Fatalf("Error registering breakglass controllers: %v", err)


### PR DESCRIPTION
https://github.com/telekom/das-schiff-breakglass/issues/20 
Added unit test for new functionality and run following manual check:
```bash
 $ kubectl get breakglassescalations.breakglass.t-caas.telekom.com  -o yaml
 apiVersion: v1
 items:
 - apiVersion: breakglass.t-caas.telekom.com/v1alpha1
   kind: BreakglassEscalation
   metadata:
     creationTimestamp: "2025-04-16T12:16:29Z"
     generation: 1
     name: kind-sample
     resourceVersion: "5233463"
     uid: e1ec7e64-d637-4621-80e7-89413d4418ab
   spec:
     allowedGroups:
     - system:authenticated
     approvers:
       users:
       - admin@mail.com
     cluster: kind
     escalatedGroup: breakglass-create-all
     username: tester@mail.com
 kind: List
 metadata:
   resourceVersion: ""
 $ kubectl auth can-i  create  pods -n user-namespace  --as tester@mail.com
 no - please request proper group assignment at http://localhost:5173/request?cluster=kind
 $ kubectl auth can-i  create  pods -n user-namespace  --as other@mail.com
 no


```