### PR TITLE
fix(frontend): require auth provider in MyPendingRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Frontend Auth Provider Consistency**: Added explicit Auth provider guards and removed non-null assertion usage in `BreakglassView`, `BreakglassSessionReview`, and `PendingApprovalsView` to fail fast instead of crashing later on missing app providers
+- **Frontend Auth Guard Consistency**: Added an explicit Auth provider guard in `MyPendingRequests` and removed nullable service fallback to prevent deferred runtime errors when app providers are misconfigured
 - **Dockerfile Cross-Compilation**: Added `GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)}` to the `go build` command in Dockerfile, ensuring correct binary architecture when building multi-platform images and falling back to the host architecture for non-BuildKit builds
 - **Helm Chart ClusterConfig Name**: Replaced no-op `default` (which defaulted a value to itself) with `required` in the ClusterConfig metadata name template, providing a clear error when `cluster.clusterID` is not set
 - **Best-Effort Cleanup on Session Failure**: `failSession()` now calls `cleanupResources()` before transitioning to Failed state, ensuring partially deployed resources (ResourceQuota, PDB, workloads) are cleaned up even on failure

--- a/frontend/src/views/MyPendingRequests.vue
+++ b/frontend/src/views/MyPendingRequests.vue
@@ -141,7 +141,10 @@ import type { SessionCR } from "@/model/breakglass";
 
 // Setup services
 const auth = inject(AuthKey);
-const breakglassService = auth ? new BreakglassService(auth) : null;
+if (!auth) {
+  throw new Error("MyPendingRequests view requires an Auth provider");
+}
+const breakglassService = new BreakglassService(auth);
 
 // Session list state
 const { requests, loading, error, loadRequests } = usePendingRequests(breakglassService);
@@ -149,7 +152,6 @@ const { requests, loading, error, loadRequests } = usePendingRequests(breakglass
 // Session actions
 const actionHandlers: ActionHandlers = {
   withdraw: async (session: SessionCR) => {
-    if (!breakglassService) throw new Error("Service not available");
     await breakglassService.withdrawMyRequest(session);
     // Remove from local list
     const idx = requests.value.findIndex((r) => getSessionKey(r) === getSessionKey(session));

--- a/frontend/tests/unit/views/MyPendingRequests.spec.ts
+++ b/frontend/tests/unit/views/MyPendingRequests.spec.ts
@@ -133,6 +133,20 @@ describe("MyPendingRequests", () => {
     return wrapper;
   };
 
+  it("throws a clear error when auth provider is missing", async () => {
+    await router.push("/my-requests");
+    await router.isReady();
+
+    expect(() => {
+      mount(MyPendingRequests, {
+        global: {
+          plugins: [router],
+          stubs: commonStubs,
+        },
+      });
+    }).toThrow("MyPendingRequests view requires an Auth provider");
+  });
+
   describe("Component Structure", () => {
     it("renders the main page container", async () => {
       const wrapper = await createWrapper();


### PR DESCRIPTION
Adds an explicit Auth provider guard in MyPendingRequests, removes nullable service fallback, and adds a missing-provider regression test. Validated with focused unit tests and frontend typecheck.