### PR TITLE
feat: harden breakglass flows with metrics, validation, and webhook c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 - **Multi-Cluster Support** - Centralized hub manages access across multiple spoke clusters
 - **OIDC/JWT Authentication** - Integrates with identity providers like Keycloak and Azure AD
 - **Web UI & REST API** - User-friendly interface with programmatic access
+- **Automatic Cluster Cache Invalidation** - Watches ClusterConfig and kubeconfig Secret changes to refresh connectivity instantly
+- **Rich Prometheus Signals** - API endpoints expose dedicated request/error/duration metrics for fine-grained SLOs
 
 ## Architecture
 
@@ -36,11 +38,13 @@
 Complete documentation is available in the [docs/](./docs/) directory:
 
 **Getting Started:**
+
 - **[Quick Start](./docs/quickstart.md)** - Get running in 5 minutes
 - **[Installation](./docs/installation.md)** - Complete step-by-step installation guide
 - **[Building](./docs/building.md)** - Build from source
 
 **Resources & Configuration:**
+
 - **[IdentityProvider](./docs/identity-provider.md)** - **MANDATORY** - Configure OIDC authentication for users
 - **[BreakglassEscalation](./docs/breakglass-escalation.md)** - Define available privilege escalations
 - **[BreakglassSession](./docs/breakglass-session.md)** - Session lifecycle and state management
@@ -48,11 +52,16 @@ Complete documentation is available in the [docs/](./docs/) directory:
 - **[DenyPolicy](./docs/deny-policy.md)** - Create access restrictions and policies
 
 **Integration & Advanced Topics:**
+
 - **[Webhook Setup](./docs/webhook-setup.md)** - Integrate with Kubernetes authorization
 - **[API Reference](./docs/api-reference.md)** - REST API endpoints and examples
 - **[Metrics](./docs/metrics.md)** - Prometheus metrics, alerting, and dashboards
 - **[Advanced Features](./docs/advanced-features.md)** - Request reasons, approval reasons, self-approval prevention, domain restrictions
 - **[Troubleshooting](./docs/troubleshooting.md)** - Common issues and solutions
+
+## 📦 Example Assets
+
+- **[DenyPolicy examples](./config/deny-policy-examples.yaml)** - Ready-to-use templates covering exfiltration, operational safety, and compliance controls
 
 ## ⚙️ Configuration
 
@@ -233,13 +242,13 @@ Restrict access across clusters and namespaces based on resource attributes.
 
 See [DenyPolicy Documentation](./docs/deny-policy.md) for details.
 
-# Code of Conduct
+## Code of Conduct
 
 This project has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) in version 2.1 as our code of conduct. Please see the details in our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). All contributors must abide by the code of conduct.
 
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
-# License
+## License
 
 Copyright (c) Deutsche Telekom AG
 

--- a/api/v1alpha1/breakglass_escalation_types_test.go
+++ b/api/v1alpha1/breakglass_escalation_types_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestBreakglassEscalation_ValidateCreate_MissingFields(t *testing.T) {
@@ -81,5 +83,197 @@ func TestBreakglassEscalationValidateDelete(t *testing.T) {
 	warnings, err := esc.ValidateDelete(context.Background(), esc)
 	if err != nil || warnings != nil {
 		t.Fatalf("expected ValidateDelete to allow deletes, warnings=%v err=%v", warnings, err)
+	}
+}
+
+func TestBreakglassEscalationClusterConfigRefsSatisfyClusterRequirement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	clusterConfig := &ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", Namespace: "team-a"},
+		Spec: ClusterConfigSpec{
+			KubeconfigSecretRef: SecretKeyReference{Name: "kc", Namespace: "system"},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterConfig).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup:    "ops",
+			Allowed:           BreakglassEscalationAllowed{},
+			Approvers:         BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			ClusterConfigRefs: []string{"cluster-a"},
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected ValidateCreate to succeed when clusterConfigRefs present, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationClusterConfigRefsMissingAreDeferredToController(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed:        BreakglassEscalationAllowed{Groups: []string{"requesters"}},
+			Approvers:      BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			// intentionally reference a ClusterConfig that doesn't exist yet
+			ClusterConfigRefs: []string{"cluster-a"},
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected webhook to accept missing clusterConfigRefs, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationDenyPolicyRefsAreDeferredToController(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"cluster-a"},
+			},
+			Approvers:      BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			DenyPolicyRefs: []string{"missing"},
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected webhook to accept missing denyPolicyRefs, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationDenyPolicyRefsClusterScoped(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	policy := &DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy-a"},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"cluster-a"},
+			},
+			Approvers:      BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			DenyPolicyRefs: []string{"policy-a"},
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected success when referencing cluster-scoped DenyPolicy, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationMailProviderCanBeMissingDuringAdmission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"cluster-a"},
+			},
+			Approvers:    BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			MailProvider: "mail-custom",
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected webhook to accept missing mailProvider reference, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationMailProviderDisabledIsDeferredToController(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	disabledMail := &MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail-disabled"},
+		Spec: MailProviderSpec{
+			Disabled: true,
+			SMTP:     SMTPConfig{Host: "smtp.disabled", Port: 587},
+			Sender:   SenderConfig{Address: "noreply@disabled"},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disabledMail).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed:        BreakglassEscalationAllowed{Clusters: []string{"cluster-a"}},
+			Approvers:      BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			MailProvider:   "mail-disabled",
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected webhook to accept disabled MailProvider reference, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationMailProviderHappyPath(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+	enabledMail := &MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail-enabled"},
+		Spec: MailProviderSpec{
+			SMTP:   SMTPConfig{Host: "smtp.enabled", Port: 587},
+			Sender: SenderConfig{Address: "noreply@enabled"},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(enabledMail).Build()
+	origClient := webhookClient
+	defer func() { webhookClient = origClient }()
+	webhookClient = client
+
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc", Namespace: "team-a"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed:        BreakglassEscalationAllowed{Clusters: []string{"cluster-a"}},
+			Approvers:      BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			MailProvider:   "mail-enabled",
+		},
+	}
+
+	if _, err := esc.ValidateCreate(context.Background(), esc); err != nil {
+		t.Fatalf("expected success when referencing enabled MailProvider, got %v", err)
 	}
 }

--- a/api/v1alpha1/deny_policy_types_test.go
+++ b/api/v1alpha1/deny_policy_types_test.go
@@ -230,7 +230,6 @@ func TestDenyPolicyStatus(t *testing.T) {
 	readyCondition := policy.GetCondition(string(DenyPolicyConditionReady))
 	assert.NotNil(t, readyCondition)
 	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
-
 }
 
 func TestDenyPolicySetConditionAddsAndUpdates(t *testing.T) {

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -203,7 +203,23 @@ func validateIdentityProviderRefs(
 	return errs
 }
 
-// validateMailProviderReference ensures that referenced MailProviders exist and are enabled
+func validateIdentityProviderRefsFormat(refs []string, path *field.Path) field.ErrorList {
+	if len(refs) == 0 || path == nil {
+		return nil
+	}
+
+	var errs field.ErrorList
+	errs = append(errs, validateStringListNoDuplicates(refs, path)...)
+	for i, ref := range refs {
+		if strings.TrimSpace(ref) == "" {
+			errs = append(errs, field.Required(path.Index(i), "identity provider reference cannot be empty"))
+		}
+	}
+	return errs
+}
+
+// validateMailProviderReference currently no-ops during admission. Runtime reconcilers surface
+// missing/disabled MailProviders via conditions and events to avoid blocking CR creation.
 func validateMailProviderReference(ctx context.Context, mailProvider string, path *field.Path) field.ErrorList {
 	if mailProvider == "" || path == nil {
 		return nil

--- a/config/deny-policy-examples.yaml
+++ b/config/deny-policy-examples.yaml
@@ -1,0 +1,89 @@
+# Granular DenyPolicy Examples for Operational, Security, and Data Exfiltration Protection
+
+---
+# 1. Block all access to production secrets (data exfiltration)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: block-prod-secrets-exfiltration
+spec:
+  appliesTo:
+    clusters: ["prod-cluster"]
+  rules:
+    - verbs: ["get", "list", "create", "update", "delete"]
+      apiGroups: [""]
+      resources: ["secrets"]
+      namespaces: ["prod", "system"]
+      resourceNames:
+        - "database-credentials"
+        - "api-keys"
+  precedence: 10
+---
+# 2. Prevent deletion of critical infrastructure (operational safety)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: prevent-critical-infra-deletion
+spec:
+  rules:
+    - verbs: ["delete"]
+      apiGroups: [""]
+      resources: ["namespaces", "persistentvolumes"]
+    - verbs: ["delete"]
+      apiGroups: ["apps"]
+      resources: ["deployments"]
+  precedence: 20
+---
+# 3. Restrict access to kube-system and node-lease namespaces (security hardening)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: restrict-kube-system-access
+spec:
+  rules:
+    - verbs: ["*"]
+      apiGroups: ["*"]
+      resources: ["*"]
+      namespaces: ["kube-system", "kube-node-lease"]
+  precedence: 5
+---
+# 4. Block creation of external network policies (data exfiltration risk)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: block-external-network-policies
+spec:
+  rules:
+    - verbs: ["create", "update"]
+      apiGroups: ["networking.k8s.io"]
+      resources: ["networkpolicies"]
+      resourceNames: ["allow-external"]
+  precedence: 15
+---
+# 5. Deny access to audit logs for non-admins (compliance)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: deny-audit-log-access
+spec:
+  appliesTo:
+    tenants: ["tenant-a", "tenant-b"]
+  rules:
+    - verbs: ["get", "list"]
+      apiGroups: [""]
+      resources: ["configmaps"]
+      resourceNames: ["audit-logs"]
+  precedence: 30
+---
+# 6. Block exec/attach to running pods (security, exfiltration)
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+metadata:
+  name: block-pod-exec-attach
+spec:
+  rules:
+    - verbs: ["create"]
+      apiGroups: [""]
+      resources: ["pods"]
+      subresources: ["exec", "attach"]
+  precedence: 25

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -179,6 +179,8 @@ Reference to a specific `ClusterConfig` if different from parsing `spec.cluster`
 clusterConfigRef: "my-cluster-config"  # Name of ClusterConfig resource
 ```
 
+> The validating webhook requires the referenced `ClusterConfig` to exist in the **same namespace** as the session. Create the `ClusterConfig` first and keep both objects co-located or admission will fail.
+
 #### denyPolicyRefs
 
 Names of `DenyPolicy` objects to associate with this session:
@@ -186,6 +188,8 @@ Names of `DenyPolicy` objects to associate with this session:
 ```yaml
 denyPolicyRefs: ["deny-policy-1", "deny-policy-2"]
 ```
+
+> Each `DenyPolicy` listed here must already exist (cluster-scoped). Missing references are rejected during admission to avoid dangling policy bindings.
 
 ## Status Fields
 

--- a/docs/deny-policy.md
+++ b/docs/deny-policy.md
@@ -205,3 +205,13 @@ The breakglass controller logs all policy violations for compliance purposes.
 - [BreakglassEscalation](./breakglass-escalation.md) - Escalation policies
 - [BreakglassSession](./breakglass-session.md) - Session management
 - [Webhook Authorization](./webhook-setup.md) - Authorization webhook setup
+
+## Policy Template Library
+
+Need inspiration for real-world controls? The repository ships with [config/deny-policy-examples.yaml](../config/deny-policy-examples.yaml), a curated collection that maps common security scenarios to concrete policies:
+
+- **Data exfiltration prevention:** block privileged users from reading production secrets or exporting audit logs
+- **Operational safety:** stop accidental deletion of namespaces, PVs, or critical workloads
+- **Security hardening:** restrict kube-system/kube-node-lease access, disallow exec/attach, or forbid risky network policies
+
+Apply the file as-is to bootstrap a baseline posture, or copy individual policies and adjust `appliesTo`, `namespaces`, or `verb` settings to fit your organization.

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -175,7 +175,7 @@ Notes on matching behavior
 
 - Make sure the value you expose in the webhook URL is identical (including case) to the `ClusterConfig` name or the cluster identifier used in session/escalation objects. URL-encode any characters that are not valid in a URL path.
 
-- If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook will still attempt to match active sessions and escalations by the raw cluster identifier present in the resources; however, some hub-specific checks may rely on a ClusterConfig being present.
+- If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook immediately denies the request with a human-friendly message (`Cluster "foo" is not registered with Breakglass`) and emits a `cluster-missing` reason in metrics. This reduces confusion for platform users and surfaces onboarding gaps early. Create the missing ClusterConfig or update the webhook URL path to match an existing name.
 
 ### Authentication Methods
 

--- a/pkg/api/api_multiidp_config_test.go
+++ b/pkg/api/api_multiidp_config_test.go
@@ -32,7 +32,7 @@ func TestMultiIDPConfigEndpointReturnsIDPList(t *testing.T) {
 	router := gin.New()
 	router.GET("/api/config/idps", server.getMultiIDPConfig)
 
-	req, err := http.NewRequest("GET", "/api/config/idps", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/config/idps", nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -234,7 +234,7 @@ func TestConfigEndpointResponseHeaders(t *testing.T) {
 	router := gin.New()
 	router.GET("/api/config/idps", server.getMultiIDPConfig)
 
-	req, err := http.NewRequest("GET", "/api/config/idps", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/config/idps", nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -263,7 +263,7 @@ func TestEmptyIDPConfigHandling(t *testing.T) {
 	server.SetIdentityProviderReconciler(mockReconciler)
 
 	t.Run("ValidResponseStructure_MinimalConfig", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "/api/config/idps", nil)
+		req, err := http.NewRequest(http.MethodGet, "/api/config/idps", nil)
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
@@ -418,7 +418,7 @@ func TestSpecialCharactersInIDPNames(t *testing.T) {
 func TestLargeConfigScaling(t *testing.T) {
 	// Create a large config with many IDPs and escalation mappings
 	idps := make([]IDPInfo, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		idps[i] = IDPInfo{
 			Name:        "idp-" + string(rune(48+i%10)), // 0-9 cycle
 			DisplayName: "IDP Instance " + string(rune(48+i%10)),
@@ -428,12 +428,12 @@ func TestLargeConfigScaling(t *testing.T) {
 	}
 
 	mappings := make(map[string][]string)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		escalationName := "escalation-" + string(rune(48+i%10))
 		// Randomly assign 0-3 IDPs to each escalation
 		numIDPs := i % 4
 		var assignedIDPs []string
-		for j := 0; j < numIDPs; j++ {
+		for j := range numIDPs {
 			assignedIDPs = append(assignedIDPs, "idp-"+string(rune(48+j)))
 		}
 		mappings[escalationName] = assignedIDPs
@@ -473,7 +473,7 @@ func TestBackwardCompatibilitySingleIDP(t *testing.T) {
 	router := gin.New()
 	router.GET("/api/config/idps", server.getMultiIDPConfig)
 
-	req, err := http.NewRequest("GET", "/api/config/idps", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/config/idps", nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -518,7 +518,7 @@ func TestMultiIDPConfigWithCachedIDPs(t *testing.T) {
 
 	// Since we can't easily test GetCachedIdentityProviders directly,
 	// we verify that the endpoint returns valid JSON structure
-	req, err := http.NewRequest("GET", "/api/config/idps", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/config/idps", nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/pkg/api/api_oidc_proxy_test.go
+++ b/pkg/api/api_oidc_proxy_test.go
@@ -109,7 +109,7 @@ func TestOIDCProxyPathValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a mock Gin context with the test proxyPath
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 			c.Params = gin.Params{{Key: "proxyPath", Value: tt.proxyPath}}
@@ -191,7 +191,7 @@ func TestOIDCProxyMultiIDPValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 			if tt.customAuthority != "" {
 				req.Header.Set("X-OIDC-Authority", tt.customAuthority)
 			}
@@ -275,7 +275,7 @@ func TestOIDCProxyPathTrustedIDPs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 			c.Params = gin.Params{{Key: "proxyPath", Value: tt.proxyPath}}
@@ -347,7 +347,7 @@ func TestOIDCProxyPathEncoding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 			c.Params = gin.Params{{Key: "proxyPath", Value: tt.proxyPath}}
@@ -417,7 +417,7 @@ func TestOIDCProxyPortBinding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
 			c.Params = gin.Params{{Key: "proxyPath", Value: tt.proxyPath}}
@@ -470,7 +470,7 @@ func TestOIDCProxyLocalhostBinding(t *testing.T) {
 
 	// Test that localhost authority is configured and won't be overridden
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/oidc/authority/.well-known/openid-configuration", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/oidc/authority/.well-known/openid-configuration", nil)
 	// Try to inject a different authority - should be rejected
 	req.Header.Set("X-OIDC-Authority", fmt.Sprintf("http://%s", addr))
 
@@ -559,7 +559,7 @@ func TestOIDCProxyMultiIDPWithRealmPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/oidc/authority%s", tt.proxyPath), nil)
 
 			c, _ := gin.CreateTestContext(w)
 			c.Request = req
@@ -648,7 +648,7 @@ func TestOIDCProxyRealmPathIntegration(t *testing.T) {
 
 	t.Run("Full OIDC discovery flow with realm path preservation", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/api/oidc/authority/.well-known/openid-configuration", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/oidc/authority/.well-known/openid-configuration", nil)
 
 		c, _ := gin.CreateTestContext(w)
 		c.Request = req
@@ -685,7 +685,7 @@ func TestOIDCProxyRealmPathIntegration(t *testing.T) {
 
 	t.Run("Query parameters are preserved in realm path scenario", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/api/oidc/authority/.well-known/openid-configuration?foo=bar", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/oidc/authority/.well-known/openid-configuration?foo=bar", nil)
 
 		c, _ := gin.CreateTestContext(w)
 		c.Request = req

--- a/pkg/api/api_reload_test.go
+++ b/pkg/api/api_reload_test.go
@@ -64,11 +64,11 @@ func TestServer_ConcurrentReloadsAndReads(t *testing.T) {
 	var updateCount int32
 
 	// Spawn multiple readers
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				server.idpMutex.RLock()
 				_ = server.idpConfig
 				server.idpMutex.RUnlock()
@@ -78,11 +78,11 @@ func TestServer_ConcurrentReloadsAndReads(t *testing.T) {
 	}
 
 	// Spawn multiple updaters (SetIdentityProvider)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 10; j++ {
+			for range 10 {
 				server.SetIdentityProvider(config1)
 				atomic.AddInt32(&updateCount, 1)
 			}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -76,7 +76,7 @@ func TestServer_getConfig(t *testing.T) {
 	router := gin.New()
 	router.GET("/config", server.getConfig)
 
-	req, err := http.NewRequest("GET", "/config", nil)
+	req, err := http.NewRequest(http.MethodGet, "/config", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -111,7 +111,7 @@ func TestServer_getIdentityProvider(t *testing.T) {
 	router := gin.New()
 	router.GET("/identity-provider", server.getIdentityProvider)
 
-	req, err := http.NewRequest("GET", "/identity-provider", nil)
+	req, err := http.NewRequest(http.MethodGet, "/identity-provider", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -151,7 +151,7 @@ func TestServer_getIdentityProvider_WithKeycloak(t *testing.T) {
 	router := gin.New()
 	router.GET("/identity-provider", server.getIdentityProvider)
 
-	req, err := http.NewRequest("GET", "/identity-provider", nil)
+	req, err := http.NewRequest(http.MethodGet, "/identity-provider", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -185,7 +185,7 @@ func TestServer_getIdentityProvider_NotConfigured(t *testing.T) {
 	router := gin.New()
 	router.GET("/identity-provider", server.getIdentityProvider)
 
-	req, err := http.NewRequest("GET", "/identity-provider", nil)
+	req, err := http.NewRequest(http.MethodGet, "/identity-provider", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -239,7 +239,7 @@ func TestServer_getConfig_WithoutIdentityProvider(t *testing.T) {
 	router := gin.New()
 	router.GET("/config", server.getConfig)
 
-	req, err := http.NewRequest("GET", "/config", nil)
+	req, err := http.NewRequest(http.MethodGet, "/config", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -274,7 +274,7 @@ func TestServer_getIdentityProvider_EmptyKeycloakConfig(t *testing.T) {
 	router := gin.New()
 	router.GET("/identity-provider", server.getIdentityProvider)
 
-	req, err := http.NewRequest("GET", "/identity-provider", nil)
+	req, err := http.NewRequest(http.MethodGet, "/identity-provider", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -308,7 +308,7 @@ func TestServer_getIdentityProvider_AllProviderTypes(t *testing.T) {
 			router := gin.New()
 			router.GET("/identity-provider", server.getIdentityProvider)
 
-			req, err := http.NewRequest("GET", "/identity-provider", nil)
+			req, err := http.NewRequest(http.MethodGet, "/identity-provider", nil)
 			assert.NoError(t, err)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
@@ -424,7 +424,7 @@ func TestServer_NoRoute_API_Json404(t *testing.T) {
 	server := NewServer(logger, cfg, true, &AuthHandler{})
 
 	// Use the engine directly and perform a request to an unknown /api/ path
-	req, err := http.NewRequest("GET", "/api/unknown/thing", nil)
+	req, err := http.NewRequest(http.MethodGet, "/api/unknown/thing", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	server.gin.ServeHTTP(w, req)
@@ -453,7 +453,7 @@ func TestServer_NoRoute_SPA_Fallback(t *testing.T) {
 	engine := gin.New()
 	engine.NoRoute(ServeSPA("/", tmpDir))
 
-	req, err := http.NewRequest("GET", "/some/page", nil)
+	req, err := http.NewRequest(http.MethodGet, "/some/page", nil)
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)

--- a/pkg/api/auth_jwt_test.go
+++ b/pkg/api/auth_jwt_test.go
@@ -62,7 +62,7 @@ func TestAuthMiddleware_ExposesTokenAndRawClaims(t *testing.T) {
 	tokStr, err := tok.SignedString(priv)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokStr)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -116,7 +116,6 @@ func TestAuthMiddleware_GroupNormalizationCases(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			router := gin.New()
 			router.Use(auth.Middleware())
@@ -136,7 +135,7 @@ func TestAuthMiddleware_GroupNormalizationCases(t *testing.T) {
 			tokStr, err := tok.SignedString(priv)
 			require.NoError(t, err)
 
-			req := httptest.NewRequest("GET", "/test", nil)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			req.Header.Set("Authorization", "Bearer "+tokStr)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
@@ -215,7 +214,7 @@ func TestAuthMiddleware_JWKSUnreachable(t *testing.T) {
 	tokStr, err := tok.SignedString(privNew)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokStr)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -263,14 +262,14 @@ func TestAuthMiddleware_NegativeTokenCases(t *testing.T) {
 	tokExp.Header["kid"] = kid
 	tokExpStr, err := tokExp.SignedString(priv)
 	require.NoError(t, err)
-	reqExp := httptest.NewRequest("GET", "/test", nil)
+	reqExp := httptest.NewRequest(http.MethodGet, "/test", nil)
 	reqExp.Header.Set("Authorization", "Bearer "+tokExpStr)
 	wExp := httptest.NewRecorder()
 	router.ServeHTTP(wExp, reqExp)
 	require.Equal(t, http.StatusUnauthorized, wExp.Code)
 
 	// 2) Malformed token (random string)
-	reqBad := httptest.NewRequest("GET", "/test", nil)
+	reqBad := httptest.NewRequest(http.MethodGet, "/test", nil)
 	reqBad.Header.Set("Authorization", "Bearer this-is-not-a-jwt")
 	wBad := httptest.NewRecorder()
 	router.ServeHTTP(wBad, reqBad)
@@ -282,7 +281,7 @@ func TestAuthMiddleware_NegativeTokenCases(t *testing.T) {
 	tokNoSub.Header["kid"] = kid
 	tokNoSubStr, err := tokNoSub.SignedString(priv)
 	require.NoError(t, err)
-	reqNoSub := httptest.NewRequest("GET", "/test", nil)
+	reqNoSub := httptest.NewRequest(http.MethodGet, "/test", nil)
 	reqNoSub.Header.Set("Authorization", "Bearer "+tokNoSubStr)
 	wNoSub := httptest.NewRecorder()
 	router.ServeHTTP(wNoSub, reqNoSub)
@@ -384,7 +383,7 @@ func TestAuthMiddleware_ValidAndInvalidJWT(t *testing.T) {
 	}
 
 	// Valid token request
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokStr)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -423,7 +422,7 @@ func TestAuthMiddleware_ValidAndInvalidJWT(t *testing.T) {
 	badStr, err := badTok.SignedString(badPriv)
 	require.NoError(t, err)
 
-	req2 := httptest.NewRequest("GET", "/test", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req2.Header.Set("Authorization", "Bearer "+badStr)
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)
@@ -466,13 +465,13 @@ func TestAuthMiddleware_MissingOrWrongHeader(t *testing.T) {
 	router.GET("/test", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
 
 	// Missing header
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 
 	// Wrong header (not Bearer)
-	req2 := httptest.NewRequest("GET", "/test", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req2.Header.Set("Authorization", "Basic abcdef")
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)
@@ -546,7 +545,7 @@ func TestAuthMiddleware_RefreshOnMissingKid(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the request in a goroutine so we can coordinate the refresh
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokStr)
 	w := httptest.NewRecorder()
 

--- a/pkg/api/auth_multiidp_test.go
+++ b/pkg/api/auth_multiidp_test.go
@@ -249,7 +249,7 @@ func TestEmptyIDPHandling(t *testing.T) {
 	tokStr, err := tok.SignedString(priv)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokStr)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
@@ -438,7 +438,7 @@ func TestMissingBearerToken(t *testing.T) {
 	})
 
 	t.Run("NoAuthorizationHeader", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/protected", nil)
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
 		// No Authorization header
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -447,7 +447,7 @@ func TestMissingBearerToken(t *testing.T) {
 	})
 
 	t.Run("InvalidBearerFormat", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/protected", nil)
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
 		req.Header.Set("Authorization", "InvalidToken")
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -456,7 +456,7 @@ func TestMissingBearerToken(t *testing.T) {
 	})
 
 	t.Run("EmptyBearerToken", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/protected", nil)
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
 		req.Header.Set("Authorization", "Bearer ")
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -155,7 +155,7 @@ func TestAuthHandler_MiddlewareErrorResponses(t *testing.T) {
 				c.JSON(http.StatusOK, gin.H{"status": "ok"})
 			})
 
-			req, err := http.NewRequest("GET", "/test", nil)
+			req, err := http.NewRequest(http.MethodGet, "/test", nil)
 			assert.NoError(t, err)
 
 			if tt.authHeader != "" {
@@ -183,7 +183,7 @@ func TestAuthHandler_MiddlewareHeaderRemoval(t *testing.T) {
 		c.JSON(http.StatusOK, gin.H{"auth_header": authHeader})
 	})
 
-	req, err := http.NewRequest("GET", "/test", nil)
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
 	assert.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer test-token")
 

--- a/pkg/api/spa_test.go
+++ b/pkg/api/spa_test.go
@@ -74,7 +74,7 @@ func TestServeSPA(t *testing.T) {
 			router := gin.New()
 			router.NoRoute(ServeSPA(tt.urlPrefix, tempDir))
 
-			req, err := http.NewRequest("GET", tt.requestPath, nil)
+			req, err := http.NewRequest(http.MethodGet, tt.requestPath, nil)
 			assert.NoError(t, err)
 
 			w := httptest.NewRecorder()
@@ -101,7 +101,7 @@ func TestServeSPA_EmptyPrefix(t *testing.T) {
 	router := gin.New()
 	router.NoRoute(ServeSPA("", tempDir))
 
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	assert.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -118,7 +118,7 @@ func TestServeSPA_NonExistentDirectory(t *testing.T) {
 	router := gin.New()
 	router.NoRoute(ServeSPA("/", "/non/existent/directory"))
 
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	assert.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/pkg/breakglass/api_metrics.go
+++ b/pkg/breakglass/api_metrics.go
@@ -1,0 +1,24 @@
+package breakglass
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/telekom/k8s-breakglass/pkg/metrics"
+)
+
+// instrumentedHandler wraps a gin handler to record API metrics consistently.
+// It tracks request counts, latency, and error status codes for the provided endpoint label.
+func instrumentedHandler(endpoint string, handler gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		metrics.APIEndpointRequests.WithLabelValues(endpoint).Inc()
+		handler(c)
+		metrics.APIEndpointDuration.WithLabelValues(endpoint).Observe(time.Since(start).Seconds())
+		status := c.Writer.Status()
+		if status >= 400 {
+			metrics.APIEndpointErrors.WithLabelValues(endpoint, strconv.Itoa(status)).Inc()
+		}
+	}
+}

--- a/pkg/breakglass/cluster_config_checker.go
+++ b/pkg/breakglass/cluster_config_checker.go
@@ -72,7 +72,6 @@ func (ccc ClusterConfigChecker) Start(ctx context.Context) {
 }
 
 func (ccc ClusterConfigChecker) runOnce(ctx context.Context, lg *zap.SugaredLogger) {
-
 	lg.Debug("Running ClusterConfig validation check")
 	list := telekomv1alpha1.ClusterConfigList{}
 	if err := ccc.Client.List(ctx, &list); err != nil {
@@ -167,7 +166,6 @@ func (ccc ClusterConfigChecker) runOnce(ctx context.Context, lg *zap.SugaredLogg
 }
 
 func (ccc ClusterConfigChecker) setStatusAndEvent(ctx context.Context, cc *telekomv1alpha1.ClusterConfig, phase, message, eventType string, lg *zap.SugaredLogger) error {
-
 	// update status with conditions
 	now := metav1.Now()
 

--- a/pkg/breakglass/cluster_config_checker_test.go
+++ b/pkg/breakglass/cluster_config_checker_test.go
@@ -110,5 +110,4 @@ func getCondition(cc *telekomv1alpha1.ClusterConfig, condType string) *metav1.Co
 		}
 	}
 	return nil
-
 }

--- a/pkg/breakglass/cluster_config_manager.go
+++ b/pkg/breakglass/cluster_config_manager.go
@@ -3,6 +3,7 @@ package breakglass
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
@@ -24,10 +25,23 @@ func (ccm *ClusterConfigManager) GetClusterConfigByName(ctx context.Context, nam
 	list := telekomv1alpha1.ClusterConfigList{}
 	// Try to use a field index (metadata.name) via MatchingFields if available.
 	if err := ccm.client.List(ctx, &list, client.MatchingFields{"metadata.name": name}); err == nil {
+		matching := make([]*telekomv1alpha1.ClusterConfig, 0, len(list.Items))
 		for i := range list.Items {
 			if list.Items[i].Name == name {
-				return &list.Items[i], nil
+				matching = append(matching, &list.Items[i])
 			}
+		}
+		switch len(matching) {
+		case 0:
+			// continue to fallback for legacy behavior
+		case 1:
+			return matching[0], nil
+		default:
+			namespaces := make([]string, 0, len(matching))
+			for _, cfg := range matching {
+				namespaces = append(namespaces, cfg.Namespace)
+			}
+			return nil, fmt.Errorf("clusterconfig name %q is not unique; found in namespaces: %s", name, strings.Join(namespaces, ","))
 		}
 	}
 
@@ -37,12 +51,24 @@ func (ccm *ClusterConfigManager) GetClusterConfigByName(ctx context.Context, nam
 		zap.S().Errorw("Failed to list ClusterConfig resources", "error", err.Error())
 		return nil, fmt.Errorf("failed to list ClusterConfig resources: %w", err)
 	}
+	matching := make([]*telekomv1alpha1.ClusterConfig, 0, len(list2.Items))
 	for i := range list2.Items {
 		if list2.Items[i].Name == name {
-			return &list2.Items[i], nil
+			matching = append(matching, &list2.Items[i])
 		}
 	}
-	return nil, fmt.Errorf("failed to get ClusterConfig by name %q: not found", name)
+	switch len(matching) {
+	case 0:
+		return nil, fmt.Errorf("failed to get ClusterConfig by name %q: not found", name)
+	case 1:
+		return matching[0], nil
+	default:
+		namespaces := make([]string, 0, len(matching))
+		for _, cfg := range matching {
+			namespaces = append(namespaces, cfg.Namespace)
+		}
+		return nil, fmt.Errorf("clusterconfig name %q is not unique; found in namespaces: %s", name, strings.Join(namespaces, ","))
+	}
 }
 
 // GetClusterConfigInNamespace fetches the ClusterConfig resource by name within the provided namespace.

--- a/pkg/breakglass/escalation_controller_handlers_test.go
+++ b/pkg/breakglass/escalation_controller_handlers_test.go
@@ -72,7 +72,7 @@ func TestHandleGetEscalations_ReturnsEscalationsForTokenGroups(t *testing.T) {
 	// Register controller with its middleware so the test middleware runs for the route
 	_ = controller.Register(engine.Group("/"+controller.BasePath(), controller.Handlers()...))
 
-	req := httptest.NewRequest("GET", "/breakglassEscalations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/breakglassEscalations", nil)
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)

--- a/pkg/breakglass/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation_status_updater_test.go
@@ -428,7 +428,7 @@ func BenchmarkDeduplicateMembersFromHierarchy(b *testing.B) {
 	}
 
 	// Populate with test data
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		hierarchy["idp-1"]["group-1"][i] = fmt.Sprintf("user%d@example.com", i)
 		hierarchy["idp-1"]["group-2"][i] = fmt.Sprintf("user%d@example.com", i+50)
 		hierarchy["idp-2"]["group-1"][i] = fmt.Sprintf("user%d@example.com", i+25)
@@ -437,7 +437,7 @@ func BenchmarkDeduplicateMembersFromHierarchy(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = deduplicateMembersFromHierarchy(hierarchy, "group-1")
 	}
 }
@@ -445,12 +445,12 @@ func BenchmarkDeduplicateMembersFromHierarchy(b *testing.B) {
 // BenchmarkNormalizeMembers benchmarks the normalize function
 func BenchmarkNormalizeMembers(b *testing.B) {
 	members := make([]string, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		members[i] = fmt.Sprintf("user%d@example.com", i)
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = normalizeMembers(members)
 	}
 }

--- a/pkg/breakglass/expire_approved_sessions.go
+++ b/pkg/breakglass/expire_approved_sessions.go
@@ -48,7 +48,7 @@ func (wc *BreakglassSessionController) ExpireApprovedSessions() {
 
 			// Persist the status change using Status().Update and retry on conflict with a few attempts.
 			var lastErr error
-			for attempt := 0; attempt < 3; attempt++ {
+			for attempt := range 3 {
 				if err := wc.sessionManager.UpdateBreakglassSessionStatus(context.Background(), ses); err == nil {
 					lastErr = nil
 					// count as expired when status update succeeds

--- a/pkg/breakglass/leadership_election_test.go
+++ b/pkg/breakglass/leadership_election_test.go
@@ -275,7 +275,7 @@ func TestLeadershipSignal_MultipleListeners(t *testing.T) {
 
 	// Both should eventually exit due to context timeout
 	completed := 0
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-done1:
 			completed++

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -88,14 +88,14 @@ func (BreakglassSessionController) BasePath() string {
 
 func (wc *BreakglassSessionController) Register(rg *gin.RouterGroup) error {
 	// RESTful endpoints for breakglass sessions (no leading slash)
-	rg.GET("", wc.handleGetBreakglassSessionStatus)             // List/filter sessions
-	rg.GET(":name", wc.handleGetBreakglassSessionByName)        // Get single session by name
-	rg.POST("", wc.handleRequestBreakglassSession)              // Create session
-	rg.POST(":name/approve", wc.handleApproveBreakglassSession) // Approve session
-	rg.POST(":name/reject", wc.handleRejectBreakglassSession)   // Reject session
-	rg.POST(":name/withdraw", wc.handleWithdrawMyRequest)       // Withdraw session (by requester)
-	rg.POST(":name/drop", wc.handleDropMySession)               // Drop session (owner can drop active or pending)
-	rg.POST(":name/cancel", wc.handleApproverCancel)            // Approver cancels a running/approved session
+	rg.GET("", instrumentedHandler("handleGetBreakglassSessionStatus", wc.handleGetBreakglassSessionStatus))           // List/filter sessions
+	rg.GET(":name", instrumentedHandler("handleGetBreakglassSessionByName", wc.handleGetBreakglassSessionByName))      // Get single session by name
+	rg.POST("", instrumentedHandler("handleRequestBreakglassSession", wc.handleRequestBreakglassSession))              // Create session
+	rg.POST(":name/approve", instrumentedHandler("handleApproveBreakglassSession", wc.handleApproveBreakglassSession)) // Approve session
+	rg.POST(":name/reject", instrumentedHandler("handleRejectBreakglassSession", wc.handleRejectBreakglassSession))    // Reject session
+	rg.POST(":name/withdraw", instrumentedHandler("handleWithdrawMyRequest", wc.handleWithdrawMyRequest))              // Withdraw session (by requester)
+	rg.POST(":name/drop", instrumentedHandler("handleDropMySession", wc.handleDropMySession))                          // Drop session (owner can drop active or pending)
+	rg.POST(":name/cancel", instrumentedHandler("handleApproverCancel", wc.handleApproverCancel))                      // Approver cancels a running/approved session
 	return nil
 }
 
@@ -2037,7 +2037,7 @@ func (wc BreakglassSessionController) filterHiddenFromUIRecipients(
 	return filtered
 }
 
-// nolint:unused // might use later
+//nolint:unused // might use later
 func (wc BreakglassSessionController) handleListClusters(c *gin.Context) {
 	reqLog := system.GetReqLogger(c, wc.log)
 	reqLog = system.EnrichReqLoggerWithAuth(c, reqLog)
@@ -2314,7 +2314,6 @@ func NewBreakglassSessionController(log *zap.SugaredLogger,
 	clusterConfigClient client.Client,
 	disableEmail ...bool,
 ) *BreakglassSessionController {
-
 	ip := KeycloakIdentityProvider{}
 
 	// Check if disableEmail flag is provided

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -185,7 +185,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 		GroupName:   "breakglass-create-all",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -195,7 +195,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 
 	// get created request and check if proper fields are set
 	getSession := func() v1alpha1.BreakglassSession {
-		req, _ := http.NewRequest("GET", "/breakglassSessions", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		response := w.Result()
@@ -219,7 +219,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 	}
 
 	// approve session
-	req, _ = http.NewRequest("POST",
+	req, _ = http.NewRequest(http.MethodPost,
 		fmt.Sprintf("/breakglassSessions/%s/approve", ses.Name),
 		nil)
 	w = httptest.NewRecorder()
@@ -236,7 +236,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 	}
 
 	// reject session -> should be invalid because session is already approved (terminal)
-	req, _ = http.NewRequest("POST",
+	req, _ = http.NewRequest(http.MethodPost,
 		fmt.Sprintf("/breakglassSessions/%s/reject", ses.Name),
 		nil)
 	w = httptest.NewRecorder()
@@ -348,7 +348,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 		GroupName:   "breakglass-create-all",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -357,7 +357,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	}
 
 	// fetch created session
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response = w.Result()
@@ -374,7 +374,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	ses := respSessions[0]
 
 	// approve session (approver@telekom.de)
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", ses.Name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", ses.Name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response = w.Result()
@@ -383,7 +383,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	}
 
 	// fetch session and assert approver fields
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response = w.Result()
@@ -413,7 +413,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	}
 
 	// reject session as a different user (rejector@telekom.de) -> should be invalid because session is terminal (approved)
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/reject", ses.Name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/reject", ses.Name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response = w.Result()
@@ -422,7 +422,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	}
 
 	// fetch session and assert approver metadata remains unchanged (reject did not overwrite)
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response = w.Result()
@@ -493,7 +493,7 @@ func TestCreateSessionAttachesOwnerReference(t *testing.T) {
 		GroupName:   "esc-group",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	resp := w.Result()
@@ -556,7 +556,7 @@ func TestCreateSessionWithoutEscalationReturns401(t *testing.T) {
 		GroupName:   "nonexistent-group",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	resp := w.Result()
@@ -565,7 +565,7 @@ func TestCreateSessionWithoutEscalationReturns401(t *testing.T) {
 	}
 
 	// Verify no sessions exist
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	resp = w.Result()
@@ -629,7 +629,7 @@ func TestEscalation_BlockSelfApproval_OverridesClusterAllow(t *testing.T) {
 
 	reqData := BreakglassSessionRequest{Clustername: "c", Username: "self@example.com", GroupName: "g-block"}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -643,7 +643,7 @@ func TestEscalation_BlockSelfApproval_OverridesClusterAllow(t *testing.T) {
 	name := created.Name
 
 	// Approve request
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode == http.StatusOK {
@@ -704,7 +704,7 @@ func TestEscalation_AllowedApproverDomains_OverridesCluster(t *testing.T) {
 	// create a session
 	reqData := BreakglassSessionRequest{Clustername: "c2", Username: "requester@ex.com", GroupName: "g-domain"}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -717,7 +717,7 @@ func TestEscalation_AllowedApproverDomains_OverridesCluster(t *testing.T) {
 	name := created.Name
 
 	// Attempt approval by approver@example.com (example.com) -> escalation restricts to example.org and should deny
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode == http.StatusOK {
@@ -778,7 +778,7 @@ func TestSessionCreatedUsesEscalationNamespace(t *testing.T) {
 		GroupName:   "g1",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -872,7 +872,7 @@ func TestFilterBreakglassSessionsByUser(t *testing.T) {
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
 	// Filter by mine=true (user1@example.com)
-	req, _ := http.NewRequest("GET", "/breakglassSessions?mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -953,7 +953,7 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("POST", "/breakglassSessions/pending-1/approve", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/pending-1/approve", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -1027,7 +1027,7 @@ func TestTerminalStateImmutability(t *testing.T) {
 	// create session
 	reqData := BreakglassSessionRequest{Clustername: "c", Username: "user@e.com", GroupName: "g"}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -1042,7 +1042,7 @@ func TestTerminalStateImmutability(t *testing.T) {
 	name := created.Name
 
 	// approve once -> OK
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1050,7 +1050,7 @@ func TestTerminalStateImmutability(t *testing.T) {
 	}
 
 	// approve second time -> conflict (409)
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusConflict {
@@ -1058,7 +1058,7 @@ func TestTerminalStateImmutability(t *testing.T) {
 	}
 
 	// attempt to reject after approval -> should be BadRequest (terminal)
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/reject", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/reject", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusBadRequest {
@@ -1132,7 +1132,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	// create session as requester user@e.com
 	reqData := BreakglassSessionRequest{Clustername: "c", Username: "user@e.com", GroupName: "g"}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -1147,7 +1147,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	name := created.Name
 
 	// approve as approver -> session becomes Approved
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1155,7 +1155,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	}
 
 	// verify approved state
-	req, _ = http.NewRequest("GET", fmt.Sprintf("/breakglassSessions/%s", name), nil)
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/breakglassSessions/%s", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	gotList := []v1alpha1.BreakglassSession{}
@@ -1171,7 +1171,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	}
 
 	// drop as owner -> should transition to Expired
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/drop", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/drop", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1179,7 +1179,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	}
 
 	// verify expired state
-	req, _ = http.NewRequest("GET", fmt.Sprintf("/breakglassSessions/%s", name), nil)
+	req, _ = http.NewRequest(http.MethodGet, fmt.Sprintf("/breakglassSessions/%s", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	gotList = []v1alpha1.BreakglassSession{}
@@ -1198,7 +1198,7 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	}
 
 	// ensure expired is terminal: further approve attempts must fail
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode == http.StatusOK {
@@ -1272,7 +1272,7 @@ func TestApproverCancelRunningSession(t *testing.T) {
 	// create session as requester user@e.com
 	reqData := BreakglassSessionRequest{Clustername: "c", Username: "user@e.com", GroupName: "g"}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -1287,7 +1287,7 @@ func TestApproverCancelRunningSession(t *testing.T) {
 	name := created.Name
 
 	// approve as approver -> session becomes Approved
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1295,7 +1295,7 @@ func TestApproverCancelRunningSession(t *testing.T) {
 	}
 
 	// cancel as approver -> should transition to Expired
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/cancel", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/cancel", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1326,7 +1326,7 @@ func TestApproverCancelRunningSession(t *testing.T) {
 	}
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/cancel", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/cancel", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusUnauthorized {
@@ -1378,7 +1378,7 @@ func TestFilterBreakglassSessionsByClusterQueryParam(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?cluster=clusterA&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?cluster=clusterA&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -1439,7 +1439,7 @@ func TestFilterBreakglassSessionsByUserQueryParam(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?user=alice@example.com&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?user=alice@example.com&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -1500,7 +1500,7 @@ func TestFilterBreakglassSessionsByGroupQueryParam(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?group=admins&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?group=admins&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -1575,7 +1575,7 @@ func TestWithdrawMyRequest_Scenarios(t *testing.T) {
 
 	// 1) Successful withdraw by owner on pending session
 	{
-		req, _ := http.NewRequest("POST", "/breakglassSessions/w-pending/withdraw", nil)
+		req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/w-pending/withdraw", nil)
 		req.Header.Set("X-Test-Email", "owner@example.com")
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
@@ -1595,7 +1595,7 @@ func TestWithdrawMyRequest_Scenarios(t *testing.T) {
 
 	// 2) Unauthorized withdraw attempt by non-owner
 	{
-		req, _ := http.NewRequest("POST", "/breakglassSessions/w-approved/withdraw", nil)
+		req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/w-approved/withdraw", nil)
 		req.Header.Set("X-Test-Email", "other@example.com")
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
@@ -1607,7 +1607,7 @@ func TestWithdrawMyRequest_Scenarios(t *testing.T) {
 
 	// 3) Owner attempts to withdraw a non-pending (approved) session -> BadRequest
 	{
-		req, _ := http.NewRequest("POST", "/breakglassSessions/w-approved/withdraw", nil)
+		req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/w-approved/withdraw", nil)
 		req.Header.Set("X-Test-Email", "owner@example.com")
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
@@ -1662,7 +1662,7 @@ func TestFilterBreakglassSessionsByClusterAndUserQueryParams(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?cluster=c1&user=u1@example.com&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?cluster=c1&user=u1@example.com&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -1736,7 +1736,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	// 1) attempt request without reason -> 422
 	reqBody := BreakglassSessionRequest{Clustername: "c1", Username: "requester@example.com", GroupName: "g-with-reason"}
 	b, _ := json.Marshal(reqBody)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -1747,7 +1747,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	// 2) request with reason -> 201
 	reqBody.Reason = "CASM-12345"
 	b, _ = json.Marshal(reqBody)
-	req, _ = http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ = http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res = w.Result()
@@ -1756,7 +1756,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	}
 
 	// fetch session and verify stored request reason
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res = w.Result()
@@ -1778,7 +1778,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	// 3) approve with approver reason
 	approveBody := map[string]string{"reason": "Approved for emergency"}
 	bb, _ := json.Marshal(approveBody)
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/approve", ses.Name), bytes.NewReader(bb))
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/approve", ses.Name), bytes.NewReader(bb))
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res = w.Result()
@@ -1787,7 +1787,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	}
 
 	// fetch session and assert approvalReason stored
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res = w.Result()
@@ -1850,7 +1850,7 @@ func TestLongReasonStored(t *testing.T) {
 	long := strings.Repeat("A", 3000)
 	reqBody := BreakglassSessionRequest{Clustername: "lc1", Username: "longreq@example.com", GroupName: "g-long", Reason: long}
 	b, _ := json.Marshal(reqBody)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -1859,7 +1859,7 @@ func TestLongReasonStored(t *testing.T) {
 	}
 
 	// fetch and assert stored
-	req, _ = http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res = w.Result()
@@ -1912,7 +1912,7 @@ func TestWhitespaceReasonRejectedWhenMandatory(t *testing.T) {
 
 	reqBody := BreakglassSessionRequest{Clustername: "wc1", Username: "ws@example.com", GroupName: "g-ws", Reason: "   "}
 	b, _ := json.Marshal(reqBody)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -1961,7 +1961,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	// create request
 	reqBody := BreakglassSessionRequest{Clustername: "oc1", Username: "owner@example.com", GroupName: "g-owner"}
 	b, _ := json.Marshal(reqBody)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -1969,7 +1969,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	}
 
 	// get session name
-	req, _ = http.NewRequest("GET", "/breakglassSessions?mine=true", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	var sessions []v1alpha1.BreakglassSession
@@ -1980,7 +1980,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	name := sessions[0].Name
 
 	// owner rejects own pending session
-	req, _ = http.NewRequest("POST", fmt.Sprintf("/breakglassSessions/%s/reject", name), nil)
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/reject", name), nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -1988,7 +1988,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	}
 
 	// verify rejected
-	req, _ = http.NewRequest("GET", "/breakglassSessions?mine=true", nil)
+	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	sessions = []v1alpha1.BreakglassSession{}
@@ -2041,7 +2041,7 @@ func TestFilterBreakglassSessionsByClusterAndGroupQueryParams(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?cluster=cluster1&group=ops&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?cluster=cluster1&group=ops&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -2101,7 +2101,7 @@ func TestFilterBreakglassSessionsByUserAndGroupQueryParams(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?user=sam@example.com&group=ops&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?user=sam@example.com&group=ops&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -2161,7 +2161,7 @@ func TestFilterBreakglassSessionsByClusterUserGroupQueryParams(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?cluster=z1&user=p@example.com&group=wheel&mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?cluster=z1&user=p@example.com&group=wheel&mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	response := w.Result()
@@ -2274,7 +2274,7 @@ func TestFilterBreakglassSessionsByState(t *testing.T) {
 
 	// helper to query by state
 	queryByState := func(state string) []v1alpha1.BreakglassSession {
-		req, _ := http.NewRequest("GET", "/breakglassSessions?state="+state+"&mine=true", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?state="+state+"&mine=true", nil)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		response := w.Result()
@@ -2346,7 +2346,7 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 
 	assertStates := func(t *testing.T, query string, want []string) {
 		t.Helper()
-		req, _ := http.NewRequest("GET", query, nil)
+		req, _ := http.NewRequest(http.MethodGet, query, nil)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		res := w.Result()
@@ -2429,7 +2429,7 @@ func TestFilterBreakglassSessionsApprovedByMe(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?mine=false&approver=false&approvedByMe=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?mine=false&approver=false&approvedByMe=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -2508,7 +2508,7 @@ func TestApproverCanSeePendingSessions(t *testing.T) {
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
 	// bob should see the pending session without specifying mine=true
-	req, _ := http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -2559,7 +2559,7 @@ func TestGetSessions_IdentityProviderErrorReturns500(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions?mine=true", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -2627,7 +2627,7 @@ func TestClusterConfig_BlockSelfApproval_PreventsSelfApproval(t *testing.T) {
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
 	// Since self-approval is blocked, the owner acting as approver should NOT see the pending session
-	req, _ := http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -2698,7 +2698,7 @@ func TestClusterConfig_AllowedApproverDomains_AllowsDomain(t *testing.T) {
 	engine := gin.New()
 	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
 
-	req, _ := http.NewRequest("GET", "/breakglassSessions", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
@@ -2797,7 +2797,7 @@ func TestFilterBreakglassSessions_ExhaustivePermutations(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		req, _ := http.NewRequest("GET", "/breakglassSessions?"+tc.query, nil)
+		req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?"+tc.query, nil)
 		if tc.header != "" {
 			req.Header.Set("X-Test-Email", tc.header)
 		}
@@ -3134,7 +3134,7 @@ func TestHiddenFromUI_SessionRequest_NoEmailsToHiddenGroups(t *testing.T) {
 		GroupName:   "admin",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -3213,7 +3213,7 @@ func TestHiddenFromUI_EscalationResponse_GroupsRemoved(t *testing.T) {
 	rg := engine.Group("/breakglassEscalations", ctrl.middleware)
 	_ = ctrl.Register(rg)
 
-	req, _ := http.NewRequest("GET", "/breakglassEscalations", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassEscalations", nil)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -3313,7 +3313,7 @@ func TestHiddenFromUI_MixedVisibleAndHidden(t *testing.T) {
 		GroupName:   "admin",
 	}
 	b, _ := json.Marshal(reqData)
-	req, _ := http.NewRequest("POST", "/breakglassSessions", bytes.NewReader(b))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 

--- a/pkg/cluster/watchers.go
+++ b/pkg/cluster/watchers.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	clientcache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// RegisterInvalidationHandlers wires controller-runtime cache event handlers to keep the ClientProvider caches fresh.
+// It watches ClusterConfig and Secret events to invalidate cached ClusterConfigs and REST configs whenever
+// a relevant object changes or is deleted.
+func RegisterInvalidationHandlers(ctx context.Context, mgr ctrl.Manager, provider *ClientProvider, log *zap.SugaredLogger) error {
+	if provider == nil {
+		return fmt.Errorf("client provider is nil")
+	}
+	if mgr == nil {
+		return fmt.Errorf("manager is nil")
+	}
+	cache := mgr.GetCache()
+	if cache == nil {
+		return fmt.Errorf("manager cache is nil")
+	}
+
+	ccInformer, err := cache.GetInformer(ctx, &telekomv1alpha1.ClusterConfig{})
+	if err != nil {
+		return fmt.Errorf("get ClusterConfig informer: %w", err)
+	}
+	if _, err := ccInformer.AddEventHandler(clientcache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldCfg := extractClusterConfig(oldObj)
+			newCfg := extractClusterConfig(newObj)
+			if newCfg == nil {
+				return
+			}
+			if oldCfg != nil && oldCfg.ResourceVersion == newCfg.ResourceVersion {
+				return
+			}
+			provider.Invalidate(newCfg.Name)
+			if log != nil {
+				log.Debugw("ClusterConfig cache invalidated", "cluster", newCfg.Name)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			cfg := extractClusterConfig(obj)
+			if cfg == nil {
+				return
+			}
+			provider.Invalidate(cfg.Name)
+			if log != nil {
+				log.Debugw("ClusterConfig cache invalidated due to delete", "cluster", cfg.Name)
+			}
+		},
+	}); err != nil {
+		return fmt.Errorf("register ClusterConfig invalidation handler: %w", err)
+	}
+
+	secretInformer, err := cache.GetInformer(ctx, &corev1.Secret{})
+	if err != nil {
+		return fmt.Errorf("get Secret informer: %w", err)
+	}
+	if _, err := secretInformer.AddEventHandler(clientcache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			sec := extractSecret(newObj)
+			if sec == nil {
+				return
+			}
+			if !provider.IsSecretTracked(sec.Namespace, sec.Name) {
+				return
+			}
+			provider.InvalidateSecret(sec.Namespace, sec.Name)
+			if log != nil {
+				log.Debugw("ClusterConfig caches invalidated due to Secret update", "secret", fmt.Sprintf("%s/%s", sec.Namespace, sec.Name))
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			sec := extractSecret(obj)
+			if sec == nil {
+				return
+			}
+			if !provider.IsSecretTracked(sec.Namespace, sec.Name) {
+				return
+			}
+			provider.InvalidateSecret(sec.Namespace, sec.Name)
+			if log != nil {
+				log.Debugw("ClusterConfig caches invalidated due to Secret delete", "secret", fmt.Sprintf("%s/%s", sec.Namespace, sec.Name))
+			}
+		},
+	}); err != nil {
+		return fmt.Errorf("register Secret invalidation handler: %w", err)
+	}
+
+	if log != nil {
+		log.Infow("Registered ClusterConfig/Secret invalidation handlers")
+	}
+	return nil
+}
+
+func extractClusterConfig(obj interface{}) *telekomv1alpha1.ClusterConfig {
+	switch t := obj.(type) {
+	case *telekomv1alpha1.ClusterConfig:
+		return t
+	case clientcache.DeletedFinalStateUnknown:
+		if cfg, ok := t.Obj.(*telekomv1alpha1.ClusterConfig); ok {
+			return cfg
+		}
+	}
+	return nil
+}
+
+func extractSecret(obj interface{}) *corev1.Secret {
+	switch t := obj.(type) {
+	case *corev1.Secret:
+		return t
+	case clientcache.DeletedFinalStateUnknown:
+		if sec, ok := t.Obj.(*corev1.Secret); ok {
+			return sec
+		}
+	}
+	return nil
+}

--- a/pkg/cluster/watchers_test.go
+++ b/pkg/cluster/watchers_test.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcache "k8s.io/client-go/tools/cache"
+
+	"github.com/stretchr/testify/assert"
+	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+func TestExtractClusterConfigHandlesDeletedFinalState(t *testing.T) {
+	cfg := &telekomv1alpha1.ClusterConfig{}
+	wrapped := clientcache.DeletedFinalStateUnknown{Obj: cfg}
+
+	assert.Same(t, cfg, extractClusterConfig(wrapped))
+}
+
+func TestExtractClusterConfigReturnsNilForUnknownTypes(t *testing.T) {
+	assert.Nil(t, extractClusterConfig("not-a-cluster"))
+}
+
+func TestExtractSecretHandlesDeletedFinalState(t *testing.T) {
+	sec := &corev1.Secret{}
+	wrapped := clientcache.DeletedFinalStateUnknown{Obj: sec}
+
+	assert.Same(t, sec, extractSecret(wrapped))
+}
+
+func TestExtractSecretReturnsNilForUnknownTypes(t *testing.T) {
+	assert.Nil(t, extractSecret(v1.Now()))
+}

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateMailProviderRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	enabledProvider := &breakglassv1alpha1.MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail-enabled"},
+		Spec: breakglassv1alpha1.MailProviderSpec{
+			SMTP:   breakglassv1alpha1.SMTPConfig{Host: "smtp.enabled", Port: 587},
+			Sender: breakglassv1alpha1.SenderConfig{Address: "noreply@enabled"},
+		},
+	}
+
+	disabledProvider := &breakglassv1alpha1.MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail-disabled"},
+		Spec: breakglassv1alpha1.MailProviderSpec{
+			Disabled: true,
+			SMTP:     breakglassv1alpha1.SMTPConfig{Host: "smtp.disabled", Port: 587},
+			Sender:   breakglassv1alpha1.SenderConfig{Address: "noreply@disabled"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(enabledProvider, disabledProvider).Build()
+	reconciler := &EscalationReconciler{client: fakeClient}
+
+	tests := []struct {
+		name         string
+		mailProvider string
+		expectErr    bool
+	}{
+		{name: "no mail provider configured", mailProvider: "", expectErr: false},
+		{name: "enabled provider", mailProvider: "mail-enabled", expectErr: false},
+		{name: "missing provider", mailProvider: "does-not-exist", expectErr: true},
+		{name: "disabled provider", mailProvider: "mail-disabled", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			esc := &breakglassv1alpha1.BreakglassEscalation{
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{MailProvider: tt.mailProvider},
+			}
+
+			err := reconciler.validateMailProviderRef(context.Background(), esc)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -1,0 +1,131 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+// RegisterCommonFieldIndexes configures the field indices required by both the
+// reconcilers and validating webhooks. These indices allow cache-backed
+// lookups for frequently queried fields (e.g., spec.cluster) and enable
+// metadata.name selectors for cluster-wide uniqueness checks.
+func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, log *zap.SugaredLogger) {
+	if idx == nil {
+		if log != nil {
+			log.Warnw("Field indexer not available from manager")
+		}
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	register := func(field string, fn func() error) {
+		if err := fn(); err != nil {
+			if log != nil {
+				log.Errorw("Failed to register field index", "field", field, "error", err, "errorType", fmt.Sprintf("%T", err))
+			}
+		} else if log != nil {
+			log.Debugw("Registered field index", "field", field)
+		}
+	}
+
+	register("BreakglassSession.spec.cluster", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.cluster", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.Cluster != "" {
+				return []string{bs.Spec.Cluster}
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassSession.spec.user", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.user", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.User != "" {
+				return []string{bs.Spec.User}
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassSession.spec.grantedGroup", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.grantedGroup", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.GrantedGroup != "" {
+				return []string{bs.Spec.GrantedGroup}
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassSession.metadata.name", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "metadata.name", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Name != "" {
+				return []string{bs.Name}
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassEscalation.spec.allowed.cluster", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.allowed.cluster", func(rawObj client.Object) []string {
+			be, ok := rawObj.(*v1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			out := make([]string, 0, len(be.Spec.Allowed.Clusters)+len(be.Spec.ClusterConfigRefs))
+			out = append(out, be.Spec.Allowed.Clusters...)
+			out = append(out, be.Spec.ClusterConfigRefs...)
+			return out
+		})
+	})
+
+	register("BreakglassEscalation.spec.allowed.group", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.allowed.group", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil {
+				return be.Spec.Allowed.Groups
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassEscalation.spec.escalatedGroup", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.escalatedGroup", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil && be.Spec.EscalatedGroup != "" {
+				return []string{be.Spec.EscalatedGroup}
+			}
+			return nil
+		})
+	})
+
+	register("BreakglassEscalation.metadata.name", func() error {
+		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "metadata.name", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil && be.Name != "" {
+				return []string{be.Name}
+			}
+			return nil
+		})
+	})
+
+	register("ClusterConfig.metadata.name", func() error {
+		return idx.IndexField(ctx, &v1alpha1.ClusterConfig{}, "metadata.name", func(rawObj client.Object) []string {
+			if cc, ok := rawObj.(*v1alpha1.ClusterConfig); ok && cc != nil && cc.Name != "" {
+				return []string{cc.Name}
+			}
+			return nil
+		})
+	})
+
+	register("ClusterConfig.spec.clusterID", func() error {
+		return idx.IndexField(ctx, &v1alpha1.ClusterConfig{}, "spec.clusterID", func(rawObj client.Object) []string {
+			if cc, ok := rawObj.(*v1alpha1.ClusterConfig); ok && cc != nil && cc.Spec.ClusterID != "" {
+				return []string{cc.Spec.ClusterID}
+			}
+			return nil
+		})
+	})
+}

--- a/pkg/mail/mail_test.go
+++ b/pkg/mail/mail_test.go
@@ -258,7 +258,7 @@ func TestSender_Send_Edge_Cases(t *testing.T) {
 
 	t.Run("Very long body", func(t *testing.T) {
 		longBody := "<html><body>"
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			longBody += "<p>This is paragraph " + string(rune(i)) + " in a very long email body that tests the mail sender's ability to handle large content sizes.</p>"
 		}
 		longBody += "</body></html>"
@@ -269,7 +269,7 @@ func TestSender_Send_Edge_Cases(t *testing.T) {
 
 	t.Run("Many receivers", func(t *testing.T) {
 		manyReceivers := make([]string, 100)
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			manyReceivers[i] = "user" + string(rune(i)) + "@example.com"
 		}
 

--- a/pkg/mail/queue_test.go
+++ b/pkg/mail/queue_test.go
@@ -103,7 +103,7 @@ func TestQueue_EnqueueMultiple(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err := queue.Enqueue("test-"+string(rune(i)), []string{"user@example.com"}, "Subject", "Body")
 		assert.NoError(t, err)
 	}
@@ -256,7 +256,7 @@ func TestQueue_ShutdownTimeout(t *testing.T) {
 	queue.Start()
 
 	// Enqueue 5 items (will take ~500ms to process all)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		err := queue.Enqueue("test-"+string(rune(i)), []string{"user@example.com"}, "Subject", "Body")
 		if err != nil {
 			t.Logf("failed to enqueue item %d: %v", i, err)
@@ -427,7 +427,7 @@ func TestQueue_ConcurrentEnqueue(t *testing.T) {
 
 	// Enqueue from multiple goroutines
 	done := make(chan error, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			err := queue.Enqueue("test-"+string(rune(48+id)), []string{"user@example.com"}, "Subject", "Body")
 			done <- err
@@ -435,7 +435,7 @@ func TestQueue_ConcurrentEnqueue(t *testing.T) {
 	}
 
 	// Collect results
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		err := <-done
 		assert.NoError(t, err)
 	}

--- a/pkg/webhook/api_end_to_end_test.go
+++ b/pkg/webhook/api_end_to_end_test.go
@@ -1,0 +1,525 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/api"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/cluster"
+	"github.com/telekom/k8s-breakglass/pkg/config"
+	"github.com/telekom/k8s-breakglass/pkg/policy"
+)
+
+var sessionIndexFnsEndToEnd = map[string]client.IndexerFunc{
+	"spec.user": func(o client.Object) []string {
+		return []string{o.(*v1alpha1.BreakglassSession).Spec.User}
+	},
+	"spec.cluster": func(o client.Object) []string {
+		return []string{o.(*v1alpha1.BreakglassSession).Spec.Cluster}
+	},
+	"spec.grantedGroup": func(o client.Object) []string {
+		return []string{o.(*v1alpha1.BreakglassSession).Spec.GrantedGroup}
+	},
+}
+
+var metadataNameIndexer = func(o client.Object) []string {
+	return []string{o.GetName()}
+}
+
+const (
+	e2eClusterName    = "cluster-e2e"
+	e2eAltClusterName = "cluster-alt"
+	e2eNamespace      = "default"
+	e2eEscalation     = "allow-create"
+	e2eGroup          = "breakglass-create-all"
+	requesterEmail    = "requester@example.com"
+	approverEmail     = "approver@example.com"
+	requesterName     = "Requester"
+	approverName      = "Approver"
+	sarPathTemplate   = "/api/breakglass/webhook/authorize/%s"
+	sessionsBasePath  = "/api/breakglassSessions"
+)
+
+type apiEndToEndEnv struct {
+	t               *testing.T
+	server          *api.Server
+	handler         http.Handler
+	sarServer       *httptest.Server
+	sarRequests     int
+	clusterName     string
+	client          client.Client
+	allowSessionSAR bool
+}
+
+func setupAPIEndToEndEnv(t *testing.T) *apiEndToEndEnv {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	env := &apiEndToEndEnv{t: t, clusterName: e2eClusterName, allowSessionSAR: true}
+	t.Setenv("BREAKGLASS_DISABLE_LOOPBACK_REWRITE", "true")
+
+	env.sarServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/apis/authorization.k8s.io/v1/subjectaccessreviews") {
+			env.sarRequests++
+			w.Header().Set("Content-Type", "application/json")
+			resp := authorizationv1.SubjectAccessReview{
+				TypeMeta: metav1.TypeMeta{APIVersion: "authorization.k8s.io/v1", Kind: "SubjectAccessReview"},
+				Status: authorizationv1.SubjectAccessReviewStatus{
+					Allowed: env.allowSessionSAR,
+					Reason:  "session allowed",
+				},
+			}
+			if !env.allowSessionSAR {
+				resp.Status.Reason = "session denied by target cluster"
+			}
+			_ = json.NewEncoder(w).Encode(&resp)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	kubeconfig := buildKubeconfig(env.sarServer.URL)
+
+	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme).WithStatusSubresource(&v1alpha1.BreakglassSession{})
+	for name, fn := range sessionIndexFnsEndToEnd {
+		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, name, fn)
+	}
+	builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer)
+	builder = builder.WithIndex(&v1alpha1.ClusterConfig{}, "metadata.name", metadataNameIndexer)
+
+	esc := &v1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      e2eEscalation,
+			Namespace: e2eNamespace,
+		},
+		Spec: v1alpha1.BreakglassEscalationSpec{
+			Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{e2eClusterName},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup: e2eGroup,
+			Approvers: v1alpha1.BreakglassEscalationApprovers{
+				Users: []string{approverEmail},
+			},
+		},
+	}
+
+	clusterCfg := &v1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      e2eClusterName,
+			Namespace: e2eNamespace,
+		},
+		Spec: v1alpha1.ClusterConfigSpec{
+			KubeconfigSecretRef: v1alpha1.SecretKeyReference{
+				Name:      "ccfg-secret",
+				Namespace: e2eNamespace,
+				Key:       "value",
+			},
+		},
+	}
+
+	clusterCfgAlt := &v1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      e2eAltClusterName,
+			Namespace: e2eNamespace,
+		},
+		Spec: v1alpha1.ClusterConfigSpec{
+			KubeconfigSecretRef: v1alpha1.SecretKeyReference{
+				Name:      "ccfg-secret",
+				Namespace: e2eNamespace,
+				Key:       "value",
+			},
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ccfg-secret",
+			Namespace: e2eNamespace,
+		},
+		Data: map[string][]byte{
+			"value": kubeconfig,
+		},
+	}
+
+	builder = builder.WithObjects(esc, clusterCfg, clusterCfgAlt, secret)
+	cli := builder.Build()
+
+	sessionManager := &breakglass.SessionManager{Client: cli}
+	escalationManager := &breakglass.EscalationManager{Client: cli}
+	logger := zaptest.NewLogger(t)
+	provider := cluster.NewClientProvider(cli, logger.Sugar())
+
+	cfg := config.Config{Frontend: config.Frontend{BaseURL: "https://breakglass.example"}}
+	auth := api.NewAuth(logger.Sugar(), cfg)
+
+	middleware := testIdentityMiddleware()
+	sessionController := breakglass.NewBreakglassSessionController(logger.Sugar(), cfg, sessionManager, escalationManager, middleware, "", provider, cli, true)
+	escalationController := breakglass.NewBreakglassEscalationController(logger.Sugar(), escalationManager, middleware, "")
+	webhookController := NewWebhookController(logger.Sugar(), cfg, sessionManager, escalationManager, provider, policy.NewEvaluator(cli, logger.Sugar()))
+	webhookController.canDoFn = func(ctx context.Context, rc *rest.Config, groups []string, sar authorizationv1.SubjectAccessReview, clusterName string) (bool, error) {
+		return false, nil
+	}
+
+	server := api.NewServer(logger, cfg, true, auth)
+	require.NoError(t, server.RegisterAll([]api.APIController{sessionController, escalationController, webhookController}))
+
+	env.server = server
+	env.handler = server.Handler()
+	env.client = cli
+
+	return env
+}
+
+func (env *apiEndToEndEnv) Close() {
+	env.sarServer.Close()
+}
+
+func (env *apiEndToEndEnv) doRequest(t *testing.T, method, path string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	reader := bytes.NewReader(body)
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func (env *apiEndToEndEnv) createSession(t *testing.T) {
+	t.Helper()
+	env.createSessionWithRequest(t, breakglass.BreakglassSessionRequest{})
+}
+
+func (env *apiEndToEndEnv) createSessionWithRequest(t *testing.T, req breakglass.BreakglassSessionRequest) {
+	t.Helper()
+	if req.Clustername == "" {
+		req.Clustername = env.clusterName
+	}
+	if req.Username == "" {
+		req.Username = requesterEmail
+	}
+	if req.GroupName == "" {
+		req.GroupName = e2eGroup
+	}
+	if req.Reason == "" {
+		req.Reason = "need breakglass access"
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	rr := env.doRequest(t, http.MethodPost, sessionsBasePath, body)
+	require.Equal(t, http.StatusCreated, rr.Code)
+}
+
+func (env *apiEndToEndEnv) listSessions(t *testing.T) []v1alpha1.BreakglassSession {
+	t.Helper()
+	rr := env.doRequest(t, http.MethodGet, sessionsBasePath, nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var sessions []v1alpha1.BreakglassSession
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &sessions))
+	return sessions
+}
+
+func (env *apiEndToEndEnv) approveSession(t *testing.T, name string) {
+	t.Helper()
+	path := fmt.Sprintf("%s/%s/approve", sessionsBasePath, name)
+	rr := env.doRequest(t, http.MethodPost, path, nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func (env *apiEndToEndEnv) invokeSAR(t *testing.T) SubjectAccessReviewResponse {
+	return env.invokeSARForClusterWithModifier(t, env.clusterName, nil)
+}
+
+func (env *apiEndToEndEnv) invokeSARForCluster(t *testing.T, clusterName string) SubjectAccessReviewResponse {
+	return env.invokeSARForClusterWithModifier(t, clusterName, nil)
+}
+
+func (env *apiEndToEndEnv) invokeSARForClusterWithModifier(t *testing.T, clusterName string, modify func(*authorizationv1.SubjectAccessReview)) SubjectAccessReviewResponse {
+	t.Helper()
+	sar := authorizationv1.SubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "authorization.k8s.io/v1", Kind: "SubjectAccessReview"},
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   requesterEmail,
+			Groups: []string{"system:authenticated"},
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "default",
+				Verb:      "create",
+				Resource:  "pods",
+			},
+		},
+	}
+	if modify != nil {
+		modify(&sar)
+	}
+	body, err := json.Marshal(sar)
+	require.NoError(t, err)
+	path := fmt.Sprintf(sarPathTemplate, clusterName)
+	rr := env.doRequest(t, http.MethodPost, path, body)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp SubjectAccessReviewResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return resp
+}
+
+func buildKubeconfig(serverURL string) []byte {
+	cfg := clientcmdapi.Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		CurrentContext: "test",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {Server: serverURL, InsecureSkipTLSVerify: true},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"test": {Token: "fake-token"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {Cluster: "test", AuthInfo: "test"},
+		},
+	}
+	data, err := clientcmd.Write(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func testIdentityMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		switch {
+		case c.Request.Method == http.MethodGet,
+			strings.Contains(path, "/approve"),
+			strings.Contains(path, "/reject"),
+			strings.Contains(path, "/cancel"):
+			c.Set("email", approverEmail)
+			c.Set("username", approverName)
+		default:
+			c.Set("email", requesterEmail)
+			c.Set("username", requesterName)
+		}
+		c.Set("groups", []string{"system:authenticated"})
+		c.Next()
+	}
+}
+
+func TestEndToEndSessionFlowAuthorizesSAR(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+
+	env.approveSession(t, sessions[0].Name)
+	sessions = env.listSessions(t)
+	require.Equal(t, v1alpha1.SessionStateApproved, sessions[0].Status.State)
+
+	resp := env.invokeSAR(t)
+	require.True(t, resp.Status.Allowed, "expected SAR to be allowed after approved session")
+	require.GreaterOrEqual(t, env.sarRequests, 1, "session SAR should have contacted the target cluster")
+}
+
+func TestEndToEndSARDeniedWithoutSession(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "expected SAR to be denied without sessions")
+	require.Contains(t, resp.Status.Reason, "Access denied")
+	require.Equal(t, 0, env.sarRequests, "no session SAR call should occur when no sessions are active")
+}
+
+func TestEndToEndSARDeniedWhileSessionPending(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	require.Equal(t, v1alpha1.SessionStatePending, sessions[0].Status.State)
+
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "pending sessions must not authorize access")
+	require.Contains(t, resp.Status.Reason, "Access denied")
+	require.Equal(t, 0, env.sarRequests, "no SARs should hit the remote cluster while session is pending")
+}
+
+func TestEndToEndSARDeniedWithExpiredSession(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	expiredAt := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	env.updateSessionStatus(t, sessions[0].Name, func(bs *v1alpha1.BreakglassSession) {
+		bs.Status.ExpiresAt = expiredAt
+		bs.Status.State = v1alpha1.SessionStateExpired
+	})
+
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "expired sessions must not authorize access")
+	require.Contains(t, resp.Status.Reason, "Access denied")
+	require.Equal(t, 0, env.sarRequests, "expired sessions must not trigger outbound SARs")
+}
+
+func TestEndToEndSARDeniedForDifferentCluster(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	resp := env.invokeSARForCluster(t, e2eAltClusterName)
+	require.False(t, resp.Status.Allowed, "sessions must be cluster-scoped")
+	require.Contains(t, resp.Status.Reason, e2eAltClusterName)
+	require.Equal(t, 0, env.sarRequests, "cluster mismatch should not call downstream SAR")
+}
+
+func TestEndToEndSARDeniedForIDPIssuerMismatch(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	const (
+		storedIssuer = "https://issuer.authorized"
+		otherIssuer  = "https://issuer.mismatched"
+	)
+	env.updateSessionSpec(t, sessions[0].Name, func(bs *v1alpha1.BreakglassSession) {
+		bs.Spec.IdentityProviderName = "trusted-idp"
+		bs.Spec.IdentityProviderIssuer = storedIssuer
+		bs.Spec.AllowIDPMismatch = false
+	})
+
+	resp := env.invokeSARForClusterWithModifier(t, env.clusterName, func(sar *authorizationv1.SubjectAccessReview) {
+		sar.Spec.Extra = map[string]authorizationv1.ExtraValue{
+			"identity.t-caas.telekom.com/issuer": {otherIssuer},
+		}
+	})
+	require.False(t, resp.Status.Allowed, "issuer mismatches must deny the request")
+	require.Contains(t, resp.Status.Reason, "different identity provider")
+	require.Equal(t, 0, env.sarRequests, "issuer mismatch should not call downstream SAR")
+}
+
+func TestEndToEndSARDeniedByGlobalDenyPolicy(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	env.createDenyPolicy(t, "global-block", v1alpha1.DenyPolicySpec{
+		AppliesTo: &v1alpha1.DenyPolicyScope{Clusters: []string{env.clusterName}},
+		Rules: []v1alpha1.DenyRule{{
+			Verbs:     []string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		}},
+	})
+
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "global deny policies should short-circuit authorization")
+	require.Contains(t, resp.Status.Reason, "Denied by policy", "deny reason should reference policy")
+	require.Equal(t, 0, env.sarRequests, "policy-denied requests never reach target cluster")
+}
+
+func TestEndToEndSARDeniedBySessionScopedPolicy(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	env.createDenyPolicy(t, "session-block", v1alpha1.DenyPolicySpec{
+		AppliesTo: &v1alpha1.DenyPolicyScope{Sessions: []string{sessions[0].Name}},
+		Rules: []v1alpha1.DenyRule{{
+			Verbs:     []string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		}},
+	})
+
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "session-scoped deny policies should block only targeted session")
+	require.Contains(t, resp.Status.Reason, "Denied by policy")
+	require.Equal(t, 0, env.sarRequests, "session policy denial should happen before downstream SAR")
+}
+
+func TestEndToEndSessionSARDeniedByTargetCluster(t *testing.T) {
+	env := setupAPIEndToEndEnv(t)
+	defer env.Close()
+
+	env.createSession(t)
+	sessions := env.listSessions(t)
+	require.Len(t, sessions, 1)
+	env.approveSession(t, sessions[0].Name)
+
+	env.allowSessionSAR = false
+	resp := env.invokeSAR(t)
+	require.False(t, resp.Status.Allowed, "target cluster RBAC denial should bubble up")
+	require.Contains(t, resp.Status.Reason, "Access denied")
+	require.Greater(t, env.sarRequests, 0, "session SAR should hit target cluster when impersonation runs")
+}
+
+func (env *apiEndToEndEnv) updateSessionStatus(t *testing.T, name string, mutate func(*v1alpha1.BreakglassSession)) {
+	t.Helper()
+	ctx := context.Background()
+	var session v1alpha1.BreakglassSession
+	require.NoError(t, env.client.Get(ctx, client.ObjectKey{Namespace: e2eNamespace, Name: name}, &session))
+	mutate(&session)
+	require.NoError(t, env.client.Status().Update(ctx, &session))
+}
+
+func (env *apiEndToEndEnv) updateSessionSpec(t *testing.T, name string, mutate func(*v1alpha1.BreakglassSession)) {
+	t.Helper()
+	ctx := context.Background()
+	var session v1alpha1.BreakglassSession
+	require.NoError(t, env.client.Get(ctx, client.ObjectKey{Namespace: e2eNamespace, Name: name}, &session))
+	mutate(&session)
+	require.NoError(t, env.client.Update(ctx, &session))
+}
+
+func (env *apiEndToEndEnv) createDenyPolicy(t *testing.T, name string, spec v1alpha1.DenyPolicySpec) {
+	t.Helper()
+	ctx := context.Background()
+	dp := &v1alpha1.DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       spec,
+	}
+	require.NoError(t, env.client.Create(ctx, dp))
+}

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -62,7 +62,7 @@ func TestHandleAuthorize_AllowsByRBAC(t *testing.T) {
 	engine := gin.New()
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -121,7 +121,7 @@ func TestHandleAuthorize_DeniedWithEscalations(t *testing.T) {
 	engine := gin.New()
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -206,7 +206,7 @@ func TestHandleAuthorize_MultiIDP_AllowedIDP(t *testing.T) {
 	engine := gin.New()
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -273,7 +273,7 @@ func TestHandleAuthorize_MultiIDP_BlockedIDP(t *testing.T) {
 	engine := gin.New()
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
@@ -353,7 +353,7 @@ func TestHandleAuthorize_NoIDPRestriction_HappyPath(t *testing.T) {
 	engine := gin.New()
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 

--- a/pkg/webhook/error_scenarios_test.go
+++ b/pkg/webhook/error_scenarios_test.go
@@ -57,7 +57,7 @@ func TestHandleAuthorize_MalformedJSON(t *testing.T) {
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
 	malformedJSON := `{"spec": invalid json`
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader([]byte(malformedJSON)))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader([]byte(malformedJSON)))
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)
@@ -98,7 +98,7 @@ func TestHandleAuthorize_NilResourceAttributes(t *testing.T) {
 	}
 
 	body, _ := json.Marshal(sar)
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)
@@ -142,7 +142,7 @@ func TestHandleAuthorize_SpecialCharactersInReason(t *testing.T) {
 	}
 
 	body, _ := json.Marshal(sar)
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)
@@ -186,7 +186,7 @@ func TestHandleAuthorize_EmptyUserField(t *testing.T) {
 	}
 
 	body, _ := json.Marshal(sar)
-	req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	engine.ServeHTTP(w, req)
@@ -218,7 +218,7 @@ func TestHandleAuthorize_ConcurrentRequests(t *testing.T) {
 	_ = wc.Register(engine.Group("/" + wc.BasePath()))
 
 	resultChan := make(chan int, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		go func(userID int) {
 			sar := authorizationv1.SubjectAccessReview{
 				TypeMeta: metav1.TypeMeta{APIVersion: "authorization.k8s.io/v1", Kind: "SubjectAccessReview"},
@@ -233,7 +233,7 @@ func TestHandleAuthorize_ConcurrentRequests(t *testing.T) {
 			}
 
 			body, _ := json.Marshal(sar)
-			req, _ := http.NewRequest("POST", "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
+			req, _ := http.NewRequest(http.MethodPost, "/breakglass/webhook/authorize/test-cluster", bytes.NewReader(body))
 			w := httptest.NewRecorder()
 
 			engine.ServeHTTP(w, req)
@@ -241,7 +241,7 @@ func TestHandleAuthorize_ConcurrentRequests(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		status := <-resultChan
 		if status == http.StatusInternalServerError {
 			t.Errorf("Concurrent request %d returned 500", i)
@@ -281,7 +281,7 @@ func TestHandleAuthorize_InvalidResourceName(t *testing.T) {
 
 	body, _ := json.Marshal(sar)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/authorize/test-cluster", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -320,7 +320,7 @@ func TestHandleAuthorize_InvalidGroupFormat(t *testing.T) {
 
 	body, _ := json.Marshal(sar)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/authorize/test-cluster", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -369,7 +369,7 @@ func TestHandleAuthorize_BothAttributeTypesPresent(t *testing.T) {
 
 	body, _ := json.Marshal(sar)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/authorize/test-cluster", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -413,7 +413,7 @@ func TestHandleAuthorize_UnicodeCharactersInUser(t *testing.T) {
 
 	body, _ := json.Marshal(sar)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/authorize/test-cluster", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -456,7 +456,7 @@ func TestHandleAuthorize_MissingContentType(t *testing.T) {
 
 	body, _ := json.Marshal(sar)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/authorize/test-cluster", bytes.NewReader(body))
+	req, _ := http.NewRequest(http.MethodPost, "/authorize/test-cluster", bytes.NewReader(body))
 	// Don't set Content-Type header
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req


### PR DESCRIPTION
…overage

instrument breakglass APIs with reusable metrics helpers and document new dashboards add controller-runtime indexes plus cluster/secret invalidation watchers to keep caches fresh tighten escalation validation, extend deny-policy docs (with examples), and refresh CLI/docs enhance webhook authorization logic, add full e2e/SAR tests, and modernize HTTP test helpers