### PR TITLE
test(frontend): align BreakglassView time mock type

### DIFF
--- a/frontend/tests/unit/views/BreakglassView.spec.ts
+++ b/frontend/tests/unit/views/BreakglassView.spec.ts
@@ -41,7 +41,7 @@ vi.mock("@/services/logger", () => ({
 
 // Mock currentTime composable
 vi.mock("@/utils/currentTime", () => ({
-  default: () => ref(new Date()),
+  default: () => ref(Date.now()),
 }));
 
 describe("BreakglassView", () => {


### PR DESCRIPTION
## Summary
Fixes a test-only type mismatch in BreakglassView unit tests where the mocked current time returned a Date object while child components expect a numeric timestamp.

## Changes
- Updated frontend/tests/unit/views/BreakglassView.spec.ts
- Changed currentTime mock from ref(new Date()) to ref(Date.now())

## Validation
- cd frontend && npm test -- tests/unit/views/BreakglassView.spec.ts
- cd frontend && npm run typecheck