### PR TITLE
fix: support day duration units (e.g., 90d, 7d) in CRD fields

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -316,15 +315,15 @@ func ValidateIdentityProvider(idp *IdentityProvider) *ValidationResult {
 			if idp.Spec.Keycloak.ClientSecretRef.Namespace == "" {
 				result.Errors = append(result.Errors, field.Required(secretRefPath.Child("namespace"), "secret namespace is required"))
 			}
-			// Validate cacheTTL duration if provided
+			// Validate cacheTTL duration if provided (supports day units like "7d")
 			if idp.Spec.Keycloak.CacheTTL != "" {
-				if _, err := time.ParseDuration(idp.Spec.Keycloak.CacheTTL); err != nil {
+				if _, err := ParseDuration(idp.Spec.Keycloak.CacheTTL); err != nil {
 					result.Errors = append(result.Errors, field.Invalid(keycloakPath.Child("cacheTTL"), idp.Spec.Keycloak.CacheTTL, fmt.Sprintf("invalid duration: %v", err)))
 				}
 			}
-			// Validate requestTimeout duration if provided
+			// Validate requestTimeout duration if provided (supports day units like "7d")
 			if idp.Spec.Keycloak.RequestTimeout != "" {
-				if _, err := time.ParseDuration(idp.Spec.Keycloak.RequestTimeout); err != nil {
+				if _, err := ParseDuration(idp.Spec.Keycloak.RequestTimeout); err != nil {
 					result.Errors = append(result.Errors, field.Invalid(keycloakPath.Child("requestTimeout"), idp.Spec.Keycloak.RequestTimeout, fmt.Sprintf("invalid duration: %v", err)))
 				}
 			}

--- a/pkg/breakglass/debug_session_api.go
+++ b/pkg/breakglass/debug_session_api.go
@@ -606,8 +606,8 @@ func (c *DebugSessionAPIController) handleRenewDebugSession(ctx *gin.Context) {
 		return
 	}
 
-	// Parse extension duration
-	extendBy, err := time.ParseDuration(req.ExtendBy)
+	// Parse extension duration (supports day units like "1d")
+	extendBy, err := v1alpha1.ParseDuration(req.ExtendBy)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid duration format"})
 		return
@@ -660,7 +660,7 @@ func (c *DebugSessionAPIController) handleRenewDebugSession(ctx *gin.Context) {
 
 		// Check total duration would not exceed max
 		if constraints.MaxDuration != "" {
-			maxDur, err := time.ParseDuration(constraints.MaxDuration)
+			maxDur, err := v1alpha1.ParseDuration(constraints.MaxDuration)
 			if err == nil && session.Status.StartsAt != nil {
 				currentDuration := time.Since(session.Status.StartsAt.Time)
 				if currentDuration+extendBy > maxDur {

--- a/pkg/breakglass/debug_session_kubectl.go
+++ b/pkg/breakglass/debug_session_kubectl.go
@@ -330,12 +330,12 @@ func (h *KubectlDebugHandler) CreatePodCopy(
 		return nil, fmt.Errorf("failed to create pod copy: %w", err)
 	}
 
-	// Calculate expiry
+	// Calculate expiry (supports day units like "1d")
 	ttl := pc.TTL
 	if ttl == "" {
 		ttl = "2h"
 	}
-	ttlDuration, err := time.ParseDuration(ttl)
+	ttlDuration, err := v1alpha1.ParseDuration(ttl)
 	if err != nil {
 		ttlDuration = 2 * time.Hour
 	}

--- a/pkg/breakglass/debug_session_reconciler.go
+++ b/pkg/breakglass/debug_session_reconciler.go
@@ -1048,16 +1048,17 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *v1alp
 	return c.client.Status().Update(ctx, ds)
 }
 
-// parseDuration parses the requested duration with template constraints
+// parseDuration parses the requested duration with template constraints.
+// Supports day units (e.g., "1d", "7d") in addition to standard Go duration units.
 func (c *DebugSessionController) parseDuration(requested string, constraints *v1alpha1.DebugSessionConstraints) time.Duration {
 	defaultDur := time.Hour
 	maxDur := 4 * time.Hour
 
 	if constraints != nil {
-		if d, err := time.ParseDuration(constraints.DefaultDuration); err == nil {
+		if d, err := v1alpha1.ParseDuration(constraints.DefaultDuration); err == nil {
 			defaultDur = d
 		}
-		if d, err := time.ParseDuration(constraints.MaxDuration); err == nil {
+		if d, err := v1alpha1.ParseDuration(constraints.MaxDuration); err == nil {
 			maxDur = d
 		}
 	}
@@ -1066,7 +1067,7 @@ func (c *DebugSessionController) parseDuration(requested string, constraints *v1
 		return defaultDur
 	}
 
-	dur, err := time.ParseDuration(requested)
+	dur, err := v1alpha1.ParseDuration(requested)
 	if err != nil {
 		return defaultDur
 	}

--- a/pkg/breakglass/duration_helpers.go
+++ b/pkg/breakglass/duration_helpers.go
@@ -63,12 +63,13 @@ func ParseApprovalTimeout(spec v1alpha1.BreakglassEscalationSpec, log *zap.Sugar
 // If the value is empty, returns defaultValue without logging.
 // If the value is present but invalid, logs a warning and returns defaultValue.
 // If the value is valid but <= 0, logs a warning and returns defaultValue.
+// Supports extended duration units including days (e.g., "7d", "90d").
 func parseDurationWithDefault(value string, defaultValue time.Duration, fieldName string, log *zap.SugaredLogger) time.Duration {
 	if value == "" {
 		return defaultValue
 	}
 
-	d, err := time.ParseDuration(value)
+	d, err := v1alpha1.ParseDuration(value)
 	if err != nil {
 		if log != nil {
 			log.Warnw("Invalid "+fieldName+" in spec; falling back to default",

--- a/pkg/breakglass/escalation_status_updater.go
+++ b/pkg/breakglass/escalation_status_updater.go
@@ -68,7 +68,7 @@ func (c *kcCache) set(k string, v []string) {
 
 func NewKeycloakGroupMemberResolver(log *zap.SugaredLogger, cfg cfgpkg.KeycloakRuntimeConfig) *KeycloakGroupMemberResolver {
 	ttl := 10 * time.Minute
-	if d, err := time.ParseDuration(cfg.CacheTTL); err == nil && d > 0 {
+	if d, err := telekomv1alpha1.ParseDuration(cfg.CacheTTL); err == nil && d > 0 {
 		ttl = d
 	}
 	gc := gocloak.NewClient(cfg.BaseURL)

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -501,8 +501,8 @@ func (wc BreakglassSessionController) handleRequestBreakglassSession(c *gin.Cont
 
 		// Validate and apply custom duration if provided
 		if request.Duration > 0 {
-			// Parse max allowed duration from string (e.g., "1h", "3600s")
-			d, err := time.ParseDuration(matchedEsc.Spec.MaxValidFor)
+			// Parse max allowed duration from string (e.g., "1h", "3600s", "7d")
+			d, err := v1alpha1.ParseDuration(matchedEsc.Spec.MaxValidFor)
 			if err != nil {
 				reqLog.Warnw("Failed to parse MaxValidFor duration", "error", err, "value", matchedEsc.Spec.MaxValidFor)
 				apiresponses.RespondInternalError(c, "parse escalation duration configuration", err, reqLog)
@@ -1683,7 +1683,7 @@ func (wc BreakglassSessionController) sendOnRequestEmail(bs v1alpha1.BreakglassS
 		// Calculate expiry time from scheduled start time using spec.MaxValidFor
 		expiryTime := bs.Spec.ScheduledStartTime.Time
 		if bs.Spec.MaxValidFor != "" {
-			if d, err := time.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
+			if d, err := v1alpha1.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
 				expiryTime = bs.Spec.ScheduledStartTime.Add(d)
 				formattedDurationStr = formatDuration(d)
 			}
@@ -1696,7 +1696,7 @@ func (wc BreakglassSessionController) sendOnRequestEmail(bs v1alpha1.BreakglassS
 	} else {
 		// Immediate session: calculate duration from MaxValidFor
 		if bs.Spec.MaxValidFor != "" {
-			if d, err := time.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
+			if d, err := v1alpha1.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
 				formattedDurationStr = formatDuration(d)
 				calculatedExpiresAtStr = time.Now().Add(d).Format("2006-01-02 15:04:05 MST")
 			}
@@ -1719,7 +1719,7 @@ func (wc BreakglassSessionController) sendOnRequestEmail(bs v1alpha1.BreakglassS
 	if bs.Spec.ScheduledStartTime != nil {
 		expiryTime = bs.Spec.ScheduledStartTime.Time
 		if bs.Spec.MaxValidFor != "" {
-			if d, err := time.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
+			if d, err := v1alpha1.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
 				expiryTime = bs.Spec.ScheduledStartTime.Add(d)
 			}
 		} else {
@@ -1729,7 +1729,7 @@ func (wc BreakglassSessionController) sendOnRequestEmail(bs v1alpha1.BreakglassS
 		// Immediate session
 		expiryTime = time.Now()
 		if bs.Spec.MaxValidFor != "" {
-			if d, err := time.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
+			if d, err := v1alpha1.ParseDuration(bs.Spec.MaxValidFor); err == nil && d > 0 {
 				expiryTime = time.Now().Add(d)
 			}
 		} else {


### PR DESCRIPTION
Go's time.ParseDuration only supports up to hours (h), but CRD defaults like RecordingRetention use day units (e.g., "90d"). This caused runtime parsing failures.

Changes:
- Add ParseDuration() in api/v1alpha1/validation_helpers.go with day support
- Update all duration parsing across the codebase to use the new function
- Remove duplicate from pkg/utils/utils.go
- Keep env var parsing in cleanup_task.go as standard (operators use hours)

Affected CRD fields: RecordingRetention, MaxValidFor, MaxDuration, DefaultDuration, ApprovalTimeout, CacheTTL, RequestTimeout, TTL