### PR TITLE
feat: add kstatus compliance to all CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **kstatus Compliance**: All CRDs now fully comply with [kstatus](https://github.com/kubernetes-sigs/cli-utils/blob/master/pkg/kstatus/README.md) requirements for proper reconciliation status detection
+  - Added `observedGeneration` field to `MailProviderStatus`, `AuditConfigStatus`, `BreakglassSessionStatus`, and `DebugSessionStatus`
+  - Controllers now populate `status.observedGeneration` when updating status to enable generation tracking
+  - Added proper `listType=map` and `listMapKey=type` markers to all condition arrays for strategic merge patch support
+  - Added `Ready` print column to `AuditConfig`, `DebugPodTemplate`, and `DebugSessionTemplate` CRDs
+  - This enables tools like `kubectl wait --for=condition=Ready` and GitOps reconciliation status tracking
+
 - **Granular Pod Operations for Debug Sessions**: Control which kubectl operations are allowed on debug session pods
   - New `AllowedPodOperations` type with toggles for `exec`, `attach`, `logs`, and `portForward`
   - `DebugSessionTemplateSpec.allowedPodOperations` field to configure permitted operations at template level

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/auditconfigstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/auditconfigstatus.go
@@ -18,6 +18,8 @@ import (
 //
 // AuditConfigStatus defines the observed state of AuditConfig.
 type AuditConfigStatusApplyConfiguration struct {
+	// ObservedGeneration reflects the generation of the most recently observed AuditConfig.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// Conditions represent the current state of the AuditConfig.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// ActiveSinks lists currently active sink names.
@@ -36,6 +38,14 @@ type AuditConfigStatusApplyConfiguration struct {
 // apply.
 func AuditConfigStatus() *AuditConfigStatusApplyConfiguration {
 	return &AuditConfigStatusApplyConfiguration{}
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *AuditConfigStatusApplyConfiguration) WithObservedGeneration(value int64) *AuditConfigStatusApplyConfiguration {
+	b.ObservedGeneration = &value
+	return b
 }
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionstatus.go
@@ -19,6 +19,8 @@ import (
 //
 // BreakglassSessionStatus defines the observed state of BreakglassSessionStatus.
 type BreakglassSessionStatusApplyConfiguration struct {
+	// ObservedGeneration reflects the generation of the most recently observed BreakglassSession.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// conditions is an array of current observed BreakglassSession conditions.
 	// Tracks conditions like Idle, Approved, Rejected, Expired, Canceled, Active, and SessionExpired
 	// Active condition: Set to True when session is approved and within validity window, False otherwise
@@ -63,6 +65,14 @@ type BreakglassSessionStatusApplyConfiguration struct {
 // apply.
 func BreakglassSessionStatus() *BreakglassSessionStatusApplyConfiguration {
 	return &BreakglassSessionStatusApplyConfiguration{}
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *BreakglassSessionStatusApplyConfiguration) WithObservedGeneration(value int64) *BreakglassSessionStatusApplyConfiguration {
+	b.ObservedGeneration = &value
+	return b
 }
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionstatus.go
@@ -19,6 +19,8 @@ import (
 //
 // DebugSessionStatus defines the observed state of DebugSession.
 type DebugSessionStatusApplyConfiguration struct {
+	// ObservedGeneration reflects the generation of the most recently observed DebugSession.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// state is the current state of the debug session.
 	State *apiv1alpha1.DebugSessionState `json:"state,omitempty"`
 	// approval tracks approval information.
@@ -60,6 +62,14 @@ type DebugSessionStatusApplyConfiguration struct {
 // apply.
 func DebugSessionStatus() *DebugSessionStatusApplyConfiguration {
 	return &DebugSessionStatusApplyConfiguration{}
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *DebugSessionStatusApplyConfiguration) WithObservedGeneration(value int64) *DebugSessionStatusApplyConfiguration {
+	b.ObservedGeneration = &value
+	return b
 }
 
 // WithState sets the State field in the declarative configuration to the given value

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mailproviderstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mailproviderstatus.go
@@ -18,6 +18,8 @@ import (
 //
 // MailProviderStatus defines the observed state of MailProvider
 type MailProviderStatusApplyConfiguration struct {
+	// ObservedGeneration reflects the generation of the most recently observed MailProvider.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// Conditions represent the latest available observations of the MailProvider's state
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 	// LastHealthCheck is the timestamp of the last successful health check
@@ -32,6 +34,14 @@ type MailProviderStatusApplyConfiguration struct {
 // apply.
 func MailProviderStatus() *MailProviderStatusApplyConfiguration {
 	return &MailProviderStatusApplyConfiguration{}
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *MailProviderStatusApplyConfiguration) WithObservedGeneration(value int64) *MailProviderStatusApplyConfiguration {
+	b.ObservedGeneration = &value
+	return b
 }
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration

--- a/api/v1alpha1/applyconfiguration/ssa/config_types.go
+++ b/api/v1alpha1/applyconfiguration/ssa/config_types.go
@@ -102,6 +102,10 @@ func MailProviderStatusFrom(status *telekomv1alpha1.MailProviderStatus) *ac.Mail
 
 	result := ac.MailProviderStatus()
 
+	if status.ObservedGeneration > 0 {
+		result.WithObservedGeneration(status.ObservedGeneration)
+	}
+
 	for i := range status.Conditions {
 		result.WithConditions(ConditionFrom(&status.Conditions[i]))
 	}
@@ -126,6 +130,10 @@ func AuditConfigStatusFrom(status *telekomv1alpha1.AuditConfigStatus) *ac.AuditC
 	}
 
 	result := ac.AuditConfigStatus()
+
+	if status.ObservedGeneration > 0 {
+		result.WithObservedGeneration(status.ObservedGeneration)
+	}
 
 	for i := range status.Conditions {
 		result.WithConditions(ConditionFrom(&status.Conditions[i]))

--- a/api/v1alpha1/applyconfiguration/ssa/ssa.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa.go
@@ -166,6 +166,11 @@ func BreakglassSessionStatusFrom(status *telekomv1alpha1.BreakglassSessionStatus
 
 	result := ac.BreakglassSessionStatus()
 
+	// Set observedGeneration for kstatus compliance
+	if status.ObservedGeneration > 0 {
+		result.WithObservedGeneration(status.ObservedGeneration)
+	}
+
 	// Set conditions
 	for i := range status.Conditions {
 		result.WithConditions(ConditionFrom(&status.Conditions[i]))
@@ -221,6 +226,11 @@ func DebugSessionStatusFrom(status *telekomv1alpha1.DebugSessionStatus) *ac.Debu
 	}
 
 	result := ac.DebugSessionStatus()
+
+	// Set observedGeneration for kstatus compliance
+	if status.ObservedGeneration > 0 {
+		result.WithObservedGeneration(status.ObservedGeneration)
+	}
 
 	// Set state
 	if status.State != "" {

--- a/api/v1alpha1/audit_config_types.go
+++ b/api/v1alpha1/audit_config_types.go
@@ -376,8 +376,16 @@ type AuditSamplingConfig struct {
 
 // AuditConfigStatus defines the observed state of AuditConfig.
 type AuditConfigStatus struct {
+	// ObservedGeneration reflects the generation of the most recently observed AuditConfig.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the current state of the AuditConfig.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// ActiveSinks lists currently active sink names.
@@ -429,6 +437,7 @@ type AuditSinkStatus struct {
 // +kubebuilder:printcolumn:name="Sinks",type=string,JSONPath=`.status.activeSinks`
 // +kubebuilder:printcolumn:name="Processed",type=integer,JSONPath=`.status.eventsProcessed`
 // +kubebuilder:printcolumn:name="Dropped",type=integer,JSONPath=`.status.eventsDropped`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // AuditConfig is the Schema for the auditconfigs API.

--- a/api/v1alpha1/breakglass_escalation_types.go
+++ b/api/v1alpha1/breakglass_escalation_types.go
@@ -288,7 +288,7 @@ type BreakglassEscalationStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=bge
 // +kubebuilder:printcolumn:name="Clusters",type=string,JSONPath=".spec.allowed.clusters",description="Clusters this escalation applies to"
 // +kubebuilder:printcolumn:name="Groups",type=string,JSONPath=".spec.allowed.groups",description="Groups allowed to request this escalation"
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="Ready status"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready status"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="The age of the escalation"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/v1alpha1/breakglass_session_types.go
+++ b/api/v1alpha1/breakglass_session_types.go
@@ -139,11 +139,19 @@ type BreakglassSessionSpec struct {
 type BreakglassSessionStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// ObservedGeneration reflects the generation of the most recently observed BreakglassSession.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// conditions is an array of current observed BreakglassSession conditions.
 	// Tracks conditions like Idle, Approved, Rejected, Expired, Canceled, Active, and SessionExpired
 	// Active condition: Set to True when session is approved and within validity window, False otherwise
 	// SessionExpired condition: Set to True when session validity period has ended, False while active
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// approvedAt is the time when the session was approved.

--- a/api/v1alpha1/debug_pod_template_types.go
+++ b/api/v1alpha1/debug_pod_template_types.go
@@ -232,6 +232,7 @@ type DebugPodTemplateStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Display Name",type=string,JSONPath=".spec.displayName",description="Human-readable name"
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=".spec.description",description="Template description"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready status"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 

--- a/api/v1alpha1/debug_session_cluster_binding_types.go
+++ b/api/v1alpha1/debug_session_cluster_binding_types.go
@@ -300,7 +300,7 @@ type NameCollision struct {
 // +kubebuilder:printcolumn:name="Template",type=string,JSONPath=`.spec.templateRef.name`
 // +kubebuilder:printcolumn:name="Clusters",type=integer,JSONPath=`.status.resolvedClusters`
 // +kubebuilder:printcolumn:name="Active",type=integer,JSONPath=`.status.activeSessionCount`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // DebugSessionClusterBinding binds DebugSessionTemplates to specific clusters

--- a/api/v1alpha1/debug_session_template_types.go
+++ b/api/v1alpha1/debug_session_template_types.go
@@ -1060,6 +1060,7 @@ type DebugSessionTemplateStatus struct {
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=".spec.mode",description="Session mode"
 // +kubebuilder:printcolumn:name="Workload Type",type=string,JSONPath=".spec.workloadType",description="Workload type"
 // +kubebuilder:printcolumn:name="Active Sessions",type=integer,JSONPath=".status.activeSessionCount",description="Active sessions count"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready status"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 

--- a/api/v1alpha1/debug_session_types.go
+++ b/api/v1alpha1/debug_session_types.go
@@ -182,6 +182,10 @@ type BindingReference struct {
 
 // DebugSessionStatus defines the observed state of DebugSession.
 type DebugSessionStatus struct {
+	// ObservedGeneration reflects the generation of the most recently observed DebugSession.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// state is the current state of the debug session.
 	// +optional
 	State DebugSessionState `json:"state,omitempty"`
@@ -230,6 +234,10 @@ type DebugSessionStatus struct {
 
 	// conditions provide detailed status information.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// message provides human-readable status information.

--- a/api/v1alpha1/identity_provider_types.go
+++ b/api/v1alpha1/identity_provider_types.go
@@ -185,7 +185,7 @@ type IdentityProviderStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/mail_provider_types.go
+++ b/api/v1alpha1/mail_provider_types.go
@@ -139,8 +139,16 @@ type RetryConfig struct {
 
 // MailProviderStatus defines the observed state of MailProvider
 type MailProviderStatus struct {
+	// ObservedGeneration reflects the generation of the most recently observed MailProvider.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the latest available observations of the MailProvider's state
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// LastHealthCheck is the timestamp of the last successful health check

--- a/config/crd/bases/breakglass.t-caas.telekom.com_auditconfigs.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_auditconfigs.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.eventsDropped
       name: Dropped
       type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -692,6 +695,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               eventsDropped:
                 description: EventsDropped is the total number of events dropped.
                 format: int64
@@ -704,6 +710,11 @@ spec:
                 description: LastEventTime is when the last event was processed.
                 format: date-time
                 type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed AuditConfig.
+                format: int64
+                type: integer
               sinkStatuses:
                 description: SinkStatuses contains per-sink status information.
                 items:

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
@@ -263,12 +263,20 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               expiresAt:
                 description: |-
                   ExpiresAt is the time when the session will expire.
                   This value is set based on spec.MaxValidFor when the session is approved.
                 format: date-time
                 type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed BreakglassSession.
+                format: int64
+                type: integer
               reasonEnded:
                 description: |-
                   reasonEnded stores a short reason for why the session ended or entered a terminal state.

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugpodtemplates.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugpodtemplates.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .spec.description
       name: Description
       type: string
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessionclusterbindings.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessionclusterbindings.yaml
@@ -27,7 +27,7 @@ spec:
     - jsonPath: .status.activeSessionCount
       name: Active
       type: integer
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
@@ -1197,6 +1197,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               deployedResources:
                 description: deployedResources lists resources created on the target
                   cluster.
@@ -1314,6 +1317,11 @@ spec:
               message:
                 description: message provides human-readable status information.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed DebugSession.
+                format: int64
+                type: integer
               participants:
                 description: participants lists users currently in the session.
                 items:

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
@@ -33,6 +33,10 @@ spec:
       jsonPath: .status.activeSessionCount
       name: Active Sessions
       type: integer
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/breakglass.t-caas.telekom.com_mailproviders.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_mailproviders.yaml
@@ -242,6 +242,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastHealthCheck:
                 description: LastHealthCheck is the timestamp of the last successful
                   health check
@@ -256,6 +259,11 @@ spec:
                 description: LastSendError contains the error message from the last
                   failed send attempt
                 type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MailProvider.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -270,6 +270,16 @@ func (c SessionManager) UpdateBreakglassSessionStatus(ctx context.Context, bs v1
 		}
 		bs.Namespace = current.Namespace
 		bs.ResourceVersion = current.ResourceVersion
+		// Set observedGeneration for kstatus compliance
+		bs.Status.ObservedGeneration = current.Generation
+	} else {
+		// Fetch current to get Generation for kstatus compliance
+		current, err := c.GetBreakglassSessionByName(ctx, bs.Name)
+		if err == nil {
+			bs.Status.ObservedGeneration = current.Generation
+		} else {
+			zap.S().Warnw("Failed to fetch BreakglassSession for observedGeneration", append(system.NamespacedFields(bs.Name, bs.Namespace), "error", err.Error())...)
+		}
 	}
 	if err := applyBreakglassSessionStatus(ctx, c, &bs); err != nil {
 		zap.S().Errorw("Failed to update BreakglassSession status", append(system.NamespacedFields(bs.Name, bs.Namespace), "error", err.Error())...)

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -9,10 +9,20 @@ import (
 )
 
 func applyBreakglassSessionStatus(ctx context.Context, c client.Client, session *telekomv1alpha1.BreakglassSession) error {
+	// Set observedGeneration for kstatus compliance
+	// Note: This is also set in SessionManager.UpdateBreakglassSessionStatus for cases where
+	// the session doesn't have Generation set
+	if session.Generation > 0 {
+		session.Status.ObservedGeneration = session.Generation
+	}
 	return ssa.ApplyBreakglassSessionStatus(ctx, c, session)
 }
 
 func applyDebugSessionStatus(ctx context.Context, c client.Client, session *telekomv1alpha1.DebugSession) error {
+	// Set observedGeneration for kstatus compliance
+	if session.Generation > 0 {
+		session.Status.ObservedGeneration = session.Generation
+	}
 	return ssa.ApplyDebugSessionStatus(ctx, c, session)
 }
 

--- a/pkg/config/audit_config_reconciler.go
+++ b/pkg/config/audit_config_reconciler.go
@@ -447,6 +447,9 @@ func (r *AuditConfigReconciler) updateStatus(ctx context.Context, config *breakg
 		}
 	}
 
+	// Set observedGeneration for kstatus compliance
+	config.Status.ObservedGeneration = config.Generation
+
 	return r.applyStatus(ctx, config)
 }
 

--- a/pkg/config/mail_provider_reconciler.go
+++ b/pkg/config/mail_provider_reconciler.go
@@ -326,6 +326,9 @@ func (r *MailProviderReconciler) updateStatusHealthy(ctx context.Context, mp *br
 			})
 	}
 
+	// Set observedGeneration for kstatus compliance
+	latest.Status.ObservedGeneration = latest.Generation
+
 	if err := r.applyStatus(ctx, &latest); err != nil {
 		if apierrors.IsConflict(err) {
 			// Another controller likely updated it - this is fine, skip retry
@@ -393,6 +396,9 @@ func (r *MailProviderReconciler) updateStatusUnhealthy(ctx context.Context, mp *
 			LastTransitionTime: metav1.Now(),
 		})
 
+	// Set observedGeneration for kstatus compliance
+	latest.Status.ObservedGeneration = latest.Generation
+
 	if err := r.applyStatus(ctx, &latest); err != nil {
 		if apierrors.IsConflict(err) {
 			// Another controller likely updated it - this is fine, skip retry
@@ -448,6 +454,9 @@ func (r *MailProviderReconciler) updateStatusDisabled(ctx context.Context, mp *b
 			Message:            "MailProvider is disabled",
 			LastTransitionTime: metav1.Now(),
 		})
+
+	// Set observedGeneration for kstatus compliance
+	latest.Status.ObservedGeneration = latest.Generation
 
 	if err := r.applyStatus(ctx, &latest); err != nil {
 		if apierrors.IsConflict(err) {


### PR DESCRIPTION
Add observedGeneration field and proper condition list markers to ensure all CRDs comply with kstatus requirements for reconciliation status detection.

Changes:
- Add observedGeneration to MailProviderStatus, AuditConfigStatus, BreakglassSessionStatus, and DebugSessionStatus
- Add listType=map and listMapKey=type markers to all condition arrays
- Add Ready print column to AuditConfig, DebugPodTemplate, and DebugSessionTemplate CRDs

This enables:
- kubectl wait --for=condition=Ready support
- GitOps reconciliation status tracking (Flux, Argo CD)
- Strategic merge patch support for conditions

Ref: https://github.com/kubernetes-sigs/cli-utils/blob/master/pkg/kstatus/README.md