### PR TITLE
fix(frontend): enforce auth provider guards in remaining views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Frontend Auth Provider Consistency**: Added explicit Auth provider guards and removed non-null assertion usage in `BreakglassView`, `BreakglassSessionReview`, and `PendingApprovalsView` to fail fast instead of crashing later on missing app providers
 - **Dockerfile Cross-Compilation**: Added `GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)}` to the `go build` command in Dockerfile, ensuring correct binary architecture when building multi-platform images and falling back to the host architecture for non-BuildKit builds
 - **Helm Chart ClusterConfig Name**: Replaced no-op `default` (which defaulted a value to itself) with `required` in the ClusterConfig metadata name template, providing a clear error when `cluster.clusterID` is not set
 - **Best-Effort Cleanup on Session Failure**: `failSession()` now calls `cleanupResources()` before transitioning to Failed state, ensuring partially deployed resources (ResourceQuota, PDB, workloads) are cleaned up even on failure

--- a/frontend/src/views/BreakglassSessionReview.vue
+++ b/frontend/src/views/BreakglassSessionReview.vue
@@ -15,8 +15,11 @@ import ApprovalModalContent from "@/components/ApprovalModalContent.vue";
 const route = useRoute();
 const user = useUser();
 const auth = inject(AuthKey);
+if (!auth) {
+  throw new Error("BreakglassSessionReview requires an Auth provider");
+}
 const authenticated = computed(() => user.value && !user.value?.expired);
-const service = new BreakglassSessionService(auth!);
+const service = new BreakglassSessionService(auth);
 const time = useCurrentTime();
 
 const resourceName = ref(route.query.name?.toString() || "");

--- a/frontend/src/views/BreakglassView.vue
+++ b/frontend/src/views/BreakglassView.vue
@@ -11,7 +11,10 @@ import { PageHeader, LoadingState, EmptyState } from "@/components/common";
 import type { Breakglass, SessionCR } from "@/model/breakglass";
 
 const auth = inject(AuthKey);
-const breakglassService = new BreakglassService(auth!);
+if (!auth) {
+  throw new Error("BreakglassView requires an Auth provider");
+}
+const breakglassService = new BreakglassService(auth);
 const time = useCurrentTime();
 
 type BreakglassWithSession = Breakglass & {

--- a/frontend/src/views/PendingApprovalsView.vue
+++ b/frontend/src/views/PendingApprovalsView.vue
@@ -245,7 +245,10 @@ import ApprovalModalContent from "@/components/ApprovalModalContent.vue";
 
 // Services
 const auth = inject(AuthKey);
-const breakglassService = new BreakglassService(auth!);
+if (!auth) {
+  throw new Error("PendingApprovalsView requires an Auth provider");
+}
+const breakglassService = new BreakglassService(auth);
 
 // State
 const pendingSessions = ref<SessionCR[]>([]);

--- a/frontend/tests/unit/views/AuthProviderGuards.spec.ts
+++ b/frontend/tests/unit/views/AuthProviderGuards.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Auth provider guard tests for views that require injected Auth context
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { ref } from "vue";
+import BreakglassSessionReview from "@/views/BreakglassSessionReview.vue";
+import PendingApprovalsView from "@/views/PendingApprovalsView.vue";
+
+vi.mock("@/services/auth", () => ({
+  useUser: vi.fn(() => ref(null)),
+}));
+
+describe("View auth provider guards", () => {
+  it("throws a clear error when BreakglassSessionReview is mounted without auth provider", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: "/review", component: BreakglassSessionReview }],
+    });
+
+    await router.push("/review");
+    await router.isReady();
+
+    expect(() => {
+      mount(BreakglassSessionReview, {
+        global: {
+          plugins: [router],
+          stubs: {
+            BreakglassSessionCard: true,
+            ApprovalModalContent: true,
+            "scale-button": true,
+            "scale-switch": true,
+            "scale-text-field": true,
+            "scale-tag": true,
+            "scale-modal": true,
+          },
+        },
+      });
+    }).toThrow("BreakglassSessionReview requires an Auth provider");
+  });
+
+  it("throws a clear error when PendingApprovalsView is mounted without auth provider", () => {
+    expect(() => {
+      mount(PendingApprovalsView, {
+        global: {
+          stubs: {
+            PageHeader: true,
+            EmptyState: true,
+            LoadingState: true,
+            StatusTag: true,
+            ReasonPanel: true,
+            ActionButton: true,
+            CountdownTimer: true,
+            SessionSummaryCard: true,
+            SessionMetaGrid: true,
+            ApprovalModalContent: true,
+            "scale-dropdown-select": true,
+            "scale-dropdown-select-option": true,
+            "scale-modal": true,
+            "scale-tag": true,
+          },
+        },
+      });
+    }).toThrow("PendingApprovalsView requires an Auth provider");
+  });
+});

--- a/frontend/tests/unit/views/BreakglassView.spec.ts
+++ b/frontend/tests/unit/views/BreakglassView.spec.ts
@@ -128,6 +128,27 @@ describe("BreakglassView", () => {
       const wrapper = await createWrapper();
       expect(wrapper.element.tagName).toBeDefined();
     });
+
+    it("throws a clear error when auth provider is missing", async () => {
+      await router.push("/");
+      await router.isReady();
+
+      expect(() => {
+        mount(BreakglassView, {
+          global: {
+            plugins: [router],
+            stubs: {
+              PageHeader: true,
+              LoadingState: true,
+              EmptyState: true,
+              BreakglassCard: true,
+              "scale-text-field": true,
+              "scale-button": true,
+            },
+          },
+        });
+      }).toThrow("BreakglassView requires an Auth provider");
+    });
   });
 
   describe("Query Parameters", () => {


### PR DESCRIPTION
## Summary
Hardens remaining frontend views to fail fast when Auth provider injection is missing, removing unsafe non-null assertions and adding regression tests.

## Changes
- BreakglassView: explicit Auth provider guard, removed non-null assertion usage
- BreakglassSessionReview: explicit Auth provider guard, removed non-null assertion usage
- PendingApprovalsView: explicit Auth provider guard, removed non-null assertion usage
- BreakglassView unit test: added missing-auth regression test
- New AuthProviderGuards unit test file for BreakglassSessionReview and PendingApprovalsView

## Validation
- cd frontend && npm test -- tests/unit/views/BreakglassView.spec.ts tests/unit/views/AuthProviderGuards.spec.ts
- cd frontend && npm run typecheck