### PR TITLE
fix: address code review improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Trailing JSON data after the main object is rejected
   - Helps catch client bugs and typos early (e.g., `cluter` instead of `cluster`)
 
+- **Configurable REST Config Cache TTL**: Added environment variable configuration for REST config cache TTL (PR #295)
+  - `BREAKGLASS_REST_CONFIG_CACHE_TTL`: Override default 5-minute TTL for OIDC cluster configs (e.g., "10m", "300s")
+  - `BREAKGLASS_KUBECONFIG_CACHE_TTL`: Override default 15-minute TTL for kubeconfig-based configs
+  - Logs warning to stderr when invalid duration strings are provided (falls back to default)
+  - Enables tuning cache behavior for different deployment scenarios
+
 - **Orphaned DebugSession Cleanup**: Fixed infinite retry loop when ClusterConfig is deleted while DebugSessions are still active
   - `cleanupResources` now gracefully handles `ErrClusterConfigNotFound` error
   - When target cluster no longer exists, cleanup is treated as complete instead of retrying every 5 seconds indefinitely

--- a/pkg/breakglass/expire_pending_sessions_test.go
+++ b/pkg/breakglass/expire_pending_sessions_test.go
@@ -15,6 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// metadataNameIndexerExpire indexes objects by their metadata.name for field selector support
+var metadataNameIndexerExpire = func(o client.Object) []string {
+	return []string{o.GetName()}
+}
+
 func TestExpirePendingSessions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := telekomv1alpha1.AddToScheme(scheme)
@@ -45,6 +50,7 @@ func TestExpirePendingSessions(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(pendingSession).
 			WithStatusSubresource(&telekomv1alpha1.BreakglassSession{}).
+			WithIndex(&telekomv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerExpire).
 			Build()
 
 		mgr := NewSessionManagerWithClient(fakeClient)
@@ -90,6 +96,7 @@ func TestExpirePendingSessions(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(recentSession).
 			WithStatusSubresource(&telekomv1alpha1.BreakglassSession{}).
+			WithIndex(&telekomv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerExpire).
 			Build()
 
 		mgr := NewSessionManagerWithClient(fakeClient)
@@ -133,6 +140,7 @@ func TestExpirePendingSessions(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(approvedSession).
 			WithStatusSubresource(&telekomv1alpha1.BreakglassSession{}).
+			WithIndex(&telekomv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerExpire).
 			Build()
 
 		mgr := NewSessionManagerWithClient(fakeClient)

--- a/pkg/breakglass/scheduled_session_test.go
+++ b/pkg/breakglass/scheduled_session_test.go
@@ -12,6 +12,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// metadataNameIndexerSched indexes objects by their metadata.name for field selector support
+var metadataNameIndexerSched = func(o client.Object) []string {
+	return []string{o.GetName()}
+}
+
 // TestScheduledSessionValidation tests that sessions with scheduled start times are properly validated
 func TestScheduledSessionValidation(t *testing.T) {
 	tests := []struct {
@@ -506,6 +511,7 @@ func TestScheduledSessionActivator_FullActivationFlow(t *testing.T) {
 		WithScheme(Scheme).
 		WithObjects(sessionToActivate, sessionNotReady, sessionAlreadyApproved, sessionMissingScheduledTime).
 		WithStatusSubresource(&v1alpha1.BreakglassSession{}).
+		WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerSched).
 		Build()
 
 	// Create session manager
@@ -609,6 +615,7 @@ func TestScheduledSessionActivator_NoSessionsToActivate(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(Scheme).
 		WithStatusSubresource(&v1alpha1.BreakglassSession{}).
+		WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerSched).
 		Build()
 
 	sesManager := NewSessionManagerWithClient(fakeClient)
@@ -656,6 +663,7 @@ func TestScheduledSessionActivator_EmailDisabled(t *testing.T) {
 		WithScheme(Scheme).
 		WithObjects(sessionToActivate).
 		WithStatusSubresource(&v1alpha1.BreakglassSession{}).
+		WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerSched).
 		Build()
 
 	sesManager := NewSessionManagerWithClient(fakeClient)

--- a/pkg/breakglass/session_manager_test.go
+++ b/pkg/breakglass/session_manager_test.go
@@ -208,6 +208,7 @@ func TestSessionManager_UpdateBreakglassSessionStatus(t *testing.T) {
 			WithScheme(Scheme).
 			WithObjects(session).
 			WithStatusSubresource(session).
+			WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
 			Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -27,5 +27,9 @@ func applyDebugSessionStatus(ctx context.Context, c client.Client, session *tele
 }
 
 func applyBreakglassEscalationStatus(ctx context.Context, c client.Client, escalation *telekomv1alpha1.BreakglassEscalation) error {
+	// Set observedGeneration for kstatus compliance
+	if escalation.Generation > 0 {
+		escalation.Status.ObservedGeneration = escalation.Generation
+	}
 	return ssa.ApplyBreakglassEscalationStatus(ctx, c, escalation)
 }


### PR DESCRIPTION
This PR addresses code quality improvements: 1) Consolidate double fetch in UpdateBreakglassSessionStatus 2) Add observedGeneration for kstatus in applyBreakglassEscalationStatus 3) Make cache TTLs configurable via env vars 4) Fix tests with metadata.name field index