### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Security Scan
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/telekom/das-schiff-breakglass/security/code-scanning/1](https://github.com/telekom/das-schiff-breakglass/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow or specifically to the `trivy` job to ensure that the GITHUB_TOKEN is limited to the least privilege necessary.

The workflow does not currently perform any actions that would require write permissions (such as pushing to the repo), so the most restrictive minimal permissions are sufficient. Setting `contents: read` in the root of the workflow is recommended. This prevents the GITHUB_TOKEN from having unnecessary write permissions, reducing the risk from compromised workflow runs.

The change should be made by adding the following block beneath the workflow name on line 2, before the `on:` key:

```yml
permissions:
  contents: read
```

No additional methods, imports, or variable definitions are required—this is a configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
