### PR TITLE
[DOC]: Add the latest three versions to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -106,6 +106,9 @@ body:
         - 0.0.6
         - 0.0.7
         - 0.0.8
+        - 0.0.9
+        - 0.0.10
+        - 0.0.11
         - main (development)
     validations:
       required: true


### PR DESCRIPTION
This ``PR`` adds the latest three versions (``0.0.9``, ``0.0.10``, and ``0.0.11``) as options for the dropdown menu to the bug report.