### PR TITLE
[FIX]: Pin dependency of script install_kustomize.sh by it's SHA git hash

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+          curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/311dbbf975369a5e871d6a1a2e3d6ce4b83d5972/hack/install_kustomize.sh | bash
           sudo mv kustomize /usr/local/bin/kustomize
 
       - name: Determine chart VERSION for this run


### PR DESCRIPTION
This ``PR`` pins the dependency of the script ``install_kustomize.sh`` with it's ``SHA`` git value in the workflow ``helm-ci.yml``.

Before this ``PR``, the download from``raw.githubusercontent.com`` of the script ``install_kustomioze`` was not pinned. Which lead to the security warning [``downloadThenRun``](https://github.com/telekom/k8s-breakglass/security/code-scanning/79). This ``PR`` fixes this security issue by pinning the dependency to the **SHA** ``311dbbf975369a5e871d6a1a2e3d6ce4b83d5972``. As a result, the security increases and the security issue shall be closed. However, a side effect of this ``PR`` is that ``install_kustomize.sh`` needs to be manually updated with future ``PRs``.