### PR TITLE
chore: add -trimpath to Dockerfile build, fix LICENSE path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ COPY pkg/ pkg/
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a \
-    -ldflags "-X github.com/telekom/k8s-breakglass/pkg/version.Version=${VERSION} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a -trimpath \
+    -ldflags "-s -w -X github.com/telekom/k8s-breakglass/pkg/version.Version=${VERSION} \
               -X github.com/telekom/k8s-breakglass/pkg/version.GitCommit=${GIT_COMMIT} \
               -X github.com/telekom/k8s-breakglass/pkg/version.BuildDate=${BUILD_DATE}" \
     -o breakglass cmd/main.go


### PR DESCRIPTION
Add -trimpath and -s -w ldflags for reproducible, smaller binaries. Fix LICENCE -> LICENSE reference to match community files rename.