### PR TITLE
refactor: use functional options for EscalationManager constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Frontend Debug Session Variables**: Improved variable form validation with inline hints showing allowed values, default indicators, and dark theme support for approval cards
+- **EscalationManager Functional Options**: Refactored `NewEscalationManagerWithClient` from type-unsafe `...any` variadic to type-safe functional options pattern (`WithLogger`, `WithConfigLoader`)
+- **Deduplicated Cluster Escalation Lookup**: Extracted `collectClusterEscalations` helper to eliminate repeated index-based query logic in `GetClusterBreakglassEscalations` and `GetClusterGroupBreakglassEscalations`
 
 ### Fixed
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,7 +211,7 @@ func main() {
 	// Create cached config loader to avoid disk reads per request
 	cfgLoader := config.NewCachedLoader(cliConfig.ConfigPath, 5*time.Second)
 
-	escalationManager := breakglass.NewEscalationManagerWithClient(reconcilerMgr.GetClient(), resolver, log, cfgLoader)
+	escalationManager := breakglass.NewEscalationManagerWithClient(reconcilerMgr.GetClient(), resolver, breakglass.WithLogger(log), breakglass.WithConfigLoader(cfgLoader))
 
 	// Build shared cluster config provider & deny policy evaluator reusing kubernetes client
 	ccProvider := cluster.NewClientProvider(escalationManager.Client, log)


### PR DESCRIPTION
## Summary

Refactor `EscalationManager` constructor to use type-safe functional options and extract a duplicated helper method.

## Changes

### Functional Options (`pkg/breakglass/escalation_manager.go`)

**Before** (type-unsafe `...any` variadic):
```go
func NewEscalationManagerWithClient(c client.Client, resolver GroupMemberResolver, opts ...any) *EscalationManager {
    for _, opt := range opts {
        switch v := opt.(type) {
        case *zap.SugaredLogger:
            em.log = v
        case *cfgpkg.CachedLoader:
            em.configLoader = v
        }
    }
}

// Call site — no type checking, silently ignores wrong types:
breakglass.NewEscalationManagerWithClient(client, resolver, log, cfgLoader)
```

**After** (type-safe functional options):
```go
type EscalationManagerOption func(*EscalationManager)

func WithLogger(log *zap.SugaredLogger) EscalationManagerOption { ... }
func WithConfigLoader(loader *cfgpkg.CachedLoader) EscalationManagerOption { ... }

func NewEscalationManagerWithClient(c client.Client, resolver GroupMemberResolver, opts ...EscalationManagerOption) *EscalationManager { ... }

// Call site — compile-time checked:
breakglass.NewEscalationManagerWithClient(client, resolver, breakglass.WithLogger(log), breakglass.WithConfigLoader(cfgLoader))
```

### Extracted Helper
- `collectClusterEscalations(ctx, cluster)` — deduplicates the repeated index-based query pattern (exact cluster match + `"*"` glob) that appeared in both `GetClusterBreakglassEscalations` and `GetClusterGroupBreakglassEscalations`

### Tests
- Extended `TestNewEscalationManagerWithClient` with subtests: no options, with logger, with config loader, with multiple options

## Verification

```
✅ go build ./... — clean compilation
✅ go test ./pkg/breakglass/... — all pass, no regressions
✅ make lint — 0 issues
```
