### PR TITLE
fix: add justification to bare nolint:gosec directives

### DIFF
--- a/e2e/api/keycloak_groupsync_functional_test.go
+++ b/e2e/api/keycloak_groupsync_functional_test.go
@@ -93,7 +93,7 @@ func getKeycloakToken(ctx context.Context, baseURL, realm, clientID, clientSecre
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // E2E test uses self-signed certs
 		},
 	}
 
@@ -128,7 +128,7 @@ func getKeycloakUser(ctx context.Context, baseURL, realm, token, email string) (
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // E2E test uses self-signed certs
 		},
 	}
 
@@ -166,7 +166,7 @@ func getKeycloakGroups(ctx context.Context, baseURL, realm, token, userID string
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // E2E test uses self-signed certs
 		},
 	}
 

--- a/e2e/api/security_mechanisms_test.go
+++ b/e2e/api/security_mechanisms_test.go
@@ -301,7 +301,7 @@ func TestSecurityApprovalRequired(t *testing.T) {
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true, //nolint:gosec
+					InsecureSkipVerify: true, //nolint:gosec // E2E test uses self-signed certs
 				},
 			},
 		}
@@ -565,7 +565,7 @@ func TestSecurityDenyPolicyEnforcement(t *testing.T) {
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true, //nolint:gosec
+					InsecureSkipVerify: true, //nolint:gosec // E2E test uses self-signed certs
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

Add justification comments to all bare `//nolint:gosec` directives in E2E test files.

## Changes

- **e2e/api/keycloak_groupsync_functional_test.go** — 3 occurrences: added `// E2E test uses self-signed certs`
- **e2e/api/security_mechanisms_test.go** — 2 occurrences: added `// E2E test uses self-signed certs`

All suppressions relate to `InsecureSkipVerify: true` in HTTP clients used only in E2E tests against local clusters with self-signed certificates.

## Why

Linters (`nolintlint`) and reviewers expect every `//nolint` directive to carry a justification so the suppression reason is auditable and doesn't mask real issues.
