### PR TITLE
Fix for Identical operands

### DIFF
--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -220,7 +220,7 @@ export default class BreakglassService {
       // Normalize approved entries to ActiveBreakglass shape used elsewhere
       const approvedNormalized = approved.map((ses: any) => ({
         name: ses?.metadata?.name || ses.name || "",
-        group: ses?.spec?.grantedGroup || ses?.spec?.grantedGroup || "",
+        group: ses?.spec?.grantedGroup || "",
         cluster: ses?.spec?.cluster || "",
         expiry: ses?.status?.expiresAt || 0,
         state: ses?.status?.state || "Approved",


### PR DESCRIPTION
To fix the problem, simply remove the redundant second reference in the expression so that only one instance of `ses?.spec?.grantedGroup` remains. This should be done on line 223 in `frontend/src/services/breakglass.ts`. No surrounding logic will be affected, so this is a single-line edit with no other dependencies or imports needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._