### PR TITLE
refactor: replace deprecated github.com/pkg/errors with stdlib errors/fmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/spf13/cobra v1.10.2
@@ -40,6 +39,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
@@ -128,7 +128,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/apiextensions-apiserver v0.35.0 // indirect
+	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4

--- a/pkg/breakglass/clusteruser.go
+++ b/pkg/breakglass/clusteruser.go
@@ -1,10 +1,10 @@
 package breakglass
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/pkg/errors"
 )
 
 type ClusterUserGroup struct {
@@ -42,7 +42,7 @@ func (r *BreakglassSessionRequest) SanitizeReason() error {
 		return err
 	}
 	if utf8.RuneCountInString(sanitized) > MaxReasonLength {
-		return errors.Errorf("reason must be at most %d characters", MaxReasonLength)
+		return fmt.Errorf("reason must be at most %d characters", MaxReasonLength)
 	}
 	r.Reason = sanitized
 	return nil
@@ -154,7 +154,7 @@ func (r *BreakglassSessionRequest) ValidateDuration(maxAllowed int64) error {
 
 	// Duration must not exceed maximum allowed
 	if r.Duration > maxAllowed {
-		return errors.Errorf("requested duration %d seconds exceeds maximum allowed %d seconds", r.Duration, maxAllowed)
+		return fmt.Errorf("requested duration %d seconds exceeds maximum allowed %d seconds", r.Duration, maxAllowed)
 	}
 
 	return nil

--- a/pkg/breakglass/escalation.go
+++ b/pkg/breakglass/escalation.go
@@ -2,8 +2,8 @@ package breakglass
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -29,7 +29,7 @@ func (ef EscalationFiltering) FilterForUserPossibleEscalations(ctx context.Conte
 	userGroups, err := ef.UserGroupExtract(ctx, ef.FilterUserData)
 	if err != nil {
 		ef.Log.Errorw("Failed to get user groups for escalation filtering", "error", err)
-		return nil, errors.Wrap(err, "failed to get user groups")
+		return nil, fmt.Errorf("failed to get user groups: %w", err)
 	}
 	ef.Log.Debugw("Retrieved user groups for escalation filtering", "userGroups", userGroups)
 	// Load config to determine OIDC prefixes for normalization
@@ -95,7 +95,7 @@ func (ef EscalationFiltering) FilterSessionsForUserApprovable(ctx context.Contex
 	userGroups, err := ef.UserGroupExtract(ctx, ef.FilterUserData)
 	if err != nil {
 		ef.Log.Errorw("Failed to get user rbac cluster groups for session filtering", "error", err)
-		return nil, errors.Wrap(err, "failed to get user rbac cluster groups")
+		return nil, fmt.Errorf("failed to get user rbac cluster groups: %w", err)
 	}
 	ef.Log.Debugw("Retrieved user groups for session filtering", "userGroups", userGroups)
 

--- a/pkg/breakglass/expire_approved_sessions.go
+++ b/pkg/breakglass/expire_approved_sessions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
@@ -58,7 +57,7 @@ func (wc *BreakglassSessionController) ExpireApprovedSessions() {
 					wc.emitSessionExpiredAuditEvent(context.Background(), &ses, "timeExpired")
 					break
 				} else {
-					lastErr = errors.Wrapf(err, "status update attempt %d failed", attempt+1)
+					lastErr = fmt.Errorf("status update attempt %d failed: %w", attempt+1, err)
 					wc.log.Warnw("failed to update expired session status (will retry)", "session", ses.Name, "attempt", attempt+1, "error", err)
 
 					// On conflict or other recoverable errors, re-fetch the latest object and reapply status changes

--- a/pkg/breakglass/group_checker.go
+++ b/pkg/breakglass/group_checker.go
@@ -2,10 +2,10 @@ package breakglass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authenticationv1alpha1 "k8s.io/api/authentication/v1alpha1"
@@ -63,7 +63,7 @@ func CanGroupsDo(ctx context.Context,
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		zap.S().Errorw("Failed to create client for CanGroupsDo", "error", err.Error())
-		return false, errors.Wrap(err, "failed to create client")
+		return false, fmt.Errorf("failed to create client: %w", err)
 	}
 
 	// Build SelfSubjectAccessReview spec based on whether we have resource or non-resource attributes
@@ -152,7 +152,7 @@ func getUserGroupsInternal(ctx context.Context, cug ClusterUserGroup, configPath
 	kubeCfg, err := getConfigForClusterName(cug.Clustername)
 	if err != nil {
 		zap.S().Errorw("GetUserGroups: rest.Config load failed", "cluster", cug.Clustername, "error", err.Error())
-		return nil, errors.Wrap(err, "failed to get config")
+		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
 
 	kubeCfg.Impersonate = rest.ImpersonationConfig{
@@ -162,7 +162,7 @@ func getUserGroupsInternal(ctx context.Context, cug ClusterUserGroup, configPath
 	client, err := kubernetes.NewForConfig(kubeCfg)
 	if err != nil {
 		zap.S().Errorw("GetUserGroups: client construction failed", "cluster", cug.Clustername, "error", err.Error())
-		return nil, errors.Wrap(err, "failed to create client")
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
 	var res runtime.Object
@@ -179,13 +179,13 @@ func getUserGroupsInternal(ctx context.Context, cug ClusterUserGroup, configPath
 
 	if err != nil {
 		zap.S().Errorw("Failed to get user's subject review", "error", err.Error())
-		return nil, errors.Wrap(err, "failed to get users subject review")
+		return nil, fmt.Errorf("failed to get users subject review: %w", err)
 	}
 
 	ui, err := getUserInfo(res)
 	if err != nil {
 		zap.S().Errorw("Failed to get user info from response", "error", err.Error())
-		return nil, errors.Wrap(err, "failed to get user info from response")
+		return nil, fmt.Errorf("failed to get user info from response: %w", err)
 	}
 
 	// Apply OIDC prefix stripping if config was loaded successfully


### PR DESCRIPTION
Replaces all usages of the deprecated github.com/pkg/errors package with the standard library errors and fmt packages, using %w verb for proper error wrapping.