### PR TITLE
[DOC]: Add the latest two versions to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -104,6 +104,8 @@ body:
         - 0.0.4
         - 0.0.5
         - 0.0.6
+        - 0.0.7
+        - 0.0.8
         - main (development)
     validations:
       required: true


### PR DESCRIPTION
This ``PR`` adds the latest two versions (``0.0.7`` and ``0.0.8``) as options for the dropdown menu to the bug report.