### PR TITLE
refactor: upgrade controller-runtime and expand SSA usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.2
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
@@ -25,7 +26,8 @@ require (
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
-	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/cli-utils v0.37.2
+	sigs.k8s.io/controller-runtime v0.23.2-0.20260202104230-4dbfa5c66aa2
 )
 
 require (
@@ -48,9 +50,7 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	github.com/zalando/go-keyring v0.2.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	sigs.k8s.io/cli-utils v0.37.2 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -35,9 +35,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -340,8 +339,8 @@ k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzk
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
 sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.23.2-0.20260202104230-4dbfa5c66aa2 h1:ns/U29Jv9QhcXBw5LyCX4v7S6/IipCOQapMFNvJrHIE=
+sigs.k8s.io/controller-runtime v0.23.2-0.20260202104230-4dbfa5c66aa2/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/pkg/breakglass/debug_session_kubectl.go
+++ b/pkg/breakglass/debug_session_kubectl.go
@@ -325,7 +325,7 @@ func (h *KubectlDebugHandler) CreatePodCopy(
 	copyPod.ResourceVersion = ""
 	copyPod.UID = ""
 
-	// Create the copy pod
+	// Create the copy pod using Create (not SSA) because each pod copy must be unique
 	if err := targetClient.Create(ctx, copyPod); err != nil {
 		return nil, fmt.Errorf("failed to create pod copy: %w", err)
 	}
@@ -500,7 +500,7 @@ func (h *KubectlDebugHandler) CreateNodeDebugPod(
 		},
 	}
 
-	// Create the pod
+	// Create the pod using Create (not SSA) because each debug pod must be unique
 	if err := targetClient.Create(ctx, debugPod); err != nil {
 		return nil, fmt.Errorf("failed to create node debug pod: %w", err)
 	}

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -232,6 +232,8 @@ func (c SessionManager) GetBreakglassSessionsWithSelector(ctx context.Context,
 }
 
 // Add new breakglass session.
+// Note: Uses Create instead of SSA because GenerateName requires Create semantics.
+// For updates, use UpdateBreakglassSession which uses SSA.
 func (c SessionManager) AddBreakglassSession(ctx context.Context, bs *v1alpha1.BreakglassSession) error {
 	zap.S().Infow("Adding new BreakglassSession", append(system.NamespacedFields(bs.Name, bs.Namespace), "user", bs.Spec.User, "cluster", bs.Spec.Cluster)...)
 	if err := c.Create(ctx, bs); err != nil {

--- a/pkg/utils/ssa.go
+++ b/pkg/utils/ssa.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	policyv1ac "k8s.io/client-go/applyconfigurations/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telekomv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -137,6 +141,16 @@ func ToApplyConfiguration(obj client.Object) (runtime.ApplyConfiguration, error)
 		return debugSessionClusterBindingToApplyConfig(o)
 	case *corev1.Secret:
 		return secretToApplyConfig(o), nil
+	case *corev1.Pod:
+		return podToApplyConfig(o)
+	case *corev1.ResourceQuota:
+		return resourceQuotaToApplyConfig(o)
+	case *policyv1.PodDisruptionBudget:
+		return pdbToApplyConfig(o)
+	case *appsv1.DaemonSet:
+		return daemonSetToApplyConfig(o)
+	case *appsv1.Deployment:
+		return deploymentToApplyConfig(o)
 	default:
 		return nil, fmt.Errorf("unsupported type for ApplyConfiguration: %T", obj)
 	}
@@ -338,6 +352,57 @@ func secretToApplyConfig(o *corev1.Secret) *corev1ac.SecretApplyConfiguration {
 		cfg.WithOwnerReferences(owners...)
 	}
 	return cfg
+}
+
+// podToApplyConfig converts a Pod to its ApplyConfiguration equivalent.
+func podToApplyConfig(o *corev1.Pod) (*corev1ac.PodApplyConfiguration, error) {
+	cfg := corev1ac.Pod(o.Name, o.Namespace)
+	if err := jsonDecodeInto(o, cfg); err != nil {
+		return nil, err
+	}
+	// Clear status - SSA should only set spec
+	cfg.Status = nil
+	return cfg, nil
+}
+
+// resourceQuotaToApplyConfig converts a ResourceQuota to its ApplyConfiguration equivalent.
+func resourceQuotaToApplyConfig(o *corev1.ResourceQuota) (*corev1ac.ResourceQuotaApplyConfiguration, error) {
+	cfg := corev1ac.ResourceQuota(o.Name, o.Namespace)
+	if err := jsonDecodeInto(o, cfg); err != nil {
+		return nil, err
+	}
+	cfg.Status = nil
+	return cfg, nil
+}
+
+// pdbToApplyConfig converts a PodDisruptionBudget to its ApplyConfiguration equivalent.
+func pdbToApplyConfig(o *policyv1.PodDisruptionBudget) (*policyv1ac.PodDisruptionBudgetApplyConfiguration, error) {
+	cfg := policyv1ac.PodDisruptionBudget(o.Name, o.Namespace)
+	if err := jsonDecodeInto(o, cfg); err != nil {
+		return nil, err
+	}
+	cfg.Status = nil
+	return cfg, nil
+}
+
+// daemonSetToApplyConfig converts a DaemonSet to its ApplyConfiguration equivalent.
+func daemonSetToApplyConfig(o *appsv1.DaemonSet) (*appsv1ac.DaemonSetApplyConfiguration, error) {
+	cfg := appsv1ac.DaemonSet(o.Name, o.Namespace)
+	if err := jsonDecodeInto(o, cfg); err != nil {
+		return nil, err
+	}
+	cfg.Status = nil
+	return cfg, nil
+}
+
+// deploymentToApplyConfig converts a Deployment to its ApplyConfiguration equivalent.
+func deploymentToApplyConfig(o *appsv1.Deployment) (*appsv1ac.DeploymentApplyConfiguration, error) {
+	cfg := appsv1ac.Deployment(o.Name, o.Namespace)
+	if err := jsonDecodeInto(o, cfg); err != nil {
+		return nil, err
+	}
+	cfg.Status = nil
+	return cfg, nil
 }
 
 // jsonDecodeInto marshals src to JSON and unmarshals into dst.


### PR DESCRIPTION
- Upgrade controller-runtime to v0.23.2-0.20260202104230-4dbfa5c66aa2 (fixes fake client SSA support, refs PR #2981, #3321, #3253)

- Add SSA ApplyConfiguration support for core Kubernetes types:
  - corev1.Pod
  - corev1.ResourceQuota
  - policyv1.PodDisruptionBudget
  - appsv1.DaemonSet
  - appsv1.Deployment

- Convert debug session reconciler operations to SSA:
  - ResourceQuota deployment (idempotent apply)
  - PodDisruptionBudget deployment (idempotent apply)
  - Workload deployment (DaemonSet/Deployment, allows updates)

- Simplify TOFU CA secret persistence using SSA:
  - No longer needs get-before-create pattern
  - Single ApplyObject call handles create or update

- Keep Create for operations requiring uniqueness guarantees:
  - BreakglassSession creation (uses GenerateName)
  - Pod copies (each must be unique)
  - Node debug pods (each must
- Upgrade controller-runtime to v0.23.2-0.20260202104230-4dbfa5c66aa2 (fixes fake client SSA support, refs PR #2981, #3321, #3253)

- Add SSA ApplyConfigukep  (fixes fake client SSA support, refs PR #2981, #3321, #3253)

