### PR TITLE
fix: reject JSON requests with unknown fields using DisallowUnknownFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Strict JSON Request Validation**: Session creation API now rejects requests with unknown/typo'd fields
+  - Unknown fields in JSON request body now return `422 Unprocessable Entity` instead of being silently ignored
+  - Trailing JSON data after the main object is rejected
+  - Helps catch client bugs and typos early (e.g., `cluter` instead of `cluster`)
+
 - **Orphaned DebugSession Cleanup**: Fixed infinite retry loop when ClusterConfig is deleted while DebugSessions are still active
   - `cleanupResources` now gracefully handles `ErrClusterConfigNotFound` error
   - When target cluster no longer exists, cleanup is treated as complete instead of retrying every 5 seconds indefinitely

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -242,6 +242,8 @@ Authorization: Bearer <token>
 
 **Request validation:**
 
+- JSON bodies must contain only known field names; requests with unknown or typo'd fields are rejected with `422 Unprocessable Entity`
+- JSON bodies must contain exactly one JSON object; trailing data is rejected
 - `reason` is optional unless the escalation's `requestReason.mandatory` is `true`.
 - `reason` must be at most 1024 characters after trimming.
 - `user` must match the authenticated identity in the request token; mismatches are rejected.


### PR DESCRIPTION
Added decodeJSONStrict helper that wraps json.NewDecoder with DisallowUnknownFields() enabled. This ensures that API requests containing unknown/typo'd field names are rejected with an error rather than being silently ignored.

This catches client bugs and configuration errors early, preventing issues where typo'd field names (e.g., 'cluter' instead of 'cluster') would result in missing required data.

Added unit tests for the strict decoding behavior.