### PR TITLE
fix: add cross-compilation to Dockerfile and fix Helm chart default no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Webhook Evaluation Order Documentation**: Updated deny-policy, debug-session, and advanced-features docs to clarify the webhook evaluation order
 - **Debug Session Roadmap Table Correction**: Corrected the debug session roadmap table to reflect the implemented behavior
 - **Auto-Approve Preview in Debug Session API**: The `/templates/:name/clusters` endpoint now returns `canAutoApprove` and `approverUsers` fields in the approval info, allowing the UI to preview whether a session will be auto-approved before creation
-- **Best-Effort Cleanup on Session Failure**: `failSession()` now calls `cleanupResources()` before transitioning to Failed state, ensuring partially deployed resources (ResourceQuota, PDB, workloads) are cleaned up even on failure
-- **Comprehensive Cleanup Edge Case Tests**: Added 22 unit tests covering failSession and cleanupResources behavior across all failure scenarios including partial deploys, nil cluster providers, idempotent re-fail, and spec preservation
 
 ### Changed
 
@@ -22,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dockerfile Cross-Compilation**: Added `GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)}` to the `go build` command in Dockerfile, ensuring correct binary architecture when building multi-platform images and falling back to the host architecture for non-BuildKit builds
+- **Helm Chart ClusterConfig Name**: Replaced no-op `default` (which defaulted a value to itself) with `required` in the ClusterConfig metadata name template, providing a clear error when `cluster.clusterID` is not set
+- **Best-Effort Cleanup on Session Failure**: `failSession()` now calls `cleanupResources()` before transitioning to Failed state, ensuring partially deployed resources (ResourceQuota, PDB, workloads) are cleaned up even on failure
+- **Comprehensive Cleanup Edge Case Tests**: Added 22 unit tests covering failSession and cleanupResources behavior across all failure scenarios including partial deploys, nil cluster providers, idempotent re-fail, and spec preservation
 - **Standardized API Error Responses**: Replaced raw `c.JSON(status, "string")` and `gin.H{"error": ...}` patterns with standardized `apiresponses` helpers across escalation controller, debug session API, cluster binding API, session controller, and OIDC proxy. All error responses now include a consistent `"code"` field (e.g., `INTERNAL_ERROR`, `BAD_REQUEST`, `UNPROCESSABLE_ENTITY`) alongside the `"error"` message
 - **Auto-Approve in resolveApproval API**: The `resolveApproval()` handler now evaluates auto-approve eligibility using `evaluateAutoApprove()`, correctly populating `canAutoApprove` in API responses
 - **Frontend Log Spam**: Removed excessive console logging of full approval objects during debug session creation

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,13 @@ COPY pkg/ pkg/
 # COPY internal/ internal/
 
 # Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+# When TARGETARCH is set (e.g., via BuildKit/buildx --platform), it is forwarded to GOARCH
+# for cross-compilation. When unset (classic docker build), GOARCH falls back to the Go
+# toolchain's host architecture via $(go env GOARCH).
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 go build -a \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a \
     -ldflags "-X github.com/telekom/k8s-breakglass/pkg/version.Version=${VERSION} \
               -X github.com/telekom/k8s-breakglass/pkg/version.GitCommit=${GIT_COMMIT} \
               -X github.com/telekom/k8s-breakglass/pkg/version.BuildDate=${BUILD_DATE}" \

--- a/charts/escalation-config/templates/clusterconfig.yaml
+++ b/charts/escalation-config/templates/clusterconfig.yaml
@@ -1,12 +1,12 @@
 apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: ClusterConfig
 metadata:
-  name: {{ default .Values.cluster.clusterID .Values.cluster.clusterID | trunc 63 | trimSuffix "-" }}
+  name: {{ required "cluster.clusterID is required" .Values.cluster.clusterID | trunc 63 | trimSuffix "-" | quote }}
   namespace: {{ .Release.Namespace }}
 spec:
-  clusterID: {{ .Values.cluster.clusterID }}
-  tenant: {{ .Values.cluster.tenant }}
-  environment: {{ .Values.cluster.environment }}
+  clusterID: {{ .Values.cluster.clusterID | quote }}
+  tenant: {{ .Values.cluster.tenant | quote }}
+  environment: {{ .Values.cluster.environment | quote }}
   {{- if .Values.cluster.site }}
   site: {{ .Values.cluster.site }}
   {{- end }}


### PR DESCRIPTION
## Summary

Build and Helm chart fixes identified during codebase audit.

## Changes

### H7: Dockerfile Cross-Compilation
Added `GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH}` to the `go build` command. The `TARGETOS` and `TARGETARCH` build args were already declared (lines 13-14) but never used in the build command, meaning multi-platform builds (`docker buildx build --platform linux/amd64,linux/arm64`) would produce binaries for the builder's architecture rather than the target.

### H8: Helm Chart ClusterConfig Name
The metadata name template used `{{ default .Values.cluster.clusterID .Values.cluster.clusterID }}` which is a no-op (defaults a value to itself). Replaced with `{{ required "cluster.clusterID is required" .Values.cluster.clusterID }}` for clear error messaging.

## Testing
- `helm lint charts/escalation-config` passes
- `helm template test charts/escalation-config` renders correctly
