### PR TITLE
[CI]: Add codecov token to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         if: always()
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: cover.out
           flags: unittests
           fail_ci_if_error: false


### PR DESCRIPTION
This ``PR`` modifies the ``codecov`` action such that it uses the repository secret ``CODECOV_TOKEN`` to upload coverage reports, which currently fails with [``error - 2025-12-04 14:10:51,955 -- Upload failed: {"message":"Token required - not valid tokenless upload"}``](https://github.com/telekom/k8s-breakglass/actions/runs/19931826837/job/57145679287).