### PR TITLE
chore: migrate fake.NewSimpleClientset to fake.NewClientset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Migrated `fake.NewSimpleClientset` to `fake.NewClientset`**: Replaced deprecated `fake.NewSimpleClientset()` calls with `fake.NewClientset()` in `pkg/breakglass/event_recorder_test.go` and removed associated `//nolint:staticcheck` suppressions (resolves #381)
+
 - **Multi-arch release builds on native runners**:
   - Release workflow now builds `linux/amd64` and `linux/arm64` images on separate native runners (no QEMU emulation)
   - Per-arch images assembled into a single multi-arch manifest via `docker buildx imagetools create`

--- a/pkg/breakglass/event_recorder_test.go
+++ b/pkg/breakglass/event_recorder_test.go
@@ -13,7 +13,7 @@ import (
 
 // Test that K8sEventRecorder emits Events into the same namespace as the object
 func TestEventRecorder_UsesObjectNamespace(t *testing.T) {
-	cs := fake.NewSimpleClientset() //nolint:staticcheck // TODO(https://github.com/telekom/k8s-breakglass/issues/381): migrate to NewClientset when available
+	cs := fake.NewClientset()
 	logger, _ := zap.NewDevelopment()
 	rec := &K8sEventRecorder{Clientset: cs, Source: corev1.EventSource{Component: "test"}, Logger: logger.Sugar()}
 
@@ -50,7 +50,7 @@ func TestEventRecorder_UsesObjectNamespace(t *testing.T) {
 
 // Test that when object has no namespace, recorder falls back to controller namespace
 func TestEventRecorder_FallbackToPodNamespace(t *testing.T) {
-	cs := fake.NewSimpleClientset() //nolint:staticcheck // TODO(https://github.com/telekom/k8s-breakglass/issues/381): migrate to NewClientset when available
+	cs := fake.NewClientset()
 	logger, _ := zap.NewDevelopment()
 	rec := &K8sEventRecorder{Clientset: cs, Source: corev1.EventSource{Component: "test"}, Namespace: "podns", Logger: logger.Sugar()}
 


### PR DESCRIPTION
## Summary

Replaces deprecated `fake.NewSimpleClientset()` calls with `fake.NewClientset()` in `pkg/breakglass/event_recorder_test.go` and removes the associated `//nolint:staticcheck` suppressions.

## Changes

- `pkg/breakglass/event_recorder_test.go`: Replace both `fake.NewSimpleClientset()` calls with `fake.NewClientset()`
- `CHANGELOG.md`: Document the migration under `[Unreleased] > Changed`

## Verification

- `make test` passes — both `TestEventRecorder_UsesObjectNamespace` and `TestEventRecorder_FallbackToPodNamespace` pass
- `grep -rn "NewSimpleClientset" --include="*.go"` returns zero results

## Complexity

**XS** — Two-line change with no behavioral change.

Closes #381
