### PR TITLE
chore: extract tool versions to versions.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lint-strict: golangci-lint ## Run golangci-lint with extended timeout (CI-friend
 .PHONY: vulncheck
 vulncheck: ## Run govulncheck to check for known vulnerabilities.
 	@command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
-	govulncheck ./...
+	$(shell go env GOPATH)/bin/govulncheck ./...
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/versions.env
+++ b/versions.env
@@ -4,6 +4,7 @@
 
 # Tool versions - Single source of truth for CI and local development
 # Used by the Makefile (via include) and indirectly by CI workflows through Make targets
+# Override on the command line: make KUSTOMIZE_VERSION=v5.9.0 kustomize
 
 # Build tools
 KUSTOMIZE_VERSION=v5.8.0


### PR DESCRIPTION
Centralize tool version management:

- Add versions.env as single source of truth for tool versions
- Replace inline tool version definitions with include versions.env
- Add lint-strict and vulncheck Makefile targets
- Update verify to include lint-strict, test, and vulncheck

Part of cross-project alignment initiative.