### PR TITLE
feat: re-enable SBOM generation and SLSA provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.inspect.outputs.digest }}
@@ -295,14 +296,7 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect "${IMG}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Multi-arch manifest digest: ${DIGEST}"
-      - name: Attest provenance (skipped temporarily)
-        # TODO: Re-enable when id-token is available in all runners.
-        # When re-enabling:
-        #   1. Add `id-token: write` to the assemble job permissions
-        #   2. Update docs/release-process.md to note provenance attestation is active
-        # Note: docs/release-process.md currently lists provenance as a goal;
-        # it is not yet enforced until this step is re-enabled.
-        if: ${{ false }}
+      - name: Attest provenance
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -410,13 +404,11 @@ jobs:
           generate_release_notes: true
       - name: Generate SBOM (Syft)
         uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
-        if: ${{ false }}
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           format: spdx-json
           artifact-name: sbom-${{ github.ref_name }}.json
       - name: Upload SBOM to Release (if GH_PUBLISH_TOKEN)
-        if: ${{ false }}
         run: |
           SBOM_FILE=sbom-${{ github.ref_name }}.json
           if [ -n "${{ secrets.GH_PUBLISH_TOKEN }}" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SBOM generation re-enabled**: Release workflow now generates SPDX-JSON SBOM via Syft (anchore/sbom-action) and uploads it to the GitHub Release
+- **SLSA provenance attestation re-enabled**: Assemble job now generates and pushes SLSA Build L1 provenance via actions/attest-build-provenance
+
 ### Changed
 
 - **Multi-arch release builds on native runners**:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -37,9 +37,9 @@ Release images are built as multi-arch manifests supporting both `linux/amd64` a
 
 1. **Prepare** — generates Kustomize manifests, cross-compiles `bgctl` binaries for all OS/arch combinations, and uploads them as artifacts.
 2. **Build** (matrix: `amd64`, `arm64`) — builds and pushes a single-platform image by digest on a native runner for each architecture.
-3. **Assemble** — downloads all per-arch digests and creates a unified multi-arch manifest tagged with the release version (and `latest` for tag pushes).
+3. **Assemble** — downloads all per-arch digests and creates a unified multi-arch manifest tagged with the release version (and `latest` for tag pushes). Generates SLSA provenance attestation for supply-chain integrity.
 4. **Artifactory** — mirrors the multi-arch image to the internal Artifactory OCI registry.
-5. **Release** — creates a GitHub Release with manifests, `bgctl` binaries, checksums, and (when enabled) an SBOM.
+5. **Release** — creates a GitHub Release with manifests, `bgctl` binaries, checksums, and SBOM (SPDX-JSON format via Syft).
 
 > **Note:** Buildx layer caching (`cache-from`/`cache-to`) is intentionally omitted in
 > release builds to ensure clean, reproducible images without layer reuse from prior


### PR DESCRIPTION
## Summary

Re-enables SBOM generation and SLSA provenance attestation in the release workflow that were previously disabled with `if: ${{ false }}`.

## Changes

- **`.github/workflows/release.yml`**:
  - Remove `if: ${{ false }}` from the SBOM generation step (Anchore/sbom-action)
  - Remove `if: ${{ false }}` from the SLSA provenance attestation step (actions/attest-build-provenance)
  - Add `id-token: write` permission to the `assemble` job (required for Sigstore-based attestation)
- **`docs/release-process.md`** — Updated to reflect that SBOM and provenance are now active

## Audit Findings

Addresses **Findings #6, #7** (HIGH — Security / Supply Chain) and **#31** (MEDIUM — Docs Accuracy) from the cross-repo audit.