### PR TITLE
[BUG]: Add key validations for key required

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -117,6 +117,7 @@ body:
         - Keycloak
         - Other OIDC provider
         - Not applicable / not tested yet
+    validations:
       required: false
 
   - type: textarea


### PR DESCRIPTION
This ``PR`` adds the key ``validations`` and puts the key ``required`` under it to fix the error ``body[9]: required is not a permitted attribute.``.

By merging this ``PR``, the error https://github.com/telekom/k8s-breakglass/blob/30171014ad7415020b77a6126715be374d8b30f5/.github/ISSUE_TEMPLATE/bug_report.yml should disappear.