### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/frontend/src/views/BreakglassSessionReview.vue
+++ b/frontend/src/views/BreakglassSessionReview.vue
@@ -11,7 +11,7 @@ import useCurrentTime from "@/util/currentTime";
 import BreakglassSessionCard from "@/components/BreakglassSessionCard.vue";
 import { handleAxiosError } from "@/services/logger";
 
-const route = useRoute()
+const route = useRoute();
 const user = useUser();
 const auth = inject(AuthKey);
 const authenticated = computed(() => user.value && !user.value?.expired);


### PR DESCRIPTION
To fix this issue, simply add a semicolon at the end of line 14 (`const route = useRoute()`). This change brings the statement in line with the surrounding code’s explicit semicolon usage, improving stylistic consistency and maintainability without affecting functionality. No additional imports or code changes are required—just this single character insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._