### PR TITLE
fix: log warnings when default/missing CORS origins are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workload Type Mismatch Warning**: Admission webhook warns when a `templateString` produces a Deployment/DaemonSet that doesn't match the configured `workloadType`
 - **Dry-Run Template Rendering in Webhooks**: Admission webhooks now perform best-effort dry-run rendering of Go-templated `templateString` values, catching execution errors and invalid YAML output at admission time instead of only at reconciliation
 - **Auto-Approve Preview in Debug Session API**: The `/templates/:name/clusters` endpoint now returns `canAutoApprove` and `approverUsers` fields in the approval info, allowing the UI to preview whether a session will be auto-approved before creation
+- **CORS Origin Warnings**: Log WARN when default localhost origins are active via `BREAKGLASS_ALLOW_DEFAULT_ORIGINS=true` and when no origins are configured at all, to prevent accidental permissive CORS in production
 
 ### Changed
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -98,7 +98,7 @@ Explicit list of browser origins allowed to make credentialed API requests (CORS
 | Property | Value |
 |----------|-------|
 | **Type** | `[]string` |
-| **Default** | Local development origins (e.g. `https://localhost:8443`) |
+| **Default** | Empty (no origins allowed). When `BREAKGLASS_ALLOW_DEFAULT_ORIGINS=true` is set **and** no custom origins are configured, falls back to local development origins: `https://localhost:8443`, `http://localhost:28081`, `http://localhost:28080`, `http://localhost:5173` |
 | **Example** | `https://breakglass.example.com`, `https://admin.example.net` |
 
 ```yaml
@@ -472,6 +472,7 @@ Some settings can be overridden via environment variables:
 |---------|----------------------|----------|
 | Config file path | `BREAKGLASS_CONFIG_PATH` | 1 (highest) |
 | Disable email | `BREAKGLASS_DISABLE_EMAIL` | 1 (highest) |
+| Enable default CORS origins | `BREAKGLASS_ALLOW_DEFAULT_ORIGINS` | 1 (highest) |
 
 ```bash
 # Use custom config file
@@ -480,6 +481,14 @@ breakglass-controller
 
 # Disable email notifications
 export BREAKGLASS_DISABLE_EMAIL=true
+breakglass-controller
+
+# Enable default localhost CORS origins (useful for local development)
+# When set to "true" and no custom origins are configured, falls back to
+# http://localhost:5173, http://localhost:28080, http://localhost:28081,
+# and https://localhost:8443 as the CORS allow-list.
+# Has no effect when custom origins are explicitly configured.
+export BREAKGLASS_ALLOW_DEFAULT_ORIGINS=true
 breakglass-controller
 ```
 


### PR DESCRIPTION
# CORS Origin Warning Logging

## Summary

Add startup warnings when permissive or missing CORS origin configurations are detected, helping operators identify security misconfigurations before they reach production.

## Problem

When `BREAKGLASS_ALLOW_DEFAULT_ORIGINS=true` was set, the server silently fell back to localhost origins (`http://localhost:5173`, `http://localhost:28080`, etc.) with no log output to indicate this was happening. Similarly, when no origins were configured at all, the server started up without any warning that browser requests with Origin headers would be blocked.

## Changes

### `pkg/api/api.go`
- `buildAllowedOrigins()` now returns a `(origins []string, usedDefaults bool)` tuple, surfacing whether localhost defaults were activated
- At the call site in `NewServer()`, three logging scenarios:
  - **WARN**: Default localhost origins activated via `BREAKGLASS_ALLOW_DEFAULT_ORIGINS=true` — message includes "not suitable for production" guidance
  - **WARN**: No origins configured and defaults not enabled — message explains browser requests will be blocked
  - **INFO**: Normal startup — logs the resolved origins list for auditability

### `pkg/api/api_test.go`
- Updated `TestBuildAllowedOrigins` to verify the `usedDefaults` return value in all three test scenarios

## Testing

- All `pkg/api` tests pass
- `make lint` reports 0 issues

## Audit Reference

Part of the comprehensive codebase audit (PR 15/19). Addresses finding M1: Missing CORS origin warnings.
