### PR TITLE
[DOC]: Add feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: 'Feature request'
+description: 'Submit a feature request for a new k8s-breakglass feature.'
+title: '[ENH]: <Write a short and informative title>'
+labels: enhancement
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a feature request. Before creating a new feature request, please make 
+        sure to take a few minutes to check the issue tracker for existing feature requests about the bug.
+        In addition, please first discuss your feature request informally, e.g. in GitHub dicussions, before
+        you formally submit one.
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: >
+        Please describe clearly and concisely what the feature is you would like.
+        The description should make your motivation clear.
+        For example,  *"I'm always frustrated when [...]"*, *"I'm working on X and would like Y to be possible"*, or even better
+        *"As a [role], I want to [goal], so that [benefit]"*.
+        If your feature request is related to another GitHub issue, please link it here too.
+      placeholder: |
+        As a [role], I want to [goal], so that [benefit].
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you would like
+      description: A clear and concise description of what you want to include.
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you have considered
+      description: |
+        A clear and concise description of any alternative solutions or features you have considered.
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I've checked existing issues and documentation
+          required: true
+        - label: I'm reporting a feature request, not a security vulnerability
+          required: true
+        - label: I've included all relevant information
+          required: true


### PR DESCRIPTION
This `PR` adds the ``feature request`` issue template so that feature requests can be processed more easily.

This `PR` is part of a greater effort to add issue templates for the most important issue categories. It is related to ``PR`` #113.