### PR TITLE
Cleanup of main.go

### DIFF
--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -41,7 +41,7 @@ patches:
     kind: Deployment
     name: manager
   path: ./resources/keycloak_wait_initcontainer.yaml
-# [CERT_CONTROLLER] this target should be commented if automated webhook certificate generation is to be used
+# [CERT-CONTROLLER] this target should be commented if automated webhook certificate generation is to be used
 - target:
     group: apps
     version: v1

--- a/pkg/breakglass/leadership_election_test.go
+++ b/pkg/breakglass/leadership_election_test.go
@@ -275,6 +275,7 @@ func TestLeadershipSignal_MultipleListeners(t *testing.T) {
 
 	// Both should eventually exit due to context timeout
 	completed := 0
+	stop := false
 	for range 2 {
 		select {
 		case <-done1:
@@ -282,6 +283,9 @@ func TestLeadershipSignal_MultipleListeners(t *testing.T) {
 		case <-done2:
 			completed++
 		case <-time.After(400 * time.Millisecond):
+			stop = true
+		}
+		if stop {
 			break
 		}
 	}

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -670,14 +670,12 @@ func (wc BreakglassSessionController) handleRequestBreakglassSession(c *gin.Cont
 
 	// Get approval timeout from escalation spec, or use cluster default
 	approvalTimeout := time.Hour // Default: 1 hour
-	if matchedEsc != nil {
-		if matchedEsc.Spec.ApprovalTimeout != "" {
-			if d, err := time.ParseDuration(matchedEsc.Spec.ApprovalTimeout); err == nil && d > 0 {
-				approvalTimeout = d
-				reqLog.Debugw("Using approval timeout from escalation spec", "approvalTimeout", approvalTimeout)
-			} else {
-				reqLog.Warnw("Invalid ApprovalTimeout in escalation spec; falling back to default", "value", matchedEsc.Spec.ApprovalTimeout, "error", err)
-			}
+	if matchedEsc != nil && matchedEsc.Spec.ApprovalTimeout != "" {
+		if d, err := time.ParseDuration(matchedEsc.Spec.ApprovalTimeout); err == nil && d > 0 {
+			approvalTimeout = d
+			reqLog.Debugw("Using approval timeout from escalation spec", "approvalTimeout", approvalTimeout)
+		} else {
+			reqLog.Warnw("Invalid ApprovalTimeout in escalation spec; falling back to default", "value", matchedEsc.Spec.ApprovalTimeout, "error", err)
 		}
 	}
 
@@ -717,7 +715,7 @@ func (wc BreakglassSessionController) handleRequestBreakglassSession(c *gin.Cont
 			"escalationName", matchedEsc.Name,
 			"cluster", bs.Spec.Cluster,
 			"grantedGroup", bs.Spec.GrantedGroup)
-	} else {
+	} else if matchedEsc != nil {
 		reqLog.Infow("Resolved approvers from escalation (explicit users + group members)",
 			"approverCount", len(allApprovers),
 			"approvers", allApprovers,

--- a/pkg/breakglass/session_state_test.go
+++ b/pkg/breakglass/session_state_test.go
@@ -977,18 +977,12 @@ func TestRegressionFix_WithdrawnSessionsShouldNotHaveRejectedAtSet(t *testing.T)
 			var session v1alpha1.BreakglassSession
 			session.Status.State = tt.state
 
-			// Simulate what the controller does based on state
-			if tt.state == v1alpha1.SessionStateRejected {
+			switch tt.state {
+			case v1alpha1.SessionStateRejected:
 				// When rejected by approver, set RejectedAt
 				session.Status.RejectedAt = metav1.Now()
-			} else if tt.state == v1alpha1.SessionStateWithdrawn {
-				// When withdrawn by user, RejectedAt should be empty
-				session.Status.RejectedAt = metav1.Time{}
-			} else if tt.state == v1alpha1.SessionStateApproved {
-				// When approved, RejectedAt should be empty
-				session.Status.RejectedAt = metav1.Time{}
-			} else if tt.state == v1alpha1.SessionStatePending {
-				// When pending, RejectedAt should be empty
+			case v1alpha1.SessionStateWithdrawn, v1alpha1.SessionStateApproved, v1alpha1.SessionStatePending:
+				// When withdrawn, approved or pending by user, RejectedAt should be empty
 				session.Status.RejectedAt = metav1.Time{}
 			}
 
@@ -1054,16 +1048,11 @@ func TestRetainedUntilSetForAllTerminalStates(t *testing.T) {
 			}
 
 			// Simulate what the controller should do for each state
-			if tt.state == v1alpha1.SessionStateRejected {
+			switch tt.state {
+			case v1alpha1.SessionStateRejected:
 				session.Status.RejectedAt = metav1.Now()
 				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
-			} else if tt.state == v1alpha1.SessionStateWithdrawn {
-				session.Status.RejectedAt = metav1.Time{}
-				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
-			} else if tt.state == v1alpha1.SessionStateExpired {
-				session.Status.RejectedAt = metav1.Time{}
-				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
-			} else if tt.state == v1alpha1.SessionStateTimeout {
+			case v1alpha1.SessionStateWithdrawn, v1alpha1.SessionStateExpired, v1alpha1.SessionStateTimeout:
 				session.Status.RejectedAt = metav1.Time{}
 				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
 			}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/cert"
+	"go.uber.org/zap"
+)
+
+type Config struct {
+	// Application flags
+	Debug bool
+
+	// Metrics server flags
+	MetricsAddr     string
+	MetricsSecure   bool
+	MetricsCertPath string
+	MetricsCertName string
+	MetricsCertKey  string
+
+	// Health probe flags
+	ProbeAddr string
+
+	// Leader election flags
+	EnableLeaderElection bool
+	LeaderElectNamespace string
+	LeaderElectID        string
+	EnableHTTP2          bool
+	EnableWebhooks       bool
+	PodNamespace         string
+
+	// Component Enable flags (for splitting controller into multiple instances)
+	EnableFrontend           bool
+	EnableAPI                bool
+	EnableCleanup            bool
+	EnableValidatingWebhooks bool
+
+	// Configuration flags
+	ConfigPath          string
+	BreakglassNamespace string
+	DisableEmail        bool
+
+	// Interval flags
+	ClusterConfigCheckInterval string
+	EscalationStatusUpdateInt  string
+
+	// Webhook-related config
+	Webhook WebhookConfig
+}
+
+type WebhookConfig struct {
+	// Webhook server flags
+	BindAddr             string
+	CertPath             string
+	CertName             string
+	CertKey              string
+	CertGeneration       bool
+	SvcName              string
+	ValidatingConfigName string
+
+	// Webhook Metrics server flags
+	MetricsAddr     string
+	MetricsSecure   bool
+	MetricsCertPath string
+	MetricsCertName string
+	MetricsCertKey  string
+}
+
+func Parse() *Config {
+	config := &Config{}
+	// Define command-line flags with environment variable fallbacks.
+	// The pattern: flag.XxxVar(&variable, "flag-name", defaultValueOrEnvValue, "help text")
+	flag.BoolVar(&config.Debug, "debug", false, "Enable debug level logging")
+
+	// Webhook server configuration
+	flag.StringVar(&config.Webhook.BindAddr, "webhook-bind-address", getEnvString("WEBHOOK_BIND_ADDRESS", "0.0.0.0:9443"),
+		"The address the webhook server binds to (host:port)")
+	flag.StringVar(&config.Webhook.CertPath, "webhook-cert-path", getEnvString("WEBHOOK_CERT_PATH", cert.DefaultWebhookPath),
+		"The directory that contains the webhook certificate")
+	flag.StringVar(&config.Webhook.CertName, "webhook-cert-name", getEnvString("WEBHOOK_CERT_NAME", cert.DefaultTLSCertFile),
+		"The name of the webhook certificate file")
+	flag.StringVar(&config.Webhook.CertKey, "webhook-cert-key", getEnvString("WEBHOOK_CERT_KEY", cert.DefaultTLSKeyFile),
+		"The name of the webhook key file")
+
+	// Metrics server configuration
+	flag.StringVar(&config.MetricsAddr, "metrics-bind-address", getEnvString("METRICS_BIND_ADDRESS", "0.0.0.0:8081"),
+		"The address the metrics endpoint binds to. "+
+			"Use :8443 for HTTPS or :8081 for HTTP, or leave as 0 to disable the metrics service")
+	flag.BoolVar(&config.MetricsSecure, "metrics-secure", getEnvBool("METRICS_SECURE", false),
+		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead")
+	flag.StringVar(&config.MetricsCertPath, "metrics-cert-path", getEnvString("METRICS_CERT_PATH", ""),
+		"The directory that contains the metrics server certificate")
+	flag.StringVar(&config.MetricsCertName, "metrics-cert-name", getEnvString("METRICS_CERT_NAME", "tls.crt"),
+		"The name of the metrics server certificate file")
+	flag.StringVar(&config.MetricsCertKey, "metrics-cert-key", getEnvString("METRICS_CERT_KEY", cert.DefaultTLSKeyFile),
+		"The name of the metrics server key file")
+
+	// Webhook metrics server configuration (separate from reconciler metrics)
+	flag.StringVar(&config.Webhook.MetricsAddr, "webhooks-metrics-bind-address", getEnvString("WEBHOOKS_METRICS_BIND_ADDRESS", ""),
+		"The address the webhook metrics endpoint binds to (separate from reconciler metrics). "+
+			"If empty, webhook metrics will use the reconciler metrics address. "+
+			"Use :8443 for HTTPS or :8083 for HTTP")
+	flag.BoolVar(&config.Webhook.MetricsSecure, "webhooks-metrics-secure", getEnvBool("WEBHOOKS_METRICS_SECURE", false),
+		"If set, the webhook metrics endpoint is served securely via HTTPS")
+	flag.StringVar(&config.Webhook.MetricsCertPath, "webhooks-metrics-cert-path", getEnvString("WEBHOOKS_METRICS_CERT_PATH", ""),
+		"The directory that contains the webhook metrics server certificate")
+	flag.StringVar(&config.Webhook.MetricsCertName, "webhooks-metrics-cert-name", getEnvString("WEBHOOKS_METRICS_CERT_NAME", cert.DefaultTLSCertFile),
+		"The name of the webhook metrics server certificate file")
+	flag.StringVar(&config.Webhook.MetricsCertKey, "webhooks-metrics-cert-key", getEnvString("WEBHOOKS_METRICS_CERT_KEY", cert.DefaultTLSKeyFile),
+		"The name of the webhook metrics server key file")
+	flag.StringVar(&config.Webhook.SvcName, "webhook-service-name", getEnvString("WEBHOOK_SERVICE_NAME", "breakglass-webhook-service"), "Name of the deployed breakglass service")
+	flag.StringVar(&config.Webhook.ValidatingConfigName, "webhook-validating-config-name", getEnvString("WEBHOOK_VALIDATING_CONFIG_NAME", ""),
+		"Name of the ValidatingWebhookConfiguration object for the webhook")
+	flag.BoolVar(&config.Webhook.CertGeneration, "webhook-cert-generation", getEnvBool("WEBHOOK_CERT_GENERATION", false), "Enable certificate generation for the webhook")
+
+	// Health probe configuration
+	flag.StringVar(&config.ProbeAddr, "health-probe-bind-address", getEnvString("PROBE_BIND_ADDRESS", ":8082"),
+		"The address the probe endpoint binds to")
+
+	// Leader election configuration
+	flag.BoolVar(&config.EnableLeaderElection, "enable-leader-election", getEnvBool("ENABLE_LEADER_ELECTION", true),
+		"Enable leader election for running multiple instances. Set to false when running a single instance")
+	flag.StringVar(&config.LeaderElectNamespace, "leader-elect-namespace", getEnvString("LEADER_ELECT_NAMESPACE", ""),
+		"The namespace where the leader election lease will be created. If empty, will default to the pod's namespace")
+	flag.StringVar(&config.LeaderElectID, "leader-elect-id", getEnvString("LEADER_ELECT_ID", "breakglass.telekom.io"),
+		"The ID used for leader election; ensures multiple instances coordinate properly")
+	flag.BoolVar(&config.EnableHTTP2, "enable-http2", getEnvBool("ENABLE_HTTP2", false),
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.BoolVar(&config.EnableWebhooks, "enable-webhooks", getEnvBool("ENABLE_WEBHOOKS", true),
+		"Enable webhook manager for BreakglassSession, BreakglassEscalation, ClusterConfig, IdentityProvider and MailProvider")
+	flag.StringVar(&config.PodNamespace, "pod-namespace", getEnvString("POD_NAMESPACE", "default"),
+		"The namespace where the pod is running (used for event recording)")
+
+	// Component enable flags for multi-instance deployments
+	// By default, all components are enabled for backwards compatibility
+	flag.BoolVar(&config.EnableFrontend, "enable-frontend", getEnvBool("ENABLE_FRONTEND", true),
+		"Enable the frontend API endpoints. Use false when deploying a webhook-only instance")
+	flag.BoolVar(&config.EnableAPI, "enable-api", getEnvBool("ENABLE_API", true),
+		"Enable the API controller for BreakglassSession and BreakglassEscalation endpoints. Use false when deploying a webhook-only instance")
+	flag.BoolVar(&config.EnableCleanup, "enable-cleanup", getEnvBool("ENABLE_CLEANUP", true),
+		"Enable the background cleanup routine for expired sessions. Use false when deploying a webhook-only instance")
+	flag.BoolVar(&config.EnableValidatingWebhooks, "enable-validating-webhooks", getEnvBool("ENABLE_VALIDATING_WEBHOOKS", true),
+		"Enable validating webhooks for breakglass CRDs. Disable when running a frontend/API-only instance")
+
+	// Interval configuration flags
+	flag.StringVar(&config.ClusterConfigCheckInterval, "cluster-config-check-interval", getEnvString("CLUSTER_CONFIG_CHECK_INTERVAL", "10m"),
+		"Interval for checking cluster configuration validity (e.g., '10m', '5m')")
+	flag.StringVar(&config.EscalationStatusUpdateInt, "escalation-status-update-interval", getEnvString("ESCALATION_STATUS_UPDATE_INTERVAL", "10m"),
+		"Interval for updating escalation status from identity provider (e.g., '10m', '5m')")
+
+	// Configuration flags
+	flag.StringVar(&config.ConfigPath, "config-path", getEnvString("BREAKGLASS_CONFIG_PATH", "./config.yaml"),
+		"Path to the breakglass configuration file")
+	flag.StringVar(&config.BreakglassNamespace, "breakglass-namespace", getEnvString("BREAKGLASS_NAMESPACE", ""),
+		"The Kubernetes namespace containing breakglass resources (e.g., IdentityProvider secrets)")
+	flag.BoolVar(&config.DisableEmail, "disable-email", getEnvBool("BREAKGLASS_DISABLE_EMAIL", false),
+		"Disable email notifications for breakglass session requests")
+
+	// Parse command-line flags and enable logging flag options
+	flag.Parse()
+
+	return config
+}
+
+func (c *Config) Print(log *zap.SugaredLogger) {
+	log.Infow("CLI Configuration",
+		// Debug and logging
+		"debug", c.Debug,
+		// Webhook server configuration
+		"webhook_bind_address", c.Webhook.BindAddr,
+		"webhook_cert_path", c.Webhook.CertPath,
+		"webhook_cert_name", c.Webhook.CertName,
+		"webhook_cert_key", c.Webhook.CertKey,
+		"webhook-service-name", c.Webhook.SvcName,
+		"webhook-validating-config-name", c.Webhook.ValidatingConfigName,
+		"webhook-cert-generation", c.Webhook.CertGeneration,
+		// Metrics server configuration
+		"metrics_bind_address", c.MetricsAddr,
+		"metrics_secure", c.MetricsSecure,
+		"metrics_cert_path", c.MetricsCertPath,
+		// Webhook metrics server configuration
+		"webhooks_metrics_bind_address", c.Webhook.MetricsAddr,
+		"webhooks_metrics_secure", c.Webhook.MetricsSecure,
+		// Health probe
+		"health_probe_bind_address", c.ProbeAddr,
+		// Leader election configuration
+		"enable_leader_election", c.EnableLeaderElection,
+		"leader_elect_namespace", c.LeaderElectNamespace,
+		"leader_elect_id", c.LeaderElectID,
+		"enable_http2", c.EnableHTTP2,
+		"pod_namespace", c.PodNamespace,
+		// Component enable flags
+		"enable_frontend", c.EnableFrontend,
+		"enable_api", c.EnableAPI,
+		"enable_cleanup", c.EnableCleanup,
+		"enable_webhooks", c.EnableWebhooks,
+		"enable_validating_webhooks", c.EnableValidatingWebhooks,
+		// Intervals
+		"cluster_config_check_interval", c.ClusterConfigCheckInterval,
+		"escalation_status_update_interval", c.EscalationStatusUpdateInt,
+		// Configuration paths
+		"config_path", c.ConfigPath,
+		"breakglass_namespace", c.BreakglassNamespace,
+		"disable_email", c.DisableEmail,
+	)
+}
+
+// DisableHTTP2 is used to configure TLS options to disable HTTP/2.
+// This is important because HTTP/2 has known vulnerabilities (CVE-2023-44487, CVE-2024-3156).
+func DisableHTTP2(c *tls.Config) {
+	c.NextProtos = []string{"http/1.1"}
+}
+
+func ParseEscalationStatusUpdateInterval(interval string, log *zap.SugaredLogger) time.Duration {
+	// Determine escalation status update interval from CLI flag (fallback to 10m)
+	escalationInterval, err := parseDuration("escalation-status-update-interval", interval, breakglass.DefaultEscalationStatusUpdateInterval)
+	if err != nil {
+		log.Warn(err)
+	}
+	return escalationInterval
+}
+
+func ParseClusterConfigCheckInterval(interval string, log *zap.SugaredLogger) time.Duration {
+	// Determine escalation status update interval from CLI flag (fallback to 10m)
+	checkInterval, err := parseDuration("cluster-config-check-interval'", interval, breakglass.DefaultClusterConfigCheckInterval)
+	if err != nil {
+		log.Warn(err)
+	}
+	return checkInterval
+}
+
+func parseDuration(name, value string, def time.Duration) (time.Duration, error) {
+	duration := def
+	if value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			duration = d
+		} else {
+			return duration, fmt.Errorf("invalid %s %q; using default %s: %w", name, value, def.String(), err)
+		}
+	}
+
+	return duration, nil
+}
+
+// getEnvString returns the value of an environment variable, or the provided default if not set.
+func getEnvString(key, defaultVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultVal
+}
+
+// getEnvBool returns the value of an environment variable as a bool, or the provided default if not set.
+// Valid true values are "true", "1", "yes" (case-insensitive).
+func getEnvBool(key string, defaultVal bool) bool {
+	if val, ok := os.LookupEnv(key); ok {
+		switch strings.ToLower(val) {
+		case "true", "1", "yes":
+			return true
+		case "false", "0", "no":
+			return false
+		}
+	}
+	return defaultVal
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,28 +1,9 @@
-package main
+package cli
 
 import (
 	"crypto/tls"
 	"testing"
 )
-
-func TestSetupLogger_DebugMode(t *testing.T) {
-	// debug true should return a non-nil logger
-	logger := setupLogger(true)
-	if logger == nil {
-		t.Fatalf("expected non-nil logger for debug mode")
-	}
-	// best-effort flush
-	_ = logger.Sync()
-}
-
-func TestSetupLogger_ProductionMode(t *testing.T) {
-	// debug false should return a non-nil logger
-	logger := setupLogger(false)
-	if logger == nil {
-		t.Fatalf("expected non-nil logger for production mode")
-	}
-	_ = logger.Sync()
-}
 
 func TestGetEnvString(t *testing.T) {
 	t.Setenv("BREAKGLASS_TEST_ENV", "custom-value")
@@ -64,7 +45,7 @@ func TestGetEnvBool(t *testing.T) {
 
 func TestDisableHTTP2(t *testing.T) {
 	cfg := &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
-	disableHTTP2(cfg)
+	DisableHTTP2(cfg)
 
 	if len(cfg.NextProtos) != 1 || cfg.NextProtos[0] != "http/1.1" {
 		t.Fatalf("expected HTTP/1.1 only, got %v", cfg.NextProtos)

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -1,0 +1,65 @@
+package leaderelection
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+func Start(ctx context.Context, wg *sync.WaitGroup, leaderElectedCh *chan struct{}, resourceLock resourcelock.Interface,
+	hostname, leaseName, leaseNamespace string, log *zap.SugaredLogger) {
+	defer wg.Done()
+	// Create callbacks for leader election
+	leaderCallbacks := leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			log.Infow("This replica acquired leadership, signaling background loops")
+			// Signal background loops that we're the leader
+			select {
+			case <-*leaderElectedCh:
+				// Already closed, we've signaled leadership
+			default:
+				close(*leaderElectedCh)
+			}
+		},
+		OnStoppedLeading: func() {
+			log.Infow("Lost leadership")
+			// Recreate the channel for the next leader to use
+			*leaderElectedCh = make(chan struct{})
+		},
+		OnNewLeader: func(identity string) {
+			if identity == hostname {
+				log.Infow("I became the leader", "identity", identity)
+			} else {
+				log.Infow("New leader elected", "identity", identity)
+			}
+		},
+	}
+
+	// Create the LeaderElector which handles the full lifecycle of leader election:
+	// - Acquires the lock when becoming leader (creates/updates the lease)
+	// - Renews the lock at the specified interval to maintain leadership
+	// - Releases the lock when context is cancelled
+	// - Detects when leadership is lost and calls OnStoppedLeading
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: 15 * time.Second, // Time the lease is held by leader
+		RenewDeadline: 10 * time.Second, // Deadline for renewing the lease before losing it
+		RetryPeriod:   2 * time.Second,  // Duration to wait between leader election tries
+		Callbacks:     leaderCallbacks,
+		WatchDog:      nil,
+		Name:          "breakglass-controller",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create LeaderElector: %v", err)
+	}
+
+	log.Infow("Starting leader election", "id", leaseName, "namespace", leaseNamespace, "identity", hostname)
+
+	// Run the leader election - this will block until context is cancelled
+	// It continuously tries to acquire the lease and renews it if successful
+	elector.Run(ctx)
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1,0 +1,152 @@
+package reconciler
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/telekom/k8s-breakglass/pkg/api"
+	"github.com/telekom/k8s-breakglass/pkg/cli"
+	"github.com/telekom/k8s-breakglass/pkg/config"
+	"github.com/telekom/k8s-breakglass/pkg/indexer"
+	"github.com/telekom/k8s-breakglass/pkg/metrics"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+func NewManager(
+	restCfg *rest.Config,
+	scheme *runtime.Scheme,
+	metricsAddr string,
+	metricsSecure bool,
+	metricsCertPath string,
+	metricsCertName string,
+	metricsCertKey string,
+	probeAddr string,
+	enableHTTP2 bool,
+	log *zap.SugaredLogger,
+) (ctrl.Manager, error) {
+	tlsOpts := []func(*tls.Config){}
+	if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, cli.DisableHTTP2)
+	}
+
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: metricsSecure,
+		TLSOpts:       tlsOpts,
+	}
+
+	if len(metricsCertPath) > 0 {
+		log.Infow("Initializing metrics certificate watcher using provided certificates",
+			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName,
+			"metrics-cert-key", metricsCertKey)
+		metricsServerOptions.CertDir = metricsCertPath
+		metricsServerOptions.CertName = metricsCertName
+		metricsServerOptions.KeyName = metricsCertKey
+	}
+
+	return ctrl.NewManager(restCfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsServerOptions,
+		HealthProbeBindAddress: probeAddr,
+		WebhookServer:          nil,
+		LeaderElection:         false,
+	})
+}
+
+// Setup starts the controller-runtime manager with field indices and IdentityProvider reconciler.
+// This function handles:
+// - Metrics server configuration with secure serving
+// - Field index setup for efficient queries
+// - IdentityProvider reconciler setup
+// - Manager startup and leader election
+// - Broadcasting leadership signal to background loops when acquired
+func Setup(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	idpLoader *config.IdentityProviderLoader,
+	server *api.Server,
+	log *zap.SugaredLogger,
+) error {
+	// Register health check handlers for liveness and readiness probes
+	// These endpoints are exposed at the health probe bind address (default :8082)
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add healthz check to reconciler manager: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add readyz check to reconciler manager: %w", err)
+	}
+	log.Info("Health check handlers registered")
+
+	if err := indexer.RegisterCommonFieldIndexes(ctx, mgr.GetFieldIndexer(), log); err != nil {
+		return fmt.Errorf("failed to register common field indexes: %w", err)
+	}
+
+	// Register IdentityProvider Reconciler with controller-runtime manager
+	log.Debugw("Setting up IdentityProvider reconciler")
+	idpReconciler := config.NewIdentityProviderReconciler(
+		mgr.GetClient(),
+		log,
+		func(reloadCtx context.Context) error {
+			return server.ReloadIdentityProvider(idpLoader)
+		},
+	)
+	idpReconciler.WithErrorHandler(func(ctx context.Context, err error) {
+		log.Errorw("IdentityProvider reconciliation error", "error", err)
+		metrics.IdentityProviderLoadFailed.WithLabelValues("reconciler_error").Inc()
+	})
+	idpReconciler.WithEventRecorder(mgr.GetEventRecorderFor("breakglass-controller"))
+	idpReconciler.WithResyncPeriod(10 * time.Minute)
+
+	// Set reconciler in API server so it can use the cached IDPs
+	// This prevents the API from querying the Kubernetes APIServer on every /api/config/idps request
+	server.SetIdentityProviderReconciler(idpReconciler)
+
+	if err := idpReconciler.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to setup IdentityProvider reconciler with manager: %w", err)
+	}
+	log.Infow("Successfully registered IdentityProvider reconciler", "resyncPeriod", "10m")
+
+	// Register BreakglassEscalation Reconciler with controller-runtime manager
+	log.Debugw("Setting up BreakglassEscalation reconciler")
+	escalationReconciler := config.NewEscalationReconciler(
+		mgr.GetClient(),
+		log,
+		mgr.GetEventRecorderFor("breakglass-escalation-controller"),
+		nil, // no onReload callback needed for escalations
+		func(ctx context.Context, err error) {
+			log.Errorw("BreakglassEscalation reconciliation error", "error", err)
+			metrics.IdentityProviderLoadFailed.WithLabelValues("escalation_reconciler_error").Inc()
+		},
+		10*time.Minute,
+	)
+
+	// Set reconciler in API server so it can use the cached escalation→IDP mapping
+	// This prevents the API from querying the Kubernetes APIServer on every /api/config/idps request
+	server.SetEscalationReconciler(escalationReconciler)
+
+	if err := escalationReconciler.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to setup BreakglassEscalation reconciler with manager: %w", err)
+	}
+	log.Infow("Successfully registered BreakglassEscalation reconciler", "resyncPeriod", "10m")
+
+	// Note: Leadership election is NOT handled by the manager at this level.
+	// Background loops (cleanup, escalation updater, cluster config checker) use the resourcelock
+	// to coordinate and run only on the leader. The signal propagation to those loops happens
+	// outside this manager in the main() function after the manager and loops are set up.
+
+	// Start manager (blocks) but we run it in a goroutine so it doesn't prevent the API server
+	// The manager runs reconcilers on all replicas (no leader election)
+	log.Infow("Starting controller-runtime reconciler manager (no leader election at manager level)")
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("controller-runtime reconciler manager exited: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// CreateScheme creates and returns a runtime scheme with all necessary types registered.
+// This includes standard Kubernetes types and all custom breakglass CRDs.
+// The same scheme instance should be reused for all Kubernetes clients to ensure consistency.
+func CreateScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+
+	// Add standard Kubernetes types (core API)
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add corev1 to scheme: %w", err)
+	}
+
+	// Add custom breakglass CRD types (v1alpha1)
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add v1alpha1 CRDs to scheme: %w", err)
+	}
+
+	return scheme, nil
+}
+
+// SetupLogger creates and configures a zap logger for the application.
+// If debug is true, it uses development mode; otherwise production mode.
+func SetupLogger(debug bool) (*zap.Logger, error) {
+	var logger *zap.Logger
+	var err error
+	if debug {
+		logger, err = zap.NewDevelopment()
+	} else {
+		logger, err = zap.NewProduction()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to create logger (debug: %t): %w", debug, err)
+	}
+	return logger, nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestSetupLogger_DebugMode(t *testing.T) {
+	// debug true should return a non-nil logger
+	logger, _ := SetupLogger(true)
+	if logger == nil {
+		t.Fatalf("expected non-nil logger for debug mode")
+	}
+	// best-effort flush
+	_ = logger.Sync()
+}
+
+func TestSetupLogger_ProductionMode(t *testing.T) {
+	// debug false should return a non-nil logger
+	logger, _ := SetupLogger(false)
+	if logger == nil {
+		t.Fatalf("expected non-nil logger for production mode")
+	}
+	_ = logger.Sync()
+}

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -1004,3 +1004,7 @@ func (wc *WebhookController) authorizeViaSessions(ctx context.Context, rc *rest.
 	}
 	return false, "", "", ""
 }
+
+func (wc *WebhookController) SetCanDoFn(f func(ctx context.Context, rc *rest.Config, groups []string, sar authorizationv1.SubjectAccessReview, clustername string) (bool, error)) {
+	wc.canDoFn = f
+}

--- a/pkg/webhook/manager.go
+++ b/pkg/webhook/manager.go
@@ -1,0 +1,197 @@
+package webhook
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/cert"
+	"github.com/telekom/k8s-breakglass/pkg/cli"
+	"github.com/telekom/k8s-breakglass/pkg/indexer"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	webhookserver "sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// Setup starts the webhook server with TLS configuration and optional separate metrics server.
+// This function is only called if webhooks are enabled via --enable-webhooks flag.
+// Webhooks are optional; they can be disabled for deployments that don't use CRD validation.
+//
+// Component flags allow splitting the controller into multiple instances:
+//   - enableValidatingWebhooks: enables validating webhooks for breakglass CRDs (BreakglassSession,
+//     BreakglassEscalation, ClusterConfig, IdentityProvider, MailProvider)
+//
+// NOTE: Subject Access Review (SAR) webhooks run on the API server (Gin), not here, and cannot
+// be independently disabled. They run whenever enable-api is true.
+func Setup(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	scheme *runtime.Scheme,
+	wc *cli.WebhookConfig,
+	enableValidatingWebhooks bool,
+	enableHTTP2 bool,
+	enableCertGeneration bool,
+) error {
+	log.Debugw("Starting webhook server setup")
+
+	// Parse webhook bind address to extract host and port
+	// webhookBindAddr should be in format "host:port" (e.g., "0.0.0.0:9443")
+	webhookHost := "0.0.0.0"
+	webhookPort := 9443
+	if parts := strings.Split(wc.BindAddr, ":"); len(parts) == 2 {
+		webhookHost = parts[0]
+		if port, err := strconv.Atoi(parts[1]); err == nil {
+			webhookPort = port
+			log.Debugw("Parsed webhook bind address", "bindAddress", wc.BindAddr, "host", webhookHost, "port", webhookPort)
+		} else {
+			log.Warnw("Failed to parse webhook port from bind address; using default", "bindAddress", wc.BindAddr, "defaultPort", 9443, "error", err)
+		}
+	}
+
+	// Webhook server configuration
+	webhookServerOptions := webhookserver.Options{
+		Host: webhookHost,
+		Port: webhookPort,
+	}
+	if !enableCertGeneration && wc.CertPath != "" {
+		webhookServerOptions.CertDir = wc.CertPath
+		webhookServerOptions.CertName = wc.CertName
+		webhookServerOptions.KeyName = wc.CertKey
+		log.Infow("Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path", wc.CertPath, "webhook-cert-name", wc.CertName,
+			"webhook-cert-key", wc.CertKey)
+	} else if !enableCertGeneration {
+		return fmt.Errorf("no webhook certificate path provided and cert generation is disabled; no webhooks will be configured")
+	} else if wc.CertPath != "" {
+		webhookServerOptions.CertDir = wc.CertPath
+		log.Infof("Cert-controller will generate certs in %q", webhookServerOptions.CertDir)
+	} else {
+		webhookServerOptions.CertDir = cert.DefaultWebhookPath
+		log.Infof("No webhook certificate path provided - cert-controller will generate certs in default directory %q", webhookServerOptions.CertDir)
+	}
+	webhookServer := webhookserver.NewServer(webhookServerOptions)
+
+	// Configure separate metrics server for webhooks (if specified)
+	// This allows running webhook-only instances with their own metrics endpoint
+	var metricsServerOptions metricsserver.Options
+	if wc.MetricsAddr != "" {
+		log.Infow("Configuring separate metrics server for webhooks",
+			"address", wc.MetricsAddr, "secure", wc.MetricsSecure)
+
+		tlsOpts := []func(*tls.Config){}
+		if !enableHTTP2 {
+			tlsOpts = append(tlsOpts, cli.DisableHTTP2)
+		}
+
+		metricsServerOptions = metricsserver.Options{
+			BindAddress:   wc.MetricsAddr,
+			SecureServing: wc.MetricsSecure,
+			TLSOpts:       tlsOpts,
+		}
+
+		if wc.MetricsSecure {
+			if wc.MetricsCertPath != "" {
+				log.Infow("Initializing webhook metrics certificate watcher using provided certificates",
+					"webhooks-metrics-cert-path", wc.MetricsCertPath, "webhooks-metrics-cert-name", wc.MetricsCertName,
+					"webhooks-metrics-cert-key", wc.MetricsCertKey)
+				metricsServerOptions.CertDir = wc.MetricsCertPath
+				metricsServerOptions.CertName = wc.MetricsCertName
+				metricsServerOptions.KeyName = wc.MetricsCertKey
+			} else {
+				if enableCertGeneration {
+					log.Infow("Initializing webhook metrics certificate watcher using generated certificates",
+						"path", webhookServerOptions.CertDir, "webhooks-metrics-cert-name", wc.MetricsCertName,
+						"webhooks-metrics-cert-key", wc.MetricsCertKey)
+					metricsServerOptions.CertDir = webhookServerOptions.CertDir
+					metricsServerOptions.CertName = wc.MetricsCertName
+					metricsServerOptions.KeyName = wc.MetricsCertKey
+				} else if wc.MetricsSecure {
+					return fmt.Errorf("unable to configure webhook metrics server - webhooks-metrics-cert-path: %s, secure: %t, cert-generation: %t",
+						wc.MetricsCertPath, wc.MetricsSecure, enableCertGeneration)
+				}
+			}
+		}
+	} else {
+		log.Infow("Webhook metrics will use default metrics endpoint; to use separate metrics, set --webhooks-metrics-bind-address")
+		metricsServerOptions = metricsserver.Options{
+			BindAddress: "0",
+		}
+	}
+
+	// Create a manager for webhooks (separate from reconciler manager)
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:           scheme,
+		WebhookServer:    webhookServer,
+		Metrics:          metricsServerOptions,
+		LeaderElection:   false,
+		LeaderElectionID: "",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start webhook server; webhooks will not be registered: %w", err)
+	}
+	log.Infow("Webhook server created successfully")
+
+	if err := indexer.RegisterCommonFieldIndexes(ctx, mgr.GetFieldIndexer(), log); err != nil {
+		return fmt.Errorf("failed to register common field indexes: %w", err)
+	}
+
+	// Register health check handlers for the webhook manager
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add webhook healthz check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add webhook readyz check: %w", err)
+	}
+	log.Infow("Webhook health check handlers registered")
+
+	type webhookRegistrar interface {
+		SetupWebhookWithManager(ctrl.Manager) error
+	}
+
+	registerWebhook := func(r webhookRegistrar, name string, mgr ctrl.Manager, log *zap.SugaredLogger) error {
+		log.Debugf("Starting webhook registration for %s", name)
+		if err := r.SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("failed to setup %s webhook with manager: %w", name, err)
+		}
+		log.Infof("Successfully registered %s webhook", name)
+		return nil
+	}
+
+	// Register validating webhooks (conditionally based on enableValidatingWebhooks)
+	if enableValidatingWebhooks {
+		if err := registerWebhook(&v1alpha1.BreakglassSession{}, "BreakglassSession", mgr, log); err != nil {
+			return err
+		}
+		if err := registerWebhook(&v1alpha1.BreakglassEscalation{}, "BreakglassEscalation", mgr, log); err != nil {
+			return err
+		}
+		if err := registerWebhook(&v1alpha1.ClusterConfig{}, "ClusterConfig", mgr, log); err != nil {
+			return err
+		}
+		if err := registerWebhook(&v1alpha1.IdentityProvider{}, "IdentityProvider", mgr, log); err != nil {
+			return err
+		}
+		if err := registerWebhook(&v1alpha1.MailProvider{}, "MailProvider", mgr, log); err != nil {
+			return err
+		}
+	} else {
+		log.Infow("Validating webhooks disabled via --enable-validating-webhooks=false")
+	}
+
+	// Start webhook server (blocks) but we run it in a goroutine so it doesn't prevent the API server
+	log.Infow("Starting webhook manager", "bindAddress", wc.BindAddr)
+
+	// Start the manager in a blocking call that will also handle cache synchronization
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("webhook server failed to start or exited with error (type: %s): %w", fmt.Sprintf("%T", err), err)
+	}
+
+	log.Infow("webhook server exited normally (this should not happen during normal operation)")
+	return nil
+}


### PR DESCRIPTION
This PR is a proposal for refactor of `cmd/main.go`. During my previous work I had an impression that `main.go` is a bit cluttered so decided to take a few moments to refactor this.

Main changes:

- parts of `main()` separated into functions
- CLI config moved to `cli` package with `Config` and `WebhookConfig` structs
- `setupWebhook` moved to `webhook` package
- `setupReconciler` moved to `reconciler` package
- `registerCommonFieldIndexes` moved to `indexes` package
- added new package `utils` for various  functions
