### PR TITLE
[DOC]: Add config file for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/telekom/k8s-breakglass/discussions
+    about: Contribute to our discussions on GitHub, e.g. by asking questions and answering already open ones.
+    
+  - name: Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/k8s-breakglass
+    about: Ask and answer usage questions on Stack Overflow.


### PR DESCRIPTION
This `PR` adds the ``config.yml`` file, and hence activates the merged issue templates.

This `PR`, besides activating issue templates, also adds two links. One to the discussions on ``GitHub`` for this project and to the ``Stackoverflow`` tag ``k8s-breakglass``.

This `PR` is part of a greater effort to add issue templates for the most important issue categories. It is related to ``PRs`` #113, #120, and #129.