### PR TITLE
chore: enforce additional linters and fix all violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,8 @@
 # golangci-lint configuration for breakglass controller
 # Aligned with t-caas team conventions (auth-operator reference config)
 #
-# Linter enablement strategy:
-#   - Phase 1 (this config): linters that pass on the existing codebase
-#   - Phase 2 (TODO): enable remaining linters after fixing existing violations
-#   Disabled linters are documented below with issue counts for prioritization.
+# All feasible linters are enabled and enforced.
+# Remaining disabled linters are documented with issue counts and rationale.
 
 version: "2"
 
@@ -35,15 +33,20 @@ linters:
     - asasalint
     - asciicheck
     - copyloopvar
+    - dupword
     - durationcheck
     - errcheck
+    - errorlint
     - gocritic
     - goprintffuncname
     - govet
+    - importas
     - ineffassign
     - loggercheck
     - nakedret
     - nosprintfhostport
+    - predeclared
+    - tparallel
     - unconvert
     - unused
 
@@ -58,32 +61,30 @@ linters:
     - usestdlibvars
     - whitespace
 
-  # TODO: Enable these linters incrementally after fixing existing violations.
-  # Listed with approximate issue counts for prioritization (lowest first):
-  #   - dupword          ~1 issue
-  #   - predeclared      ~4 issues   (shadows predeclared identifiers)
-  #   - importas         ~4 issues
-  #   - dogsled          ~8 issues
-  #   - noctx            ~11 issues   (most violations in tests)
-  #   - errorlint        ~12 issues
-  #   - nilnil           ~12 issues
-  #   - nilerr           ~14 issues
-  #   - nolintlint       ~15 issues
-  #   - dupl             ~17 issues
-  #   - gosec            ~18 issues   (many false positives for TLS config)
-  #   - prealloc         ~18 issues
-  #   - gocyclo          ~48 issues
-  #   - lll              ~56 issues
-  #   - errchkjson       ~62 issues
-  #   - goconst          ~67 issues
-  #   - intrange         ~96 issues
-  #   - thelper          various      (test helpers missing t.Helper())
-  #   - tparallel        various      (improper t.Parallel() usage)
-  #   - unparam          various      (false positives in interface impls)
-  #   - revive           ~381 issues  (noisy for exported comment checks)
-  #   - godot            ~785 issues  (comment period enforcement)
-  # When enabling, also uncomment the corresponding settings and exclusion
-  # rules below.
+  # Disabled linters — documented with issue counts and rationale:
+  #
+  # Fixable but high-volume (best addressed in dedicated PRs):
+  #   - noctx          ~304 issues  (http.NewRequest → NewRequestWithContext; mostly in tests)
+  #   - intrange        ~96 issues  (for i := 0; i < n; i++ → for i := range n)
+  #   - errchkjson      ~62 issues  (unchecked json.Marshal/Unmarshal errors)
+  #   - goconst         ~67 issues  (repeated string literals → constants)
+  #   - thelper         ~158 issues (test helpers missing t.Helper())
+  #   - prealloc        ~18 issues  (slice preallocation suggestions)
+  #   - unparam         ~19 issues  (false positives in interface implementations)
+  #
+  # Too noisy / style-only (low value-to-noise ratio):
+  #   - godot          ~1726 issues (comment period enforcement)
+  #   - revive          ~747 issues (exported comment checks)
+  #   - lll            ~1468 issues (line length limits)
+  #   - dupl            ~104 issues (code duplication detection — many false positives in tests)
+  #   - gocyclo          ~17 issues (cyclomatic complexity)
+  #
+  # Intentional patterns in this codebase:
+  #   - nilnil          ~12 issues  (nil, nil returns are idiomatic for "not found, not an error")
+  #   - nilerr          ~14 issues  (mostly e2e wait helpers returning false, nil to retry)
+  #   - gosec          ~161 issues  (many false positives for TLS config in tests)
+  #   - dogsled           ~8 issues (multi-return test helpers are standard Go test patterns)
+  #   - nolintlint       ~15 issues (would require adding explanations to all nolint directives)
 
   settings:
     gocritic:

--- a/api/v1alpha1/breakglass_escalation_types_test.go
+++ b/api/v1alpha1/breakglass_escalation_types_test.go
@@ -325,12 +325,12 @@ func TestBreakglassEscalationValidateUpdate_WithValidationErrors(t *testing.T) {
 	}
 
 	// Update with missing required fields
-	new := &BreakglassEscalation{
+	updated := &BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{Name: "esc"},
 		Spec:       BreakglassEscalationSpec{}, // Empty spec, missing escalatedGroup
 	}
 
-	_, err := old.ValidateUpdate(context.Background(), old, new)
+	_, err := old.ValidateUpdate(context.Background(), old, updated)
 	if err == nil {
 		t.Fatal("expected error when updated object has validation errors")
 	}

--- a/api/v1alpha1/samples_validation_test.go
+++ b/api/v1alpha1/samples_validation_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -259,7 +260,7 @@ func splitYAMLDocuments(t *testing.T, data []byte) [][]byte {
 
 	for {
 		doc, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -132,7 +132,7 @@ func listObjectsByName(ctx context.Context, reader client.Reader, list client.Ob
 
 	if err := reader.List(ctx, list, client.MatchingFields{"metadata.name": name}); err != nil {
 		if fallbackErr := reader.List(ctx, list); fallbackErr != nil {
-			return fmt.Errorf("list by name for %T failed: %v; fallback list failed: %w", list, err, fallbackErr)
+			return fmt.Errorf("list by name for %T failed: %w; fallback list failed: %w", list, err, fallbackErr)
 		}
 	}
 
@@ -1344,7 +1344,7 @@ func parseResourceQuantity(q string) (int64, error) {
 			}
 			_, err := strconv.ParseFloat(numPart, 64)
 			if err != nil {
-				return 0, fmt.Errorf("invalid numeric value: %v", err)
+				return 0, fmt.Errorf("invalid numeric value: %w", err)
 			}
 			hasValidSuffix = true
 			break

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1120,7 +1120,7 @@ func buildOIDCProxyHTTPRequest(c *gin.Context, target string) (*http.Request, er
 		method = http.MethodPost
 		bodyBytes, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", errOIDCProxyReadBody, err)
+			return nil, fmt.Errorf("%w: %w", errOIDCProxyReadBody, err)
 		}
 		body = bytes.NewReader(bodyBytes)
 	}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -785,6 +785,7 @@ func TestNormalizeOrigin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.expected, normalizeOrigin(tt.input))
 		})
 	}

--- a/pkg/api/oidc_proxy_helpers_test.go
+++ b/pkg/api/oidc_proxy_helpers_test.go
@@ -71,6 +71,7 @@ func TestNormalizeProxyPath(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.expected, normalizeProxyPath(tt.input))
 		})
 	}
@@ -90,6 +91,7 @@ func TestHasEncodedTraversal(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.expected, hasEncodedTraversal(tt.input))
 		})
 	}

--- a/pkg/bgctl/client/client_test.go
+++ b/pkg/bgctl/client/client_test.go
@@ -103,8 +103,8 @@ func TestClientDoError(t *testing.T) {
 	err = client.do(context.Background(), http.MethodGet, "/missing", nil, nil)
 	require.Error(t, err)
 
-	httpErr, ok := err.(*HTTPError)
-	require.True(t, ok)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
 	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
 	require.Contains(t, httpErr.Message, "not found")
 }

--- a/pkg/bgctl/client/escalations_test.go
+++ b/pkg/bgctl/client/escalations_test.go
@@ -187,7 +187,7 @@ func TestEscalationsList_ServerError(t *testing.T) {
 	_, err = client.Escalations().List(context.Background())
 	require.Error(t, err)
 
-	httpErr, ok := err.(*HTTPError)
-	require.True(t, ok)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 }

--- a/pkg/breakglass/auxiliary_resource_manager.go
+++ b/pkg/breakglass/auxiliary_resource_manager.go
@@ -712,7 +712,7 @@ func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error 
 				EnabledResources: []string{},
 			}
 			if err := renderer.ValidateTemplate(res.TemplateString, sampleCtx); err != nil {
-				errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: invalid templateString: %v", i, err))
+				errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: invalid templateString: %w", i, err))
 			}
 		}
 
@@ -728,13 +728,13 @@ func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error 
 				var err error
 				templateBytes, err = json.Marshal(res.Template.Object)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: failed to marshal template object: %v", i, err))
+					errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: failed to marshal template object: %w", i, err))
 					continue
 				}
 			}
 
 			if err := yaml.Unmarshal(templateBytes, &obj); err != nil {
-				errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: invalid YAML template: %v", i, err))
+				errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: invalid YAML template: %w", i, err))
 			} else {
 				// Check for apiVersion and kind
 				if _, ok := obj["apiVersion"]; !ok {

--- a/pkg/breakglass/debug_session_kubectl.go
+++ b/pkg/breakglass/debug_session_kubectl.go
@@ -599,13 +599,13 @@ func (h *KubectlDebugHandler) hasImageDigest(image string) bool {
 	return strings.Contains(image, "@sha256:")
 }
 
-func (h *KubectlDebugHandler) isCapabilityAllowed(cap string, maxCaps []string) bool {
+func (h *KubectlDebugHandler) isCapabilityAllowed(capability string, maxCaps []string) bool {
 	if len(maxCaps) == 0 {
 		return true // No restrictions
 	}
 
 	for _, allowed := range maxCaps {
-		if strings.EqualFold(cap, allowed) {
+		if strings.EqualFold(capability, allowed) {
 			return true
 		}
 	}

--- a/pkg/breakglass/debug_session_security_test.go
+++ b/pkg/breakglass/debug_session_security_test.go
@@ -339,10 +339,4 @@ func TestDebugSessionSecurity_RenewalLimits(t *testing.T) {
 	})
 }
 
-// min returns the minimum of two integers
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
+// Go 1.21+ provides builtin min(), so this custom helper is removed.

--- a/pkg/breakglass/escalation_status_updater_dependencies_test.go
+++ b/pkg/breakglass/escalation_status_updater_dependencies_test.go
@@ -124,7 +124,8 @@ func TestEventEmissionWithEventRecorder(t *testing.T) {
 	// Verify event was recorded
 	select {
 	case event := <-fakeRecorder.Events:
-		// Event format is "Normal TestEvent TestEvent Test message"
+		// Event format is "Normal TestEvent TestEvent Test message" — reason and action share the name.
+		//nolint:dupword // literal event format contains intentional duplicate word
 		assert.Contains(t, event, "Normal")
 		assert.Contains(t, event, "TestEvent")
 		assert.Contains(t, event, "Test message")

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -1004,7 +1004,7 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	// Ignore errors; payload is optional. Guard against nil Request.Body which can occur in tests/clients.
 	if c.Request != nil && c.Request.Body != nil {
 		if err := decodeJSONStrict(c.Request.Body, &approverPayload); err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				reqLog.Debugw("Failed to decode optional approver payload (using empty values)", "error", err)
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,12 +334,12 @@ func Load(configPath ...string) (Config, error) {
 
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return config, fmt.Errorf("trying to open breakglass config file %s: %v", configPath, err)
+		return config, fmt.Errorf("trying to open breakglass config file %s: %w", configPath, err)
 	}
 
 	err = yaml.Unmarshal(content, &config)
 	if err != nil {
-		return config, fmt.Errorf("error unmarshaling YAML %s: %v", configPath, err)
+		return config, fmt.Errorf("error unmarshaling YAML %s: %w", configPath, err)
 	}
 	return config, nil
 }

--- a/pkg/webhook/ephemeral.go
+++ b/pkg/webhook/ephemeral.go
@@ -94,13 +94,13 @@ func (w *EphemeralContainerWebhook) Handle(ctx context.Context, req admission.Re
 	return admission.Allowed("allowed by debug session")
 }
 
-func findNewEphemeralContainers(old, new []corev1.EphemeralContainer) []corev1.EphemeralContainer {
+func findNewEphemeralContainers(old, current []corev1.EphemeralContainer) []corev1.EphemeralContainer {
 	added := []corev1.EphemeralContainer{}
 	oldMap := make(map[string]bool)
 	for _, c := range old {
 		oldMap[c.Name] = true
 	}
-	for _, c := range new {
+	for _, c := range current {
 		if !oldMap[c.Name] {
 			added = append(added, c)
 		}


### PR DESCRIPTION
## Summary

Enable 5 new linters (`dupword`, `errorlint`, `importas`, `predeclared`, `tparallel`) and fix all existing violations. All lint checks and unit tests pass.

## Changes

### New Linters Enabled
- **errorlint**: Proper error wrapping with `%w` and `errors.Is`/`errors.As` checks
- **predeclared**: Renamed variables/params shadowing Go builtins (`new`→`updated`, `cap`→`capability`, `new`→`current`); removed custom `min()` function (Go 1.21+ builtin)
- **tparallel**: Added `t.Parallel()` to subtests in table-driven tests
- **dupword**: Enabled with 1 false-positive suppression (literal event format string)
- **importas**: Enabled (0 existing violations)

### Code Fixes
- 12 `errorlint` fixes across 8 files
- 4 `predeclared` fixes across 4 files
- 3 `tparallel` fixes across 2 files
- 1 `dupword` false positive suppressed

### Still Disabled (documented with rationale)

**High-volume fixable (best in dedicated PRs):**
- `noctx` (~304 issues) — `http.NewRequest` → `NewRequestWithContext`, mostly in tests
- `intrange` (~96 issues) — for-loop range modernization
- `errchkjson` (~62 issues) — unchecked json.Marshal/Unmarshal
- `goconst` (~67 issues) — repeated string literals
- `thelper` (~158 issues) — test helpers missing `t.Helper()`
- `prealloc` (~18 issues) — slice preallocation
- `unparam` (~19 issues) — false positives in interface impls

**Too noisy / style-only:**
- `godot` (~1726 issues) — comment period enforcement
- `revive` (~747 issues) — exported comment checks
- `lll` (~1468 issues) — line length limits
- `dupl` (~104 issues) — code duplication detection
- `gocyclo` (~17 issues) — cyclomatic complexity

**Intentional patterns:**
- `nilnil` (~12 issues) — `nil, nil` returns are idiomatic for "not found, not an error"
- `nilerr` (~14 issues) — e2e wait helpers returning `false, nil` to retry
- `gosec` (~161 issues) — false positives for TLS config in tests
- `dogsled` (~8 issues) — multi-return test helpers are standard Go patterns
- `nolintlint` (~15 issues) — would require adding explanations to all nolint directives
