### PR TITLE
fix: complete import alias rename and go fmt to restore CI

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/auditsinkconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/auditsinkconfig.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // AuditSinkConfigApplyConfiguration represents a declarative configuration of the AuditSinkConfig type for use
@@ -20,7 +20,7 @@ type AuditSinkConfigApplyConfiguration struct {
 	// Name is a unique identifier for this sink.
 	Name *string `json:"name,omitempty"`
 	// Type is the sink type.
-	Type *apiv1alpha1.AuditSinkType `json:"type,omitempty"`
+	Type *breakglassv1alpha1.AuditSinkType `json:"type,omitempty"`
 	// Kafka configuration (required when type=kafka).
 	Kafka *KafkaSinkSpecApplyConfiguration `json:"kafka,omitempty"`
 	// Webhook configuration (required when type=webhook).
@@ -54,7 +54,7 @@ func (b *AuditSinkConfigApplyConfiguration) WithName(value string) *AuditSinkCon
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Type field is set to the value of the last call.
-func (b *AuditSinkConfigApplyConfiguration) WithType(value apiv1alpha1.AuditSinkType) *AuditSinkConfigApplyConfiguration {
+func (b *AuditSinkConfigApplyConfiguration) WithType(value breakglassv1alpha1.AuditSinkType) *AuditSinkConfigApplyConfiguration {
 	b.Type = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/auxiliaryresource.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/auxiliaryresource.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -44,7 +44,7 @@ type AuxiliaryResourceApplyConfiguration struct {
 	// deleteAfter specifies if this resource should be deleted after session ends.
 	DeleteAfter *bool `json:"deleteAfter,omitempty"`
 	// failurePolicy determines behavior if resource creation fails.
-	FailurePolicy *apiv1alpha1.AuxiliaryResourceFailurePolicy `json:"failurePolicy,omitempty"`
+	FailurePolicy *breakglassv1alpha1.AuxiliaryResourceFailurePolicy `json:"failurePolicy,omitempty"`
 	// optional marks this resource as optional (same as failurePolicy=ignore).
 	// Deprecated: Use failurePolicy instead. Removal target: v1beta1.
 	Optional *bool `json:"optional,omitempty"`
@@ -115,7 +115,7 @@ func (b *AuxiliaryResourceApplyConfiguration) WithDeleteAfter(value bool) *Auxil
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *AuxiliaryResourceApplyConfiguration) WithFailurePolicy(value apiv1alpha1.AuxiliaryResourceFailurePolicy) *AuxiliaryResourceApplyConfiguration {
+func (b *AuxiliaryResourceApplyConfiguration) WithFailurePolicy(value breakglassv1alpha1.AuxiliaryResourceFailurePolicy) *AuxiliaryResourceApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionstatus.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
@@ -48,7 +48,7 @@ type BreakglassSessionStatusApplyConfiguration struct {
 	// This value is set based on spec.retainFor when the session is approved.
 	RetainedUntil *metav1.Time `json:"retainedUntil,omitempty"`
 	// State represents the current state of the Breakglass session.
-	State *apiv1alpha1.BreakglassSessionState `json:"state,omitempty"`
+	State *breakglassv1alpha1.BreakglassSessionState `json:"state,omitempty"`
 	// approver is the identity (email) of the last approver who changed the session state.
 	Approver *string `json:"approver,omitempty"`
 	// approvers is a list of identities (emails) who have approved this session.
@@ -147,7 +147,7 @@ func (b *BreakglassSessionStatusApplyConfiguration) WithRetainedUntil(value meta
 // WithState sets the State field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the State field is set to the value of the last call.
-func (b *BreakglassSessionStatusApplyConfiguration) WithState(value apiv1alpha1.BreakglassSessionState) *BreakglassSessionStatusApplyConfiguration {
+func (b *BreakglassSessionStatusApplyConfiguration) WithState(value breakglassv1alpha1.BreakglassSessionState) *BreakglassSessionStatusApplyConfiguration {
 	b.State = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/clusterconfigspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/clusterconfigspec.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // ClusterConfigSpecApplyConfiguration represents a declarative configuration of the ClusterConfigSpec type for use
@@ -30,7 +30,7 @@ type ClusterConfigSpecApplyConfiguration struct {
 	Location *string `json:"location,omitempty"`
 	// authType specifies the authentication method for connecting to the target cluster.
 	// Defaults to "Kubeconfig" if kubeconfigSecretRef is specified, "OIDC" if oidcAuth is specified.
-	AuthType *apiv1alpha1.ClusterAuthType `json:"authType,omitempty"`
+	AuthType *breakglassv1alpha1.ClusterAuthType `json:"authType,omitempty"`
 	// kubeconfigSecretRef references a secret containing an admin-level kubeconfig for the target cluster.
 	// Required when authType is "Kubeconfig". The referenced Secret MUST exist in the specified namespace and contain the key (default: "value", compatible with cluster-api).
 	KubeconfigSecretRef *SecretKeyReferenceApplyConfiguration `json:"kubeconfigSecretRef,omitempty"`
@@ -66,7 +66,7 @@ type ClusterConfigSpecApplyConfiguration struct {
 	// Kubernetes API server OIDC configuration.
 	// Common values: "email" (recommended), "preferred_username", "sub"
 	// If not set, falls back to global config kubernetes.userIdentifierClaim.
-	UserIdentifierClaim *apiv1alpha1.UserIdentifierClaimType `json:"userIdentifierClaim,omitempty"`
+	UserIdentifierClaim *breakglassv1alpha1.UserIdentifierClaimType `json:"userIdentifierClaim,omitempty"`
 }
 
 // ClusterConfigSpecApplyConfiguration constructs a declarative configuration of the ClusterConfigSpec type for use with
@@ -118,7 +118,7 @@ func (b *ClusterConfigSpecApplyConfiguration) WithLocation(value string) *Cluste
 // WithAuthType sets the AuthType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the AuthType field is set to the value of the last call.
-func (b *ClusterConfigSpecApplyConfiguration) WithAuthType(value apiv1alpha1.ClusterAuthType) *ClusterConfigSpecApplyConfiguration {
+func (b *ClusterConfigSpecApplyConfiguration) WithAuthType(value breakglassv1alpha1.ClusterAuthType) *ClusterConfigSpecApplyConfiguration {
 	b.AuthType = &value
 	return b
 }
@@ -202,7 +202,7 @@ func (b *ClusterConfigSpecApplyConfiguration) WithMailProvider(value string) *Cl
 // WithUserIdentifierClaim sets the UserIdentifierClaim field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the UserIdentifierClaim field is set to the value of the last call.
-func (b *ClusterConfigSpecApplyConfiguration) WithUserIdentifierClaim(value apiv1alpha1.UserIdentifierClaimType) *ClusterConfigSpecApplyConfiguration {
+func (b *ClusterConfigSpecApplyConfiguration) WithUserIdentifierClaim(value breakglassv1alpha1.UserIdentifierClaimType) *ClusterConfigSpecApplyConfiguration {
 	b.UserIdentifierClaim = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionparticipant.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionparticipant.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +26,7 @@ type DebugSessionParticipantApplyConfiguration struct {
 	// displayName is the human-readable name of the participant (from OIDC "name" claim).
 	DisplayName *string `json:"displayName,omitempty"`
 	// role is the participant's role (owner or participant).
-	Role *apiv1alpha1.ParticipantRole `json:"role,omitempty"`
+	Role *breakglassv1alpha1.ParticipantRole `json:"role,omitempty"`
 	// joinedAt is when the user joined the session.
 	JoinedAt *v1.Time `json:"joinedAt,omitempty"`
 	// leftAt is when the user left the session (if they have left).
@@ -66,7 +66,7 @@ func (b *DebugSessionParticipantApplyConfiguration) WithDisplayName(value string
 // WithRole sets the Role field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Role field is set to the value of the last call.
-func (b *DebugSessionParticipantApplyConfiguration) WithRole(value apiv1alpha1.ParticipantRole) *DebugSessionParticipantApplyConfiguration {
+func (b *DebugSessionParticipantApplyConfiguration) WithRole(value breakglassv1alpha1.ParticipantRole) *DebugSessionParticipantApplyConfiguration {
 	b.Role = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessionstatus.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
@@ -22,7 +22,7 @@ type DebugSessionStatusApplyConfiguration struct {
 	// ObservedGeneration reflects the generation of the most recently observed DebugSession.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// state is the current state of the debug session.
-	State *apiv1alpha1.DebugSessionState `json:"state,omitempty"`
+	State *breakglassv1alpha1.DebugSessionState `json:"state,omitempty"`
 	// approval tracks approval information.
 	Approval *DebugSessionApprovalApplyConfiguration `json:"approval,omitempty"`
 	// participants lists users currently in the session.
@@ -79,7 +79,7 @@ func (b *DebugSessionStatusApplyConfiguration) WithObservedGeneration(value int6
 // WithState sets the State field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the State field is set to the value of the last call.
-func (b *DebugSessionStatusApplyConfiguration) WithState(value apiv1alpha1.DebugSessionState) *DebugSessionStatusApplyConfiguration {
+func (b *DebugSessionStatusApplyConfiguration) WithState(value breakglassv1alpha1.DebugSessionState) *DebugSessionStatusApplyConfiguration {
 	b.State = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessiontemplatespec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessiontemplatespec.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -24,7 +24,7 @@ type DebugSessionTemplateSpecApplyConfiguration struct {
 	Description *string `json:"description,omitempty"`
 	// mode specifies the debug session mode: "workload", "kubectl-debug", or "hybrid".
 	// Defaults to "workload" for backward compatibility.
-	Mode *apiv1alpha1.DebugSessionTemplateMode `json:"mode,omitempty"`
+	Mode *breakglassv1alpha1.DebugSessionTemplateMode `json:"mode,omitempty"`
 	// podTemplateRef references a DebugPodTemplate for the pod specification.
 	// Required when mode is "workload" or "hybrid".
 	// The referenced template can itself contain {{ .Vars.* }} placeholders.
@@ -44,7 +44,7 @@ type DebugSessionTemplateSpecApplyConfiguration struct {
 	ExtraDeployVariables []ExtraDeployVariableApplyConfiguration `json:"extraDeployVariables,omitempty"`
 	// workloadType specifies the type of workload to create (DaemonSet or Deployment).
 	// Required when mode is "workload" or "hybrid".
-	WorkloadType *apiv1alpha1.DebugWorkloadType `json:"workloadType,omitempty"`
+	WorkloadType *breakglassv1alpha1.DebugWorkloadType `json:"workloadType,omitempty"`
 	// replicas specifies the number of replicas for Deployment workloads.
 	// Defaults to 1. Ignored for DaemonSet workloads.
 	Replicas *int32 `json:"replicas,omitempty"`
@@ -161,7 +161,7 @@ func (b *DebugSessionTemplateSpecApplyConfiguration) WithDescription(value strin
 // WithMode sets the Mode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Mode field is set to the value of the last call.
-func (b *DebugSessionTemplateSpecApplyConfiguration) WithMode(value apiv1alpha1.DebugSessionTemplateMode) *DebugSessionTemplateSpecApplyConfiguration {
+func (b *DebugSessionTemplateSpecApplyConfiguration) WithMode(value breakglassv1alpha1.DebugSessionTemplateMode) *DebugSessionTemplateSpecApplyConfiguration {
 	b.Mode = &value
 	return b
 }
@@ -206,7 +206,7 @@ func (b *DebugSessionTemplateSpecApplyConfiguration) WithExtraDeployVariables(va
 // WithWorkloadType sets the WorkloadType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the WorkloadType field is set to the value of the last call.
-func (b *DebugSessionTemplateSpecApplyConfiguration) WithWorkloadType(value apiv1alpha1.DebugWorkloadType) *DebugSessionTemplateSpecApplyConfiguration {
+func (b *DebugSessionTemplateSpecApplyConfiguration) WithWorkloadType(value breakglassv1alpha1.DebugWorkloadType) *DebugSessionTemplateSpecApplyConfiguration {
 	b.WorkloadType = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/extradeployvariable.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/extradeployvariable.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -27,7 +27,7 @@ type ExtraDeployVariableApplyConfiguration struct {
 	// description provides help text for the user.
 	Description *string `json:"description,omitempty"`
 	// inputType defines the UI input control and value type.
-	InputType *apiv1alpha1.ExtraDeployInputType `json:"inputType,omitempty"`
+	InputType *breakglassv1alpha1.ExtraDeployInputType `json:"inputType,omitempty"`
 	// options provides choices for select/multiSelect input types.
 	// Required when inputType is select or multiSelect.
 	Options []SelectOptionApplyConfiguration `json:"options,omitempty"`
@@ -82,7 +82,7 @@ func (b *ExtraDeployVariableApplyConfiguration) WithDescription(value string) *E
 // WithInputType sets the InputType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the InputType field is set to the value of the last call.
-func (b *ExtraDeployVariableApplyConfiguration) WithInputType(value apiv1alpha1.ExtraDeployInputType) *ExtraDeployVariableApplyConfiguration {
+func (b *ExtraDeployVariableApplyConfiguration) WithInputType(value breakglassv1alpha1.ExtraDeployInputType) *ExtraDeployVariableApplyConfiguration {
 	b.InputType = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/identityproviderspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/identityproviderspec.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // IdentityProviderSpecApplyConfiguration represents a declarative configuration of the IdentityProviderSpec type for use
@@ -22,7 +22,7 @@ type IdentityProviderSpecApplyConfiguration struct {
 	OIDC *OIDCConfigApplyConfiguration `json:"oidc,omitempty"`
 	// GroupSyncProvider specifies which provider to use for group synchronization (optional)
 	// If not set, group synchronization is disabled
-	GroupSyncProvider *apiv1alpha1.GroupSyncProvider `json:"groupSyncProvider,omitempty"`
+	GroupSyncProvider *breakglassv1alpha1.GroupSyncProvider `json:"groupSyncProvider,omitempty"`
 	// Keycloak holds Keycloak-specific configuration for group synchronization
 	// Required when groupSyncProvider is "Keycloak"
 	Keycloak *KeycloakGroupSyncApplyConfiguration `json:"keycloak,omitempty"`
@@ -61,7 +61,7 @@ func (b *IdentityProviderSpecApplyConfiguration) WithOIDC(value *OIDCConfigApply
 // WithGroupSyncProvider sets the GroupSyncProvider field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the GroupSyncProvider field is set to the value of the last call.
-func (b *IdentityProviderSpecApplyConfiguration) WithGroupSyncProvider(value apiv1alpha1.GroupSyncProvider) *IdentityProviderSpecApplyConfiguration {
+func (b *IdentityProviderSpecApplyConfiguration) WithGroupSyncProvider(value breakglassv1alpha1.GroupSyncProvider) *IdentityProviderSpecApplyConfiguration {
 	b.GroupSyncProvider = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/namespaceselectorrequirement.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/namespaceselectorrequirement.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package v1alpha1
 
 import (
-	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // NamespaceSelectorRequirementApplyConfiguration represents a declarative configuration of the NamespaceSelectorRequirement type for use
@@ -22,7 +22,7 @@ type NamespaceSelectorRequirementApplyConfiguration struct {
 	Key *string `json:"key,omitempty"`
 	// operator represents a key's relationship to a set of values.
 	// Valid operators: In, NotIn, Exists, DoesNotExist.
-	Operator *apiv1alpha1.NamespaceSelectorOperator `json:"operator,omitempty"`
+	Operator *breakglassv1alpha1.NamespaceSelectorOperator `json:"operator,omitempty"`
 	// values is an array of string values.
 	// Required for In and NotIn operators.
 	// Must be empty for Exists and DoesNotExist.
@@ -46,7 +46,7 @@ func (b *NamespaceSelectorRequirementApplyConfiguration) WithKey(value string) *
 // WithOperator sets the Operator field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Operator field is set to the value of the last call.
-func (b *NamespaceSelectorRequirementApplyConfiguration) WithOperator(value apiv1alpha1.NamespaceSelectorOperator) *NamespaceSelectorRequirementApplyConfiguration {
+func (b *NamespaceSelectorRequirementApplyConfiguration) WithOperator(value breakglassv1alpha1.NamespaceSelectorOperator) *NamespaceSelectorRequirementApplyConfiguration {
 	b.Operator = &value
 	return b
 }

--- a/api/v1alpha1/applyconfiguration/utils.go
+++ b/api/v1alpha1/applyconfiguration/utils.go
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package applyconfiguration
 
 import (
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	apiv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/api/v1alpha1"
 	internal "github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/internal"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -22,259 +22,259 @@ import (
 func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
 	// Group=breakglass.t-caas.telekom.com, Version=v1alpha1
-	case v1alpha1.SchemeGroupVersion.WithKind("AdditionalResourceRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AdditionalResourceRef"):
 		return &apiv1alpha1.AdditionalResourceRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AllowedPodOperations"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AllowedPodOperations"):
 		return &apiv1alpha1.AllowedPodOperationsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AllowedPodRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AllowedPodRef"):
 		return &apiv1alpha1.AllowedPodRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditConfig"):
 		return &apiv1alpha1.AuditConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditConfigSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditConfigSpec"):
 		return &apiv1alpha1.AuditConfigSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditConfigStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditConfigStatus"):
 		return &apiv1alpha1.AuditConfigStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditDestination"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditDestination"):
 		return &apiv1alpha1.AuditDestinationApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditFilterConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditFilterConfig"):
 		return &apiv1alpha1.AuditFilterConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditQueueConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditQueueConfig"):
 		return &apiv1alpha1.AuditQueueConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditSamplingConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditSamplingConfig"):
 		return &apiv1alpha1.AuditSamplingConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditSinkConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditSinkConfig"):
 		return &apiv1alpha1.AuditSinkConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuditSinkStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuditSinkStatus"):
 		return &apiv1alpha1.AuditSinkStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AutoApproveConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AutoApproveConfig"):
 		return &apiv1alpha1.AutoApproveConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuxiliaryResource"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuxiliaryResource"):
 		return &apiv1alpha1.AuxiliaryResourceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("AuxiliaryResourceStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("AuxiliaryResourceStatus"):
 		return &apiv1alpha1.AuxiliaryResourceStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BindingReference"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BindingReference"):
 		return &apiv1alpha1.BindingReferenceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalation"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalation"):
 		return &apiv1alpha1.BreakglassEscalationApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationAllowed"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationAllowed"):
 		return &apiv1alpha1.BreakglassEscalationAllowedApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationApprovers"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationApprovers"):
 		return &apiv1alpha1.BreakglassEscalationApproversApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationSpec"):
 		return &apiv1alpha1.BreakglassEscalationSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassEscalationStatus"):
 		return &apiv1alpha1.BreakglassEscalationStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassSession"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassSession"):
 		return &apiv1alpha1.BreakglassSessionApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassSessionSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassSessionSpec"):
 		return &apiv1alpha1.BreakglassSessionSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("BreakglassSessionStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("BreakglassSessionStatus"):
 		return &apiv1alpha1.BreakglassSessionStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ClusterConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ClusterConfig"):
 		return &apiv1alpha1.ClusterConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ClusterConfigSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ClusterConfigSpec"):
 		return &apiv1alpha1.ClusterConfigSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ClusterConfigStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ClusterConfigStatus"):
 		return &apiv1alpha1.ClusterConfigStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("CopiedPodRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("CopiedPodRef"):
 		return &apiv1alpha1.CopiedPodRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugApprovalReasonConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugApprovalReasonConfig"):
 		return &apiv1alpha1.DebugApprovalReasonConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugContainerOverride"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugContainerOverride"):
 		return &apiv1alpha1.DebugContainerOverrideApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPDBConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPDBConfig"):
 		return &apiv1alpha1.DebugPDBConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodMetadata"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodMetadata"):
 		return &apiv1alpha1.DebugPodMetadataApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodOverrides"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodOverrides"):
 		return &apiv1alpha1.DebugPodOverridesApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodSpec"):
 		return &apiv1alpha1.DebugPodSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodSpecInner"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodSpecInner"):
 		return &apiv1alpha1.DebugPodSpecInnerApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodSpecOverrides"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodSpecOverrides"):
 		return &apiv1alpha1.DebugPodSpecOverridesApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplate"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplate"):
 		return &apiv1alpha1.DebugPodTemplateApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateReference"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateReference"):
 		return &apiv1alpha1.DebugPodTemplateReferenceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateSpec"):
 		return &apiv1alpha1.DebugPodTemplateSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugPodTemplateStatus"):
 		return &apiv1alpha1.DebugPodTemplateStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugRequestReasonConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugRequestReasonConfig"):
 		return &apiv1alpha1.DebugRequestReasonConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugResourceQuotaConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugResourceQuotaConfig"):
 		return &apiv1alpha1.DebugResourceQuotaConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSession"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSession"):
 		return &apiv1alpha1.DebugSessionApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionAllowed"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionAllowed"):
 		return &apiv1alpha1.DebugSessionAllowedApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionApproval"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionApproval"):
 		return &apiv1alpha1.DebugSessionApprovalApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionApprovers"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionApprovers"):
 		return &apiv1alpha1.DebugSessionApproversApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionAuditConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionAuditConfig"):
 		return &apiv1alpha1.DebugSessionAuditConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBinding"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBinding"):
 		return &apiv1alpha1.DebugSessionClusterBindingApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBindingSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBindingSpec"):
 		return &apiv1alpha1.DebugSessionClusterBindingSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBindingStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionClusterBindingStatus"):
 		return &apiv1alpha1.DebugSessionClusterBindingStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionConstraints"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionConstraints"):
 		return &apiv1alpha1.DebugSessionConstraintsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionNotificationConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionNotificationConfig"):
 		return &apiv1alpha1.DebugSessionNotificationConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionParticipant"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionParticipant"):
 		return &apiv1alpha1.DebugSessionParticipantApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionSpec"):
 		return &apiv1alpha1.DebugSessionSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionStatus"):
 		return &apiv1alpha1.DebugSessionStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplate"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplate"):
 		return &apiv1alpha1.DebugSessionTemplateApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplateSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplateSpec"):
 		return &apiv1alpha1.DebugSessionTemplateSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplateStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DebugSessionTemplateStatus"):
 		return &apiv1alpha1.DebugSessionTemplateStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DenyPolicy"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DenyPolicy"):
 		return &apiv1alpha1.DenyPolicyApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DenyPolicyScope"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DenyPolicyScope"):
 		return &apiv1alpha1.DenyPolicyScopeApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DenyPolicySpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DenyPolicySpec"):
 		return &apiv1alpha1.DenyPolicySpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DenyPolicyStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DenyPolicyStatus"):
 		return &apiv1alpha1.DenyPolicyStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DenyRule"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DenyRule"):
 		return &apiv1alpha1.DenyRuleApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("DeployedResourceRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("DeployedResourceRef"):
 		return &apiv1alpha1.DeployedResourceRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("EphemeralContainerRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("EphemeralContainerRef"):
 		return &apiv1alpha1.EphemeralContainerRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("EphemeralContainersConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("EphemeralContainersConfig"):
 		return &apiv1alpha1.EphemeralContainersConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ExtraDeployVariable"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ExtraDeployVariable"):
 		return &apiv1alpha1.ExtraDeployVariableApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("HostNamespacesConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("HostNamespacesConfig"):
 		return &apiv1alpha1.HostNamespacesConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("IdentityProvider"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("IdentityProvider"):
 		return &apiv1alpha1.IdentityProviderApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("IdentityProviderSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("IdentityProviderSpec"):
 		return &apiv1alpha1.IdentityProviderSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("IdentityProviderStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("IdentityProviderStatus"):
 		return &apiv1alpha1.IdentityProviderStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ImpersonationConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ImpersonationConfig"):
 		return &apiv1alpha1.ImpersonationConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KafkaSASLSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KafkaSASLSpec"):
 		return &apiv1alpha1.KafkaSASLSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KafkaSinkSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KafkaSinkSpec"):
 		return &apiv1alpha1.KafkaSinkSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KafkaTLSSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KafkaTLSSpec"):
 		return &apiv1alpha1.KafkaTLSSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KeycloakGroupSync"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KeycloakGroupSync"):
 		return &apiv1alpha1.KeycloakGroupSyncApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KubectlDebugConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KubectlDebugConfig"):
 		return &apiv1alpha1.KubectlDebugConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KubectlDebugStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KubectlDebugStatus"):
 		return &apiv1alpha1.KubectlDebugStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("KubernetesSinkSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("KubernetesSinkSpec"):
 		return &apiv1alpha1.KubernetesSinkSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("LogSinkSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("LogSinkSpec"):
 		return &apiv1alpha1.LogSinkSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("MailProvider"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("MailProvider"):
 		return &apiv1alpha1.MailProviderApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("MailProviderSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("MailProviderSpec"):
 		return &apiv1alpha1.MailProviderSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("MailProviderStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("MailProviderStatus"):
 		return &apiv1alpha1.MailProviderStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NameCollision"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NameCollision"):
 		return &apiv1alpha1.NameCollisionApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NamespaceConstraints"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NamespaceConstraints"):
 		return &apiv1alpha1.NamespaceConstraintsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NamespaceFilter"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NamespaceFilter"):
 		return &apiv1alpha1.NamespaceFilterApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NamespaceSelectorRequirement"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NamespaceSelectorRequirement"):
 		return &apiv1alpha1.NamespaceSelectorRequirementApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NamespaceSelectorTerm"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NamespaceSelectorTerm"):
 		return &apiv1alpha1.NamespaceSelectorTermApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NodeDebugConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NodeDebugConfig"):
 		return &apiv1alpha1.NodeDebugConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("NotificationExclusions"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("NotificationExclusions"):
 		return &apiv1alpha1.NotificationExclusionsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("OIDCAuthConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("OIDCAuthConfig"):
 		return &apiv1alpha1.OIDCAuthConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("OIDCConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("OIDCConfig"):
 		return &apiv1alpha1.OIDCConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("OIDCFromIdentityProviderConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("OIDCFromIdentityProviderConfig"):
 		return &apiv1alpha1.OIDCFromIdentityProviderConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodContainerStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodContainerStatus"):
 		return &apiv1alpha1.PodContainerStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodCopyConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodCopyConfig"):
 		return &apiv1alpha1.PodCopyConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodSecurityApprovers"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodSecurityApprovers"):
 		return &apiv1alpha1.PodSecurityApproversApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodSecurityExemptions"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodSecurityExemptions"):
 		return &apiv1alpha1.PodSecurityExemptionsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodSecurityOverrides"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodSecurityOverrides"):
 		return &apiv1alpha1.PodSecurityOverridesApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodSecurityRules"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodSecurityRules"):
 		return &apiv1alpha1.PodSecurityRulesApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodSecurityScope"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodSecurityScope"):
 		return &apiv1alpha1.PodSecurityScopeApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("PodTemplateResourceStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("PodTemplateResourceStatus"):
 		return &apiv1alpha1.PodTemplateResourceStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ReasonConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ReasonConfig"):
 		return &apiv1alpha1.ReasonConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ResolvedBindingRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ResolvedBindingRef"):
 		return &apiv1alpha1.ResolvedBindingRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ResolvedClusterRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ResolvedClusterRef"):
 		return &apiv1alpha1.ResolvedClusterRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ResolvedTemplateRef"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ResolvedTemplateRef"):
 		return &apiv1alpha1.ResolvedTemplateRefApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("RetryConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("RetryConfig"):
 		return &apiv1alpha1.RetryConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("RiskFactors"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("RiskFactors"):
 		return &apiv1alpha1.RiskFactorsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("RiskThreshold"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("RiskThreshold"):
 		return &apiv1alpha1.RiskThresholdApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SchedulingConstraints"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SchedulingConstraints"):
 		return &apiv1alpha1.SchedulingConstraintsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SchedulingOption"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SchedulingOption"):
 		return &apiv1alpha1.SchedulingOptionApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SchedulingOptions"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SchedulingOptions"):
 		return &apiv1alpha1.SchedulingOptionsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SecretKeyReference"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SecretKeyReference"):
 		return &apiv1alpha1.SecretKeyReferenceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SecretKeySelector"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SecretKeySelector"):
 		return &apiv1alpha1.SecretKeySelectorApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SelectOption"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SelectOption"):
 		return &apiv1alpha1.SelectOptionApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SenderConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SenderConfig"):
 		return &apiv1alpha1.SenderConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("ServiceAccountReference"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("ServiceAccountReference"):
 		return &apiv1alpha1.ServiceAccountReferenceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SessionLimitGroupOverride"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SessionLimitGroupOverride"):
 		return &apiv1alpha1.SessionLimitGroupOverrideApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SessionLimits"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SessionLimits"):
 		return &apiv1alpha1.SessionLimitsApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SessionLimitsOverride"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SessionLimitsOverride"):
 		return &apiv1alpha1.SessionLimitsOverrideApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("SMTPConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("SMTPConfig"):
 		return &apiv1alpha1.SMTPConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("TemplateReference"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("TemplateReference"):
 		return &apiv1alpha1.TemplateReferenceApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("TerminalSharingConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("TerminalSharingConfig"):
 		return &apiv1alpha1.TerminalSharingConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("TerminalSharingStatus"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("TerminalSharingStatus"):
 		return &apiv1alpha1.TerminalSharingStatusApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("TokenExchangeConfig"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("TokenExchangeConfig"):
 		return &apiv1alpha1.TokenExchangeConfigApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("VariableValidation"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("VariableValidation"):
 		return &apiv1alpha1.VariableValidationApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("WebhookSinkSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("WebhookSinkSpec"):
 		return &apiv1alpha1.WebhookSinkSpecApplyConfiguration{}
-	case v1alpha1.SchemeGroupVersion.WithKind("WebhookTLSSpec"):
+	case breakglassv1alpha1.SchemeGroupVersion.WithKind("WebhookTLSSpec"):
 		return &apiv1alpha1.WebhookTLSSpecApplyConfiguration{}
 
 	}

--- a/e2e/api/breakglass_session_api_test.go
+++ b/e2e/api/breakglass_session_api_test.go
@@ -94,15 +94,15 @@ type BreakglassSessionRequest struct {
 
 // SessionSummary represents a session in list responses
 type SessionSummary struct {
-	Name      string                                 `json:"name"`
-	Namespace string                                 `json:"namespace"`
-	Cluster   string                                 `json:"cluster"`
-	User      string                                 `json:"user"`
-	Group     string                                 `json:"group"`
+	Name      string                                    `json:"name"`
+	Namespace string                                    `json:"namespace"`
+	Cluster   string                                    `json:"cluster"`
+	User      string                                    `json:"user"`
+	Group     string                                    `json:"group"`
 	State     breakglassv1alpha1.BreakglassSessionState `json:"state"`
-	Reason    string                                 `json:"reason,omitempty"`
-	CreatedAt metav1.Time                            `json:"createdAt"`
-	ExpiresAt *metav1.Time                           `json:"expiresAt,omitempty"`
+	Reason    string                                    `json:"reason,omitempty"`
+	CreatedAt metav1.Time                               `json:"createdAt"`
+	ExpiresAt *metav1.Time                              `json:"expiresAt,omitempty"`
 }
 
 // ListSessions lists all breakglass sessions
@@ -160,7 +160,7 @@ func (c *BreakglassSessionAPIClient) GetSession(ctx context.Context, t *testing.
 	// The API returns an envelope with session and approvalMeta
 	var envelope struct {
 		Session      breakglassv1alpha1.BreakglassSession `json:"session"`
-		ApprovalMeta interface{}                       `json:"approvalMeta"`
+		ApprovalMeta interface{}                          `json:"approvalMeta"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		// Fallback: try parsing as bare session object

--- a/e2e/api/debug_session_api_test.go
+++ b/e2e/api/debug_session_api_test.go
@@ -73,16 +73,16 @@ type DebugSessionListResponse struct {
 
 // DebugSessionSummary represents a summarized debug session for list responses
 type DebugSessionSummary struct {
-	Name          string                            `json:"name"`
-	TemplateRef   string                            `json:"templateRef"`
-	Cluster       string                            `json:"cluster"`
-	RequestedBy   string                            `json:"requestedBy"`
+	Name          string                               `json:"name"`
+	TemplateRef   string                               `json:"templateRef"`
+	Cluster       string                               `json:"cluster"`
+	RequestedBy   string                               `json:"requestedBy"`
 	State         breakglassv1alpha1.DebugSessionState `json:"state"`
-	StartsAt      *metav1.Time                      `json:"startsAt,omitempty"`
-	ExpiresAt     *metav1.Time                      `json:"expiresAt,omitempty"`
-	Participants  int                               `json:"participants"`
-	IsParticipant bool                              `json:"isParticipant"`
-	AllowedPods   int                               `json:"allowedPods"`
+	StartsAt      *metav1.Time                         `json:"startsAt,omitempty"`
+	ExpiresAt     *metav1.Time                         `json:"expiresAt,omitempty"`
+	Participants  int                                  `json:"participants"`
+	IsParticipant bool                                 `json:"isParticipant"`
+	AllowedPods   int                                  `json:"allowedPods"`
 }
 
 // DebugSessionTemplateAPIResponse matches the API response structure for templates

--- a/e2e/cli/cli_comprehensive_test.go
+++ b/e2e/cli/cli_comprehensive_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/e2e/helpers"
 	bgctlcmd "github.com/telekom/k8s-breakglass/pkg/bgctl/cmd"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/config"
@@ -121,7 +121,7 @@ func TestCLIAuthWithTokenOverride(t *testing.T) {
 		output, err := tc.runCommandWithToken("escalation", "list", "-o", "json")
 		require.NoError(t, err, "Should list escalations with token override")
 
-		var escalations []v1alpha1.BreakglassEscalation
+		var escalations []breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &escalations)
 		require.NoError(t, err, "Should parse escalation list")
 		t.Logf("Listed %d escalations with token override", len(escalations))
@@ -404,7 +404,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		output, err := tc.runCommandWithToken("session", "list", "-o", "json")
 		require.NoError(t, err)
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err)
 		t.Logf("Found %d existing sessions", len(sessions))
@@ -420,7 +420,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err)
 
@@ -439,7 +439,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		output, err := tc.runCommandWithToken("session", "get", sessionName, "-o", "json")
 		require.NoError(t, err)
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err)
 		assert.Equal(t, sessionName, session.Name)
@@ -454,7 +454,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err)
 		for _, s := range sessions {
@@ -474,7 +474,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		output, err := tc.runCommandWithToken("session", "list", "--mine", "-o", "json")
 		require.NoError(t, err)
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err)
 		// All should be for our user
@@ -507,7 +507,7 @@ func TestCLISessionFullLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err)
 
@@ -551,7 +551,7 @@ func TestCLIEscalationCommands(t *testing.T) {
 		output, err := tc.runCommandWithToken("escalation", "list", "-o", "json")
 		require.NoError(t, err)
 
-		var escalations []v1alpha1.BreakglassEscalation
+		var escalations []breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &escalations)
 		require.NoError(t, err)
 		t.Logf("Found %d escalations", len(escalations))
@@ -567,7 +567,7 @@ func TestCLIEscalationCommands(t *testing.T) {
 		output, err := tc.runCommandWithToken("escalation", "list", "-o", "json")
 		require.NoError(t, err)
 
-		var escalations []v1alpha1.BreakglassEscalation
+		var escalations []breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &escalations)
 		require.NoError(t, err)
 
@@ -577,7 +577,7 @@ func TestCLIEscalationCommands(t *testing.T) {
 		output, err = tc.runCommandWithToken("escalation", "get", escName, "-o", "json")
 		require.NoError(t, err)
 
-		var esc v1alpha1.BreakglassEscalation
+		var esc breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &esc)
 		require.NoError(t, err)
 		assert.Equal(t, escName, esc.Name)
@@ -679,7 +679,7 @@ func TestCLIDebugSessionCommands(t *testing.T) {
 		output, err := tc.runCommandWithToken("debug", "pod-template", "list", "-o", "json")
 		require.NoError(t, err)
 
-		var templates []v1alpha1.DebugPodTemplate
+		var templates []breakglassv1alpha1.DebugPodTemplate
 		err = json.Unmarshal([]byte(output), &templates)
 		require.NoError(t, err)
 		t.Logf("Found %d debug pod templates", len(templates))
@@ -730,7 +730,7 @@ func TestCLIDebugSessionCommands(t *testing.T) {
 		)
 		require.NoError(t, err, "Debug session creation should succeed when templates are available")
 
-		var session v1alpha1.DebugSession
+		var session breakglassv1alpha1.DebugSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err)
 		sessionName := session.Name
@@ -882,7 +882,7 @@ func TestCLIListPagination(t *testing.T) {
 		output, err := tc.runCommandWithToken("session", "list", "--all", "-o", "json")
 		require.NoError(t, err)
 
-		var allSessions []v1alpha1.BreakglassSession
+		var allSessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &allSessions)
 		require.NoError(t, err)
 
@@ -890,7 +890,7 @@ func TestCLIListPagination(t *testing.T) {
 		output, err = tc.runCommandWithToken("session", "list", "--page", "1", "--page-size", "5", "-o", "json")
 		require.NoError(t, err)
 
-		var pagedSessions []v1alpha1.BreakglassSession
+		var pagedSessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &pagedSessions)
 		require.NoError(t, err)
 
@@ -1135,7 +1135,7 @@ func TestCLIEdgeCases(t *testing.T) {
 		if err != nil {
 			t.Logf("Request with all flags error: %v", err)
 		} else {
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err)
 			assert.NotEmpty(t, session.Name)
@@ -1159,7 +1159,7 @@ func TestCLIClusterOperations(t *testing.T) {
 		output, err := tc.runCommandWithToken("escalation", "list", "-o", "json")
 		require.NoError(t, err, "Should be able to list escalations")
 
-		var escalations []v1alpha1.BreakglassEscalation
+		var escalations []breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &escalations)
 		require.NoError(t, err, "Should parse escalations")
 
@@ -1229,7 +1229,7 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		output, err := runWithToken(requesterToken, "escalation", "list", "-o", "json")
 		require.NoError(t, err, "Requester should be able to list escalations")
 
-		var escalations []v1alpha1.BreakglassEscalation
+		var escalations []breakglassv1alpha1.BreakglassEscalation
 		err = json.Unmarshal([]byte(output), &escalations)
 		require.NoError(t, err, "Should parse escalation list")
 		t.Logf("Found %d escalations available", len(escalations))
@@ -1247,7 +1247,7 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err, "Session request should succeed")
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err, "Should parse created session")
 		require.NotEmpty(t, session.Name, "Session should have a name")
@@ -1263,7 +1263,7 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		output, err := runWithToken(requesterToken, "session", "list", "--mine", "-o", "json")
 		require.NoError(t, err, "Should list my sessions")
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err, "Should parse session list")
 
@@ -1284,18 +1284,18 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 
 		// Poll until pending state
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.BreakglassSessionState
+		var lastState breakglassv1alpha1.BreakglassSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requesterToken, "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get session")
 
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.SessionStatePending {
+			if lastState == breakglassv1alpha1.SessionStatePending {
 				t.Logf("Session %s reached Pending state", sessionName)
 				return
 			}
@@ -1320,18 +1320,18 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 
 		// Poll until approved state
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.BreakglassSessionState
+		var lastState breakglassv1alpha1.BreakglassSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requesterToken, "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get session")
 
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.SessionStateApproved {
+			if lastState == breakglassv1alpha1.SessionStateApproved {
 				t.Logf("Session %s reached Approved state", sessionName)
 				require.NotEmpty(t, session.Status.Approvers, "Session should have approvers recorded")
 				t.Logf("Approved by: %v", session.Status.Approvers)
@@ -1358,7 +1358,7 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err, "Should list approved sessions")
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err, "Should parse session list")
 
@@ -1366,7 +1366,7 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		for _, s := range sessions {
 			if s.Name == sessionName {
 				found = true
-				assert.Equal(t, v1alpha1.SessionStateApproved, s.Status.State)
+				assert.Equal(t, breakglassv1alpha1.SessionStateApproved, s.Status.State)
 				break
 			}
 		}
@@ -1395,15 +1395,15 @@ func TestCLIFullChainSessionLifecycle(t *testing.T) {
 		output, err := runWithToken(requesterToken, "session", "get", sessionName, "-o", "json")
 		require.NoError(t, err, "Should get session")
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err, "Should parse session")
 
 		// Session should be in Approved state (or Expired if TTL is short)
-		validFinalStates := []v1alpha1.BreakglassSessionState{
-			v1alpha1.SessionStateApproved,
-			v1alpha1.SessionStateExpired,
-			v1alpha1.SessionStateWithdrawn,
+		validFinalStates := []breakglassv1alpha1.BreakglassSessionState{
+			breakglassv1alpha1.SessionStateApproved,
+			breakglassv1alpha1.SessionStateExpired,
+			breakglassv1alpha1.SessionStateWithdrawn,
 		}
 		found := false
 		for _, s := range validFinalStates {
@@ -1492,7 +1492,7 @@ func TestCLIFullChainDebugSessionLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err, "Debug session creation should succeed when templates are available")
 
-		var session v1alpha1.DebugSession
+		var session breakglassv1alpha1.DebugSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err, "Should parse created debug session")
 		require.NotEmpty(t, session.Name, "Debug session should have a name")
@@ -1509,23 +1509,23 @@ func TestCLIFullChainDebugSessionLifecycle(t *testing.T) {
 		require.NotEmpty(t, sessionName, "Session should have been created in previous step")
 
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.DebugSessionState
+		var lastState breakglassv1alpha1.DebugSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requesterToken, "debug", "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get debug session")
 
-			var session v1alpha1.DebugSession
+			var session breakglassv1alpha1.DebugSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse debug session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.DebugSessionStatePending {
+			if lastState == breakglassv1alpha1.DebugSessionStatePending {
 				t.Logf("Debug session %s reached Pending state (will require approval)", sessionName)
 				return
 			}
 			// Auto-approved - session went directly to Active or already past Pending
-			if lastState == v1alpha1.DebugSessionStateActive {
+			if lastState == breakglassv1alpha1.DebugSessionStateActive {
 				t.Logf("Debug session %s was auto-approved, now in %s state", sessionName, lastState)
 				wasAutoApproved = true
 				return
@@ -1554,18 +1554,18 @@ func TestCLIFullChainDebugSessionLifecycle(t *testing.T) {
 		require.NotEmpty(t, sessionName, "Session should have been created in previous step")
 
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.DebugSessionState
+		var lastState breakglassv1alpha1.DebugSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requesterToken, "debug", "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get debug session")
 
-			var session v1alpha1.DebugSession
+			var session breakglassv1alpha1.DebugSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse debug session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.DebugSessionStateActive {
+			if lastState == breakglassv1alpha1.DebugSessionStateActive {
 				t.Logf("Debug session %s reached Active state", sessionName)
 				return
 			}
@@ -1592,18 +1592,18 @@ func TestCLIFullChainDebugSessionLifecycle(t *testing.T) {
 		require.NotEmpty(t, sessionName, "Session should have been created in previous step")
 
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.DebugSessionState
+		var lastState breakglassv1alpha1.DebugSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requesterToken, "debug", "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get debug session")
 
-			var session v1alpha1.DebugSession
+			var session breakglassv1alpha1.DebugSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse debug session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.DebugSessionStateTerminated || lastState == v1alpha1.DebugSessionStateExpired {
+			if lastState == breakglassv1alpha1.DebugSessionStateTerminated || lastState == breakglassv1alpha1.DebugSessionStateExpired {
 				t.Logf("Debug session %s reached final state %s - lifecycle complete", sessionName, lastState)
 				return
 			}
@@ -1669,7 +1669,7 @@ func TestCLIFullChainMultiActorWorkflow(t *testing.T) {
 		)
 		require.NoError(t, err, "Session request should succeed")
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err, "Should parse created session")
 
@@ -1687,7 +1687,7 @@ func TestCLIFullChainMultiActorWorkflow(t *testing.T) {
 		output, err := runWithToken(approverToken, "session", "list", "--state", "pending", "-o", "json")
 		require.NoError(t, err, "Approver should list pending sessions")
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &sessions)
 		require.NoError(t, err, "Should parse session list")
 
@@ -1716,18 +1716,18 @@ func TestCLIFullChainMultiActorWorkflow(t *testing.T) {
 		require.NotEmpty(t, sessionName, "Session must be created first")
 
 		deadline := time.Now().Add(helpers.WaitForStateTimeout)
-		var lastState v1alpha1.BreakglassSessionState
+		var lastState breakglassv1alpha1.BreakglassSessionState
 
 		for time.Now().Before(deadline) {
 			output, err := runWithToken(requester1Token, "session", "get", sessionName, "-o", "json")
 			require.NoError(t, err, "Should get session")
 
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse session")
 
 			lastState = session.Status.State
-			if lastState == v1alpha1.SessionStateRejected {
+			if lastState == breakglassv1alpha1.SessionStateRejected {
 				t.Logf("Session %s reached Rejected state", sessionName)
 				return
 			}
@@ -1745,11 +1745,11 @@ func TestCLIFullChainMultiActorWorkflow(t *testing.T) {
 		output, err := runWithToken(requester1Token, "session", "get", sessionName, "-o", "json")
 		require.NoError(t, err, "Should get session")
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal([]byte(output), &session)
 		require.NoError(t, err, "Should parse session")
 
-		assert.Equal(t, v1alpha1.SessionStateRejected, session.Status.State,
+		assert.Equal(t, breakglassv1alpha1.SessionStateRejected, session.Status.State,
 			"Session should remain in rejected state")
 		t.Logf("Verified session %s is in Rejected state and cannot be used", sessionName)
 	})

--- a/e2e/cli/cli_e2e_test.go
+++ b/e2e/cli/cli_e2e_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/client"
 	bgctlcmd "github.com/telekom/k8s-breakglass/pkg/bgctl/cmd"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/config"
@@ -21,19 +21,19 @@ import (
 func TestCLIListSessions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/breakglassSessions" {
-			_ = json.NewEncoder(w).Encode([]v1alpha1.BreakglassSession{
+			_ = json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassSession{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "session-1",
 						CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
 					},
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      "cluster-1",
 						User:         "user@example.com",
 						GrantedGroup: "breakglass-admin",
 					},
-					Status: v1alpha1.BreakglassSessionStatus{
-						State:     v1alpha1.SessionStatePending,
+					Status: breakglassv1alpha1.BreakglassSessionStatus{
+						State:     breakglassv1alpha1.SessionStatePending,
 						ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
 					},
 				},
@@ -50,7 +50,7 @@ func TestCLIListSessions(t *testing.T) {
 	root.SetArgs([]string{"--server", server.URL, "--token", "test", "session", "list", "-o", "json"})
 	require.NoError(t, root.Execute())
 
-	var sessions []v1alpha1.BreakglassSession
+	var sessions []breakglassv1alpha1.BreakglassSession
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &sessions))
 	require.Len(t, sessions, 1)
 	require.Equal(t, "session-1", sessions[0].Name)
@@ -66,7 +66,7 @@ func TestCLIDebugSessionList(t *testing.T) {
 						TemplateRef: "template-1",
 						Cluster:     "cluster-1",
 						RequestedBy: "user@example.com",
-						State:       v1alpha1.DebugSessionStatePending,
+						State:       breakglassv1alpha1.DebugSessionStatePending,
 					},
 				},
 				Total: 1,

--- a/e2e/cli/cli_multicluster_test.go
+++ b/e2e/cli/cli_multicluster_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/e2e/helpers"
 	bgctlcmd "github.com/telekom/k8s-breakglass/pkg/bgctl/cmd"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/config"
@@ -98,7 +98,7 @@ func TestCLIMultiCluster(t *testing.T) {
 		err := root.Execute()
 		require.NoError(t, err)
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal(buf.Bytes(), &session)
 		require.NoError(t, err)
 
@@ -126,7 +126,7 @@ func TestCLIMultiCluster(t *testing.T) {
 		err := root.Execute()
 		require.NoError(t, err)
 
-		var session v1alpha1.BreakglassSession
+		var session breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal(buf.Bytes(), &session)
 		require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestCLIMultiCluster(t *testing.T) {
 		err := root.Execute()
 		require.NoError(t, err)
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal(buf.Bytes(), &sessions)
 		require.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestCLIMultiCluster(t *testing.T) {
 		err := root.Execute()
 		require.NoError(t, err)
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		err = json.Unmarshal(buf.Bytes(), &sessions)
 		require.NoError(t, err)
 
@@ -223,7 +223,7 @@ func TestCLIDebugSessionsMultiCluster(t *testing.T) {
 		err := root.Execute()
 		require.NoError(t, err)
 
-		var templates []v1alpha1.DebugSessionTemplate
+		var templates []breakglassv1alpha1.DebugSessionTemplate
 		err = json.Unmarshal(buf.Bytes(), &templates)
 		require.NoError(t, err)
 
@@ -236,7 +236,7 @@ func TestCLIDebugSessionsMultiCluster(t *testing.T) {
 	t.Run("request debug session on spoke-a", func(t *testing.T) {
 		// Ensure we have a debug template - fixtures must be loaded in E2E setup
 		hubClient := helpers.GetClientForCluster(t, mcConfig.HubKubeconfig)
-		var templates v1alpha1.DebugSessionTemplateList
+		var templates breakglassv1alpha1.DebugSessionTemplateList
 		err := hubClient.List(ctx, &templates, client.InNamespace(helpers.GetTestNamespace()))
 		require.NoError(t, err, "Should list debug templates")
 		require.NotEmpty(t, templates.Items, "DebugSessionTemplates must exist in E2E environment - check that fixtures are loaded")
@@ -260,7 +260,7 @@ func TestCLIDebugSessionsMultiCluster(t *testing.T) {
 		err = root.Execute()
 		require.NoError(t, err)
 
-		var session v1alpha1.DebugSession
+		var session breakglassv1alpha1.DebugSession
 		err = json.Unmarshal(buf.Bytes(), &session)
 		require.NoError(t, err)
 

--- a/e2e/cli/two_persona_test.go
+++ b/e2e/cli/two_persona_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/e2e/helpers"
 	bgctlcmd "github.com/telekom/k8s-breakglass/pkg/bgctl/cmd"
 )
@@ -159,7 +159,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			return
 		}
 
-		var sessions []v1alpha1.BreakglassSession
+		var sessions []breakglassv1alpha1.BreakglassSession
 		if err := json.Unmarshal([]byte(output), &sessions); err != nil {
 			t.Logf("Warning: Failed to parse sessions for cleanup: %v", err)
 			return
@@ -173,12 +173,12 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			// Only match on group and cluster - let the user be whatever the requester's identity is
 			if s.Spec.GrantedGroup == group && s.Spec.Cluster == cluster {
 				switch s.Status.State {
-				case v1alpha1.SessionStateApproved:
+				case breakglassv1alpha1.SessionStateApproved:
 					t.Logf("Dropping existing approved session: %s", s.Name)
 					if _, err := runAsRequester("session", "drop", s.Name); err != nil {
 						t.Logf("Warning: Failed to drop session %s: %v", s.Name, err)
 					}
-				case v1alpha1.SessionStatePending:
+				case breakglassv1alpha1.SessionStatePending:
 					t.Logf("Withdrawing existing pending session: %s", s.Name)
 					if _, err := runAsRequester("session", "withdraw", s.Name); err != nil {
 						t.Logf("Warning: Failed to withdraw session %s: %v", s.Name, err)
@@ -227,7 +227,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			}
 			require.NoError(t, err, "Requester should create session")
 
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err, "Should parse session")
 
@@ -245,11 +245,11 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 				output, err := runAsRequester("session", "get", sessionName, "-o", "json")
 				require.NoError(t, err)
 
-				var session v1alpha1.BreakglassSession
+				var session breakglassv1alpha1.BreakglassSession
 				err = json.Unmarshal([]byte(output), &session)
 				require.NoError(t, err)
 
-				if session.Status.State == v1alpha1.SessionStatePending {
+				if session.Status.State == breakglassv1alpha1.SessionStatePending {
 					t.Logf("Session %s is Pending", sessionName)
 					return
 				}
@@ -291,11 +291,11 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 				output, err := runAsRequester("session", "get", sessionName, "-o", "json")
 				require.NoError(t, err)
 
-				var session v1alpha1.BreakglassSession
+				var session breakglassv1alpha1.BreakglassSession
 				err = json.Unmarshal([]byte(output), &session)
 				require.NoError(t, err)
 
-				if session.Status.State == v1alpha1.SessionStateApproved {
+				if session.Status.State == breakglassv1alpha1.SessionStateApproved {
 					t.Logf("Session %s is Approved", sessionName)
 					assert.NotEmpty(t, session.Status.Approvers, "Approvers should be recorded")
 					return
@@ -320,7 +320,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			)
 			require.NoError(t, err, "Should list approved sessions")
 
-			var sessions []v1alpha1.BreakglassSession
+			var sessions []breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &sessions)
 			require.NoError(t, err)
 
@@ -377,7 +377,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			}
 			require.NoError(t, err, "Requester should create session")
 
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &session)
 			require.NoError(t, err)
 
@@ -395,11 +395,11 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 				output, err := runAsRequester("session", "get", rejectedSessionName, "-o", "json")
 				require.NoError(t, err)
 
-				var session v1alpha1.BreakglassSession
+				var session breakglassv1alpha1.BreakglassSession
 				err = json.Unmarshal([]byte(output), &session)
 				require.NoError(t, err)
 
-				if session.Status.State == v1alpha1.SessionStatePending {
+				if session.Status.State == breakglassv1alpha1.SessionStatePending {
 					return
 				}
 				time.Sleep(helpers.PollInterval)
@@ -428,11 +428,11 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 				output, err := runAsRequester("session", "get", rejectedSessionName, "-o", "json")
 				require.NoError(t, err)
 
-				var session v1alpha1.BreakglassSession
+				var session breakglassv1alpha1.BreakglassSession
 				err = json.Unmarshal([]byte(output), &session)
 				require.NoError(t, err)
 
-				if session.Status.State == v1alpha1.SessionStateRejected {
+				if session.Status.State == breakglassv1alpha1.SessionStateRejected {
 					t.Logf("Session %s is Rejected", rejectedSessionName)
 					return
 				}
@@ -455,7 +455,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			var sessions []v1alpha1.BreakglassSession
+			var sessions []breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &sessions)
 			require.NoError(t, err)
 
@@ -477,7 +477,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			output, err := runAsRequester("session", "list", "--mine", "-o", "json")
 			require.NoError(t, err, "Requester should list their sessions")
 
-			var sessions []v1alpha1.BreakglassSession
+			var sessions []breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &sessions)
 			require.NoError(t, err)
 			t.Logf("Requester has %d sessions", len(sessions))
@@ -488,7 +488,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			output, err := runAsApprover("session", "list", "-o", "json")
 			require.NoError(t, err, "Approver should list all sessions")
 
-			var sessions []v1alpha1.BreakglassSession
+			var sessions []breakglassv1alpha1.BreakglassSession
 			err = json.Unmarshal([]byte(output), &sessions)
 			require.NoError(t, err)
 			t.Logf("Approver sees %d sessions", len(sessions))
@@ -503,7 +503,7 @@ func TestTwoPersonaGoFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// Both should see escalations (may differ based on group membership)
-			var escalations1, escalations2 []v1alpha1.BreakglassEscalation
+			var escalations1, escalations2 []breakglassv1alpha1.BreakglassEscalation
 			_ = json.Unmarshal([]byte(output1), &escalations1)
 			_ = json.Unmarshal([]byte(output2), &escalations2)
 

--- a/e2e/kubectl_debug_test.go
+++ b/e2e/kubectl_debug_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/e2e/helpers"
 )
 
@@ -46,23 +46,23 @@ func TestKubectlDebuggingMode(t *testing.T) {
 	// 1. Create a DebugSessionTemplate for kubectl-debug mode
 	templateName := "e2e-kubectl-debug-tmpl"
 
-	tmpl := &v1alpha1.DebugSessionTemplate{
+	tmpl := &breakglassv1alpha1.DebugSessionTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: templateName,
 		},
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "E2E Kubectl Debug",
-			Mode:        v1alpha1.DebugSessionModeKubectlDebug,
-			Rules: v1alpha1.DebugSessionRules{
+			Mode:        breakglassv1alpha1.DebugSessionModeKubectlDebug,
+			Rules: breakglassv1alpha1.DebugSessionRules{
 				AutoApprove: true,
 			},
-			KubectlDebug: &v1alpha1.KubectlDebugConfig{
-				EphemeralContainers: &v1alpha1.EphemeralContainerConfig{
+			KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+				EphemeralContainers: &breakglassv1alpha1.EphemeralContainerConfig{
 					Enabled:        true,
 					AllowedImages:  []string{"busybox", "alpine"},
 					RequireNonRoot: false,
 				},
-				NodeDebug: &v1alpha1.NodeDebugConfig{
+				NodeDebug: &breakglassv1alpha1.NodeDebugConfig{
 					Enabled: true,
 				},
 			},
@@ -110,20 +110,20 @@ func TestKubectlDebuggingMode(t *testing.T) {
 		Reason:      "E2E Test Ephemeral",
 	})
 	require.NoError(t, err)
-	cleanup.Add(&v1alpha1.DebugSession{
+	cleanup.Add(&breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: session.Name, Namespace: session.Namespace},
 	})
 
 	helpers.WaitForDebugSessionState(t, ctx, cli, session.Name, session.Namespace,
-		v1alpha1.DebugSessionStateActive, helpers.WaitForStateTimeout)
+		breakglassv1alpha1.DebugSessionStateActive, helpers.WaitForStateTimeout)
 
 	t.Log("Debug session activated for kubectl-debug mode")
 
 	// 4. Verify session is active and has correct mode
-	var activeSession v1alpha1.DebugSession
+	var activeSession breakglassv1alpha1.DebugSession
 	err = cli.Get(ctx, client.ObjectKey{Name: session.Name, Namespace: session.Namespace}, &activeSession)
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.DebugSessionStateActive, activeSession.Status.State)
+	require.Equal(t, breakglassv1alpha1.DebugSessionStateActive, activeSession.Status.State)
 
 	t.Log("Kubectl debug mode test passed - session created and activated")
 }
@@ -142,22 +142,22 @@ func TestTerminalSharingMode(t *testing.T) {
 	// Create template with terminal sharing enabled
 	templateName := "e2e-terminal-sharing-tmpl"
 
-	tmpl := &v1alpha1.DebugSessionTemplate{
+	tmpl := &breakglassv1alpha1.DebugSessionTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: templateName,
 		},
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName:     "E2E Terminal Sharing",
-			Mode:            v1alpha1.DebugSessionModeWorkload,
-			WorkloadType:    v1alpha1.DebugWorkloadDeployment,
+			Mode:            breakglassv1alpha1.DebugSessionModeWorkload,
+			WorkloadType:    breakglassv1alpha1.DebugWorkloadDeployment,
 			TargetNamespace: "default",
-			Rules: v1alpha1.DebugSessionRules{
+			Rules: breakglassv1alpha1.DebugSessionRules{
 				AutoApprove: true,
 			},
-			PodTemplateRef: &v1alpha1.DebugPodTemplateRef{
+			PodTemplateRef: &breakglassv1alpha1.DebugPodTemplateRef{
 				Name: "netshoot-base",
 			},
-			TerminalSharing: &v1alpha1.TerminalSharingConfig{
+			TerminalSharing: &breakglassv1alpha1.TerminalSharingConfig{
 				Enabled:         true,
 				Provider:        "tmux",
 				MaxParticipants: 5,
@@ -167,14 +167,14 @@ func TestTerminalSharingMode(t *testing.T) {
 	cleanup.Add(tmpl)
 
 	// Create base pod template
-	podTmpl := &v1alpha1.DebugPodTemplate{
+	podTmpl := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "netshoot-base",
 		},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			DisplayName: "Netshoot Base",
-			Template: v1alpha1.DebugPodSpec{
-				Spec: v1alpha1.DebugPodSpecInner{
+			Template: breakglassv1alpha1.DebugPodSpec{
+				Spec: breakglassv1alpha1.DebugPodSpecInner{
 					Containers: []corev1.Container{
 						{
 							Name:    "debug",
@@ -201,15 +201,15 @@ func TestTerminalSharingMode(t *testing.T) {
 		Reason:      "E2E Test Terminal Sharing",
 	})
 	require.NoError(t, err)
-	cleanup.Add(&v1alpha1.DebugSession{
+	cleanup.Add(&breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: session.Name, Namespace: session.Namespace},
 	})
 
 	helpers.WaitForDebugSessionState(t, ctx, cli, session.Name, session.Namespace,
-		v1alpha1.DebugSessionStateActive, helpers.WaitForConditionTimeout)
+		breakglassv1alpha1.DebugSessionStateActive, helpers.WaitForConditionTimeout)
 
 	// Verify terminal sharing is configured in status
-	var activeSession v1alpha1.DebugSession
+	var activeSession breakglassv1alpha1.DebugSession
 	err = cli.Get(ctx, client.ObjectKey{Name: session.Name, Namespace: session.Namespace}, &activeSession)
 	require.NoError(t, err)
 	require.NotNil(t, activeSession.Status.TerminalSharing, "Terminal sharing status should be set")

--- a/pkg/bgctl/client/debug.go
+++ b/pkg/bgctl/client/debug.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,18 +26,18 @@ type DebugSessionListOptions struct {
 }
 
 type DebugSessionSummary struct {
-	Name                 string                         `json:"name"`
-	TemplateRef          string                         `json:"templateRef"`
-	Cluster              string                         `json:"cluster"`
-	RequestedBy          string                         `json:"requestedBy"`
-	State                v1alpha1.DebugSessionState     `json:"state"`
-	StatusMessage        string                         `json:"statusMessage,omitempty"`
-	StartsAt             *metav1.Time                   `json:"startsAt,omitempty"`
-	ExpiresAt            *metav1.Time                   `json:"expiresAt,omitempty"`
-	Participants         int                            `json:"participants"`
-	IsParticipant        bool                           `json:"isParticipant"`
-	AllowedPods          int                            `json:"allowedPods"`
-	AllowedPodOperations *v1alpha1.AllowedPodOperations `json:"allowedPodOperations,omitempty"`
+	Name                 string                                   `json:"name"`
+	TemplateRef          string                                   `json:"templateRef"`
+	Cluster              string                                   `json:"cluster"`
+	RequestedBy          string                                   `json:"requestedBy"`
+	State                breakglassv1alpha1.DebugSessionState     `json:"state"`
+	StatusMessage        string                                   `json:"statusMessage,omitempty"`
+	StartsAt             *metav1.Time                             `json:"startsAt,omitempty"`
+	ExpiresAt            *metav1.Time                             `json:"expiresAt,omitempty"`
+	Participants         int                                      `json:"participants"`
+	IsParticipant        bool                                     `json:"isParticipant"`
+	AllowedPods          int                                      `json:"allowedPods"`
+	AllowedPodOperations *breakglassv1alpha1.AllowedPodOperations `json:"allowedPodOperations,omitempty"`
 }
 
 type DebugSessionListResponse struct {
@@ -49,7 +49,7 @@ type DebugSessionListResponse struct {
 // The DebugSession is embedded to match the server API which returns the session
 // at the root level (not wrapped in a "debugSession" field).
 type DebugSessionDetailResponse struct {
-	v1alpha1.DebugSession
+	breakglassv1alpha1.DebugSession
 }
 
 type CreateDebugSessionRequest struct {
@@ -122,7 +122,7 @@ func (s *DebugSessionService) List(ctx context.Context, opts DebugSessionListOpt
 	return &resp, nil
 }
 
-func (s *DebugSessionService) Get(ctx context.Context, name, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Get(ctx context.Context, name, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	endpoint := fmt.Sprintf("api/debugSessions/%s", url.PathEscape(name))
 	if namespace != "" {
 		endpoint = endpoint + "?namespace=" + url.QueryEscape(namespace)
@@ -134,7 +134,7 @@ func (s *DebugSessionService) Get(ctx context.Context, name, namespace string) (
 	return &resp.DebugSession, nil
 }
 
-func (s *DebugSessionService) Create(ctx context.Context, req CreateDebugSessionRequest) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Create(ctx context.Context, req CreateDebugSessionRequest) (*breakglassv1alpha1.DebugSession, error) {
 	endpoint := "api/debugSessions"
 	var resp DebugSessionDetailResponse
 	if err := s.client.do(ctx, http.MethodPost, endpoint, req, &resp); err != nil {
@@ -143,35 +143,35 @@ func (s *DebugSessionService) Create(ctx context.Context, req CreateDebugSession
 	return &resp.DebugSession, nil
 }
 
-func (s *DebugSessionService) Join(ctx context.Context, name, role, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Join(ctx context.Context, name, role, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	payload := JoinDebugSessionRequest{Role: role}
 	return s.action(ctx, name, "join", namespace, payload)
 }
 
-func (s *DebugSessionService) Leave(ctx context.Context, name, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Leave(ctx context.Context, name, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	return s.action(ctx, name, "leave", namespace, nil)
 }
 
-func (s *DebugSessionService) Renew(ctx context.Context, name, extendBy, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Renew(ctx context.Context, name, extendBy, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	payload := RenewDebugSessionRequest{ExtendBy: extendBy}
 	return s.action(ctx, name, "renew", namespace, payload)
 }
 
-func (s *DebugSessionService) Terminate(ctx context.Context, name, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Terminate(ctx context.Context, name, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	return s.action(ctx, name, "terminate", namespace, nil)
 }
 
-func (s *DebugSessionService) Approve(ctx context.Context, name, reason, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Approve(ctx context.Context, name, reason, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	payload := ApprovalRequest{Reason: reason}
 	return s.action(ctx, name, "approve", namespace, payload)
 }
 
-func (s *DebugSessionService) Reject(ctx context.Context, name, reason, namespace string) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) Reject(ctx context.Context, name, reason, namespace string) (*breakglassv1alpha1.DebugSession, error) {
 	payload := ApprovalRequest{Reason: reason}
 	return s.action(ctx, name, "reject", namespace, payload)
 }
 
-func (s *DebugSessionService) action(ctx context.Context, name, action, namespace string, payload any) (*v1alpha1.DebugSession, error) {
+func (s *DebugSessionService) action(ctx context.Context, name, action, namespace string, payload any) (*breakglassv1alpha1.DebugSession, error) {
 	endpoint := fmt.Sprintf("api/debugSessions/%s/%s", url.PathEscape(name), action)
 	if namespace != "" {
 		endpoint = endpoint + "?namespace=" + url.QueryEscape(namespace)
@@ -225,19 +225,19 @@ type DebugTemplateService struct {
 
 // DebugSessionTemplateSummary represents a template summary from the API
 type DebugSessionTemplateSummary struct {
-	Name                  string                            `json:"name"`
-	DisplayName           string                            `json:"displayName"`
-	Description           string                            `json:"description,omitempty"`
-	Mode                  v1alpha1.DebugSessionTemplateMode `json:"mode"`
-	WorkloadType          v1alpha1.DebugWorkloadType        `json:"workloadType,omitempty"`
-	PodTemplateRef        string                            `json:"podTemplateRef,omitempty"`
-	TargetNamespace       string                            `json:"targetNamespace,omitempty"`
-	Constraints           *v1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
-	AllowedClusters       []string                          `json:"allowedClusters,omitempty"`
-	AllowedGroups         []string                          `json:"allowedGroups,omitempty"`
-	RequiresApproval      bool                              `json:"requiresApproval"`
-	HasAvailableClusters  bool                              `json:"hasAvailableClusters"`            // True if at least one cluster is available
-	AvailableClusterCount int                               `json:"availableClusterCount,omitempty"` // Number of clusters user can deploy to
+	Name                  string                                      `json:"name"`
+	DisplayName           string                                      `json:"displayName"`
+	Description           string                                      `json:"description,omitempty"`
+	Mode                  breakglassv1alpha1.DebugSessionTemplateMode `json:"mode"`
+	WorkloadType          breakglassv1alpha1.DebugWorkloadType        `json:"workloadType,omitempty"`
+	PodTemplateRef        string                                      `json:"podTemplateRef,omitempty"`
+	TargetNamespace       string                                      `json:"targetNamespace,omitempty"`
+	Constraints           *breakglassv1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
+	AllowedClusters       []string                                    `json:"allowedClusters,omitempty"`
+	AllowedGroups         []string                                    `json:"allowedGroups,omitempty"`
+	RequiresApproval      bool                                        `json:"requiresApproval"`
+	HasAvailableClusters  bool                                        `json:"hasAvailableClusters"`            // True if at least one cluster is available
+	AvailableClusterCount int                                         `json:"availableClusterCount,omitempty"` // Number of clusters user can deploy to
 }
 
 // DebugTemplateListResponse represents the API response for template list
@@ -288,38 +288,38 @@ type TemplateClustersResponse struct {
 // AvailableClusterDetail represents a cluster with resolved constraints for a template.
 // When multiple bindings match a cluster, BindingOptions contains all available options.
 type AvailableClusterDetail struct {
-	Name                          string                            `json:"name"`
-	DisplayName                   string                            `json:"displayName,omitempty"`
-	Environment                   string                            `json:"environment,omitempty"`
-	Location                      string                            `json:"location,omitempty"`
-	Site                          string                            `json:"site,omitempty"`
-	Tenant                        string                            `json:"tenant,omitempty"`
-	BindingRef                    *BindingReference                 `json:"bindingRef,omitempty"`     // Default/primary binding (backward compat)
-	BindingOptions                []BindingOption                   `json:"bindingOptions,omitempty"` // All available binding options
-	Constraints                   *v1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
-	SchedulingConstraints         *SchedulingConstraintsSummary     `json:"schedulingConstraints,omitempty"`
-	SchedulingOptions             *SchedulingOptionsResponse        `json:"schedulingOptions,omitempty"`
-	NamespaceConstraints          *NamespaceConstraintsResponse     `json:"namespaceConstraints,omitempty"`
-	Impersonation                 *ImpersonationSummary             `json:"impersonation,omitempty"`
-	RequiredAuxResourceCategories []string                          `json:"requiredAuxiliaryResourceCategories,omitempty"`
-	Approval                      *ApprovalInfo                     `json:"approval,omitempty"`
-	Status                        *ClusterStatusInfo                `json:"status,omitempty"`
+	Name                          string                                      `json:"name"`
+	DisplayName                   string                                      `json:"displayName,omitempty"`
+	Environment                   string                                      `json:"environment,omitempty"`
+	Location                      string                                      `json:"location,omitempty"`
+	Site                          string                                      `json:"site,omitempty"`
+	Tenant                        string                                      `json:"tenant,omitempty"`
+	BindingRef                    *BindingReference                           `json:"bindingRef,omitempty"`     // Default/primary binding (backward compat)
+	BindingOptions                []BindingOption                             `json:"bindingOptions,omitempty"` // All available binding options
+	Constraints                   *breakglassv1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
+	SchedulingConstraints         *SchedulingConstraintsSummary               `json:"schedulingConstraints,omitempty"`
+	SchedulingOptions             *SchedulingOptionsResponse                  `json:"schedulingOptions,omitempty"`
+	NamespaceConstraints          *NamespaceConstraintsResponse               `json:"namespaceConstraints,omitempty"`
+	Impersonation                 *ImpersonationSummary                       `json:"impersonation,omitempty"`
+	RequiredAuxResourceCategories []string                                    `json:"requiredAuxiliaryResourceCategories,omitempty"`
+	Approval                      *ApprovalInfo                               `json:"approval,omitempty"`
+	Status                        *ClusterStatusInfo                          `json:"status,omitempty"`
 }
 
 // BindingOption represents a single binding option with its resolved configuration
 type BindingOption struct {
-	BindingRef                    BindingReference                  `json:"bindingRef"`
-	DisplayName                   string                            `json:"displayName,omitempty"`
-	Constraints                   *v1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
-	SchedulingConstraints         *SchedulingConstraintsSummary     `json:"schedulingConstraints,omitempty"`
-	SchedulingOptions             *SchedulingOptionsResponse        `json:"schedulingOptions,omitempty"`
-	NamespaceConstraints          *NamespaceConstraintsResponse     `json:"namespaceConstraints,omitempty"`
-	Impersonation                 *ImpersonationSummary             `json:"impersonation,omitempty"`
-	RequiredAuxResourceCategories []string                          `json:"requiredAuxiliaryResourceCategories,omitempty"`
-	Approval                      *ApprovalInfo                     `json:"approval,omitempty"`
-	RequestReason                 *ReasonConfigInfo                 `json:"requestReason,omitempty"`
-	ApprovalReason                *ReasonConfigInfo                 `json:"approvalReason,omitempty"`
-	Notification                  *NotificationConfigInfo           `json:"notification,omitempty"`
+	BindingRef                    BindingReference                            `json:"bindingRef"`
+	DisplayName                   string                                      `json:"displayName,omitempty"`
+	Constraints                   *breakglassv1alpha1.DebugSessionConstraints `json:"constraints,omitempty"`
+	SchedulingConstraints         *SchedulingConstraintsSummary               `json:"schedulingConstraints,omitempty"`
+	SchedulingOptions             *SchedulingOptionsResponse                  `json:"schedulingOptions,omitempty"`
+	NamespaceConstraints          *NamespaceConstraintsResponse               `json:"namespaceConstraints,omitempty"`
+	Impersonation                 *ImpersonationSummary                       `json:"impersonation,omitempty"`
+	RequiredAuxResourceCategories []string                                    `json:"requiredAuxiliaryResourceCategories,omitempty"`
+	Approval                      *ApprovalInfo                               `json:"approval,omitempty"`
+	RequestReason                 *ReasonConfigInfo                           `json:"requestReason,omitempty"`
+	ApprovalReason                *ReasonConfigInfo                           `json:"approvalReason,omitempty"`
+	Notification                  *NotificationConfigInfo                     `json:"notification,omitempty"`
 }
 
 // BindingReference identifies the binding that enabled access
@@ -472,9 +472,9 @@ func (d *DebugPodTemplateService) List(ctx context.Context) (*DebugPodTemplateLi
 	return &resp, nil
 }
 
-func (d *DebugPodTemplateService) Get(ctx context.Context, name string) (*v1alpha1.DebugPodTemplate, error) {
+func (d *DebugPodTemplateService) Get(ctx context.Context, name string) (*breakglassv1alpha1.DebugPodTemplate, error) {
 	endpoint := fmt.Sprintf("api/debugSessions/podTemplates/%s", url.PathEscape(name))
-	var template v1alpha1.DebugPodTemplate
+	var template breakglassv1alpha1.DebugPodTemplate
 	if err := d.client.do(ctx, http.MethodGet, endpoint, nil, &template); err != nil {
 		return nil, err
 	}

--- a/pkg/bgctl/client/debug_test.go
+++ b/pkg/bgctl/client/debug_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,7 +33,7 @@ func TestDebugSessionsList(t *testing.T) {
 				TemplateRef:  "template-1",
 				Cluster:      "cluster-a",
 				RequestedBy:  "user@example.com",
-				State:        v1alpha1.DebugSessionStateActive,
+				State:        breakglassv1alpha1.DebugSessionStateActive,
 				StartsAt:     &startsAt,
 				ExpiresAt:    &expiresAt,
 				Participants: 2,
@@ -67,19 +67,19 @@ func TestDebugSessionsList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Sessions, 1)
 	assert.Equal(t, "debug-session-1", result.Sessions[0].Name)
-	assert.Equal(t, v1alpha1.DebugSessionStateActive, result.Sessions[0].State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, result.Sessions[0].State)
 }
 
 func TestDebugSessionsGet(t *testing.T) {
-	debugSession := v1alpha1.DebugSession{
+	debugSession := breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			TemplateRef: "template-1",
 			Cluster:     "test-cluster",
 			RequestedBy: "user@example.com",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
 		},
 	}
 
@@ -98,7 +98,7 @@ func TestDebugSessionsGet(t *testing.T) {
 	result, err := client.DebugSessions().Get(context.Background(), "debug-session-123", "")
 	require.NoError(t, err)
 	assert.Equal(t, "debug-session-123", result.Name)
-	assert.Equal(t, v1alpha1.DebugSessionStateActive, result.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, result.Status.State)
 }
 
 func TestDebugSessionsCreate(t *testing.T) {
@@ -113,9 +113,9 @@ func TestDebugSessionsCreate(t *testing.T) {
 		assert.Equal(t, "cluster-a", req.Cluster)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-new"},
-				Spec: v1alpha1.DebugSessionSpec{
+				Spec: breakglassv1alpha1.DebugSessionSpec{
 					TemplateRef: req.TemplateRef,
 					Cluster:     req.Cluster,
 					RequestedBy: "test@example.com",
@@ -145,10 +145,10 @@ func TestDebugSessionsTerminate(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
-				Status: v1alpha1.DebugSessionStatus{
-					State: v1alpha1.DebugSessionStateTerminated,
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					State: breakglassv1alpha1.DebugSessionStateTerminated,
 				},
 			},
 		}
@@ -162,7 +162,7 @@ func TestDebugSessionsTerminate(t *testing.T) {
 
 	result, err := client.DebugSessions().Terminate(context.Background(), "debug-session-123", "")
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.DebugSessionStateTerminated, result.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, result.Status.State)
 }
 
 func TestDebugSessionsApprove(t *testing.T) {
@@ -175,10 +175,10 @@ func TestDebugSessionsApprove(t *testing.T) {
 		assert.Equal(t, "approved for testing", req.Reason)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
-				Status: v1alpha1.DebugSessionStatus{
-					State: v1alpha1.DebugSessionStateActive,
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					State: breakglassv1alpha1.DebugSessionStateActive,
 				},
 			},
 		}
@@ -192,7 +192,7 @@ func TestDebugSessionsApprove(t *testing.T) {
 
 	result, err := client.DebugSessions().Approve(context.Background(), "debug-session-123", "approved for testing", "")
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.DebugSessionStateActive, result.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, result.Status.State)
 }
 
 func TestDebugSessionsReject(t *testing.T) {
@@ -201,10 +201,10 @@ func TestDebugSessionsReject(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
-				Status: v1alpha1.DebugSessionStatus{
-					State: v1alpha1.DebugSessionStateTerminated,
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					State: breakglassv1alpha1.DebugSessionStateTerminated,
 				},
 			},
 		}
@@ -218,7 +218,7 @@ func TestDebugSessionsReject(t *testing.T) {
 
 	result, err := client.DebugSessions().Reject(context.Background(), "debug-session-123", "not needed", "")
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.DebugSessionStateTerminated, result.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, result.Status.State)
 }
 
 func TestDebugSessionsJoin(t *testing.T) {
@@ -231,7 +231,7 @@ func TestDebugSessionsJoin(t *testing.T) {
 		assert.Equal(t, "participant", req.Role)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
 			},
 		}
@@ -254,7 +254,7 @@ func TestDebugSessionsLeave(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
 			},
 		}
@@ -281,7 +281,7 @@ func TestDebugSessionsRenew(t *testing.T) {
 		assert.Equal(t, "30m", req.ExtendBy)
 
 		response := DebugSessionDetailResponse{
-			DebugSession: v1alpha1.DebugSession{
+			DebugSession: breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "debug-session-123"},
 			},
 		}
@@ -425,9 +425,9 @@ func TestDebugPodTemplatesList(t *testing.T) {
 }
 
 func TestDebugPodTemplatesGet(t *testing.T) {
-	template := v1alpha1.DebugPodTemplate{
+	template := breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "pod-template-1"},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			DisplayName: "Pod Template",
 		},
 	}
@@ -657,7 +657,7 @@ func TestDebugTemplatesGetClusters(t *testing.T) {
 						Location:    "eu-west",
 						Site:        "datacenter-1",
 						Tenant:      "acme-corp",
-						Constraints: &v1alpha1.DebugSessionConstraints{
+						Constraints: &breakglassv1alpha1.DebugSessionConstraints{
 							MaxDuration:     "2h",
 							DefaultDuration: "30m",
 						},

--- a/pkg/bgctl/client/escalations.go
+++ b/pkg/bgctl/client/escalations.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 type EscalationService struct {
@@ -16,16 +16,16 @@ func (c *Client) Escalations() *EscalationService {
 	return &EscalationService{client: c}
 }
 
-func (e *EscalationService) List(ctx context.Context) ([]v1alpha1.BreakglassEscalation, error) {
+func (e *EscalationService) List(ctx context.Context) ([]breakglassv1alpha1.BreakglassEscalation, error) {
 	endpoint := "api/breakglassEscalations"
-	var escs []v1alpha1.BreakglassEscalation
+	var escs []breakglassv1alpha1.BreakglassEscalation
 	if err := e.client.do(ctx, http.MethodGet, endpoint, nil, &escs); err != nil {
 		return nil, err
 	}
 	return escs, nil
 }
 
-func (e *EscalationService) Get(ctx context.Context, name string) (*v1alpha1.BreakglassEscalation, error) {
+func (e *EscalationService) Get(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassEscalation, error) {
 	escs, err := e.List(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/bgctl/client/escalations_test.go
+++ b/pkg/bgctl/client/escalations_test.go
@@ -16,17 +16,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEscalationsList(t *testing.T) {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-1"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "admin",
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-a", "cluster-b"},
 					Groups:   []string{"developers"},
 				},
@@ -34,9 +34,9 @@ func TestEscalationsList(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-2"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "viewer",
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-c"},
 					Groups:   []string{"readers"},
 				},
@@ -64,16 +64,16 @@ func TestEscalationsList(t *testing.T) {
 }
 
 func TestEscalationsGet(t *testing.T) {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-1"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "admin",
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-2"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "viewer",
 			},
 		},
@@ -101,7 +101,7 @@ func TestEscalationsGet(t *testing.T) {
 }
 
 func TestEscalationsGet_NotFound(t *testing.T) {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-1"},
 		},
@@ -122,19 +122,19 @@ func TestEscalationsGet_NotFound(t *testing.T) {
 }
 
 func TestEscalationsListClusters(t *testing.T) {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-1"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-a", "cluster-b"},
 				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-2"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-b", "cluster-c"}, // cluster-b is duplicate
 				},
 			},
@@ -162,7 +162,7 @@ func TestEscalationsListClusters(t *testing.T) {
 func TestEscalationsListClusters_Empty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]v1alpha1.BreakglassEscalation{})
+		_ = json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassEscalation{})
 	}))
 	defer server.Close()
 

--- a/pkg/bgctl/client/sessions.go
+++ b/pkg/bgctl/client/sessions.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 type SessionService struct {
@@ -42,7 +42,7 @@ type SessionActionRequest struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]v1alpha1.BreakglassSession, error) {
+func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]breakglassv1alpha1.BreakglassSession, error) {
 	endpoint := "api/breakglassSessions"
 	params := url.Values{}
 	if opts.Cluster != "" {
@@ -72,7 +72,7 @@ func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]v
 	if encoded := params.Encode(); encoded != "" {
 		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
 	}
-	var sessions []v1alpha1.BreakglassSession
+	var sessions []breakglassv1alpha1.BreakglassSession
 	if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &sessions); err != nil {
 		return nil, err
 	}
@@ -81,11 +81,11 @@ func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]v
 
 // SessionGetResponse wraps the session with authorization metadata
 type SessionGetResponse struct {
-	Session      v1alpha1.BreakglassSession `json:"session"`
-	ApprovalMeta map[string]interface{}     `json:"approvalMeta,omitempty"`
+	Session      breakglassv1alpha1.BreakglassSession `json:"session"`
+	ApprovalMeta map[string]interface{}               `json:"approvalMeta,omitempty"`
 }
 
-func (s *SessionService) Get(ctx context.Context, name string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Get(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassSession, error) {
 	endpoint := fmt.Sprintf("api/breakglassSessions/%s", url.PathEscape(name))
 	var resp SessionGetResponse
 	if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
@@ -94,38 +94,38 @@ func (s *SessionService) Get(ctx context.Context, name string) (*v1alpha1.Breakg
 	return &resp.Session, nil
 }
 
-func (s *SessionService) Request(ctx context.Context, req SessionRequest) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Request(ctx context.Context, req SessionRequest) (*breakglassv1alpha1.BreakglassSession, error) {
 	endpoint := "api/breakglassSessions"
-	var session v1alpha1.BreakglassSession
+	var session breakglassv1alpha1.BreakglassSession
 	if err := s.client.do(ctx, http.MethodPost, endpoint, req, &session); err != nil {
 		return nil, err
 	}
 	return &session, nil
 }
 
-func (s *SessionService) Approve(ctx context.Context, name, reason string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Approve(ctx context.Context, name, reason string) (*breakglassv1alpha1.BreakglassSession, error) {
 	return s.action(ctx, name, "approve", reason)
 }
 
-func (s *SessionService) Reject(ctx context.Context, name, reason string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Reject(ctx context.Context, name, reason string) (*breakglassv1alpha1.BreakglassSession, error) {
 	return s.action(ctx, name, "reject", reason)
 }
 
-func (s *SessionService) Withdraw(ctx context.Context, name string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Withdraw(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassSession, error) {
 	return s.action(ctx, name, "withdraw", "")
 }
 
-func (s *SessionService) Drop(ctx context.Context, name string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Drop(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassSession, error) {
 	return s.action(ctx, name, "drop", "")
 }
 
-func (s *SessionService) Cancel(ctx context.Context, name string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) Cancel(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassSession, error) {
 	return s.action(ctx, name, "cancel", "")
 }
 
-func (s *SessionService) action(ctx context.Context, name, action, reason string) (*v1alpha1.BreakglassSession, error) {
+func (s *SessionService) action(ctx context.Context, name, action, reason string) (*breakglassv1alpha1.BreakglassSession, error) {
 	endpoint := fmt.Sprintf("api/breakglassSessions/%s/%s", url.PathEscape(name), action)
-	var session v1alpha1.BreakglassSession
+	var session breakglassv1alpha1.BreakglassSession
 	var payload *SessionActionRequest
 	if reason != "" {
 		payload = &SessionActionRequest{Reason: reason}

--- a/pkg/bgctl/client/sessions_test.go
+++ b/pkg/bgctl/client/sessions_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSessionsList(t *testing.T) {
-	sessions := []v1alpha1.BreakglassSession{
+	sessions := []breakglassv1alpha1.BreakglassSession{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1"},
-			Spec:       v1alpha1.BreakglassSessionSpec{User: "user@example.com"},
+			Spec:       breakglassv1alpha1.BreakglassSessionSpec{User: "user@example.com"},
 		},
 	}
 
@@ -47,9 +47,9 @@ func TestSessionsList(t *testing.T) {
 }
 
 func TestSessionsGet(t *testing.T) {
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-		Spec:       v1alpha1.BreakglassSessionSpec{User: "user@example.com"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{User: "user@example.com"},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -87,9 +87,9 @@ func TestSessionsRequest(t *testing.T) {
 		require.Equal(t, "test-cluster", req.Cluster)
 		require.Equal(t, "admin", req.Group)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-new"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster:      req.Cluster,
 				GrantedGroup: req.Group,
 			},
@@ -121,10 +121,10 @@ func TestSessionsApprove(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		require.Equal(t, "approved for testing", req.Reason)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateApproved,
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -137,7 +137,7 @@ func TestSessionsApprove(t *testing.T) {
 
 	result, err := client.Sessions().Approve(context.Background(), "session-123", "approved for testing")
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.SessionStateApproved, result.Status.State)
+	require.Equal(t, breakglassv1alpha1.SessionStateApproved, result.Status.State)
 }
 
 func TestSessionsReject(t *testing.T) {
@@ -149,10 +149,10 @@ func TestSessionsReject(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		require.Equal(t, "not authorized", req.Reason)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateRejected,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateRejected,
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -165,7 +165,7 @@ func TestSessionsReject(t *testing.T) {
 
 	result, err := client.Sessions().Reject(context.Background(), "session-123", "not authorized")
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.SessionStateRejected, result.Status.State)
+	require.Equal(t, breakglassv1alpha1.SessionStateRejected, result.Status.State)
 }
 
 func TestSessionsWithdraw(t *testing.T) {
@@ -173,10 +173,10 @@ func TestSessionsWithdraw(t *testing.T) {
 		require.Equal(t, "/api/breakglassSessions/session-123/withdraw", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateWithdrawn,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateWithdrawn,
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -189,7 +189,7 @@ func TestSessionsWithdraw(t *testing.T) {
 
 	result, err := client.Sessions().Withdraw(context.Background(), "session-123")
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.SessionStateWithdrawn, result.Status.State)
+	require.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, result.Status.State)
 }
 
 func TestSessionsDrop(t *testing.T) {
@@ -197,10 +197,10 @@ func TestSessionsDrop(t *testing.T) {
 		require.Equal(t, "/api/breakglassSessions/session-123/drop", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateExpired,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateExpired,
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -213,7 +213,7 @@ func TestSessionsDrop(t *testing.T) {
 
 	result, err := client.Sessions().Drop(context.Background(), "session-123")
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.SessionStateExpired, result.Status.State)
+	require.Equal(t, breakglassv1alpha1.SessionStateExpired, result.Status.State)
 }
 
 func TestSessionsCancel(t *testing.T) {
@@ -221,10 +221,10 @@ func TestSessionsCancel(t *testing.T) {
 		require.Equal(t, "/api/breakglassSessions/session-123/cancel", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
-		response := v1alpha1.BreakglassSession{
+		response := breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-123"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateExpired,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateExpired,
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -237,11 +237,11 @@ func TestSessionsCancel(t *testing.T) {
 
 	result, err := client.Sessions().Cancel(context.Background(), "session-123")
 	require.NoError(t, err)
-	require.Equal(t, v1alpha1.SessionStateExpired, result.Status.State)
+	require.Equal(t, breakglassv1alpha1.SessionStateExpired, result.Status.State)
 }
 
 func TestSessionsList_WithFilters(t *testing.T) {
-	sessions := []v1alpha1.BreakglassSession{
+	sessions := []breakglassv1alpha1.BreakglassSession{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1"},
 		},

--- a/pkg/bgctl/cmd/debug_test.go
+++ b/pkg/bgctl/cmd/debug_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/client"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -176,7 +176,7 @@ func setupMockDebugServer(t *testing.T) *httptest.Server {
 				TemplateRef:  "template-1",
 				Cluster:      "cluster-a",
 				RequestedBy:  "user@example.com",
-				State:        v1alpha1.DebugSessionStateActive,
+				State:        breakglassv1alpha1.DebugSessionStateActive,
 				StartsAt:     &startsAt,
 				ExpiresAt:    &expiresAt,
 				Participants: 2,
@@ -552,7 +552,7 @@ func TestDebugSessionCreateCommand_WithSetFlag(t *testing.T) {
 			}
 			// Return mock session
 			w.Header().Set("Content-Type", "application/json")
-			session := v1alpha1.DebugSession{
+			session := breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-session",
 					Namespace: "breakglass",

--- a/pkg/bgctl/cmd/escalation_test.go
+++ b/pkg/bgctl/cmd/escalation_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -107,29 +107,29 @@ func writeTestConfigForEscalation(t *testing.T, serverURL string) string {
 
 // Mock server for integration-style tests
 func setupMockEscalationServer(t *testing.T) *httptest.Server {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-escalation-1"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "admin",
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-a", "cluster-b"},
 					Groups:   []string{"developers"},
 				},
-				Approvers: v1alpha1.BreakglassEscalationApprovers{
+				Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 					Groups: []string{"approvers"},
 				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-escalation-2"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "viewer",
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"cluster-b", "cluster-c"},
 					Groups:   []string{"readers"},
 				},
-				Approvers: v1alpha1.BreakglassEscalationApprovers{
+				Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 					Users: []string{"admin@example.com"},
 				},
 			},
@@ -168,7 +168,7 @@ func TestEscalationListCommand_WithMockServer(t *testing.T) {
 
 	require.NoError(t, err)
 
-	var result []v1alpha1.BreakglassEscalation
+	var result []breakglassv1alpha1.BreakglassEscalation
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
 	assert.Len(t, result, 2)
 	assert.Equal(t, "test-escalation-1", result[0].Name)

--- a/pkg/bgctl/cmd/session.go
+++ b/pkg/bgctl/cmd/session.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/client"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/output"
 )
@@ -234,7 +234,7 @@ func newSessionGetCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -283,7 +283,7 @@ func newSessionRequestCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -321,7 +321,7 @@ func newSessionApproveCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -352,7 +352,7 @@ func newSessionRejectCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -382,7 +382,7 @@ func newSessionWithdrawCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -410,7 +410,7 @@ func newSessionDropCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)
@@ -438,7 +438,7 @@ func newSessionCancelCommand() *cobra.Command {
 			}
 			format := output.Format(rt.OutputFormat())
 			if format == output.FormatTable {
-				output.WriteSessionTable(rt.Writer(), []v1alpha1.BreakglassSession{*session})
+				output.WriteSessionTable(rt.Writer(), []breakglassv1alpha1.BreakglassSession{*session})
 				return nil
 			}
 			return output.WriteObject(rt.Writer(), format, session)

--- a/pkg/bgctl/output/table.go
+++ b/pkg/bgctl/output/table.go
@@ -7,11 +7,11 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/client"
 )
 
-func WriteSessionTable(w io.Writer, sessions []v1alpha1.BreakglassSession) {
+func WriteSessionTable(w io.Writer, sessions []breakglassv1alpha1.BreakglassSession) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tUSER\tSTATE\tCREATED\tEXPIRES")
 	for _, s := range sessions {
@@ -25,7 +25,7 @@ func WriteSessionTable(w io.Writer, sessions []v1alpha1.BreakglassSession) {
 	_ = tw.Flush()
 }
 
-func WriteSessionTableWide(w io.Writer, sessions []v1alpha1.BreakglassSession) {
+func WriteSessionTableWide(w io.Writer, sessions []breakglassv1alpha1.BreakglassSession) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tUSER\tGROUP\tSTATE\tCREATED\tAPPROVER\tEXPIRES")
 	for _, s := range sessions {
@@ -39,7 +39,7 @@ func WriteSessionTableWide(w io.Writer, sessions []v1alpha1.BreakglassSession) {
 	_ = tw.Flush()
 }
 
-func WriteEscalationTable(w io.Writer, escs []v1alpha1.BreakglassEscalation) {
+func WriteEscalationTable(w io.Writer, escs []breakglassv1alpha1.BreakglassEscalation) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTERS\tALLOWED_GROUPS\tESCALATED_GROUP\tAPPROVERS")
 	for _, e := range escs {
@@ -85,7 +85,7 @@ func WriteDebugSessionTableWide(w io.Writer, sessions []client.DebugSessionSumma
 
 // formatAllowedPodOperations returns a short string representation of allowed pod operations.
 // Returns a comma-separated list of enabled operations (e.g., "exec,logs,attach").
-func formatAllowedPodOperations(ops *v1alpha1.AllowedPodOperations) string {
+func formatAllowedPodOperations(ops *breakglassv1alpha1.AllowedPodOperations) string {
 	if ops == nil {
 		// Default behavior when not specified: exec, attach, portforward enabled
 		return "exec,attach,portforward"

--- a/pkg/bgctl/output/table_test.go
+++ b/pkg/bgctl/output/table_test.go
@@ -14,25 +14,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/bgctl/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestWriteSessionTable(t *testing.T) {
 	now := time.Now()
-	sessions := []v1alpha1.BreakglassSession{
+	sessions := []breakglassv1alpha1.BreakglassSession{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "session-1",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster: "cluster-a",
 				User:    "user@example.com",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:     v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
 				ExpiresAt: metav1.NewTime(now.Add(1 * time.Hour)),
 			},
 		},
@@ -41,12 +41,12 @@ func TestWriteSessionTable(t *testing.T) {
 				Name:              "session-2",
 				CreationTimestamp: metav1.NewTime(now),
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster: "cluster-b",
 				User:    "admin@example.com",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStatePending,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStatePending,
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func TestWriteSessionTable(t *testing.T) {
 
 func TestWriteSessionTable_EmptyList(t *testing.T) {
 	buf := &bytes.Buffer{}
-	WriteSessionTable(buf, []v1alpha1.BreakglassSession{})
+	WriteSessionTable(buf, []breakglassv1alpha1.BreakglassSession{})
 
 	output := buf.String()
 	// Should still have header
@@ -89,19 +89,19 @@ func TestWriteSessionTable_EmptyList(t *testing.T) {
 
 func TestWriteSessionTableWide(t *testing.T) {
 	now := time.Now()
-	sessions := []v1alpha1.BreakglassSession{
+	sessions := []breakglassv1alpha1.BreakglassSession{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "session-1",
 				CreationTimestamp: metav1.NewTime(now),
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster:      "cluster-a",
 				User:         "user@example.com",
 				GrantedGroup: "admins",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:     v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
 				Approver:  "approver@example.com",
 				ExpiresAt: metav1.NewTime(now.Add(1 * time.Hour)),
 			},
@@ -120,16 +120,16 @@ func TestWriteSessionTableWide(t *testing.T) {
 }
 
 func TestWriteEscalationTable(t *testing.T) {
-	escalations := []v1alpha1.BreakglassEscalation{
+	escalations := []breakglassv1alpha1.BreakglassEscalation{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "escalation-1"},
-			Spec: v1alpha1.BreakglassEscalationSpec{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 				EscalatedGroup: "cluster-admin",
-				Allowed: v1alpha1.BreakglassEscalationAllowed{
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 					Clusters: []string{"prod-1", "prod-2"},
 					Groups:   []string{"developers"},
 				},
-				Approvers: v1alpha1.BreakglassEscalationApprovers{
+				Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 					Groups: []string{"security-team"},
 					Users:  []string{"lead@example.com"},
 				},
@@ -165,7 +165,7 @@ func TestWriteDebugSessionTable(t *testing.T) {
 			TemplateRef:  "debug-template",
 			Cluster:      "dev-cluster",
 			RequestedBy:  "developer@example.com",
-			State:        v1alpha1.DebugSessionStateActive,
+			State:        breakglassv1alpha1.DebugSessionStateActive,
 			StartsAt:     &startsAt,
 			ExpiresAt:    &expiresAt,
 			Participants: 2,
@@ -201,7 +201,7 @@ func TestWriteDebugSessionTableWide(t *testing.T) {
 			TemplateRef:  "debug-template",
 			Cluster:      "dev-cluster",
 			RequestedBy:  "developer@example.com",
-			State:        v1alpha1.DebugSessionStateActive,
+			State:        breakglassv1alpha1.DebugSessionStateActive,
 			StartsAt:     &startsAt,
 			ExpiresAt:    &expiresAt,
 			Participants: 2,
@@ -241,12 +241,12 @@ func TestWriteDebugSessionTableWide_WithAllowedPodOperations(t *testing.T) {
 			TemplateRef:  "debug-template",
 			Cluster:      "dev-cluster",
 			RequestedBy:  "developer@example.com",
-			State:        v1alpha1.DebugSessionStateActive,
+			State:        breakglassv1alpha1.DebugSessionStateActive,
 			StartsAt:     &startsAt,
 			ExpiresAt:    &expiresAt,
 			Participants: 2,
 			AllowedPods:  5,
-			AllowedPodOperations: &v1alpha1.AllowedPodOperations{
+			AllowedPodOperations: &breakglassv1alpha1.AllowedPodOperations{
 				Exec:        &boolTrue,
 				Attach:      &boolFalse,
 				Logs:        &boolTrue,
@@ -272,7 +272,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		ops      *v1alpha1.AllowedPodOperations
+		ops      *breakglassv1alpha1.AllowedPodOperations
 		expected string
 	}{
 		{
@@ -282,7 +282,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 		},
 		{
 			name: "all enabled",
-			ops: &v1alpha1.AllowedPodOperations{
+			ops: &breakglassv1alpha1.AllowedPodOperations{
 				Exec:        &boolTrue,
 				Attach:      &boolTrue,
 				Logs:        &boolTrue,
@@ -292,7 +292,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 		},
 		{
 			name: "all disabled",
-			ops: &v1alpha1.AllowedPodOperations{
+			ops: &breakglassv1alpha1.AllowedPodOperations{
 				Exec:        &boolFalse,
 				Attach:      &boolFalse,
 				Logs:        &boolFalse,
@@ -302,7 +302,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 		},
 		{
 			name: "only exec enabled",
-			ops: &v1alpha1.AllowedPodOperations{
+			ops: &breakglassv1alpha1.AllowedPodOperations{
 				Exec:        &boolTrue,
 				Attach:      &boolFalse,
 				Logs:        &boolFalse,
@@ -312,7 +312,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 		},
 		{
 			name: "only logs enabled",
-			ops: &v1alpha1.AllowedPodOperations{
+			ops: &breakglassv1alpha1.AllowedPodOperations{
 				Exec:        &boolFalse,
 				Attach:      &boolFalse,
 				Logs:        &boolTrue,
@@ -322,7 +322,7 @@ func TestFormatAllowedPodOperations(t *testing.T) {
 		},
 		{
 			name:     "empty struct uses defaults per field",
-			ops:      &v1alpha1.AllowedPodOperations{},
+			ops:      &breakglassv1alpha1.AllowedPodOperations{},
 			expected: "exec,attach,portforward",
 		},
 	}
@@ -342,7 +342,7 @@ func TestWriteDebugSessionTable_NilTimes(t *testing.T) {
 			TemplateRef: "template",
 			Cluster:     "cluster",
 			RequestedBy: "user@example.com",
-			State:       v1alpha1.DebugSessionStatePending,
+			State:       breakglassv1alpha1.DebugSessionStatePending,
 			StartsAt:    nil,
 			ExpiresAt:   nil,
 		},
@@ -524,7 +524,7 @@ func TestWriteTemplateClusterTable(t *testing.T) {
 						{BindingRef: client.BindingReference{Name: "binding-1", Namespace: "ns-1"}},
 						{BindingRef: client.BindingReference{Name: "binding-2", Namespace: "ns-2"}},
 					},
-					Constraints: &v1alpha1.DebugSessionConstraints{MaxDuration: "2h"},
+					Constraints: &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: "2h"},
 					Approval:    &client.ApprovalInfo{Required: true},
 				},
 			},
@@ -610,7 +610,7 @@ func TestWriteTemplateClusterTableWide(t *testing.T) {
 						{BindingRef: client.BindingReference{Name: "binding-2", Namespace: "ns-2"}},
 						{BindingRef: client.BindingReference{Name: "binding-3", Namespace: "ns-3"}},
 					},
-					Constraints:          &v1alpha1.DebugSessionConstraints{MaxDuration: "2h"},
+					Constraints:          &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: "2h"},
 					NamespaceConstraints: &client.NamespaceConstraintsResponse{DefaultNamespace: "debug-ns"},
 					SchedulingOptions: &client.SchedulingOptionsResponse{
 						Required: true,
@@ -729,7 +729,7 @@ func TestWriteBindingOptionsTable(t *testing.T) {
 				{
 					BindingRef:           client.BindingReference{Name: "admin-binding", Namespace: "breakglass"},
 					DisplayName:          "Admin Access",
-					Constraints:          &v1alpha1.DebugSessionConstraints{MaxDuration: "1h"},
+					Constraints:          &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: "1h"},
 					NamespaceConstraints: &client.NamespaceConstraintsResponse{DefaultNamespace: "admin-ns"},
 					SchedulingOptions: &client.SchedulingOptionsResponse{
 						Options: []client.SchedulingOptionResponse{{Name: "opt"}},

--- a/pkg/breakglass/auxiliary_resource_manager.go
+++ b/pkg/breakglass/auxiliary_resource_manager.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/utils"
@@ -64,12 +64,12 @@ func (m *AuxiliaryResourceManager) SetAuditManager(am *audit.Manager) {
 // Returns the list of deployed resource statuses.
 func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 	ctx context.Context,
-	session *v1alpha1.DebugSession,
-	template *v1alpha1.DebugSessionTemplateSpec,
-	binding *v1alpha1.DebugSessionClusterBinding,
+	session *breakglassv1alpha1.DebugSession,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
 	targetClient client.Client,
 	targetNamespace string,
-) ([]v1alpha1.AuxiliaryResourceStatus, error) {
+) ([]breakglassv1alpha1.AuxiliaryResourceStatus, error) {
 	if template == nil || len(template.AuxiliaryResources) == 0 {
 		return nil, nil
 	}
@@ -83,7 +83,7 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 	// Build context for template rendering (including enabled resources list)
 	renderCtx := m.buildRenderContext(session, template, binding, targetNamespace, enabledResources)
 
-	var statuses []v1alpha1.AuxiliaryResourceStatus
+	var statuses []breakglassv1alpha1.AuxiliaryResourceStatus
 	var deployErrors []error
 
 	// Deploy resources that should be created before debug pods
@@ -102,7 +102,7 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 				"error", err)
 			deployErrors = append(deployErrors, err)
 
-			if auxRes.FailurePolicy == v1alpha1.AuxiliaryResourceFailurePolicyFail {
+			if auxRes.FailurePolicy == breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail {
 				metrics.AuxiliaryResourceDeployments.WithLabelValues(session.Spec.Cluster, auxRes.Category, "failure").Inc()
 				return statuses, fmt.Errorf("failed to deploy required auxiliary resource %s: %w", auxRes.Name, err)
 			}
@@ -123,7 +123,7 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 // CleanupAuxiliaryResources removes all auxiliary resources created for a session.
 func (m *AuxiliaryResourceManager) CleanupAuxiliaryResources(
 	ctx context.Context,
-	session *v1alpha1.DebugSession,
+	session *breakglassv1alpha1.DebugSession,
 	targetClient client.Client,
 ) error {
 	if len(session.Status.AuxiliaryResourceStatuses) == 0 {
@@ -163,7 +163,7 @@ func (m *AuxiliaryResourceManager) CleanupAuxiliaryResources(
 				continue
 			}
 
-			addlStatus := v1alpha1.AuxiliaryResourceStatus{
+			addlStatus := breakglassv1alpha1.AuxiliaryResourceStatus{
 				Name:         status.Name,
 				Category:     status.Category,
 				Kind:         addlRes.Kind,
@@ -199,10 +199,10 @@ func (m *AuxiliaryResourceManager) CleanupAuxiliaryResources(
 
 // filterEnabledResources determines which auxiliary resources should be deployed.
 func (m *AuxiliaryResourceManager) filterEnabledResources(
-	template *v1alpha1.DebugSessionTemplateSpec,
-	binding *v1alpha1.DebugSessionClusterBinding,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
 	selectedByUser []string,
-) []v1alpha1.AuxiliaryResource {
+) []breakglassv1alpha1.AuxiliaryResource {
 	if template == nil {
 		return nil
 	}
@@ -244,7 +244,7 @@ func (m *AuxiliaryResourceManager) filterEnabledResources(
 		userSelected[name] = true
 	}
 
-	var enabled []v1alpha1.AuxiliaryResource
+	var enabled []breakglassv1alpha1.AuxiliaryResource
 	for _, res := range template.AuxiliaryResources {
 		// Check if category is required
 		if requiredCategories[res.Category] {
@@ -277,21 +277,21 @@ func (m *AuxiliaryResourceManager) filterEnabledResources(
 
 // buildRenderContext creates the context used for template rendering.
 func (m *AuxiliaryResourceManager) buildRenderContext(
-	session *v1alpha1.DebugSession,
-	template *v1alpha1.DebugSessionTemplateSpec,
-	binding *v1alpha1.DebugSessionClusterBinding,
+	session *breakglassv1alpha1.DebugSession,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
 	targetNamespace string,
-	enabledResources []v1alpha1.AuxiliaryResource,
-) v1alpha1.AuxiliaryResourceContext {
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	enabledResources []breakglassv1alpha1.AuxiliaryResource,
+) breakglassv1alpha1.AuxiliaryResourceContext {
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:        session.Name,
 			Namespace:   session.Namespace,
 			Cluster:     session.Spec.Cluster,
 			RequestedBy: session.Spec.RequestedBy,
 			Reason:      session.Spec.Reason,
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   targetNamespace,
 			ClusterName: session.Spec.Cluster,
 		},
@@ -315,14 +315,14 @@ func (m *AuxiliaryResourceManager) buildRenderContext(
 	}
 
 	if template != nil {
-		ctx.Template = v1alpha1.AuxiliaryResourceTemplateContext{
+		ctx.Template = breakglassv1alpha1.AuxiliaryResourceTemplateContext{
 			Name:        session.Spec.TemplateRef,
 			DisplayName: template.DisplayName,
 		}
 	}
 
 	if binding != nil {
-		ctx.Binding = v1alpha1.AuxiliaryResourceBindingContext{
+		ctx.Binding = breakglassv1alpha1.AuxiliaryResourceBindingContext{
 			Name:      binding.Name,
 			Namespace: binding.Namespace,
 		}
@@ -343,8 +343,8 @@ func (m *AuxiliaryResourceManager) buildRenderContext(
 // buildVarsFromSession extracts user-provided variable values from session spec
 // and applies defaults from template definition.
 func (m *AuxiliaryResourceManager) buildVarsFromSession(
-	session *v1alpha1.DebugSession,
-	template *v1alpha1.DebugSessionTemplateSpec,
+	session *breakglassv1alpha1.DebugSession,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
 ) map[string]string {
 	vars := make(map[string]string)
 
@@ -413,11 +413,11 @@ func (m *AuxiliaryResourceManager) deployResource(
 	ctx context.Context,
 	targetClient client.Client,
 	targetNamespace string,
-	auxRes v1alpha1.AuxiliaryResource,
-	renderCtx v1alpha1.AuxiliaryResourceContext,
-	session *v1alpha1.DebugSession,
-) (v1alpha1.AuxiliaryResourceStatus, error) {
-	status := v1alpha1.AuxiliaryResourceStatus{
+	auxRes breakglassv1alpha1.AuxiliaryResource,
+	renderCtx breakglassv1alpha1.AuxiliaryResourceContext,
+	session *breakglassv1alpha1.DebugSession,
+) (breakglassv1alpha1.AuxiliaryResourceStatus, error) {
+	status := breakglassv1alpha1.AuxiliaryResourceStatus{
 		Name:     auxRes.Name,
 		Category: auxRes.Category,
 	}
@@ -550,7 +550,7 @@ func (m *AuxiliaryResourceManager) deployResource(
 			status.Namespace = obj.GetNamespace()
 		} else {
 			// Track additional resources from multi-document YAML
-			status.AdditionalResources = append(status.AdditionalResources, v1alpha1.AdditionalResourceRef{
+			status.AdditionalResources = append(status.AdditionalResources, breakglassv1alpha1.AdditionalResourceRef{
 				Kind:         obj.GetKind(),
 				APIVersion:   obj.GetAPIVersion(),
 				ResourceName: obj.GetName(),
@@ -573,7 +573,7 @@ func (m *AuxiliaryResourceManager) deployResource(
 }
 
 // renderTemplate renders a Go template with the given context.
-func (m *AuxiliaryResourceManager) renderTemplate(templateBytes []byte, ctx v1alpha1.AuxiliaryResourceContext) ([]byte, error) {
+func (m *AuxiliaryResourceManager) renderTemplate(templateBytes []byte, ctx breakglassv1alpha1.AuxiliaryResourceContext) ([]byte, error) {
 	// Convert context to map for template
 	ctxMap, err := toMap(ctx)
 	if err != nil {
@@ -612,8 +612,8 @@ func toMap(v interface{}) (map[string]interface{}, error) {
 func (m *AuxiliaryResourceManager) deleteResource(
 	ctx context.Context,
 	targetClient client.Client,
-	status v1alpha1.AuxiliaryResourceStatus,
-	session *v1alpha1.DebugSession,
+	status breakglassv1alpha1.AuxiliaryResourceStatus,
+	session *breakglassv1alpha1.DebugSession,
 ) error {
 	// Create unstructured object for deletion
 	obj := &unstructured.Unstructured{}
@@ -657,7 +657,7 @@ func (m *AuxiliaryResourceManager) deleteResource(
 }
 
 // ValidateAuxiliaryResources validates all auxiliary resources in a template.
-func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error {
+func ValidateAuxiliaryResources(resources []breakglassv1alpha1.AuxiliaryResource) []error {
 	var errs []error
 	seenNames := make(map[string]bool)
 	seenCategories := make(map[string][]string) // category -> resource names
@@ -694,14 +694,14 @@ func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error 
 		if hasTemplateString {
 			renderer := NewTemplateRenderer()
 			// Use sample context for validation
-			sampleCtx := v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			sampleCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name:        "validation-session",
 					Namespace:   "breakglass-system",
 					Cluster:     "validation-cluster",
 					RequestedBy: "validator@example.com",
 				},
-				Target: v1alpha1.AuxiliaryResourceTargetContext{
+				Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 					Namespace:   "breakglass-debug",
 					ClusterName: "validation-cluster",
 				},
@@ -748,9 +748,9 @@ func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error 
 
 		// Validate failure policy
 		switch res.FailurePolicy {
-		case "", v1alpha1.AuxiliaryResourceFailurePolicyFail,
-			v1alpha1.AuxiliaryResourceFailurePolicyIgnore,
-			v1alpha1.AuxiliaryResourceFailurePolicyWarn:
+		case "", breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail,
+			breakglassv1alpha1.AuxiliaryResourceFailurePolicyIgnore,
+			breakglassv1alpha1.AuxiliaryResourceFailurePolicyWarn:
 			// Valid
 		default:
 			errs = append(errs, fmt.Errorf("auxiliaryResources[%d]: invalid failurePolicy %q", i, res.FailurePolicy))
@@ -763,15 +763,15 @@ func ValidateAuxiliaryResources(resources []v1alpha1.AuxiliaryResource) []error 
 // AddAuxiliaryResourceToDeployedResources tracks an auxiliary resource in the session's deployed resources.
 // This includes the primary resource and any additional resources from multi-document YAML templates.
 func AddAuxiliaryResourceToDeployedResources(
-	session *v1alpha1.DebugSession,
-	status v1alpha1.AuxiliaryResourceStatus,
+	session *breakglassv1alpha1.DebugSession,
+	status breakglassv1alpha1.AuxiliaryResourceStatus,
 ) {
 	if !status.Created {
 		return
 	}
 
 	// Helper to add a ref if not already present
-	addRef := func(ref v1alpha1.DeployedResourceRef) {
+	addRef := func(ref breakglassv1alpha1.DeployedResourceRef) {
 		for _, existing := range session.Status.DeployedResources {
 			if existing.Kind == ref.Kind &&
 				existing.Name == ref.Name &&
@@ -783,7 +783,7 @@ func AddAuxiliaryResourceToDeployedResources(
 	}
 
 	// Add primary resource
-	addRef(v1alpha1.DeployedResourceRef{
+	addRef(breakglassv1alpha1.DeployedResourceRef{
 		Kind:       status.Kind,
 		APIVersion: status.APIVersion,
 		Name:       status.ResourceName,
@@ -794,7 +794,7 @@ func AddAuxiliaryResourceToDeployedResources(
 
 	// Add additional resources from multi-document YAML templates
 	for _, addlRes := range status.AdditionalResources {
-		addRef(v1alpha1.DeployedResourceRef{
+		addRef(breakglassv1alpha1.DeployedResourceRef{
 			Kind:       addlRes.Kind,
 			APIVersion: addlRes.APIVersion,
 			Name:       addlRes.ResourceName,
@@ -809,7 +809,7 @@ func AddAuxiliaryResourceToDeployedResources(
 // using kstatus and updates the session status accordingly.
 func (m *AuxiliaryResourceManager) CheckAuxiliaryResourcesReadiness(
 	ctx context.Context,
-	session *v1alpha1.DebugSession,
+	session *breakglassv1alpha1.DebugSession,
 	targetClient client.Client,
 ) (allReady bool, err error) {
 	if len(session.Status.AuxiliaryResourceStatuses) == 0 {

--- a/pkg/breakglass/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/auxiliary_resource_manager_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func newTestAuxiliaryResourceManager() *AuxiliaryResourceManager {
@@ -63,8 +63,8 @@ func TestSetAuditManager(t *testing.T) {
 func TestFilterEnabledResources_NoneEnabledByDefault(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network"},
 			{Name: "rbac", Category: "rbac"},
 		},
@@ -79,8 +79,8 @@ func TestFilterEnabledResources_NoneEnabledByDefault(t *testing.T) {
 func TestFilterEnabledResources_EnabledByDefault(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network"},
 			{Name: "rbac", Category: "rbac"},
 		},
@@ -98,8 +98,8 @@ func TestFilterEnabledResources_EnabledByDefault(t *testing.T) {
 func TestFilterEnabledResources_RequiredCategory(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network-isolation"},
 			{Name: "rbac", Category: "rbac"},
 		},
@@ -114,14 +114,14 @@ func TestFilterEnabledResources_RequiredCategory(t *testing.T) {
 func TestFilterEnabledResources_BindingOverrideEnables(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network"},
 		},
 	}
 
-	binding := &v1alpha1.DebugSessionClusterBinding{
-		Spec: v1alpha1.DebugSessionClusterBindingSpec{
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 			AuxiliaryResourceOverrides: map[string]bool{
 				"network": true,
 			},
@@ -136,15 +136,15 @@ func TestFilterEnabledResources_BindingOverrideEnables(t *testing.T) {
 func TestFilterEnabledResources_BindingCannotDisableRequired(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network-isolation"},
 		},
 		RequiredAuxiliaryResourceCategories: []string{"network-isolation"},
 	}
 
-	binding := &v1alpha1.DebugSessionClusterBinding{
-		Spec: v1alpha1.DebugSessionClusterBindingSpec{
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 			AuxiliaryResourceOverrides: map[string]bool{
 				"network-isolation": false, // Attempt to disable required category
 			},
@@ -159,8 +159,8 @@ func TestFilterEnabledResources_BindingCannotDisableRequired(t *testing.T) {
 func TestFilterEnabledResources_UserSelection(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "netpol", Category: "network"},
 			{Name: "monitoring", Category: "monitoring"},
 		},
@@ -181,12 +181,12 @@ func TestFilterEnabledResources_NilTemplate(t *testing.T) {
 func TestBuildRenderContext(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			RequestedBy: "user@example.com",
 			Cluster:     "prod-cluster",
 			Reason:      "Debugging issue",
@@ -194,18 +194,18 @@ func TestBuildRenderContext(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
 		DisplayName: "Test Template",
 	}
 
-	binding := &v1alpha1.DebugSessionClusterBinding{
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-binding",
 			Namespace: "team-a",
 		},
 	}
 
-	enabledResources := []v1alpha1.AuxiliaryResource{
+	enabledResources := []breakglassv1alpha1.AuxiliaryResource{
 		{Name: "resource-1", Category: "network"},
 	}
 
@@ -223,12 +223,12 @@ func TestBuildRenderContext(t *testing.T) {
 func TestRenderTemplate_SimpleTemplate(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:   "debug-123",
 			Reason: "test reason",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace: "debug-ns",
 		},
 	}
@@ -247,8 +247,8 @@ namespace: "{{ .target.namespace }}"`)
 func TestRenderTemplate_WithSprigFunctions(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name: "debug-session-abc123",
 		},
 	}
@@ -269,7 +269,7 @@ default: "{{ .session.reason | default "no-reason" }}"`)
 func TestRenderTemplate_InvalidTemplate(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	ctx := v1alpha1.AuxiliaryResourceContext{}
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	// Invalid template syntax
 	tmpl := []byte(`{{ .session.name | unknownFunction }}`)
@@ -281,8 +281,8 @@ func TestRenderTemplate_InvalidTemplate(t *testing.T) {
 func TestRenderTemplate_MissingField(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{},
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{},
 	}
 
 	// Use lowercase JSON field names
@@ -297,7 +297,7 @@ namespace: "{{ .target.namespace }}"`)
 func TestDeployAuxiliaryResources_NilTemplate(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{}
+	session := &breakglassv1alpha1.DebugSession{}
 
 	statuses, err := mgr.DeployAuxiliaryResources(
 		context.Background(),
@@ -315,9 +315,9 @@ func TestDeployAuxiliaryResources_NilTemplate(t *testing.T) {
 func TestDeployAuxiliaryResources_EmptyResources(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{}
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{},
+	session := &breakglassv1alpha1.DebugSession{}
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{},
 	}
 
 	statuses, err := mgr.DeployAuxiliaryResources(
@@ -336,9 +336,9 @@ func TestDeployAuxiliaryResources_EmptyResources(t *testing.T) {
 func TestCleanupAuxiliaryResources_NoResources(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{},
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{},
 		},
 	}
 
@@ -349,9 +349,9 @@ func TestCleanupAuxiliaryResources_NoResources(t *testing.T) {
 func TestCleanupAuxiliaryResources_AlreadyDeleted(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:    "netpol",
 					Created: true,
@@ -366,13 +366,13 @@ func TestCleanupAuxiliaryResources_AlreadyDeleted(t *testing.T) {
 }
 
 func TestAddAuxiliaryResourceToDeployedResources(t *testing.T) {
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			DeployedResources: []v1alpha1.DeployedResourceRef{},
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			DeployedResources: []breakglassv1alpha1.DeployedResourceRef{},
 		},
 	}
 
-	status := v1alpha1.AuxiliaryResourceStatus{
+	status := breakglassv1alpha1.AuxiliaryResourceStatus{
 		Name:         "netpol",
 		Created:      true,
 		APIVersion:   "networking.k8s.io/v1",
@@ -391,13 +391,13 @@ func TestAddAuxiliaryResourceToDeployedResources(t *testing.T) {
 }
 
 func TestAddAuxiliaryResourceToDeployedResources_NotCreated(t *testing.T) {
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			DeployedResources: []v1alpha1.DeployedResourceRef{},
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			DeployedResources: []breakglassv1alpha1.DeployedResourceRef{},
 		},
 	}
 
-	status := v1alpha1.AuxiliaryResourceStatus{
+	status := breakglassv1alpha1.AuxiliaryResourceStatus{
 		Name:    "netpol",
 		Created: false, // Not created
 	}
@@ -408,9 +408,9 @@ func TestAddAuxiliaryResourceToDeployedResources_NotCreated(t *testing.T) {
 }
 
 func TestAddAuxiliaryResourceToDeployedResources_Deduplication(t *testing.T) {
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			DeployedResources: []v1alpha1.DeployedResourceRef{
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			DeployedResources: []breakglassv1alpha1.DeployedResourceRef{
 				{
 					Kind:      "NetworkPolicy",
 					Name:      "debug-netpol",
@@ -420,7 +420,7 @@ func TestAddAuxiliaryResourceToDeployedResources_Deduplication(t *testing.T) {
 		},
 	}
 
-	status := v1alpha1.AuxiliaryResourceStatus{
+	status := breakglassv1alpha1.AuxiliaryResourceStatus{
 		Name:         "netpol",
 		Created:      true,
 		Kind:         "NetworkPolicy",
@@ -434,14 +434,14 @@ func TestAddAuxiliaryResourceToDeployedResources_Deduplication(t *testing.T) {
 }
 
 func TestAddAuxiliaryResourceToDeployedResources_WithAdditionalResources(t *testing.T) {
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
-			DeployedResources: []v1alpha1.DeployedResourceRef{},
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			DeployedResources: []breakglassv1alpha1.DeployedResourceRef{},
 		},
 	}
 
 	// Status with additional resources from multi-document YAML
-	status := v1alpha1.AuxiliaryResourceStatus{
+	status := breakglassv1alpha1.AuxiliaryResourceStatus{
 		Name:         "network-bundle",
 		Category:     "network",
 		Created:      true,
@@ -449,7 +449,7 @@ func TestAddAuxiliaryResourceToDeployedResources_WithAdditionalResources(t *test
 		APIVersion:   "networking.k8s.io/v1",
 		ResourceName: "debug-netpol",
 		Namespace:    "debug-ns",
-		AdditionalResources: []v1alpha1.AdditionalResourceRef{
+		AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 			{
 				Kind:         "ServiceAccount",
 				APIVersion:   "v1",
@@ -486,7 +486,7 @@ func TestAddAuxiliaryResourceToDeployedResources_WithAdditionalResources(t *test
 }
 
 func TestValidateAuxiliaryResources_ValidTemplate(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "netpol",
 			Category: "network",
@@ -499,7 +499,7 @@ func TestValidateAuxiliaryResources_ValidTemplate(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_MissingName(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "", // Missing name
 			Category: "network",
@@ -513,7 +513,7 @@ func TestValidateAuxiliaryResources_MissingName(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_MissingTemplate(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test",
 			Category: "network",
@@ -539,7 +539,7 @@ func TestValidateAuxiliaryResources_ValidWithTemplateObject(t *testing.T) {
 		},
 	}
 
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test",
 			Category: "config",
@@ -553,7 +553,7 @@ func TestValidateAuxiliaryResources_ValidWithTemplateObject(t *testing.T) {
 
 func TestValidateAuxiliaryResources_ValidWithTemplateString(t *testing.T) {
 	// Test that templateString is accepted
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:           "test",
 			Category:       "config",
@@ -566,7 +566,7 @@ func TestValidateAuxiliaryResources_ValidWithTemplateString(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_DuplicateNames(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "same-name",
 			Category: "network",
@@ -585,7 +585,7 @@ func TestValidateAuxiliaryResources_DuplicateNames(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_MissingAPIVersionInTemplate(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test",
 			Category: "network",
@@ -599,7 +599,7 @@ func TestValidateAuxiliaryResources_MissingAPIVersionInTemplate(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_MissingKindInTemplate(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test",
 			Category: "network",
@@ -615,7 +615,7 @@ func TestValidateAuxiliaryResources_MissingKindInTemplate(t *testing.T) {
 func TestDeployResource_ConfigMap(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -624,19 +624,19 @@ func TestDeployResource_ConfigMap(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
 	}
 
 	// Use lowercase JSON field names in template
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:     "test-config",
 		Category: "configmap",
 		Template: runtime.RawExtension{Raw: []byte(`apiVersion: v1
@@ -648,13 +648,13 @@ data:
 		CreateBefore: true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 			Cluster:   "prod",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "debug-ns",
 			ClusterName: "prod",
 		},
@@ -682,7 +682,7 @@ func TestDeployResource_WithTemplateObject(t *testing.T) {
 	// Test that Template.Object is correctly handled when deploying auxiliary resources
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -691,12 +691,12 @@ func TestDeployResource_WithTemplateObject(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -717,20 +717,20 @@ func TestDeployResource_WithTemplateObject(t *testing.T) {
 		},
 	}
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:         "test-object",
 		Category:     "configmap",
 		Template:     runtime.RawExtension{Object: cm},
 		CreateBefore: true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 			Cluster:   "prod",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "debug-ns",
 			ClusterName: "prod",
 		},
@@ -758,7 +758,7 @@ func TestDeployResource_MultiDocumentYAML(t *testing.T) {
 	// Test that multi-document YAML templates correctly track all resources
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -767,12 +767,12 @@ func TestDeployResource_MultiDocumentYAML(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -801,20 +801,20 @@ type: Opaque
 stringData:
   password: test123`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "multi-resource",
 		Category:       "config",
 		TemplateString: multiDocTemplate,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 			Cluster:   "prod",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "debug-ns",
 			ClusterName: "prod",
 		},
@@ -857,7 +857,7 @@ func TestCleanupAuxiliaryResources_WithAdditionalResources(t *testing.T) {
 	// Test that cleanup deletes additional resources from multi-document YAML
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	// Create the resources that will be cleaned up
 	cm1 := &corev1.ConfigMap{
@@ -881,16 +881,16 @@ func TestCleanupAuxiliaryResources_WithAdditionalResources(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "multi-resource",
 					Category:     "config",
@@ -899,7 +899,7 @@ func TestCleanupAuxiliaryResources_WithAdditionalResources(t *testing.T) {
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "debug-ns",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -1008,7 +1008,7 @@ func TestToMap_FuncFailsToMarshal(t *testing.T) {
 
 func TestRenderTemplate_EmptyTemplate(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	ctx := v1alpha1.AuxiliaryResourceContext{}
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	result, err := mgr.renderTemplate([]byte(""), ctx)
 	require.NoError(t, err)
@@ -1017,7 +1017,7 @@ func TestRenderTemplate_EmptyTemplate(t *testing.T) {
 
 func TestRenderTemplate_NilTemplate(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	ctx := v1alpha1.AuxiliaryResourceContext{}
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	result, err := mgr.renderTemplate(nil, ctx)
 	require.NoError(t, err)
@@ -1026,7 +1026,7 @@ func TestRenderTemplate_NilTemplate(t *testing.T) {
 
 func TestRenderTemplate_MalformedBraces(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	ctx := v1alpha1.AuxiliaryResourceContext{}
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	// Unclosed template braces
 	tmpl := []byte(`name: "{{ .session.name"`)
@@ -1037,7 +1037,7 @@ func TestRenderTemplate_MalformedBraces(t *testing.T) {
 
 func TestRenderTemplate_NestedInvalidSyntax(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	ctx := v1alpha1.AuxiliaryResourceContext{}
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	// Invalid nesting
 	tmpl := []byte(`{{ if .session.name }}{{ end {{ end }}`)
@@ -1052,14 +1052,14 @@ func TestRenderTemplate_NestedInvalidSyntax(t *testing.T) {
 
 func TestFilterEnabledResources_BindingAddsRequiredCategory(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "res1", Category: "cat1", Template: runtime.RawExtension{}},
 			{Name: "res2", Category: "cat2", Template: runtime.RawExtension{}},
 		},
 	}
-	binding := &v1alpha1.DebugSessionClusterBinding{
-		Spec: v1alpha1.DebugSessionClusterBindingSpec{
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 			RequiredAuxiliaryResourceCategories: []string{"cat1"},
 		},
 	}
@@ -1070,8 +1070,8 @@ func TestFilterEnabledResources_BindingAddsRequiredCategory(t *testing.T) {
 
 func TestFilterEnabledResources_DefaultEnabled(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "res1", Category: "cat1", Template: runtime.RawExtension{}},
 			{Name: "res2", Category: "cat2", Template: runtime.RawExtension{}},
 		},
@@ -1087,9 +1087,9 @@ func TestFilterEnabledResources_DefaultEnabled(t *testing.T) {
 
 func TestFilterEnabledResources_NilBinding(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	template := &v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
 		RequiredAuxiliaryResourceCategories: []string{"security"},
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "net-policy", Category: "security", Template: runtime.RawExtension{}},
 		},
 	}
@@ -1099,8 +1099,8 @@ func TestFilterEnabledResources_NilBinding(t *testing.T) {
 
 func TestFilterEnabledResources_EmptySelectedByUser(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
-	template := &v1alpha1.DebugSessionTemplateSpec{
-		AuxiliaryResources: []v1alpha1.AuxiliaryResource{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
 			{Name: "res1", Category: "optional", Template: runtime.RawExtension{}},
 		},
 	}
@@ -1109,7 +1109,7 @@ func TestFilterEnabledResources_EmptySelectedByUser(t *testing.T) {
 }
 
 func TestValidateAuxiliaryResources_ValidTemplateString(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test-pvc",
 			Category: "storage",
@@ -1131,7 +1131,7 @@ spec:
 }
 
 func TestValidateAuxiliaryResources_TemplateStringWithMultiDoc(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test-resources",
 			Category: "storage",
@@ -1160,7 +1160,7 @@ data:
 }
 
 func TestValidateAuxiliaryResources_InvalidTemplateStringSyntax(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:     "test-invalid",
 			Category: "storage",
@@ -1177,7 +1177,7 @@ metadata:
 }
 
 func TestValidateAuxiliaryResources_MutuallyExclusiveTemplates(t *testing.T) {
-	auxResources := []v1alpha1.AuxiliaryResource{
+	auxResources := []breakglassv1alpha1.AuxiliaryResource{
 		{
 			Name:           "test-both",
 			Category:       "storage",
@@ -1196,22 +1196,22 @@ func TestBuildVarsFromSession(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		session  *v1alpha1.DebugSession
-		template *v1alpha1.DebugSessionTemplateSpec
+		session  *breakglassv1alpha1.DebugSession
+		template *breakglassv1alpha1.DebugSessionTemplateSpec
 		expected map[string]string
 	}{
 		{
 			name: "no variables",
-			session: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{},
+			session: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{},
 			},
-			template: &v1alpha1.DebugSessionTemplateSpec{},
+			template: &breakglassv1alpha1.DebugSessionTemplateSpec{},
 			expected: map[string]string{},
 		},
 		{
 			name: "user provided values",
-			session: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{
+			session: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{
 					ExtraDeployValues: map[string]apiextensionsv1.JSON{
 						"pvcSize":      {Raw: []byte(`"50Gi"`)},
 						"createPvc":    {Raw: []byte(`true`)},
@@ -1219,7 +1219,7 @@ func TestBuildVarsFromSession(t *testing.T) {
 					},
 				},
 			},
-			template: &v1alpha1.DebugSessionTemplateSpec{},
+			template: &breakglassv1alpha1.DebugSessionTemplateSpec{},
 			expected: map[string]string{
 				"pvcSize":      "50Gi",
 				"createPvc":    "true",
@@ -1228,11 +1228,11 @@ func TestBuildVarsFromSession(t *testing.T) {
 		},
 		{
 			name: "defaults from template",
-			session: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{},
+			session: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{},
 			},
-			template: &v1alpha1.DebugSessionTemplateSpec{
-				ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			template: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 					{Name: "pvcSize", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 					{Name: "enabled", Default: &apiextensionsv1.JSON{Raw: []byte(`false`)}},
 				},
@@ -1244,15 +1244,15 @@ func TestBuildVarsFromSession(t *testing.T) {
 		},
 		{
 			name: "user values override defaults",
-			session: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{
+			session: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{
 					ExtraDeployValues: map[string]apiextensionsv1.JSON{
 						"pvcSize": {Raw: []byte(`"100Gi"`)}, // Override default
 					},
 				},
 			},
-			template: &v1alpha1.DebugSessionTemplateSpec{
-				ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			template: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 					{Name: "pvcSize", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 					{Name: "enabled", Default: &apiextensionsv1.JSON{Raw: []byte(`true`)}},
 				},
@@ -1331,12 +1331,12 @@ func TestExtractJSONValue(t *testing.T) {
 func TestBuildRenderContext_VarsAndMetadata(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod-cluster",
 			RequestedBy: "user@example.com",
 			Reason:      "Testing",
@@ -1348,15 +1348,15 @@ func TestBuildRenderContext_VarsAndMetadata(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
 		DisplayName: "Test Template",
-		ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+		ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 			{Name: "pvcSize", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 			{Name: "region", Default: &apiextensionsv1.JSON{Raw: []byte(`"eu-west-1"`)}},
 		},
 	}
 
-	enabledResources := []v1alpha1.AuxiliaryResource{
+	enabledResources := []breakglassv1alpha1.AuxiliaryResource{
 		{Name: "pvc"},
 		{Name: "config"},
 	}
@@ -1379,8 +1379,8 @@ func TestBuildRenderContext_VarsAndMetadata(t *testing.T) {
 func TestCheckAuxiliaryResourcesReadiness_NoResources(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
-		Status: v1alpha1.DebugSessionStatus{
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
 			AuxiliaryResourceStatuses: nil, // No resources
 		},
 	}
@@ -1395,13 +1395,13 @@ func TestCheckAuxiliaryResourcesReadiness_AlreadyReady(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
 	readyAt := "2024-01-01T00:00:00Z"
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "test-cm",
 					Created:      true,
@@ -1425,13 +1425,13 @@ func TestCheckAuxiliaryResourcesReadiness_AlreadyReady(t *testing.T) {
 func TestCheckAuxiliaryResourcesReadiness_NotCreated(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:    "test-cm",
 					Created: false, // Not created
@@ -1450,13 +1450,13 @@ func TestCheckAuxiliaryResourcesReadiness_Deleted(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 
 	deletedAt := "2024-01-01T00:00:00Z"
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "test-cm",
 					Created:      true,
@@ -1500,13 +1500,13 @@ func TestCheckAuxiliaryResourcesReadiness_ConfigMapReady(t *testing.T) {
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "test-cm",
 					Created:      true,
@@ -1542,13 +1542,13 @@ func TestCheckAuxiliaryResourcesReadiness_ResourceNotFound(t *testing.T) {
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "missing-cm",
 					Created:      true,
@@ -1591,13 +1591,13 @@ func TestCheckAuxiliaryResourcesReadiness_MixedStates(t *testing.T) {
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "ready-cm",
 					Created:      true,
@@ -1703,7 +1703,7 @@ func TestDeployResource_MultiDocumentYAML_EmptyDocuments(t *testing.T) {
 	// Test that empty documents (whitespace only) are skipped
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1712,12 +1712,12 @@ func TestDeployResource_MultiDocumentYAML_EmptyDocuments(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -1742,20 +1742,20 @@ metadata:
 data:
   key2: value2`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "empty-doc-test",
 		Category:       "config",
 		TemplateString: multiDocWithEmpty,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 			Cluster:   "prod",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "debug-ns",
 			ClusterName: "prod",
 		},
@@ -1786,7 +1786,7 @@ func TestDeployResource_MultiDocumentYAML_InvalidSecondDocument(t *testing.T) {
 	// Test failure when second document is invalid YAML
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1795,12 +1795,12 @@ func TestDeployResource_MultiDocumentYAML_InvalidSecondDocument(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -1820,14 +1820,14 @@ metadata:
 name: invalid - no indentation
   nested: wrong`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "invalid-doc-test",
 		Category:       "config",
 		TemplateString: invalidSecondDoc,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Labels:      map[string]string{},
 		Annotations: map[string]string{},
 	}
@@ -1851,7 +1851,7 @@ func TestDeployResource_MultiDocumentYAML_ConditionalAllExcluded(t *testing.T) {
 	// Test when all documents are conditionally excluded
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1860,12 +1860,12 @@ func TestDeployResource_MultiDocumentYAML_ConditionalAllExcluded(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -1886,14 +1886,14 @@ metadata:
   name: secret-1
 {{- end }}`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "conditional-test",
 		Category:       "config",
 		TemplateString: conditionalTemplate,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Vars: map[string]string{
 			"createConfig": "false",
 			"createSecret": "false",
@@ -1923,7 +1923,7 @@ func TestDeployResource_MultiDocumentYAML_PartialConditional(t *testing.T) {
 	// Test when some documents are conditionally excluded
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -1932,12 +1932,12 @@ func TestDeployResource_MultiDocumentYAML_PartialConditional(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -1965,14 +1965,14 @@ metadata:
 data:
   key: value`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "partial-conditional-test",
 		Category:       "config",
 		TemplateString: conditionalTemplate,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Vars: map[string]string{
 			"createOptional": "false",
 		},
@@ -2002,7 +2002,7 @@ func TestDeployResource_NoTemplateDefinedError(t *testing.T) {
 	// Test error when neither templateString nor template is defined
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2011,24 +2011,24 @@ func TestDeployResource_NoTemplateDefinedError(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod",
 		},
 	}
 
 	// No template defined
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:     "no-template",
 		Category: "config",
 		// Neither TemplateString nor Template is set
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{}
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	status, err := mgr.deployResource(
 		context.Background(),
@@ -2048,7 +2048,7 @@ func TestDeployResource_TemplateRenderingError(t *testing.T) {
 	// Test error when template rendering fails
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2057,24 +2057,24 @@ func TestDeployResource_TemplateRenderingError(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod",
 		},
 	}
 
 	// Invalid template syntax
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "bad-template",
 		Category:       "config",
 		TemplateString: `{{ .invalid.syntax | unknownFunc }}`, // unknownFunc doesn't exist
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{}
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{}
 
 	status, err := mgr.deployResource(
 		context.Background(),
@@ -2094,7 +2094,7 @@ func TestCleanupAuxiliaryResources_PartialFailure(t *testing.T) {
 	// Test cleanup when deleting one resource fails but others succeed
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	// Only create config-1 (config-2 and config-3 will fail to delete because they don't exist)
 	// But NotFound errors are handled gracefully
@@ -2113,16 +2113,16 @@ func TestCleanupAuxiliaryResources_PartialFailure(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "multi-resource",
 					Category:     "config",
@@ -2131,7 +2131,7 @@ func TestCleanupAuxiliaryResources_PartialFailure(t *testing.T) {
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "debug-ns",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -2164,7 +2164,7 @@ func TestCleanupAuxiliaryResources_SkipsAlreadyDeleted(t *testing.T) {
 	// Test that cleanup skips resources already marked as deleted
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2174,16 +2174,16 @@ func TestCleanupAuxiliaryResources_SkipsAlreadyDeleted(t *testing.T) {
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
 	deletedAt := "2024-01-01T00:00:00Z"
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "already-deleted",
 					Category:     "config",
@@ -2194,7 +2194,7 @@ func TestCleanupAuxiliaryResources_SkipsAlreadyDeleted(t *testing.T) {
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "debug-ns",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -2248,13 +2248,13 @@ func TestCheckAuxiliaryResourcesReadiness_WithAdditionalResources_AllReady(t *te
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "multi-resource",
 					Created:      true,
@@ -2263,7 +2263,7 @@ func TestCheckAuxiliaryResourcesReadiness_WithAdditionalResources_AllReady(t *te
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "default",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -2318,13 +2318,13 @@ func TestCheckAuxiliaryResourcesReadiness_WithAdditionalResources_SomeNotReady(t
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "multi-resource",
 					Created:      true,
@@ -2333,7 +2333,7 @@ func TestCheckAuxiliaryResourcesReadiness_WithAdditionalResources_SomeNotReady(t
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "default",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -2371,13 +2371,13 @@ func TestCheckAuxiliaryResourcesReadiness_AdditionalResourceAlreadyDeleted(t *te
 		Build()
 
 	mgr := newTestAuxiliaryResourceManager()
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			AuxiliaryResourceStatuses: []v1alpha1.AuxiliaryResourceStatus{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
 				{
 					Name:         "multi-resource",
 					Created:      true,
@@ -2386,7 +2386,7 @@ func TestCheckAuxiliaryResourcesReadiness_AdditionalResourceAlreadyDeleted(t *te
 					APIVersion:   "v1",
 					ResourceName: "config-1",
 					Namespace:    "default",
-					AdditionalResources: []v1alpha1.AdditionalResourceRef{
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
 						{
 							Kind:         "ConfigMap",
 							APIVersion:   "v1",
@@ -2410,7 +2410,7 @@ func TestDeployResource_MultiDocumentYAML_DifferentKinds(t *testing.T) {
 	// Test multi-document with different resource kinds
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -2419,12 +2419,12 @@ func TestDeployResource_MultiDocumentYAML_DifferentKinds(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	mgr := NewAuxiliaryResourceManager(logger, fakeClient)
 
-	session := &v1alpha1.DebugSession{
+	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "prod",
 			TemplateRef: "test-template",
 		},
@@ -2451,14 +2451,14 @@ type: Opaque
 stringData:
   password: secret123`
 
-	auxRes := v1alpha1.AuxiliaryResource{
+	auxRes := breakglassv1alpha1.AuxiliaryResource{
 		Name:           "multi-kind-test",
 		Category:       "rbac",
 		TemplateString: multiKindTemplate,
 		CreateBefore:   true,
 	}
 
-	renderCtx := v1alpha1.AuxiliaryResourceContext{
+	renderCtx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Labels:      map[string]string{"test": "label"},
 		Annotations: map[string]string{"test": "annotation"},
 	}

--- a/pkg/breakglass/cleanup_duplicate_sessions_test.go
+++ b/pkg/breakglass/cleanup_duplicate_sessions_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +20,7 @@ import (
 
 // stateIndexer is a field index function used by the fake client for status.state queries.
 var stateIndexer = func(o client.Object) []string {
-	bs := o.(*v1alpha1.BreakglassSession)
+	bs := o.(*breakglassv1alpha1.BreakglassSession)
 	if bs.Status.State != "" {
 		return []string{string(bs.Status.State)}
 	}
@@ -31,9 +31,9 @@ func newFakeClientWithSessions(objects ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(Scheme).
 		WithObjects(objects...).
-		WithStatusSubresource(&v1alpha1.BreakglassSession{}).
-		WithIndex(&v1alpha1.BreakglassSession{}, "status.state", stateIndexer).
-		WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", func(o client.Object) []string {
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", stateIndexer).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", func(o client.Object) []string {
 			return []string{o.GetName()}
 		}).
 		Build()
@@ -55,299 +55,299 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 	})
 
 	t.Run("single session — no-op", func(t *testing.T) {
-		s := &v1alpha1.BreakglassSession{
+		s := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "only-one",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.Now(),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(s)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var got v1alpha1.BreakglassSession
+		var got breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s), &got))
-		assert.Equal(t, v1alpha1.SessionStatePending, got.Status.State, "single session must not be touched")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got.Status.State, "single session must not be touched")
 	})
 
 	t.Run("two sessions different triples — no-op", func(t *testing.T) {
-		s1 := &v1alpha1.BreakglassSession{
+		s1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "sess-a",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.Now(),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		s2 := &v1alpha1.BreakglassSession{
+		s2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "sess-b",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.Now(),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2", GrantedGroup: "g2"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateApproved},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2", GrantedGroup: "g2"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
 		}
 		fc := newFakeClientWithSessions(s1, s2)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var got1, got2 v1alpha1.BreakglassSession
+		var got1, got2 breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s1), &got1))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s2), &got2))
-		assert.Equal(t, v1alpha1.SessionStatePending, got1.Status.State)
-		assert.Equal(t, v1alpha1.SessionStateApproved, got2.Status.State)
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got1.Status.State)
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, got2.Status.State)
 	})
 
 	t.Run("duplicate pending sessions — oldest kept, newest withdrawn", func(t *testing.T) {
 		now := time.Now()
-		oldest := &v1alpha1.BreakglassSession{
+		oldest := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "oldest",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		newest := &v1alpha1.BreakglassSession{
+		newest := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "newest",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(oldest, newest)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var gotOld, gotNew v1alpha1.BreakglassSession
+		var gotOld, gotNew breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(oldest), &gotOld))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(newest), &gotNew))
 
-		assert.Equal(t, v1alpha1.SessionStatePending, gotOld.Status.State, "oldest must be kept")
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, gotNew.Status.State, "newest must be withdrawn (Pending→Withdrawn)")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, gotOld.Status.State, "oldest must be kept")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, gotNew.Status.State, "newest must be withdrawn (Pending→Withdrawn)")
 		assert.Equal(t, "withdrawn", gotNew.Status.ReasonEnded)
 
 		// Verify condition was added
 		require.NotEmpty(t, gotNew.Status.Conditions)
 		cond := gotNew.Status.Conditions[len(gotNew.Status.Conditions)-1]
-		assert.Equal(t, string(v1alpha1.SessionConditionTypeCanceled), cond.Type)
+		assert.Equal(t, string(breakglassv1alpha1.SessionConditionTypeCanceled), cond.Type)
 		assert.Equal(t, "DuplicateSessionWithdrawn", cond.Reason)
 	})
 
 	t.Run("duplicate approved sessions — oldest kept, newest expired with metadata", func(t *testing.T) {
 		now := time.Now()
-		oldest := &v1alpha1.BreakglassSession{
+		oldest := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "approved-old",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-20 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateApproved},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
 		}
-		newest := &v1alpha1.BreakglassSession{
+		newest := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "approved-new",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateApproved},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
 		}
 		fc := newFakeClientWithSessions(oldest, newest)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var gotOld, gotNew v1alpha1.BreakglassSession
+		var gotOld, gotNew breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(oldest), &gotOld))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(newest), &gotNew))
 
-		assert.Equal(t, v1alpha1.SessionStateApproved, gotOld.Status.State, "oldest approved kept")
-		assert.Equal(t, v1alpha1.SessionStateExpired, gotNew.Status.State, "newest approved expired")
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, gotOld.Status.State, "oldest approved kept")
+		assert.Equal(t, breakglassv1alpha1.SessionStateExpired, gotNew.Status.State, "newest approved expired")
 		assert.Equal(t, "duplicateCleanup", gotNew.Status.ReasonEnded, "ReasonEnded must be documented value")
 		assert.False(t, gotNew.Status.ExpiresAt.IsZero(), "ExpiresAt must be set when forcing Expired")
 
 		// Verify condition was added
 		require.NotEmpty(t, gotNew.Status.Conditions)
 		cond := gotNew.Status.Conditions[len(gotNew.Status.Conditions)-1]
-		assert.Equal(t, string(v1alpha1.SessionConditionTypeExpired), cond.Type)
+		assert.Equal(t, string(breakglassv1alpha1.SessionConditionTypeExpired), cond.Type)
 		assert.Equal(t, "DuplicateSessionTerminated", cond.Reason)
 	})
 
 	t.Run("three duplicates — approved kept over older pending", func(t *testing.T) {
 		now := time.Now()
-		s1 := &v1alpha1.BreakglassSession{
+		s1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "s1",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateApproved},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
 		}
-		s2 := &v1alpha1.BreakglassSession{
+		s2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "s2",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-20 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		s3 := &v1alpha1.BreakglassSession{
+		s3 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "s3",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateWaitingForScheduledTime},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateWaitingForScheduledTime},
 		}
 		fc := newFakeClientWithSessions(s1, s2, s3)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var got1, got2, got3 v1alpha1.BreakglassSession
+		var got1, got2, got3 breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s1), &got1))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s2), &got2))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s3), &got3))
 
-		assert.Equal(t, v1alpha1.SessionStateApproved, got1.Status.State, "approved session kept (highest priority)")
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, got2.Status.State, "pending withdrawn")
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, got3.Status.State, "waiting withdrawn")
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, got1.Status.State, "approved session kept (highest priority)")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, got2.Status.State, "pending withdrawn")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, got3.Status.State, "waiting withdrawn")
 	})
 
 	t.Run("mixed active and terminal sessions — terminal ignored", func(t *testing.T) {
 		now := time.Now()
-		active := &v1alpha1.BreakglassSession{
+		active := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "active",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		expired := &v1alpha1.BreakglassSession{
+		expired := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "expired",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateExpired},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateExpired},
 		}
 		fc := newFakeClientWithSessions(active, expired)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var gotActive, gotExpired v1alpha1.BreakglassSession
+		var gotActive, gotExpired breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(active), &gotActive))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(expired), &gotExpired))
 
-		assert.Equal(t, v1alpha1.SessionStatePending, gotActive.Status.State, "active session untouched")
-		assert.Equal(t, v1alpha1.SessionStateExpired, gotExpired.Status.State, "terminal session untouched")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, gotActive.Status.State, "active session untouched")
+		assert.Equal(t, breakglassv1alpha1.SessionStateExpired, gotExpired.Status.State, "terminal session untouched")
 	})
 
 	t.Run("different groups same cluster/user — not duplicates", func(t *testing.T) {
 		now := time.Now()
-		s1 := &v1alpha1.BreakglassSession{
+		s1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "group-a",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "admin"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "admin"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		s2 := &v1alpha1.BreakglassSession{
+		s2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "group-b",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "viewer"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "viewer"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(s1, s2)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var got1, got2 v1alpha1.BreakglassSession
+		var got1, got2 breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s1), &got1))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s2), &got2))
 
-		assert.Equal(t, v1alpha1.SessionStatePending, got1.Status.State)
-		assert.Equal(t, v1alpha1.SessionStatePending, got2.Status.State)
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got1.Status.State)
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got2.Status.State)
 	})
 
 	t.Run("newer approved kept over older pending — state priority wins", func(t *testing.T) {
 		now := time.Now()
-		olderPending := &v1alpha1.BreakglassSession{
+		olderPending := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "older-pending",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		newerApproved := &v1alpha1.BreakglassSession{
+		newerApproved := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "newer-approved",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStateApproved},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
 		}
 		fc := newFakeClientWithSessions(olderPending, newerApproved)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var gotPending, gotApproved v1alpha1.BreakglassSession
+		var gotPending, gotApproved breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(olderPending), &gotPending))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(newerApproved), &gotApproved))
 
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, gotPending.Status.State, "older pending withdrawn")
-		assert.Equal(t, v1alpha1.SessionStateApproved, gotApproved.Status.State, "newer approved kept")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, gotPending.Status.State, "older pending withdrawn")
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, gotApproved.Status.State, "newer approved kept")
 	})
 
 	t.Run("nil logger — does not panic", func(t *testing.T) {
 		now := time.Now()
-		s1 := &v1alpha1.BreakglassSession{
+		s1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "dup1",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		s2 := &v1alpha1.BreakglassSession{
+		s2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "dup2",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(s1, s2)
 		mgr := NewSessionManagerWithClient(fc)
@@ -355,47 +355,47 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 		// Should not panic with nil logger
 		CleanupDuplicateSessions(ctx, nil, &mgr)
 
-		var got1, got2 v1alpha1.BreakglassSession
+		var got1, got2 breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s1), &got1))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s2), &got2))
 
-		assert.Equal(t, v1alpha1.SessionStatePending, got1.Status.State, "oldest kept")
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, got2.Status.State, "newest withdrawn")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got1.Status.State, "oldest kept")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, got2.Status.State, "newest withdrawn")
 	})
 
 	t.Run("name tie-breaker — same state and timestamp", func(t *testing.T) {
 		// When two sessions have the same state priority and creation timestamp,
 		// the one with the lexicographically smaller name is kept.
 		ts := metav1.NewTime(time.Now().Add(-10 * time.Minute))
-		sA := &v1alpha1.BreakglassSession{
+		sA := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "aaa-session",
 				Namespace:         "breakglass",
 				CreationTimestamp: ts,
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		sZ := &v1alpha1.BreakglassSession{
+		sZ := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "zzz-session",
 				Namespace:         "breakglass",
 				CreationTimestamp: ts,
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(sA, sZ)
 		mgr := NewSessionManagerWithClient(fc)
 
 		CleanupDuplicateSessions(ctx, logger, &mgr)
 
-		var gotA, gotZ v1alpha1.BreakglassSession
+		var gotA, gotZ breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(sA), &gotA))
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(sZ), &gotZ))
 
-		assert.Equal(t, v1alpha1.SessionStatePending, gotA.Status.State, "aaa-session (smaller name) must be kept")
-		assert.Equal(t, v1alpha1.SessionStateWithdrawn, gotZ.Status.State, "zzz-session (larger name) must be withdrawn")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, gotA.Status.State, "aaa-session (smaller name) must be kept")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, gotZ.Status.State, "zzz-session (larger name) must be withdrawn")
 	})
 
 	t.Run("context cancellation — stops processing early", func(t *testing.T) {
@@ -403,23 +403,23 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel() // cancel immediately
 
-		s1 := &v1alpha1.BreakglassSession{
+		s1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ctx-dup1",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
-		s2 := &v1alpha1.BreakglassSession{
+		s2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "ctx-dup2",
 				Namespace:         "breakglass",
 				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
 			},
-			Spec:   v1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
-			Status: v1alpha1.BreakglassSessionStatus{State: v1alpha1.SessionStatePending},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 		}
 		fc := newFakeClientWithSessions(s1, s2)
 		mgr := NewSessionManagerWithClient(fc)
@@ -427,26 +427,26 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 		// With cancelled context, the duplicate loop should exit early
 		CleanupDuplicateSessions(cancelCtx, logger, &mgr)
 
-		var got2 v1alpha1.BreakglassSession
+		var got2 breakglassv1alpha1.BreakglassSession
 		require.NoError(t, fc.Get(ctx, client.ObjectKeyFromObject(s2), &got2))
 		// Duplicate should NOT have been withdrawn because context was cancelled
-		assert.Equal(t, v1alpha1.SessionStatePending, got2.Status.State, "cancelled context prevents duplicate processing")
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got2.Status.State, "cancelled context prevents duplicate processing")
 	})
 }
 
 func TestSessionStatePriority(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		state    v1alpha1.BreakglassSessionState
+		state    breakglassv1alpha1.BreakglassSessionState
 		expected int
 	}{
-		{v1alpha1.SessionStateApproved, 3},
-		{v1alpha1.SessionStateWaitingForScheduledTime, 2},
-		{v1alpha1.SessionStatePending, 1},
-		{v1alpha1.SessionStateExpired, 0},
-		{v1alpha1.SessionStateWithdrawn, 0},
-		{v1alpha1.SessionStateRejected, 0},
-		{v1alpha1.BreakglassSessionState("unknown"), 0},
+		{breakglassv1alpha1.SessionStateApproved, 3},
+		{breakglassv1alpha1.SessionStateWaitingForScheduledTime, 2},
+		{breakglassv1alpha1.SessionStatePending, 1},
+		{breakglassv1alpha1.SessionStateExpired, 0},
+		{breakglassv1alpha1.SessionStateWithdrawn, 0},
+		{breakglassv1alpha1.SessionStateRejected, 0},
+		{breakglassv1alpha1.BreakglassSessionState("unknown"), 0},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.state), func(t *testing.T) {

--- a/pkg/breakglass/cluster_binding_api.go
+++ b/pkg/breakglass/cluster_binding_api.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 
 	"github.com/gin-gonic/gin"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"go.uber.org/zap"
@@ -116,7 +116,7 @@ type ResolvedClusterInfo struct {
 
 // handleListClusterBindings returns a list of all cluster bindings
 func (c *ClusterBindingAPIController) handleListClusterBindings(ctx *gin.Context) {
-	bindingList := &v1alpha1.DebugSessionClusterBindingList{}
+	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
 	if err := c.client.List(ctx, bindingList); err != nil {
 		c.log.Errorw("Failed to list cluster bindings", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list cluster bindings")
@@ -178,7 +178,7 @@ func (c *ClusterBindingAPIController) handleGetClusterBinding(ctx *gin.Context) 
 		return
 	}
 
-	binding := &v1alpha1.DebugSessionClusterBinding{}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{}
 	if err := c.client.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: name}, binding); err != nil {
 		if apierrors.IsNotFound(err) {
 			apiresponses.RespondNotFoundSimple(ctx, fmt.Sprintf("cluster binding %s/%s not found", namespace, name))
@@ -201,7 +201,7 @@ func (c *ClusterBindingAPIController) handleListBindingsForCluster(ctx *gin.Cont
 	}
 
 	// First get the ClusterConfig to access its labels
-	clusterConfig := &v1alpha1.ClusterConfig{}
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{}
 	if err := c.client.Get(ctx, ctrlclient.ObjectKey{Name: clusterName}, clusterConfig); err != nil {
 		if apierrors.IsNotFound(err) {
 			apiresponses.RespondNotFoundSimple(ctx, fmt.Sprintf("cluster %s not found", clusterName))
@@ -213,7 +213,7 @@ func (c *ClusterBindingAPIController) handleListBindingsForCluster(ctx *gin.Cont
 	}
 
 	// List all bindings
-	bindingList := &v1alpha1.DebugSessionClusterBindingList{}
+	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
 	if err := c.client.List(ctx, bindingList); err != nil {
 		c.log.Errorw("Failed to list cluster bindings", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list cluster bindings")
@@ -240,7 +240,7 @@ func (c *ClusterBindingAPIController) handleListBindingsForCluster(ctx *gin.Cont
 }
 
 // bindingMatchesCluster checks if a binding applies to the given cluster
-func (c *ClusterBindingAPIController) bindingMatchesCluster(binding *v1alpha1.DebugSessionClusterBinding, clusterName string, clusterConfig *v1alpha1.ClusterConfig) bool {
+func (c *ClusterBindingAPIController) bindingMatchesCluster(binding *breakglassv1alpha1.DebugSessionClusterBinding, clusterName string, clusterConfig *breakglassv1alpha1.ClusterConfig) bool {
 	// Check explicit cluster list
 	for _, cluster := range binding.Spec.Clusters {
 		if cluster == clusterName {
@@ -264,7 +264,7 @@ func (c *ClusterBindingAPIController) bindingMatchesCluster(binding *v1alpha1.De
 }
 
 // bindingToResponse converts a DebugSessionClusterBinding to API response
-func (c *ClusterBindingAPIController) bindingToResponse(binding *v1alpha1.DebugSessionClusterBinding) ClusterBindingResponse {
+func (c *ClusterBindingAPIController) bindingToResponse(binding *breakglassv1alpha1.DebugSessionClusterBinding) ClusterBindingResponse {
 	resp := ClusterBindingResponse{
 		Name:               binding.Name,
 		Namespace:          binding.Namespace,
@@ -319,21 +319,21 @@ func (c *ClusterBindingAPIController) bindingToResponse(binding *v1alpha1.DebugS
 
 // GetBindingsForCluster returns all bindings that apply to a specific cluster
 // This is a helper method for internal use
-func (c *ClusterBindingAPIController) GetBindingsForCluster(ctx context.Context, clusterName string) ([]v1alpha1.DebugSessionClusterBinding, error) {
+func (c *ClusterBindingAPIController) GetBindingsForCluster(ctx context.Context, clusterName string) ([]breakglassv1alpha1.DebugSessionClusterBinding, error) {
 	// Get the ClusterConfig
-	clusterConfig := &v1alpha1.ClusterConfig{}
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{}
 	if err := c.client.Get(ctx, ctrlclient.ObjectKey{Name: clusterName}, clusterConfig); err != nil {
 		return nil, fmt.Errorf("failed to get cluster config: %w", err)
 	}
 
 	// List all bindings
-	bindingList := &v1alpha1.DebugSessionClusterBindingList{}
+	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
 	if err := c.client.List(ctx, bindingList); err != nil {
 		return nil, fmt.Errorf("failed to list cluster bindings: %w", err)
 	}
 
 	// Filter matching bindings
-	var matching []v1alpha1.DebugSessionClusterBinding
+	var matching []breakglassv1alpha1.DebugSessionClusterBinding
 	for _, binding := range bindingList.Items {
 		if c.bindingMatchesCluster(&binding, clusterName, clusterConfig) {
 			matching = append(matching, binding)
@@ -348,7 +348,7 @@ func (c *ClusterBindingAPIController) GetBindingsForCluster(ctx context.Context,
 // - It is not disabled
 // - It has not expired (expiresAt is nil or in the future)
 // - It is effective (effectiveFrom is nil or in the past)
-func IsBindingActive(binding *v1alpha1.DebugSessionClusterBinding) bool {
+func IsBindingActive(binding *breakglassv1alpha1.DebugSessionClusterBinding) bool {
 	if binding.Spec.Disabled {
 		return false
 	}

--- a/pkg/breakglass/debug_session_api_test.go
+++ b/pkg/breakglass/debug_session_api_test.go
@@ -890,12 +890,12 @@ func TestDebugSessionAPIController_CreateSessionErrors(t *testing.T) {
 			Build()
 
 		// Create a new object with the same name (not DeepCopy, to avoid copying resourceVersion)
-		newSession := &telekomv1alpha1.DebugSession{
+		newSession := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "duplicate-session",
 				Namespace: "breakglass",
 			},
-			Spec: telekomv1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster:     "production",
 				TemplateRef: "standard-debug",
 				RequestedBy: "other-user@example.com",
@@ -912,12 +912,12 @@ func TestDebugSessionAPIController_CreateSessionErrors(t *testing.T) {
 	// overhead of a pre-check Get() + SSA Apply pattern. See the inline comment in
 	// debug_session_api.go for the full rationale.
 	t.Run("create_vs_ssa_conflict_detection", func(t *testing.T) {
-		existingSession := &telekomv1alpha1.DebugSession{
+		existingSession := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "debug-alice-prod-20250101120000",
 				Namespace: "breakglass",
 			},
-			Spec: telekomv1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster:     "production",
 				TemplateRef: "standard-debug",
 				RequestedBy: "alice@example.com",
@@ -935,12 +935,12 @@ func TestDebugSessionAPIController_CreateSessionErrors(t *testing.T) {
 		//   1. Get() to check existence (one round-trip)
 		//   2. Apply() to create (another round-trip)
 		// With Create(), we get existence-check + creation in a single call.
-		duplicate := &telekomv1alpha1.DebugSession{
+		duplicate := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "debug-alice-prod-20250101120000",
 				Namespace: "breakglass",
 			},
-			Spec: telekomv1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster:     "production",
 				TemplateRef: "standard-debug",
 				RequestedBy: "alice@example.com",
@@ -953,7 +953,7 @@ func TestDebugSessionAPIController_CreateSessionErrors(t *testing.T) {
 			"Create() natively detects duplicate session names without a pre-check Get()")
 
 		// Verify the original session is unchanged (Create does not silently update)
-		var fetched telekomv1alpha1.DebugSession
+		var fetched breakglassv1alpha1.DebugSession
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
 			Name:      "debug-alice-prod-20250101120000",
 			Namespace: "breakglass",

--- a/pkg/breakglass/debug_session_kubectl_extra_test.go
+++ b/pkg/breakglass/debug_session_kubectl_extra_test.go
@@ -26,42 +26,42 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func TestFindActiveSession(t *testing.T) {
 	scheme := newKubectlTestScheme()
 
-	activeSession := &v1alpha1.DebugSession{
+	activeSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "active-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "test-cluster",
 			RequestedBy: "user@example.com",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
-			Participants: []v1alpha1.DebugSessionParticipant{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
 				{User: "user@example.com"},
 			},
 		},
 	}
 
-	otherSession := &v1alpha1.DebugSession{
+	otherSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
-		Spec:       v1alpha1.DebugSessionSpec{Cluster: "other-cluster"},
-		Status:     v1alpha1.DebugSessionStatus{State: v1alpha1.DebugSessionStateActive},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "other-cluster"},
+		Status:     breakglassv1alpha1.DebugSessionStatus{State: breakglassv1alpha1.DebugSessionStateActive},
 	}
 
-	expiredSession := &v1alpha1.DebugSession{
+	expiredSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "expired", Namespace: "default"},
-		Spec:       v1alpha1.DebugSessionSpec{Cluster: "test-cluster", RequestedBy: "user@example.com"},
-		Status: v1alpha1.DebugSessionStatus{
-			State:     v1alpha1.DebugSessionStateActive,
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "test-cluster", RequestedBy: "user@example.com"},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State:     breakglassv1alpha1.DebugSessionStateActive,
 			ExpiresAt: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
-			Participants: []v1alpha1.DebugSessionParticipant{
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
 				{User: "user@example.com"},
 			},
 		},

--- a/pkg/breakglass/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug_session_kubectl_test.go
@@ -30,7 +30,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
 )
 
@@ -53,7 +53,7 @@ func (m *mockClientProvider) GetClient(_ context.Context, clusterName string) (c
 func newKubectlTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
 	return scheme
 }
 
@@ -62,7 +62,7 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		session      *v1alpha1.DebugSession
+		session      *breakglassv1alpha1.DebugSession
 		namespace    string
 		podName      string
 		image        string
@@ -73,11 +73,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 	}{
 		{
 			name: "valid request",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:       true,
 								AllowedImages: []string{"busybox:*", "alpine:*"},
 							},
@@ -94,8 +94,8 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "no resolved template",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{},
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{},
 			},
 			namespace:    "default",
 			podName:      "test-pod",
@@ -105,9 +105,9 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "ephemeral containers not configured",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
 						KubectlDebug: nil,
 					},
 				},
@@ -120,11 +120,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "ephemeral containers disabled",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled: false,
 							},
 						},
@@ -139,13 +139,13 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "namespace denied",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:          true,
-								DeniedNamespaces: &v1alpha1.NamespaceFilter{Patterns: []string{"kube-system", "kube-*"}},
+								DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"kube-system", "kube-*"}},
 							},
 						},
 					},
@@ -159,11 +159,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "image not allowed",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:       true,
 								AllowedImages: []string{"busybox:*"},
 							},
@@ -179,11 +179,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "requires image digest",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:            true,
 								RequireImageDigest: true,
 							},
@@ -199,11 +199,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "valid with image digest",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:            true,
 								RequireImageDigest: true,
 							},
@@ -218,11 +218,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "capability not allowed",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:         true,
 								MaxCapabilities: []string{"NET_ADMIN"},
 							},
@@ -239,11 +239,11 @@ func TestKubectlDebugHandler_ValidateEphemeralContainerRequest(t *testing.T) {
 		},
 		{
 			name: "requires non-root",
-			session: &v1alpha1.DebugSession{
-				Status: v1alpha1.DebugSessionStatus{
-					ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-						KubectlDebug: &v1alpha1.KubectlDebugConfig{
-							EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+			session: &breakglassv1alpha1.DebugSession{
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+							EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 								Enabled:        true,
 								RequireNonRoot: true,
 							},
@@ -291,8 +291,8 @@ func TestKubectlDebugHandler_isNamespaceAllowed(t *testing.T) {
 	tests := []struct {
 		name      string
 		namespace string
-		allowed   *v1alpha1.NamespaceFilter
-		denied    *v1alpha1.NamespaceFilter
+		allowed   *breakglassv1alpha1.NamespaceFilter
+		denied    *breakglassv1alpha1.NamespaceFilter
 		expected  bool
 	}{
 		{
@@ -306,42 +306,42 @@ func TestKubectlDebugHandler_isNamespaceAllowed(t *testing.T) {
 			name:      "explicitly denied",
 			namespace: "kube-system",
 			allowed:   nil,
-			denied:    &v1alpha1.NamespaceFilter{Patterns: []string{"kube-system"}},
+			denied:    &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"kube-system"}},
 			expected:  false,
 		},
 		{
 			name:      "denied by pattern",
 			namespace: "kube-public",
 			allowed:   nil,
-			denied:    &v1alpha1.NamespaceFilter{Patterns: []string{"kube-*"}},
+			denied:    &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"kube-*"}},
 			expected:  false,
 		},
 		{
 			name:      "allowed list only - match",
 			namespace: "default",
-			allowed:   &v1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
+			allowed:   &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
 			denied:    nil,
 			expected:  true,
 		},
 		{
 			name:      "allowed list only - no match",
 			namespace: "other",
-			allowed:   &v1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
+			allowed:   &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
 			denied:    nil,
 			expected:  false,
 		},
 		{
 			name:      "allowed by pattern",
 			namespace: "app-frontend",
-			allowed:   &v1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
+			allowed:   &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"default", "app-*"}},
 			denied:    nil,
 			expected:  true,
 		},
 		{
 			name:      "denied takes precedence",
 			namespace: "app-secret",
-			allowed:   &v1alpha1.NamespaceFilter{Patterns: []string{"app-*"}},
-			denied:    &v1alpha1.NamespaceFilter{Patterns: []string{"app-secret"}},
+			allowed:   &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"app-*"}},
+			denied:    &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"app-secret"}},
 			expected:  false,
 		},
 	}
@@ -542,20 +542,20 @@ func TestKubectlDebugHandler_InjectEphemeralContainer(t *testing.T) {
 	}
 
 	// Create a test session
-	testSession := &v1alpha1.DebugSession{
+	testSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
-			ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-				Mode: v1alpha1.DebugSessionModeKubectlDebug,
-				KubectlDebug: &v1alpha1.KubectlDebugConfig{
-					EphemeralContainers: &v1alpha1.EphemeralContainersConfig{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeKubectlDebug,
+				KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+					EphemeralContainers: &breakglassv1alpha1.EphemeralContainersConfig{
 						Enabled: true,
 					},
 				},
@@ -572,7 +572,7 @@ func TestKubectlDebugHandler_InjectEphemeralContainer(t *testing.T) {
 	hubClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(testSession).
-		WithStatusSubresource(&v1alpha1.DebugSession{}).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		Build()
 
 	mockProvider := &mockClientProvider{
@@ -670,20 +670,20 @@ func TestKubectlDebugHandler_CreatePodCopy(t *testing.T) {
 	}
 
 	// Create a test session
-	testSession := &v1alpha1.DebugSession{
+	testSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session-12345678",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
-			ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-				Mode: v1alpha1.DebugSessionModeKubectlDebug,
-				KubectlDebug: &v1alpha1.KubectlDebugConfig{
-					PodCopy: &v1alpha1.PodCopyConfig{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeKubectlDebug,
+				KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+					PodCopy: &breakglassv1alpha1.PodCopyConfig{
 						Enabled:         true,
 						TargetNamespace: "debug-copies",
 						TTL:             "1h",
@@ -701,7 +701,7 @@ func TestKubectlDebugHandler_CreatePodCopy(t *testing.T) {
 	hubClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(testSession).
-		WithStatusSubresource(&v1alpha1.DebugSession{}).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		Build()
 
 	mockProvider := &mockClientProvider{
@@ -792,24 +792,24 @@ func TestKubectlDebugHandler_CreateNodeDebugPod(t *testing.T) {
 	}
 
 	// Create a test session
-	testSession := &v1alpha1.DebugSession{
+	testSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session-12345678",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
-			ResolvedTemplate: &v1alpha1.DebugSessionTemplateSpec{
-				Mode:            v1alpha1.DebugSessionModeKubectlDebug,
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode:            breakglassv1alpha1.DebugSessionModeKubectlDebug,
 				TargetNamespace: "breakglass-debug",
-				KubectlDebug: &v1alpha1.KubectlDebugConfig{
-					NodeDebug: &v1alpha1.NodeDebugConfig{
+				KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+					NodeDebug: &breakglassv1alpha1.NodeDebugConfig{
 						Enabled:       true,
 						AllowedImages: []string{"busybox:stable"},
-						HostNamespaces: &v1alpha1.HostNamespacesConfig{
+						HostNamespaces: &breakglassv1alpha1.HostNamespacesConfig{
 							HostNetwork: true,
 							HostPID:     true,
 							HostIPC:     false,
@@ -828,7 +828,7 @@ func TestKubectlDebugHandler_CreateNodeDebugPod(t *testing.T) {
 	hubClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(testSession).
-		WithStatusSubresource(&v1alpha1.DebugSession{}).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		Build()
 
 	mockProvider := &mockClientProvider{
@@ -911,15 +911,15 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 		mockProvider := &mockClientProvider{}
 		handler := NewKubectlDebugHandler(hubClient, mockProvider)
 
-		session := &v1alpha1.DebugSession{
+		session := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "breakglass",
 			},
-			Spec: v1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster: "test-cluster",
 			},
-			Status: v1alpha1.DebugSessionStatus{
+			Status: breakglassv1alpha1.DebugSessionStatus{
 				KubectlDebugStatus: nil, // No kubectl debug status
 			},
 		}
@@ -938,17 +938,17 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 		}
 		handler := NewKubectlDebugHandler(hubClient, mockProvider)
 
-		session := &v1alpha1.DebugSession{
+		session := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "breakglass",
 			},
-			Spec: v1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster: "test-cluster",
 			},
-			Status: v1alpha1.DebugSessionStatus{
-				KubectlDebugStatus: &v1alpha1.KubectlDebugStatus{
-					CopiedPods: []v1alpha1.CopiedPodRef{
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				KubectlDebugStatus: &breakglassv1alpha1.KubectlDebugStatus{
+					CopiedPods: []breakglassv1alpha1.CopiedPodRef{
 						{CopyName: "pod-copy", CopyNamespace: "default"},
 					},
 				},
@@ -972,18 +972,18 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 			}).
 			Build()
 
-		session := &v1alpha1.DebugSession{
+		session := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "breakglass",
 			},
-			Spec: v1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster: "test-cluster",
 			},
-			Status: v1alpha1.DebugSessionStatus{
-				State: v1alpha1.DebugSessionStateTerminated,
-				KubectlDebugStatus: &v1alpha1.KubectlDebugStatus{
-					CopiedPods: []v1alpha1.CopiedPodRef{
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State: breakglassv1alpha1.DebugSessionStateTerminated,
+				KubectlDebugStatus: &breakglassv1alpha1.KubectlDebugStatus{
+					CopiedPods: []breakglassv1alpha1.CopiedPodRef{
 						{CopyName: "pod-copy", CopyNamespace: "default"},
 					},
 				},
@@ -1023,17 +1023,17 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 		}
 		handler := NewKubectlDebugHandler(hubClient, mockProvider)
 
-		session := &v1alpha1.DebugSession{
+		session := &breakglassv1alpha1.DebugSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "orphaned-session",
 				Namespace: "breakglass",
 			},
-			Spec: v1alpha1.DebugSessionSpec{
+			Spec: breakglassv1alpha1.DebugSessionSpec{
 				Cluster: "deleted-cluster",
 			},
-			Status: v1alpha1.DebugSessionStatus{
-				KubectlDebugStatus: &v1alpha1.KubectlDebugStatus{
-					CopiedPods: []v1alpha1.CopiedPodRef{
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				KubectlDebugStatus: &breakglassv1alpha1.KubectlDebugStatus{
+					CopiedPods: []breakglassv1alpha1.CopiedPodRef{
 						{CopyName: "pod-copy", CopyNamespace: "default"},
 					},
 				},

--- a/pkg/breakglass/duration_helpers.go
+++ b/pkg/breakglass/duration_helpers.go
@@ -19,42 +19,42 @@ package breakglass
 import (
 	"time"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 )
 
 // ParseRetainFor parses the RetainFor duration from a session spec.
 // Returns DefaultRetainForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
-func ParseRetainFor(spec v1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
+func ParseRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
 	return parseDurationWithDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
 }
 
 // ParseMaxValidFor parses the MaxValidFor duration from a session spec.
 // Returns DefaultValidForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
-func ParseMaxValidFor(spec v1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
+func ParseMaxValidFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
 	return parseDurationWithDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
 }
 
 // ParseEscalationMaxValidFor parses the MaxValidFor duration from an escalation spec.
 // Returns DefaultValidForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
-func ParseEscalationMaxValidFor(spec v1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
+func ParseEscalationMaxValidFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
 	return parseDurationWithDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
 }
 
 // ParseEscalationRetainFor parses the RetainFor duration from an escalation spec.
 // Returns DefaultRetainForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
-func ParseEscalationRetainFor(spec v1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
+func ParseEscalationRetainFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
 	return parseDurationWithDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
 }
 
 // ParseApprovalTimeout parses the ApprovalTimeout duration from an escalation spec.
 // Returns the default approval timeout (1 hour) if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
-func ParseApprovalTimeout(spec v1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
+func ParseApprovalTimeout(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
 	const defaultApprovalTimeout = time.Hour
 	return parseDurationWithDefault(spec.ApprovalTimeout, defaultApprovalTimeout, "ApprovalTimeout", log)
 }
@@ -69,7 +69,7 @@ func parseDurationWithDefault(value string, defaultValue time.Duration, fieldNam
 		return defaultValue
 	}
 
-	d, err := v1alpha1.ParseDuration(value)
+	d, err := breakglassv1alpha1.ParseDuration(value)
 	if err != nil {
 		if log != nil {
 			log.Warnw("Invalid "+fieldName+" in spec; falling back to default",

--- a/pkg/breakglass/duration_helpers_test.go
+++ b/pkg/breakglass/duration_helpers_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 )
 
@@ -77,7 +77,7 @@ func TestParseRetainFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := v1alpha1.BreakglassSessionSpec{RetainFor: tt.value}
+			spec := breakglassv1alpha1.BreakglassSessionSpec{RetainFor: tt.value}
 			result := ParseRetainFor(spec, log)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -121,7 +121,7 @@ func TestParseMaxValidFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := v1alpha1.BreakglassSessionSpec{MaxValidFor: tt.value}
+			spec := breakglassv1alpha1.BreakglassSessionSpec{MaxValidFor: tt.value}
 			result := ParseMaxValidFor(spec, log)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -155,7 +155,7 @@ func TestParseEscalationMaxValidFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := v1alpha1.BreakglassEscalationSpec{MaxValidFor: tt.value}
+			spec := breakglassv1alpha1.BreakglassEscalationSpec{MaxValidFor: tt.value}
 			result := ParseEscalationMaxValidFor(spec, log)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -195,7 +195,7 @@ func TestParseApprovalTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := v1alpha1.BreakglassEscalationSpec{ApprovalTimeout: tt.value}
+			spec := breakglassv1alpha1.BreakglassEscalationSpec{ApprovalTimeout: tt.value}
 			result := ParseApprovalTimeout(spec, log)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -242,11 +242,11 @@ func TestParseDurationOrDefault(t *testing.T) {
 
 func TestParseDurationWithNilLogger(t *testing.T) {
 	// Ensure nil logger doesn't panic
-	spec := v1alpha1.BreakglassSessionSpec{RetainFor: "invalid"}
+	spec := breakglassv1alpha1.BreakglassSessionSpec{RetainFor: "invalid"}
 	result := ParseRetainFor(spec, nil)
 	assert.Equal(t, DefaultRetainForDuration, result)
 
-	spec2 := v1alpha1.BreakglassSessionSpec{MaxValidFor: "1h"}
+	spec2 := breakglassv1alpha1.BreakglassSessionSpec{MaxValidFor: "1h"}
 	result2 := ParseMaxValidFor(spec2, nil)
 	assert.Equal(t, time.Hour, result2)
 }
@@ -293,7 +293,7 @@ func TestParseEscalationRetainFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := v1alpha1.BreakglassEscalationSpec{RetainFor: tt.value}
+			spec := breakglassv1alpha1.BreakglassEscalationSpec{RetainFor: tt.value}
 			result := ParseEscalationRetainFor(spec, log)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/breakglass/escalation_controller.go
+++ b/pkg/breakglass/escalation_controller.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
@@ -24,7 +24,7 @@ type BreakglassEscalationController struct {
 }
 
 // dropK8sInternalFieldsEscalation removes K8s internal fields from BreakglassEscalation for API response
-func dropK8sInternalFieldsEscalation(e *v1alpha1.BreakglassEscalation) {
+func dropK8sInternalFieldsEscalation(e *breakglassv1alpha1.BreakglassEscalation) {
 	if e == nil {
 		return
 	}
@@ -39,7 +39,7 @@ func dropK8sInternalFieldsEscalation(e *v1alpha1.BreakglassEscalation) {
 	e.Status.IDPGroupMemberships = nil
 }
 
-func dropK8sInternalFieldsEscalationList(list []v1alpha1.BreakglassEscalation) []v1alpha1.BreakglassEscalation {
+func dropK8sInternalFieldsEscalationList(list []breakglassv1alpha1.BreakglassEscalation) []breakglassv1alpha1.BreakglassEscalation {
 	for i := range list {
 		dropK8sInternalFieldsEscalation(&list[i])
 	}
@@ -117,7 +117,7 @@ func (ec BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 	reqLog.With("escalationCount", len(escalations)).Debug("Successfully fetched escalations from manager")
 
 	// Policy: hide "read-only" escalation if user already possesses the read-only group (no privilege gain)
-	filtered := make([]v1alpha1.BreakglassEscalation, 0, len(escalations))
+	filtered := make([]breakglassv1alpha1.BreakglassEscalation, 0, len(escalations))
 	userGroupSet := map[string]struct{}{}
 	for _, g := range userGroups {
 		userGroupSet[g] = struct{}{}
@@ -143,7 +143,7 @@ func (ec BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 	}
 
 	// Return full objects including (future) status with approverGroupMembers for UI
-	response := make([]v1alpha1.BreakglassEscalation, 0, len(filtered))
+	response := make([]breakglassv1alpha1.BreakglassEscalation, 0, len(filtered))
 	response = append(response, filtered...)
 
 	// Filter out hidden groups from the response - they should not be visible to users in the UI
@@ -217,7 +217,7 @@ func NewBreakglassEscalationController(log *zap.SugaredLogger,
 }
 
 // isEscalationReady checks if an escalation has Ready=True condition.
-func isEscalationReady(esc *v1alpha1.BreakglassEscalation) bool {
+func isEscalationReady(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 	for _, cond := range esc.Status.Conditions {
 		if cond.Type == "Ready" && cond.Status == metav1.ConditionTrue {
 			return true

--- a/pkg/breakglass/escalation_controller_test.go
+++ b/pkg/breakglass/escalation_controller_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func TestBreakglassEscalationController_BasePath(t *testing.T) {
@@ -73,7 +73,7 @@ func TestNewBreakglassEscalationController(t *testing.T) {
 }
 
 func TestDropK8sInternalFieldsEscalationStripsMetadataAndStatus(t *testing.T) {
-	esc := &v1alpha1.BreakglassEscalation{
+	esc := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             types.UID("12345"),
 			ResourceVersion: "9001",
@@ -84,7 +84,7 @@ func TestDropK8sInternalFieldsEscalationStripsMetadataAndStatus(t *testing.T) {
 				"visible": "keep",
 			},
 		},
-		Status: v1alpha1.BreakglassEscalationStatus{
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
 			ApproverGroupMembers: map[string][]string{"ops": {"alice", "bob"}},
 			IDPGroupMemberships: map[string]map[string][]string{
 				"azure": {

--- a/pkg/breakglass/escalation_test.go
+++ b/pkg/breakglass/escalation_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"go.uber.org/zap"
 )
@@ -59,7 +59,7 @@ func TestFilterForUserPossibleEscalations(t *testing.T) {
 	testCases := []struct {
 		TestName             string
 		Filter               breakglass.EscalationFiltering
-		Escalations          []v1alpha1.BreakglassEscalation
+		Escalations          []breakglassv1alpha1.BreakglassEscalation
 		ExpectedOutputGroups []string
 		ErrExpected          bool
 	}{
@@ -72,22 +72,22 @@ func TestFilterForUserPossibleEscalations(t *testing.T) {
 				UserGroupExtract: extractGroups,
 			},
 
-			Escalations: []v1alpha1.BreakglassEscalation{
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Escalations: []breakglassv1alpha1.BreakglassEscalation{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{SampleBaseGroup},
 					},
 					EscalatedGroup: SampleEscalationGroup,
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{SampleBaseGroup},
 					},
 					EscalatedGroup: SampleEscalationGroup,
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
 			},
 			ExpectedOutputGroups: []string{SampleEscalationGroup, SampleEscalationGroup},
@@ -104,38 +104,38 @@ func TestFilterForUserPossibleEscalations(t *testing.T) {
 				},
 			},
 
-			Escalations: []v1alpha1.BreakglassEscalation{
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Escalations: []breakglassv1alpha1.BreakglassEscalation{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{SampleBaseGroup, "other_group"},
 					},
 					EscalatedGroup: SampleEscalationGroup,
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{"other_group"},
 					},
 					EscalatedGroup: "escalation_2",
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{"third_group"},
 					},
 					EscalatedGroup: SampleEscalationGroup,
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{"other_group", "yet_another"},
 					},
 					EscalatedGroup: "escalation_3",
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
 			},
 			ExpectedOutputGroups: []string{SampleEscalationGroup, "escalation_2", "escalation_3"},
@@ -152,14 +152,14 @@ func TestFilterForUserPossibleEscalations(t *testing.T) {
 				},
 			},
 
-			Escalations: []v1alpha1.BreakglassEscalation{
-				{Spec: v1alpha1.BreakglassEscalationSpec{
-					Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Escalations: []breakglassv1alpha1.BreakglassEscalation{
+				{Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 						Clusters: []string{SampleUserData.Clustername},
 						Groups:   []string{SampleBaseGroup},
 					},
 					EscalatedGroup: SampleEscalationGroup,
-					Approvers:      v1alpha1.BreakglassEscalationApprovers{},
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{},
 				}},
 			},
 			ExpectedOutputGroups: []string{},
@@ -225,8 +225,8 @@ func TestFilterSessionsForUserApprovable(t *testing.T) {
 	testCases := []struct {
 		TestName                     string
 		Filter                       breakglass.EscalationFiltering
-		Escalations                  []v1alpha1.BreakglassEscalation
-		InputSessions                []v1alpha1.BreakglassSession
+		Escalations                  []breakglassv1alpha1.BreakglassEscalation
+		InputSessions                []breakglassv1alpha1.BreakglassSession
 		ExpectedOutputSessionsGroups []string
 		ErrExpected                  bool
 	}{
@@ -240,16 +240,16 @@ func TestFilterSessionsForUserApprovable(t *testing.T) {
 					return []string{"admins1"}, nil
 				},
 			},
-			Escalations: []v1alpha1.BreakglassEscalation{
+			Escalations: []breakglassv1alpha1.BreakglassEscalation{
 				// test_group -> escalation1 for sample user aprovable by name
 				{
-					Spec: v1alpha1.BreakglassEscalationSpec{
-						Allowed: v1alpha1.BreakglassEscalationAllowed{
+					Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+						Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 							Clusters: []string{SampleUserData.Clustername},
 							Groups:   []string{"test_group"},
 						},
 						EscalatedGroup: "escalation1",
-						Approvers: v1alpha1.BreakglassEscalationApprovers{
+						Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 							Users:  []string{SampleApproverData.Username},
 							Groups: []string{},
 						},
@@ -257,13 +257,13 @@ func TestFilterSessionsForUserApprovable(t *testing.T) {
 				},
 				// test_group2 -> escalation2 for sample user approvable by group admins1
 				{
-					Spec: v1alpha1.BreakglassEscalationSpec{
-						Allowed: v1alpha1.BreakglassEscalationAllowed{
+					Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+						Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 							Clusters: []string{SampleUserData.Clustername},
 							Groups:   []string{"test_group2"},
 						},
 						EscalatedGroup: "escalation2",
-						Approvers: v1alpha1.BreakglassEscalationApprovers{
+						Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 							Users:  []string{},
 							Groups: []string{"admins1"},
 						},
@@ -271,43 +271,43 @@ func TestFilterSessionsForUserApprovable(t *testing.T) {
 				},
 				// test_group3 -> escalation3 for sample user approvable by group admins2
 				{
-					Spec: v1alpha1.BreakglassEscalationSpec{
-						Allowed: v1alpha1.BreakglassEscalationAllowed{
+					Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+						Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 							Clusters: []string{SampleApproverData.Clustername},
 							Groups:   []string{"test_group3"},
 						},
 						EscalatedGroup: "escalation3",
-						Approvers: v1alpha1.BreakglassEscalationApprovers{
+						Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
 							Users:  []string{},
 							Groups: []string{"admins2"},
 						},
 					},
 				},
 			},
-			InputSessions: []v1alpha1.BreakglassSession{
+			InputSessions: []breakglassv1alpha1.BreakglassSession{
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation1",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation10",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation2",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation3",
@@ -326,31 +326,31 @@ func TestFilterSessionsForUserApprovable(t *testing.T) {
 					return []string{"admins1"}, nil
 				},
 			},
-			Escalations: []v1alpha1.BreakglassEscalation{},
-			InputSessions: []v1alpha1.BreakglassSession{
+			Escalations: []breakglassv1alpha1.BreakglassEscalation{},
+			InputSessions: []breakglassv1alpha1.BreakglassSession{
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation1",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation10",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation2",
 					},
 				},
 				{
-					Spec: v1alpha1.BreakglassSessionSpec{
+					Spec: breakglassv1alpha1.BreakglassSessionSpec{
 						Cluster:      SampleApproverData.Clustername,
 						User:         SampleUserData.Username,
 						GrantedGroup: "escalation3",

--- a/pkg/breakglass/identity_provider.go
+++ b/pkg/breakglass/identity_provider.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/gin-gonic/gin"
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 )
 
@@ -14,7 +14,7 @@ type IdentityProvider interface {
 	GetIdentity(*gin.Context) string
 	// GetUserIdentifier returns the user identifier based on the configured claim type.
 	// This is used to match the OIDC claim configuration on spoke clusters.
-	GetUserIdentifier(*gin.Context, v1alpha1.UserIdentifierClaimType) (string, error)
+	GetUserIdentifier(*gin.Context, breakglassv1alpha1.UserIdentifierClaimType) (string, error)
 }
 
 type KeycloakIdentityProvider struct {
@@ -54,20 +54,20 @@ func (kip KeycloakIdentityProvider) GetUsername(c *gin.Context) string {
 
 // GetUserIdentifier returns the user identifier based on the configured claim type.
 // It maps the UserIdentifierClaimType to the corresponding JWT claim value stored in context.
-func (kip KeycloakIdentityProvider) GetUserIdentifier(c *gin.Context, claimType v1alpha1.UserIdentifierClaimType) (string, error) {
+func (kip KeycloakIdentityProvider) GetUserIdentifier(c *gin.Context, claimType breakglassv1alpha1.UserIdentifierClaimType) (string, error) {
 	var identifier string
 	switch claimType {
-	case v1alpha1.UserIdentifierClaimEmail:
+	case breakglassv1alpha1.UserIdentifierClaimEmail:
 		identifier = c.GetString("email")
 		if identifier == "" {
 			return "", errors.New("email claim not found in token")
 		}
-	case v1alpha1.UserIdentifierClaimPreferredUsername:
+	case breakglassv1alpha1.UserIdentifierClaimPreferredUsername:
 		identifier = c.GetString("username")
 		if identifier == "" {
 			return "", errors.New("preferred_username claim not found in token")
 		}
-	case v1alpha1.UserIdentifierClaimSub:
+	case breakglassv1alpha1.UserIdentifierClaimSub:
 		identifier = c.GetString("user_id")
 		if identifier == "" {
 			return "", errors.New("sub claim not found in token")

--- a/pkg/breakglass/identity_provider_test.go
+++ b/pkg/breakglass/identity_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 )
 
@@ -169,7 +169,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		claimType        v1alpha1.UserIdentifierClaimType
+		claimType        breakglassv1alpha1.UserIdentifierClaimType
 		email            string
 		username         string
 		userID           string
@@ -178,7 +178,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 	}{
 		{
 			name:             "Email claim - valid",
-			claimType:        v1alpha1.UserIdentifierClaimEmail,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimEmail,
 			email:            "test@example.com",
 			username:         "testuser",
 			userID:           "sub-123",
@@ -187,7 +187,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 		},
 		{
 			name:             "Email claim - missing",
-			claimType:        v1alpha1.UserIdentifierClaimEmail,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimEmail,
 			email:            "",
 			username:         "testuser",
 			userID:           "sub-123",
@@ -196,7 +196,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 		},
 		{
 			name:             "Preferred username claim - valid",
-			claimType:        v1alpha1.UserIdentifierClaimPreferredUsername,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimPreferredUsername,
 			email:            "test@example.com",
 			username:         "testuser",
 			userID:           "sub-123",
@@ -205,7 +205,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 		},
 		{
 			name:             "Preferred username claim - missing",
-			claimType:        v1alpha1.UserIdentifierClaimPreferredUsername,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimPreferredUsername,
 			email:            "test@example.com",
 			username:         "",
 			userID:           "sub-123",
@@ -214,7 +214,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 		},
 		{
 			name:             "Sub claim - valid",
-			claimType:        v1alpha1.UserIdentifierClaimSub,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimSub,
 			email:            "test@example.com",
 			username:         "testuser",
 			userID:           "sub-123",
@@ -223,7 +223,7 @@ func TestKeycloakIdentityProvider_GetUserIdentifier(t *testing.T) {
 		},
 		{
 			name:             "Sub claim - missing",
-			claimType:        v1alpha1.UserIdentifierClaimSub,
+			claimType:        breakglassv1alpha1.UserIdentifierClaimSub,
 			email:            "test@example.com",
 			username:         "testuser",
 			userID:           "",

--- a/pkg/breakglass/multi_idp_session_test.go
+++ b/pkg/breakglass/multi_idp_session_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -12,15 +12,15 @@ import (
 // when neither escalation nor cluster have IDP restrictions
 func TestAllowIDPMismatch_Logic_HappyPath(t *testing.T) {
 	// Simulate: escalation with NO IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{}, // Empty = no restrictions
 		},
 	}
 
 	// Simulate: cluster with NO IDP restrictions
-	clusterConfig := &v1alpha1.ClusterConfig{
-		Spec: v1alpha1.ClusterConfigSpec{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			IdentityProviderRefs: []string{}, // Empty = no restrictions
 		},
 	}
@@ -39,15 +39,15 @@ func TestAllowIDPMismatch_Logic_HappyPath(t *testing.T) {
 // when escalation has IDP restrictions
 func TestAllowIDPMismatch_Logic_WithEscalationRestriction(t *testing.T) {
 	// Simulate: escalation WITH IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{"keycloak", "ldap"}, // Has restrictions
 		},
 	}
 
 	// Simulate: cluster with NO IDP restrictions
-	clusterConfig := &v1alpha1.ClusterConfig{
-		Spec: v1alpha1.ClusterConfigSpec{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			IdentityProviderRefs: []string{}, // Empty = no restrictions
 		},
 	}
@@ -66,15 +66,15 @@ func TestAllowIDPMismatch_Logic_WithEscalationRestriction(t *testing.T) {
 // when cluster has IDP restrictions
 func TestAllowIDPMismatch_Logic_WithClusterRestriction(t *testing.T) {
 	// Simulate: escalation with NO IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{}, // Empty = no restrictions
 		},
 	}
 
 	// Simulate: cluster WITH IDP restrictions
-	clusterConfig := &v1alpha1.ClusterConfig{
-		Spec: v1alpha1.ClusterConfigSpec{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			IdentityProviderRefs: []string{"keycloak"}, // Has restrictions
 		},
 	}
@@ -93,15 +93,15 @@ func TestAllowIDPMismatch_Logic_WithClusterRestriction(t *testing.T) {
 // when both escalation AND cluster have IDP restrictions
 func TestAllowIDPMismatch_Logic_WithBothRestrictions(t *testing.T) {
 	// Simulate: escalation WITH IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{"keycloak"}, // Has restrictions
 		},
 	}
 
 	// Simulate: cluster WITH IDP restrictions (different IDP)
-	clusterConfig := &v1alpha1.ClusterConfig{
-		Spec: v1alpha1.ClusterConfigSpec{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			IdentityProviderRefs: []string{"ldap"}, // Has restrictions
 		},
 	}
@@ -119,12 +119,12 @@ func TestAllowIDPMismatch_Logic_WithBothRestrictions(t *testing.T) {
 // TestSessionCreated_HasAllowIDPMismatchField_HappyPath tests that created session has AllowIDPMismatch field set
 func TestSessionCreated_HasAllowIDPMismatchField_HappyPath(t *testing.T) {
 	// Create a session as it would be created in the API
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:          "prod-cluster",
 			User:             "user@example.com",
 			GrantedGroup:     "admin",
@@ -140,12 +140,12 @@ func TestSessionCreated_HasAllowIDPMismatchField_HappyPath(t *testing.T) {
 // TestSessionCreated_WithIDPIssuer_HappyPath tests that session captures the authentication IDP issuer
 func TestSessionCreated_WithIDPIssuer_HappyPath(t *testing.T) {
 	// Create a session as it would be created during authentication
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
@@ -166,8 +166,8 @@ func TestSessionCreated_WithIDPIssuer_HappyPath(t *testing.T) {
 // when cluster manager is nil
 func TestDefaultAllowIDPMismatch_WhenClusterManagerNil_BadPath(t *testing.T) {
 	// Simulate: escalation with NO IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{}, // No restrictions
 		},
 	}
@@ -187,8 +187,8 @@ func TestDefaultAllowIDPMismatch_WhenClusterManagerNil_BadPath(t *testing.T) {
 // TestDefaultAllowIDPMismatch_WhenClusterNotFound_BadPath tests graceful defaults when cluster doesn't exist
 func TestDefaultAllowIDPMismatch_WhenClusterNotFound_BadPath(t *testing.T) {
 	// Simulate: escalation with NO IDP restrictions
-	escalation := &v1alpha1.BreakglassEscalation{
-		Spec: v1alpha1.BreakglassEscalationSpec{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{}, // No restrictions
 		},
 	}
@@ -208,15 +208,15 @@ func TestDefaultAllowIDPMismatch_WhenClusterNotFound_BadPath(t *testing.T) {
 // TestMultiIDPApprovalFlow_RequestFromIDP1_ApprovedByIDP2 tests approval flow across IDPs
 func TestMultiIDPApprovalFlow_RequestFromIDP1_ApprovedByIDP2(t *testing.T) {
 	// Create escalation that allows both IDPs
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multi-idp-escalation",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassEscalationSpec{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{"idp-1", "idp-2"},
 		},
-		Status: v1alpha1.BreakglassEscalationStatus{
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
 			ApproverGroupMembers: map[string][]string{
 				"admin": {
 					"user1@idp1.com", // From IDP-1
@@ -244,12 +244,12 @@ func TestMultiIDPApprovalFlow_RequestFromIDP1_ApprovedByIDP2(t *testing.T) {
 // TestMultiIDPApprovalFlow_SingleIDPBlocking tests that single IDP approval can be blocked
 func TestMultiIDPApprovalFlow_SingleIDPBlocking(t *testing.T) {
 	// Create escalation that allows only IDP-1
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "single-idp-escalation",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassEscalationSpec{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{"idp-1"}, // Only IDP-1
 		},
 	}
@@ -272,15 +272,15 @@ func TestMultiIDPApprovalFlow_SingleIDPBlocking(t *testing.T) {
 // TestMultiIDPEmailResolution_DeduplicatedList_HappyPath tests email resolution with deduplication
 func TestMultiIDPEmailResolution_DeduplicatedList_HappyPath(t *testing.T) {
 	// Create escalation with deduplicated members from multiple IDPs
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multi-idp-escalation",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassEscalationSpec{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			AllowedIdentityProviders: []string{"idp-1", "idp-2"},
 		},
-		Status: v1alpha1.BreakglassEscalationStatus{
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
 			// Deduplicated list of approvers (same user across IDPs appears once)
 			ApproverGroupMembers: map[string][]string{
 				"admin": {
@@ -320,12 +320,12 @@ func TestMultiIDPEmailResolution_DeduplicatedList_HappyPath(t *testing.T) {
 // TestMultiIDPEmailResolution_FullHierarchyPreserved_HappyPath tests hierarchy preservation
 func TestMultiIDPEmailResolution_FullHierarchyPreserved_HappyPath(t *testing.T) {
 	// Create escalation with preserved hierarchy
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multi-idp-escalation",
 			Namespace: "default",
 		},
-		Status: v1alpha1.BreakglassEscalationStatus{
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
 			IDPGroupMemberships: map[string]map[string][]string{
 				"idp-1": {
 					"admin": {"user1@example.com", "user2@example.com"},
@@ -363,39 +363,39 @@ func TestMultiIDPEmailResolution_FullHierarchyPreserved_HappyPath(t *testing.T) 
 
 // TestGroupSyncStatus_Success_HappyPath tests successful group sync status
 func TestGroupSyncStatus_Success_HappyPath(t *testing.T) {
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-escalation",
 			Namespace: "default",
 		},
 	}
 	escalation.SetCondition(metav1.Condition{
-		Type:   string(v1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
+		Type:   string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
 		Status: metav1.ConditionTrue,
 		Reason: "GroupMembersResolved",
 	})
 
-	condition := escalation.GetCondition(string(v1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	condition := escalation.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
 	assert.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionTrue, condition.Status)
 }
 
 // TestGroupSyncStatus_PartialFailure_HappyPath tests partial failure status
 func TestGroupSyncStatus_PartialFailure_HappyPath(t *testing.T) {
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-escalation",
 			Namespace: "default",
 		},
 	}
 	escalation.SetCondition(metav1.Condition{
-		Type:    string(v1alpha1.BreakglassEscalationConditionReady),
+		Type:    string(breakglassv1alpha1.BreakglassEscalationConditionReady),
 		Status:  metav1.ConditionFalse,
 		Reason:  "PartialFailure",
 		Message: "Some IDPs failed to resolve members",
 	})
 
-	condition := escalation.GetCondition(string(v1alpha1.BreakglassEscalationConditionReady))
+	condition := escalation.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionReady))
 	assert.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "PartialFailure", condition.Reason)
@@ -403,20 +403,20 @@ func TestGroupSyncStatus_PartialFailure_HappyPath(t *testing.T) {
 
 // TestGroupSyncStatus_CompleteFailed_HappyPath tests complete failure status
 func TestGroupSyncStatus_CompleteFailed_HappyPath(t *testing.T) {
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-escalation",
 			Namespace: "default",
 		},
 	}
 	escalation.SetCondition(metav1.Condition{
-		Type:    string(v1alpha1.BreakglassEscalationConditionReady),
+		Type:    string(breakglassv1alpha1.BreakglassEscalationConditionReady),
 		Status:  metav1.ConditionFalse,
 		Reason:  "CompleteFailed",
 		Message: "All IDPs failed to resolve members",
 	})
 
-	condition := escalation.GetCondition(string(v1alpha1.BreakglassEscalationConditionReady))
+	condition := escalation.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionReady))
 	assert.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "CompleteFailed", condition.Reason)

--- a/pkg/breakglass/pod_template_rendering_test.go
+++ b/pkg/breakglass/pod_template_rendering_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,12 +40,12 @@ func TestBuildPodRenderContext(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "my-template",
 			RequestedBy:     "user@example.com",
@@ -57,18 +57,18 @@ func TestBuildPodRenderContext(t *testing.T) {
 				"replicaCount": {Raw: []byte(`3`)},
 			},
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			Approval: &v1alpha1.DebugSessionApproval{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			Approval: &breakglassv1alpha1.DebugSessionApproval{
 				ApprovedBy: "admin@example.com",
 				ApprovedAt: &metav1.Time{},
 			},
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "Test Template",
-			ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 				{
 					Name:    "pvcSize",
 					Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)},
@@ -121,25 +121,25 @@ func TestBuildVarsFromSession_PodTemplate(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		ds           *v1alpha1.DebugSession
-		templateSpec *v1alpha1.DebugSessionTemplateSpec
+		ds           *breakglassv1alpha1.DebugSession
+		templateSpec *breakglassv1alpha1.DebugSessionTemplateSpec
 		want         map[string]string
 	}{
 		{
 			name: "no variables",
-			ds: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{},
+			ds: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{},
 			},
-			templateSpec: &v1alpha1.DebugSessionTemplateSpec{},
+			templateSpec: &breakglassv1alpha1.DebugSessionTemplateSpec{},
 			want:         map[string]string{},
 		},
 		{
 			name: "defaults only",
-			ds: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{},
+			ds: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{},
 			},
-			templateSpec: &v1alpha1.DebugSessionTemplateSpec{
-				ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			templateSpec: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 					{Name: "size", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 					{Name: "enabled", Default: &apiextensionsv1.JSON{Raw: []byte(`true`)}},
 				},
@@ -151,15 +151,15 @@ func TestBuildVarsFromSession_PodTemplate(t *testing.T) {
 		},
 		{
 			name: "user values override defaults",
-			ds: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{
+			ds: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{
 					ExtraDeployValues: map[string]apiextensionsv1.JSON{
 						"size": {Raw: []byte(`"50Gi"`)},
 					},
 				},
 			},
-			templateSpec: &v1alpha1.DebugSessionTemplateSpec{
-				ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			templateSpec: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 					{Name: "size", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 				},
 			},
@@ -169,8 +169,8 @@ func TestBuildVarsFromSession_PodTemplate(t *testing.T) {
 		},
 		{
 			name: "various data types",
-			ds: &v1alpha1.DebugSession{
-				Spec: v1alpha1.DebugSessionSpec{
+			ds: &breakglassv1alpha1.DebugSession{
+				Spec: breakglassv1alpha1.DebugSessionSpec{
 					ExtraDeployValues: map[string]apiextensionsv1.JSON{
 						"stringVal": {Raw: []byte(`"hello"`)},
 						"boolVal":   {Raw: []byte(`false`)},
@@ -180,7 +180,7 @@ func TestBuildVarsFromSession_PodTemplate(t *testing.T) {
 					},
 				},
 			},
-			templateSpec: &v1alpha1.DebugSessionTemplateSpec{},
+			templateSpec: &breakglassv1alpha1.DebugSessionTemplateSpec{},
 			want: map[string]string{
 				"stringVal": "hello",
 				"boolVal":   "false",
@@ -208,7 +208,7 @@ func TestRenderPodTemplateString(t *testing.T) {
 	tests := []struct {
 		name        string
 		templateStr string
-		ctx         v1alpha1.AuxiliaryResourceContext
+		ctx         breakglassv1alpha1.AuxiliaryResourceContext
 		wantSpec    corev1.PodSpec
 		wantErr     bool
 		errContains string
@@ -221,7 +221,7 @@ containers:
     image: busybox:latest
     command: ["sleep", "infinity"]
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{},
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{},
 			wantSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -240,7 +240,7 @@ containers:
     image: {{ .vars.image }}
     command: ["sleep", "{{ .vars.sleepTime }}"]
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"containerName": "my-container",
 					"image":         "alpine:3.18",
@@ -269,8 +269,8 @@ containers:
       - name: CLUSTER
         value: {{ .session.cluster | quote }}
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name:    "my-debug-session-12345",
 					Cluster: "production-cluster",
 				},
@@ -304,7 +304,7 @@ volumes:
       claimName: {{ .vars.pvcName }}
 {{- end }}
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"mountPvc": "true",
 					"pvcName":  "test-pvc",
@@ -335,7 +335,7 @@ volumes:
 		{
 			name:        "invalid template syntax",
 			templateStr: `{{ .invalid.syntax`,
-			ctx:         v1alpha1.AuxiliaryResourceContext{},
+			ctx:         breakglassv1alpha1.AuxiliaryResourceContext{},
 			wantErr:     true,
 			errContains: "template rendering failed",
 		},
@@ -369,8 +369,8 @@ func TestRenderPodOverridesTemplate(t *testing.T) {
 	tests := []struct {
 		name          string
 		templateStr   string
-		ctx           v1alpha1.AuxiliaryResourceContext
-		wantOverrides *v1alpha1.DebugPodSpecOverrides
+		ctx           breakglassv1alpha1.AuxiliaryResourceContext
+		wantOverrides *breakglassv1alpha1.DebugPodSpecOverrides
 		wantErr       bool
 	}{
 		{
@@ -379,8 +379,8 @@ func TestRenderPodOverridesTemplate(t *testing.T) {
 hostNetwork: true
 hostPID: false
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{},
-			wantOverrides: &v1alpha1.DebugPodSpecOverrides{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{},
+			wantOverrides: &breakglassv1alpha1.DebugPodSpecOverrides{
 				HostNetwork: &trueVal,
 				HostPID:     &falseVal,
 			},
@@ -393,13 +393,13 @@ hostNetwork: true
 {{- end }}
 hostPID: {{ .vars.enableHostPID }}
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"enableHostNetwork": "true",
 					"enableHostPID":     "false",
 				},
 			},
-			wantOverrides: &v1alpha1.DebugPodSpecOverrides{
+			wantOverrides: &breakglassv1alpha1.DebugPodSpecOverrides{
 				HostNetwork: &trueVal,
 				HostPID:     &falseVal,
 			},
@@ -411,12 +411,12 @@ hostPID: {{ .vars.enableHostPID }}
 hostNetwork: true
 {{- end }}
 `,
-			ctx: v1alpha1.AuxiliaryResourceContext{
+			ctx: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"enableHostNetwork": "false",
 				},
 			},
-			wantOverrides: &v1alpha1.DebugPodSpecOverrides{},
+			wantOverrides: &breakglassv1alpha1.DebugPodSpecOverrides{},
 		},
 	}
 
@@ -445,7 +445,7 @@ func TestApplyPodOverridesStruct(t *testing.T) {
 	tests := []struct {
 		name      string
 		spec      corev1.PodSpec
-		overrides *v1alpha1.DebugPodSpecOverrides
+		overrides *breakglassv1alpha1.DebugPodSpecOverrides
 		wantSpec  corev1.PodSpec
 	}{
 		{
@@ -453,7 +453,7 @@ func TestApplyPodOverridesStruct(t *testing.T) {
 			spec: corev1.PodSpec{
 				HostNetwork: false,
 			},
-			overrides: &v1alpha1.DebugPodSpecOverrides{
+			overrides: &breakglassv1alpha1.DebugPodSpecOverrides{
 				HostNetwork: &trueVal,
 			},
 			wantSpec: corev1.PodSpec{
@@ -463,7 +463,7 @@ func TestApplyPodOverridesStruct(t *testing.T) {
 		{
 			name: "apply all overrides",
 			spec: corev1.PodSpec{},
-			overrides: &v1alpha1.DebugPodSpecOverrides{
+			overrides: &breakglassv1alpha1.DebugPodSpecOverrides{
 				HostNetwork: &trueVal,
 				HostPID:     &trueVal,
 				HostIPC:     &falseVal,
@@ -483,7 +483,7 @@ func TestApplyPodOverridesStruct(t *testing.T) {
 		{
 			name:      "empty overrides",
 			spec:      corev1.PodSpec{HostNetwork: true},
-			overrides: &v1alpha1.DebugPodSpecOverrides{},
+			overrides: &breakglassv1alpha1.DebugPodSpecOverrides{},
 			wantSpec:  corev1.PodSpec{HostNetwork: true},
 		},
 	}
@@ -503,12 +503,12 @@ func TestBuildPodSpec_WithTemplateString(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "fio-template",
 			RequestedBy:     "user@example.com",
@@ -520,8 +520,8 @@ func TestBuildPodSpec_WithTemplateString(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "FIO Storage Test",
 			PodTemplateString: `
 containers:
@@ -536,7 +536,7 @@ volumes:
     persistentVolumeClaim:
       claimName: pvc-{{ .session.name | trunc 8 }}
 `,
-			ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 				{Name: "pvcSize", Default: &apiextensionsv1.JSON{Raw: []byte(`"10Gi"`)}},
 			},
 		},
@@ -568,12 +568,12 @@ func TestBuildPodSpec_WithOverridesTemplate(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "network-debug",
 			TargetNamespace: "target-ns",
@@ -583,10 +583,10 @@ func TestBuildPodSpec_WithOverridesTemplate(t *testing.T) {
 		},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
-			Template: &v1alpha1.DebugPodSpec{
-				Spec: v1alpha1.DebugPodSpecInner{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
+			Template: &breakglassv1alpha1.DebugPodSpec{
+				Spec: breakglassv1alpha1.DebugPodSpecInner{
 					Containers: []corev1.Container{
 						{
 							Name:    "netshoot",
@@ -599,8 +599,8 @@ func TestBuildPodSpec_WithOverridesTemplate(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "Network Debug",
 			PodOverridesTemplate: `
 {{- if eq .vars.enableHostNetwork "true" }}
@@ -608,7 +608,7 @@ hostNetwork: true
 hostPID: true
 {{- end }}
 `,
-			ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+			ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 				{Name: "enableHostNetwork", Default: &apiextensionsv1.JSON{Raw: []byte(`false`)}},
 			},
 		},
@@ -635,12 +635,12 @@ func TestBuildPodSpec_WithDebugPodTemplateTemplateString(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "production-cluster",
 			TemplateRef:     "dynamic-debug",
 			TargetNamespace: "target-ns",
@@ -653,11 +653,11 @@ func TestBuildPodSpec_WithDebugPodTemplateTemplateString(t *testing.T) {
 	}
 
 	// DebugPodTemplate with templateString instead of structured template
-	podTemplate := &v1alpha1.DebugPodTemplate{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dynamic-pod-template",
 		},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			// Template is nil - using templateString instead
 			TemplateString: `
 containers:
@@ -683,8 +683,8 @@ containers:
 	}
 
 	// DebugSessionTemplate that references the DebugPodTemplate
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No PodTemplateString - will use the referenced podTemplate's templateString
 		},
 	}
@@ -720,29 +720,29 @@ func TestBuildPodSpec_DebugPodTemplateNeitherTemplateNorTemplateString(t *testin
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "test-cluster",
 			TemplateRef: "invalid-template",
 		},
 	}
 
 	// DebugPodTemplate with neither template nor templateString (invalid)
-	podTemplate := &v1alpha1.DebugPodTemplate{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "invalid-pod-template",
 		},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			// Both Template and TemplateString are nil/empty
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{},
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
 	}
 
 	_, err := controller.buildPodSpec(ds, template, podTemplate)
@@ -756,12 +756,12 @@ func TestBuildPodSpec_OverridesDisabled(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "network-debug",
 			TargetNamespace: "target-ns",
@@ -771,10 +771,10 @@ func TestBuildPodSpec_OverridesDisabled(t *testing.T) {
 		},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
-			Template: &v1alpha1.DebugPodSpec{
-				Spec: v1alpha1.DebugPodSpecInner{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
+			Template: &breakglassv1alpha1.DebugPodSpec{
+				Spec: breakglassv1alpha1.DebugPodSpecInner{
 					Containers: []corev1.Container{
 						{Name: "debug", Image: "busybox"},
 					},
@@ -783,8 +783,8 @@ func TestBuildPodSpec_OverridesDisabled(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodOverridesTemplate: `
 {{- if eq .vars.enableHostNetwork "true" }}
 hostNetwork: true
@@ -841,7 +841,7 @@ containers:
     command: ["sleep", "infinity"]
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	// Should have a valid PodSpec
@@ -883,8 +883,8 @@ spec:
       storage: {{ .vars.pvcSize | default "10Gi" }}
 `
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name: "test-session",
 		},
 		Vars: map[string]string{
@@ -952,7 +952,7 @@ spec:
       storage: 10Gi
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	// Verify PodSpec
@@ -998,7 +998,7 @@ data:
   key: value
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	// Verify PodSpec
@@ -1016,7 +1016,7 @@ func TestRenderPodTemplateStringMultiDoc_EmptyTemplate(t *testing.T) {
 	}
 
 	// Empty template
-	_, err := controller.renderPodTemplateStringMultiDoc("", v1alpha1.AuxiliaryResourceContext{})
+	_, err := controller.renderPodTemplateStringMultiDoc("", breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }
@@ -1036,7 +1036,7 @@ data:
   key: value
 `
 
-	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing apiVersion or kind")
 }
@@ -1061,13 +1061,13 @@ data:
   requestedBy: {{ .session.requestedBy }}
 `
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:        "very-long-session-name-12345",
 			Cluster:     "prod-cluster",
 			RequestedBy: "user@example.com",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace: "debug-ns",
 		},
 		Vars: map[string]string{
@@ -1115,7 +1115,7 @@ spec:
 `
 
 	// Test with PVC enabled
-	ctx := v1alpha1.AuxiliaryResourceContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Vars: map[string]string{"createPVC": "true"},
 	}
 	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, ctx)
@@ -1123,7 +1123,7 @@ spec:
 	assert.Len(t, result.AdditionalResources, 1)
 
 	// Test with PVC disabled
-	ctx = v1alpha1.AuxiliaryResourceContext{
+	ctx = breakglassv1alpha1.AuxiliaryResourceContext{
 		Vars: map[string]string{"createPVC": "false"},
 	}
 	result, err = controller.renderPodTemplateStringMultiDoc(templateStr, ctx)
@@ -1137,12 +1137,12 @@ func TestBuildPodSpec_MultiDocReturnsAdditionalResources(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "storage-test",
 			RequestedBy:     "user@example.com",
@@ -1150,8 +1150,8 @@ func TestBuildPodSpec_MultiDocReturnsAdditionalResources(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "Storage Test",
 			PodTemplateString: `containers:
   - name: fio
@@ -1198,26 +1198,26 @@ func TestBuildPodSpec_StructuredTemplateNoAdditionalResources(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "simple",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{},
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
-			Template: &v1alpha1.DebugPodSpec{
-				Spec: v1alpha1.DebugPodSpecInner{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
+			Template: &breakglassv1alpha1.DebugPodSpec{
+				Spec: breakglassv1alpha1.DebugPodSpecInner{
 					Containers: []corev1.Container{
 						{Name: "debug", Image: "busybox"},
 					},
@@ -1244,26 +1244,26 @@ func TestBuildPodSpec_DebugPodTemplateMultiDoc(t *testing.T) {
 		log: logger,
 	}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "with-pod-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No PodTemplateString - will use podTemplate's templateString
 		},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			TemplateString: `containers:
   - name: app
     image: app:latest
@@ -1332,7 +1332,7 @@ spec:
           add: ["NET_ADMIN", "NET_RAW"]
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	// Should extract PodSpec correctly
@@ -1378,7 +1378,7 @@ data:
   key: value
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	require.Len(t, result.PodSpec.Containers, 1)
@@ -1417,7 +1417,7 @@ spec:
               memory: "128Mi"
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	// Should return the full Deployment as Workload
@@ -1456,7 +1456,7 @@ spec:
           command: ["sleep", "infinity"]
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	require.NotNil(t, result.Workload)
@@ -1485,7 +1485,7 @@ spec:
           image: busybox
 `
 
-	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported manifest kind")
 	assert.Contains(t, err.Error(), "Job")
@@ -1504,7 +1504,7 @@ spec:
       emptyDir: {}
 `
 
-	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no containers")
 }
@@ -1519,7 +1519,7 @@ func TestRenderPodTemplateStringMultiDoc_BareSpecEmptyContainersError(t *testing
     emptyDir: {}
 `
 
-	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	_, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no containers")
 }
@@ -1565,7 +1565,7 @@ spec:
         type: DirectoryOrCreate
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	assert.Nil(t, result.Workload, "Pod manifests should not produce a workload")
@@ -1626,7 +1626,7 @@ spec:
         sizeLimit: {{ .vars.captureStorageGi | default "2" }}Gi
 `
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
 		Vars: map[string]string{
 			"captureStorageGi": "5",
 		},
@@ -1683,7 +1683,7 @@ spec:
         type: Directory
 `
 
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 
 	require.Len(t, result.PodSpec.Containers, 1)
@@ -1708,13 +1708,13 @@ func newBuildWorkloadController() *DebugSessionController {
 	return &DebugSessionController{log: zap.NewNop().Sugar()}
 }
 
-func newBuildWorkloadSession(name string) *v1alpha1.DebugSession {
-	return &v1alpha1.DebugSession{
+func newBuildWorkloadSession(name string) *breakglassv1alpha1.DebugSession {
+	return &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
@@ -1728,9 +1728,9 @@ func TestBuildWorkload_KindPodWrappedInDaemonSet(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("pod-to-ds")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: v1
 kind: Pod
 metadata:
@@ -1776,9 +1776,9 @@ func TestBuildWorkload_KindPodWrappedInDeployment(t *testing.T) {
 	ds := newBuildWorkloadSession("pod-to-deploy")
 
 	replicas := int32(3)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &replicas,
 			PodTemplateString: `apiVersion: v1
 kind: Pod
@@ -1805,9 +1805,9 @@ func TestBuildWorkload_FullDeploymentTemplate(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("full-deploy")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1858,9 +1858,9 @@ func TestBuildWorkload_FullDaemonSetTemplate(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("full-ds")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1900,9 +1900,9 @@ func TestBuildWorkload_WorkloadTypeMismatch(t *testing.T) {
 	ds := newBuildWorkloadSession("mismatch")
 
 	// Template produces a DaemonSet but workloadType is Deployment
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1933,9 +1933,9 @@ func TestBuildWorkload_FullDeploymentReplicasOverride(t *testing.T) {
 	ds := newBuildWorkloadSession("replicas-override")
 
 	overrideReplicas := int32(2)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &overrideReplicas,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
@@ -1968,10 +1968,10 @@ func TestBuildWorkload_FullDeploymentResourceQuotaExceeded(t *testing.T) {
 	ds := newBuildWorkloadSession("quota-exceed")
 
 	maxPods := int32(2)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
-			ResourceQuota: &v1alpha1.DebugResourceQuotaConfig{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
+			ResourceQuota: &breakglassv1alpha1.DebugResourceQuotaConfig{
 				MaxPods: &maxPods,
 			},
 			PodTemplateString: `apiVersion: apps/v1
@@ -2004,9 +2004,9 @@ func TestBuildWorkload_BareSpecBackwardCompatible(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("bare-spec")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `containers:
   - name: debug
     image: alpine:3.19
@@ -2033,20 +2033,20 @@ func TestBuildPodSpec_KindPodInSessionTemplate(t *testing.T) {
 	// Tests that buildPodSpec correctly handles kind: Pod in PodTemplateString
 	controller := newBuildWorkloadController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodTemplateString: `apiVersion: v1
 kind: Pod
 metadata:
@@ -2074,24 +2074,24 @@ func TestBuildPodSpec_KindPodInDebugPodTemplate(t *testing.T) {
 	// Tests that buildPodSpec handles kind: Pod in DebugPodTemplate.TemplateString
 	controller := newBuildWorkloadController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{},
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			TemplateString: `apiVersion: v1
 kind: Pod
 spec:
@@ -2123,7 +2123,7 @@ kind: Pod
 metadata:
   name: no-spec-pod
 `
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'spec'")
 	assert.Nil(t, result)
@@ -2140,7 +2140,7 @@ spec:
     - name: debug
       image: busybox:latest
 `
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.PodSpec.Containers, 1)
@@ -2166,7 +2166,7 @@ spec:
     spec:
       containers: []
 `
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "containers")
 	assert.Nil(t, result)
@@ -2190,7 +2190,7 @@ spec:
     spec:
       containers: []
 `
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "containers")
 	assert.Nil(t, result)
@@ -2201,7 +2201,7 @@ func TestRenderPodTemplateStringMultiDoc_InvalidYAML(t *testing.T) {
 
 	// Completely invalid YAML
 	templateStr := `{{{not valid yaml: [`
-	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, v1alpha1.AuxiliaryResourceContext{})
+	result, err := controller.renderPodTemplateStringMultiDoc(templateStr, breakglassv1alpha1.AuxiliaryResourceContext{})
 	require.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -2210,8 +2210,8 @@ func TestBuildWorkload_UnknownWorkloadType(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("unknown-type")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			WorkloadType: "StatefulSet", // unsupported type
 			PodTemplateString: `containers:
   - name: debug
@@ -2231,9 +2231,9 @@ func TestBuildWorkload_DeploymentNilReplicasDefaultsToOne(t *testing.T) {
 	ds := newBuildWorkloadSession("nil-replicas")
 
 	// Template without Replicas set (nil)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			// Replicas: nil — should default to 1
 			PodTemplateString: `containers:
   - name: debug
@@ -2254,9 +2254,9 @@ func TestBuildWorkload_RestartPolicyOverriddenForBareSpecDaemonSet(t *testing.T)
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("restart-override")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			// Bare PodSpec with RestartPolicy=Never (should be overridden to Always)
 			PodTemplateString: `containers:
   - name: debug
@@ -2278,15 +2278,15 @@ restartPolicy: Never
 func TestBuildWorkload_FullDeploymentWithSchedulingConstraints(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("sched-constraints")
-	ds.Spec.ResolvedSchedulingConstraints = &v1alpha1.SchedulingConstraints{
+	ds.Spec.ResolvedSchedulingConstraints = &breakglassv1alpha1.SchedulingConstraints{
 		NodeSelector: map[string]string{
 			"node-role.kubernetes.io/debug": "true",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -2323,9 +2323,9 @@ func TestBuildWorkload_FullDeploymentWithTolerations(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("tolerations")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			AdditionalTolerations: []corev1.Toleration{
 				{
 					Key:      "debug-node",
@@ -2377,9 +2377,9 @@ func TestBuildWorkload_FullDaemonSetWithSessionNodeSelector(t *testing.T) {
 		"kubernetes.io/hostname": "worker-01",
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -2416,11 +2416,11 @@ func TestBuildWorkload_FullDeploymentWithPodOverrides(t *testing.T) {
 	ds := newBuildWorkloadSession("pod-overrides")
 
 	hostNetTrue := true
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
-			PodOverrides: &v1alpha1.DebugPodOverrides{
-				Spec: &v1alpha1.DebugPodSpecOverrides{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
+			PodOverrides: &breakglassv1alpha1.DebugPodOverrides{
+				Spec: &breakglassv1alpha1.DebugPodSpecOverrides{
 					HostNetwork: &hostNetTrue,
 				},
 			},
@@ -2460,9 +2460,9 @@ func TestBuildWorkload_FullDeploymentLabelMerging(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("label-merge")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -2508,9 +2508,9 @@ func TestBuildWorkload_FullDaemonSetWithAffinityOverrides(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("affinity")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			AffinityOverrides: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -2566,10 +2566,10 @@ func TestBuildWorkload_FullDeploymentWithResourceQuota(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("resource-quota")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
-			ResourceQuota: &v1alpha1.DebugResourceQuotaConfig{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
+			ResourceQuota: &breakglassv1alpha1.DebugResourceQuotaConfig{
 				EnforceResourceRequests: true,
 				EnforceResourceLimits:   true,
 			},
@@ -2605,9 +2605,9 @@ func TestBuildWorkload_FullDeploymentRestartPolicyEnforced(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("restart-enforce")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			// Full Deployment with RestartPolicy=Never (should be overridden)
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
@@ -2825,9 +2825,9 @@ func TestBuildWorkload_FullDaemonSetRestartPolicyOverride(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("ds-restart")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -2863,9 +2863,9 @@ func TestBuildWorkload_FullDeploymentNilReplicasDefaultsToOne(t *testing.T) {
 	ds := newBuildWorkloadSession("nil-replicas")
 
 	// Full Deployment template without replicas field
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			// Replicas not set on template.Spec either
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
@@ -2901,9 +2901,9 @@ func TestBuildWorkload_FullDeploymentWithAdditionalResources(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("deploy-extra")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -2945,9 +2945,9 @@ func TestBuildWorkload_FullDaemonSetLabelMerging(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("ds-labels")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -2997,9 +2997,9 @@ func TestBuildWorkload_SessionLabelsExcludeControllerOwned(t *testing.T) {
 		"custom-label":        "should-be-kept",
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -3026,9 +3026,9 @@ func TestBuildWorkload_WithBindingLabelsAndAnnotations(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("binding-labels")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			Labels: map[string]string{
 				"template-label": "from-template",
 			},
@@ -3042,8 +3042,8 @@ func TestBuildWorkload_WithBindingLabelsAndAnnotations(t *testing.T) {
 		},
 	}
 
-	binding := &v1alpha1.DebugSessionClusterBinding{
-		Spec: v1alpha1.DebugSessionClusterBindingSpec{
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 			Labels: map[string]string{
 				"binding-label": "from-binding",
 			},
@@ -3053,10 +3053,10 @@ func TestBuildWorkload_WithBindingLabelsAndAnnotations(t *testing.T) {
 		},
 	}
 
-	podTemplate := &v1alpha1.DebugPodTemplate{
-		Spec: v1alpha1.DebugPodTemplateSpec{
-			Template: &v1alpha1.DebugPodSpec{
-				Metadata: &v1alpha1.DebugPodMetadata{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
+			Template: &breakglassv1alpha1.DebugPodSpec{
+				Metadata: &breakglassv1alpha1.DebugPodMetadata{
 					Labels: map[string]string{
 						"podtemplate-label": "from-podtemplate",
 					},
@@ -3092,11 +3092,11 @@ func TestBuildWorkload_BareSpecDeploymentMaxPodsExceeded(t *testing.T) {
 
 	maxPods := int32(1)
 	replicas := int32(5)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &replicas,
-			ResourceQuota: &v1alpha1.DebugResourceQuotaConfig{
+			ResourceQuota: &breakglassv1alpha1.DebugResourceQuotaConfig{
 				MaxPods: &maxPods,
 			},
 			PodTemplateString: `containers:
@@ -3117,12 +3117,12 @@ func TestBuildWorkload_BareSpecDeploymentMaxPodsExceeded(t *testing.T) {
 func TestBuildPodSpec_PodTemplateStringTakesPriority(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "priority-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
@@ -3130,8 +3130,8 @@ func TestBuildPodSpec_PodTemplateStringTakesPriority(t *testing.T) {
 	}
 
 	// Template has both podTemplateString and podTemplate would be set
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodTemplateString: `containers:
   - name: from-template-string
     image: busybox:latest
@@ -3140,9 +3140,9 @@ func TestBuildPodSpec_PodTemplateStringTakesPriority(t *testing.T) {
 	}
 
 	// podTemplate exists but should be ignored since podTemplateString is set
-	podTemplate := &v1alpha1.DebugPodTemplate{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod-template"},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			TemplateString: `containers:
   - name: from-pod-template
     image: alpine:latest
@@ -3159,20 +3159,20 @@ func TestBuildPodSpec_PodTemplateStringTakesPriority(t *testing.T) {
 func TestBuildPodSpec_NoPodTemplateStringNoPodTemplate(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "empty-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No podTemplateString
 		},
 	}
@@ -3187,12 +3187,12 @@ func TestBuildPodSpec_NoPodTemplateStringNoPodTemplate(t *testing.T) {
 func TestBuildPodSpec_WithAllThreePodOverrideFlags(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "overrides-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
@@ -3202,14 +3202,14 @@ func TestBuildPodSpec_WithAllThreePodOverrideFlags(t *testing.T) {
 	hostNet := true
 	hostPID := true
 	hostIPC := true
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
 `,
-			PodOverrides: &v1alpha1.DebugPodOverrides{
-				Spec: &v1alpha1.DebugPodSpecOverrides{
+			PodOverrides: &breakglassv1alpha1.DebugPodOverrides{
+				Spec: &breakglassv1alpha1.DebugPodSpecOverrides{
 					HostNetwork: &hostNet,
 					HostPID:     &hostPID,
 					HostIPC:     &hostIPC,
@@ -3230,15 +3230,15 @@ func TestBuildPodSpec_WithAllThreePodOverrideFlags(t *testing.T) {
 func TestBuildVarsFromSession_NilRawBytes(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			ExtraDeployValues: map[string]apiextensionsv1.JSON{
 				"nullVar": {Raw: nil},
 			},
 		},
 	}
 
-	templateSpec := &v1alpha1.DebugSessionTemplateSpec{}
+	templateSpec := &breakglassv1alpha1.DebugSessionTemplateSpec{}
 
 	vars := controller.buildVarsFromSession(ds, templateSpec)
 	// Nil raw bytes should produce empty string
@@ -3248,12 +3248,12 @@ func TestBuildVarsFromSession_NilRawBytes(t *testing.T) {
 func TestBuildVarsFromSession_NilDefaultRawBytes(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{},
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{},
 	}
 
-	templateSpec := &v1alpha1.DebugSessionTemplateSpec{
-		ExtraDeployVariables: []v1alpha1.ExtraDeployVariable{
+	templateSpec := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		ExtraDeployVariables: []breakglassv1alpha1.ExtraDeployVariable{
 			{
 				Name:    "varWithNilDefault",
 				Default: &apiextensionsv1.JSON{Raw: nil},
@@ -3270,15 +3270,15 @@ func TestBuildVarsFromSession_NilDefaultRawBytes(t *testing.T) {
 func TestBuildVarsFromSession_NestedJSONObject(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			ExtraDeployValues: map[string]apiextensionsv1.JSON{
 				"nested": {Raw: []byte(`{"key":"value","num":123}`)},
 			},
 		},
 	}
 
-	templateSpec := &v1alpha1.DebugSessionTemplateSpec{}
+	templateSpec := &breakglassv1alpha1.DebugSessionTemplateSpec{}
 
 	vars := controller.buildVarsFromSession(ds, templateSpec)
 	// Nested JSON object falls through to raw string
@@ -3289,15 +3289,15 @@ func TestBuildVarsFromSession_NestedJSONObject(t *testing.T) {
 func TestBuildVarsFromSession_EmptyRawBytes(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			ExtraDeployValues: map[string]apiextensionsv1.JSON{
 				"emptyVar": {Raw: []byte{}},
 			},
 		},
 	}
 
-	templateSpec := &v1alpha1.DebugSessionTemplateSpec{}
+	templateSpec := &breakglassv1alpha1.DebugSessionTemplateSpec{}
 
 	vars := controller.buildVarsFromSession(ds, templateSpec)
 	assert.Equal(t, "", vars["emptyVar"], "empty Raw bytes should produce empty string")
@@ -3306,8 +3306,8 @@ func TestBuildVarsFromSession_EmptyRawBytes(t *testing.T) {
 func TestBuildVarsFromSession_NilTemplateSpec(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			ExtraDeployValues: map[string]apiextensionsv1.JSON{
 				"userVar": {Raw: []byte(`"hello"`)},
 			},
@@ -3322,15 +3322,15 @@ func TestBuildVarsFromSession_NilTemplateSpec(t *testing.T) {
 func TestBuildVarsFromSession_ArrayValue(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
-		Spec: v1alpha1.DebugSessionSpec{
+	ds := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			ExtraDeployValues: map[string]apiextensionsv1.JSON{
 				"tags": {Raw: []byte(`["tag1","tag2","tag3"]`)},
 			},
 		},
 	}
 
-	templateSpec := &v1alpha1.DebugSessionTemplateSpec{}
+	templateSpec := &breakglassv1alpha1.DebugSessionTemplateSpec{}
 	vars := controller.buildVarsFromSession(ds, templateSpec)
 	assert.Equal(t, "tag1,tag2,tag3", vars["tags"],
 		"string array should be joined with commas")
@@ -3341,12 +3341,12 @@ func TestBuildVarsFromSession_ArrayValue(t *testing.T) {
 func TestBuildPodRenderContext_EmptyRequestedBy(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ctx-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			RequestedBy:     "", // empty
@@ -3354,8 +3354,8 @@ func TestBuildPodRenderContext_EmptyRequestedBy(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "Test Template",
 		},
 	}
@@ -3369,12 +3369,12 @@ func TestBuildPodRenderContext_EmptyRequestedBy(t *testing.T) {
 func TestBuildPodRenderContext_WithTemplateLabelsAndAnnotations(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ctx-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			RequestedBy:     "user@example.com",
@@ -3382,8 +3382,8 @@ func TestBuildPodRenderContext_WithTemplateLabelsAndAnnotations(t *testing.T) {
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			DisplayName: "Test Template",
 		},
 	}
@@ -3399,12 +3399,12 @@ func TestBuildPodRenderContext_WithTemplateLabelsAndAnnotations(t *testing.T) {
 func TestBuildPodRenderContext_ExtraDeployValuesWithoutTemplateVars(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vars-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
@@ -3414,8 +3414,8 @@ func TestBuildPodRenderContext_ExtraDeployValuesWithoutTemplateVars(t *testing.T
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No ExtraDeployVariables defined — user-provided values should still be in Vars
 		},
 	}
@@ -3488,19 +3488,19 @@ func TestExtractJSONValueForPod_AdditionalCases(t *testing.T) {
 
 // ==================== Helper Functions ====================
 
-func newTestRenderContext() v1alpha1.AuxiliaryResourceContext {
-	return v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+func newTestRenderContext() breakglassv1alpha1.AuxiliaryResourceContext {
+	return breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:        "test-session",
 			Namespace:   "breakglass-system",
 			Cluster:     "test-cluster",
 			RequestedBy: "user@example.com",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "target-ns",
 			ClusterName: "test-cluster",
 		},
-		Template: v1alpha1.AuxiliaryResourceTemplateContext{
+		Template: breakglassv1alpha1.AuxiliaryResourceTemplateContext{
 			Name:        "test-template",
 			DisplayName: "Test Template",
 		},
@@ -3737,12 +3737,12 @@ func TestDeployPodTemplateResource_SetsNamespaceWhenEmpty(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3764,12 +3764,12 @@ func TestDeployPodTemplateResource_PreservesExistingNamespace(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3791,12 +3791,12 @@ func TestDeployPodTemplateResource_SetsLabels(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "prod-cluster",
 		},
 	}
@@ -3821,12 +3821,12 @@ func TestDeployPodTemplateResource_MergesExistingLabels(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3854,12 +3854,12 @@ func TestDeployPodTemplateResource_SetsAnnotations(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3882,12 +3882,12 @@ func TestDeployPodTemplateResource_MergesExistingAnnotations(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3913,12 +3913,12 @@ func TestDeployPodTemplateResource_UpdatesSessionStatus(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3958,12 +3958,12 @@ func TestDeployPodTemplateResource_MultipleResources(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -3994,12 +3994,12 @@ func TestDeployPodTemplateResource_NilLabelsAndAnnotations(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "test-cluster",
 		},
 	}
@@ -4031,9 +4031,9 @@ func TestBuildWorkload_DeploymentWithZeroReplicas(t *testing.T) {
 	ds := newBuildWorkloadSession("zero-replicas")
 
 	replicas := int32(0)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &replicas,
 			PodTemplateString: `containers:
   - name: debug
@@ -4056,8 +4056,8 @@ func TestBuildWorkload_EmptyWorkloadTypeDefaultsToDaemonSet(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("default-type")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			WorkloadType: "", // empty → should default to DaemonSet
 			PodTemplateString: `containers:
   - name: debug
@@ -4080,9 +4080,9 @@ func TestBuildWorkload_DaemonSetAnnotationsFromSession(t *testing.T) {
 		"session-annotation": "from-session",
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -4106,9 +4106,9 @@ func TestBuildWorkload_DeploymentAnnotationsFromSession(t *testing.T) {
 		"session-annotation": "deploy-from-session",
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -4128,9 +4128,9 @@ func TestBuildWorkload_WorkloadNameFormat(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("my-session")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -4152,9 +4152,9 @@ func TestBuildWorkload_BareSpecRestartPolicyAlreadyAlways(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("already-always")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `restartPolicy: Always
 containers:
   - name: debug
@@ -4175,9 +4175,9 @@ func TestBuildWorkload_BareSpecRestartPolicyNever(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("never-restart")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `restartPolicy: Never
 containers:
   - name: debug
@@ -4199,9 +4199,9 @@ func TestBuildWorkload_DeploymentSelectorMatchLabels(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("selector-test")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -4224,9 +4224,9 @@ func TestBuildWorkload_DaemonSetSelectorMatchLabels(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("ds-selector")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest
@@ -4251,9 +4251,9 @@ func TestBuildWorkload_FullDeploymentWithReplicasFromBoth(t *testing.T) {
 	ds := newBuildWorkloadSession("replicas-both")
 
 	dstReplicas := int32(3)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &dstReplicas,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
@@ -4292,11 +4292,11 @@ func TestBuildWorkload_FullDeploymentMaxPodsExceeded(t *testing.T) {
 
 	replicas := int32(5)
 	maxPods := int32(2)
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			Replicas:     &replicas,
-			ResourceQuota: &v1alpha1.DebugResourceQuotaConfig{
+			ResourceQuota: &breakglassv1alpha1.DebugResourceQuotaConfig{
 				MaxPods: &maxPods,
 			},
 			PodTemplateString: `apiVersion: apps/v1
@@ -4329,9 +4329,9 @@ func TestBuildWorkload_FullDeploymentNameAndNamespaceOverridden(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("override-name")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -4369,9 +4369,9 @@ func TestBuildWorkload_FullDaemonSetNameAndNamespaceOverridden(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("ds-override")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -4406,9 +4406,9 @@ func TestBuildWorkload_FullDeploymentSelectorOverridden(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("selector-override")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDeployment,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDeployment,
 			PodTemplateString: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -4443,9 +4443,9 @@ func TestBuildWorkload_FullDaemonSetSelectorOverridden(t *testing.T) {
 	controller := newBuildWorkloadController()
 	ds := newBuildWorkloadSession("ds-selector-override")
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
-			WorkloadType: v1alpha1.DebugWorkloadDaemonSet,
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
 			PodTemplateString: `apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -4480,28 +4480,28 @@ spec:
 func TestBuildPodSpec_PodTemplateWithTemplateStringOnly(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pt-ts-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No PodTemplateString on DST
 		},
 	}
 
 	// PodTemplate with TemplateString
-	podTemplate := &v1alpha1.DebugPodTemplate{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "pt-with-ts"},
-		Spec: v1alpha1.DebugPodTemplateSpec{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
 			TemplateString: `containers:
   - name: from-podtemplate-ts
     image: alpine:latest
@@ -4518,30 +4518,30 @@ func TestBuildPodSpec_PodTemplateWithTemplateStringOnly(t *testing.T) {
 func TestBuildPodSpec_PodTemplateWithStructuredTemplate(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pt-struct-test",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			// No PodTemplateString on DST
 		},
 	}
 
 	// PodTemplate with structured Template (not templateString)
-	podTemplate := &v1alpha1.DebugPodTemplate{
+	podTemplate := &breakglassv1alpha1.DebugPodTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "pt-structured"},
-		Spec: v1alpha1.DebugPodTemplateSpec{
-			Template: &v1alpha1.DebugPodSpec{
-				Spec: v1alpha1.DebugPodSpecInner{
+		Spec: breakglassv1alpha1.DebugPodTemplateSpec{
+			Template: &breakglassv1alpha1.DebugPodSpec{
+				Spec: breakglassv1alpha1.DebugPodSpecInner{
 					Containers: []corev1.Container{
 						{
 							Name:  "from-structured",
@@ -4562,20 +4562,20 @@ func TestBuildPodSpec_PodTemplateWithStructuredTemplate(t *testing.T) {
 func TestBuildPodSpec_ErrorFromRenderPodTemplateString(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "render-err",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
 		},
 	}
 
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodTemplateString: `{{ .undefined.field.chain }}`, // will fail execution
 		},
 	}
@@ -4588,12 +4588,12 @@ func TestBuildPodSpec_ErrorFromRenderPodTemplateString(t *testing.T) {
 func TestBuildPodSpec_PodOverridesTemplateString(t *testing.T) {
 	controller := newTestController()
 
-	ds := &v1alpha1.DebugSession{
+	ds := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "overrides-ts",
 			Namespace: "breakglass-system",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:         "test-cluster",
 			TemplateRef:     "test-template",
 			TargetNamespace: "target-ns",
@@ -4601,8 +4601,8 @@ func TestBuildPodSpec_PodOverridesTemplateString(t *testing.T) {
 	}
 
 	hostNet := true
-	template := &v1alpha1.DebugSessionTemplate{
-		Spec: v1alpha1.DebugSessionTemplateSpec{
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 			PodTemplateString: `containers:
   - name: debug
     image: busybox:latest

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
@@ -60,7 +60,7 @@ func (ssa *ScheduledSessionActivator) WithMailService(mailService MailEnqueuer, 
 // This allows the RBAC group to be applied and the session to become usable.
 func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 	// Use indexed query to fetch only sessions waiting for scheduled time
-	sessions, err := ssa.sessionManager.GetSessionsByState(context.Background(), v1.SessionStateWaitingForScheduledTime)
+	sessions, err := ssa.sessionManager.GetSessionsByState(context.Background(), breakglassv1alpha1.SessionStateWaitingForScheduledTime)
 	if err != nil {
 		ssa.log.Error("error listing sessions for scheduled activation", zap.String("error", err.Error()))
 		return
@@ -90,7 +90,7 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 			"now", now)
 
 		// Transition to Approved state
-		ses.Status.State = v1.SessionStateApproved
+		ses.Status.State = breakglassv1alpha1.SessionStateApproved
 		ses.Status.ActualStartTime = metav1.Now()
 
 		// Add condition for audit trail
@@ -128,7 +128,7 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 }
 
 // sendSessionActivatedEmail sends a notification when a scheduled session becomes active
-func (ssa *ScheduledSessionActivator) sendSessionActivatedEmail(session v1.BreakglassSession) {
+func (ssa *ScheduledSessionActivator) sendSessionActivatedEmail(session breakglassv1alpha1.BreakglassSession) {
 	if ssa.disableEmail || ssa.mailService == nil || !ssa.mailService.IsEnabled() {
 		return
 	}

--- a/pkg/breakglass/session_approval_timeout.go
+++ b/pkg/breakglass/session_approval_timeout.go
@@ -4,12 +4,12 @@ package breakglass
 import (
 	"time"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
-func IsSessionApprovalTimedOut(session v1alpha1.BreakglassSession) bool {
+func IsSessionApprovalTimedOut(session breakglassv1alpha1.BreakglassSession) bool {
 	// If session is already in timeout state, it's not "approval timed out" anymore - it's already timed out
-	if session.Status.State == v1alpha1.SessionStateTimeout {
+	if session.Status.State == breakglassv1alpha1.SessionStateTimeout {
 		return false
 	}
 	// Session must be pending (not approved or rejected)

--- a/pkg/breakglass/session_controller_builder_test.go
+++ b/pkg/breakglass/session_controller_builder_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/mail"
@@ -150,17 +150,17 @@ func TestSendSessionApprovalEmail_NoMailAvailable(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:  "approver@example.com",
 			ExpiresAt: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 		},
@@ -190,17 +190,17 @@ func TestSendSessionApprovalEmail_WithMailService(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithMailService(mockMailService)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:  "approver@example.com",
 			ExpiresAt: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 		},
@@ -233,18 +233,18 @@ func TestSendSessionApprovalEmail_WithScheduledTime(t *testing.T) {
 	).WithMailService(mockMailService)
 
 	scheduledTime := metav1.NewTime(time.Now().Add(2 * time.Hour))
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session-scheduled",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:               "user@example.com",
 			GrantedGroup:       "admin",
 			Cluster:            "test-cluster",
 			ScheduledStartTime: &scheduledTime,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:  "approver@example.com",
 			ExpiresAt: metav1.NewTime(time.Now().Add(4 * time.Hour)),
 		},
@@ -272,17 +272,17 @@ func TestSendSessionApprovalEmail_WithMailServiceDisabled(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithMailService(mockMailService)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:  "approver@example.com",
 			ExpiresAt: metav1.NewTime(time.Now().Add(1 * time.Hour)),
 		},
@@ -308,17 +308,17 @@ func TestSendSessionRejectionEmail_NoMailAvailable(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:       "approver@example.com",
 			RejectedAt:     metav1.NewTime(time.Now()),
 			ApprovalReason: "Test rejection reason",
@@ -349,17 +349,17 @@ func TestSendSessionRejectionEmail_WithMailService(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithMailService(mockMailService)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:       "approver@example.com",
 			RejectedAt:     metav1.NewTime(time.Now()),
 			ApprovalReason: "Test rejection reason",
@@ -392,17 +392,17 @@ func TestSendSessionRejectionEmail_WithMailServiceDisabled(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithMailService(mockMailService)
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			Approver:       "approver@example.com",
 			RejectedAt:     metav1.NewTime(time.Now()),
 			ApprovalReason: "Test rejection reason",
@@ -429,12 +429,12 @@ func TestEmitSessionExpiredAuditEvent_NoAuditService(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
@@ -462,12 +462,12 @@ func TestEmitSessionExpiredAuditEvent_AuditServiceDisabled(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithAuditService(mockAudit)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
@@ -497,12 +497,12 @@ func TestEmitSessionExpiredAuditEvent_TimeExpired(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithAuditService(mockAudit)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
@@ -534,12 +534,12 @@ func TestEmitSessionExpiredAuditEvent_ApprovalTimeout(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithAuditService(mockAudit)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "timeout-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "prod-cluster",
@@ -569,18 +569,18 @@ func TestEmitSessionAuditEvent_NoAuditService(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
@@ -605,18 +605,18 @@ func TestEmitSessionAuditEvent_AuditServiceDisabled(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithAuditService(mockAudit)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "user@example.com",
 			GrantedGroup: "admin",
 			Cluster:      "test-cluster",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
@@ -643,18 +643,18 @@ func TestEmitSessionAuditEvent_WithAuditService(t *testing.T) {
 		nil, "/config/config.yaml", nil, cli,
 	).WithAuditService(mockAudit)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "approved-session",
 			Namespace: "test-ns",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			User:         "requester@example.com",
 			GrantedGroup: "breakglass-admin",
 			Cluster:      "production",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 

--- a/pkg/breakglass/session_manager_test.go
+++ b/pkg/breakglass/session_manager_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -128,16 +128,16 @@ func TestSessionManager_GetAllBreakglassSessions(t *testing.T) {
 	})
 
 	t.Run("returns sessions", func(t *testing.T) {
-		session1 := &v1alpha1.BreakglassSession{
+		session1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user1@example.com",
 				Cluster: "cluster-a",
 			},
 		}
-		session2 := &v1alpha1.BreakglassSession{
+		session2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-2", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user2@example.com",
 				Cluster: "cluster-b",
 			},
@@ -160,8 +160,8 @@ func TestSessionManager_GetUserBreakglassSessions(t *testing.T) {
 	t.Run("empty list when no sessions exist", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
-			WithIndex(&v1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
-				bs := o.(*v1alpha1.BreakglassSession)
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
+				bs := o.(*breakglassv1alpha1.BreakglassSession)
 				if bs.Spec.User != "" {
 					return []string{bs.Spec.User}
 				}
@@ -176,23 +176,23 @@ func TestSessionManager_GetUserBreakglassSessions(t *testing.T) {
 	})
 
 	t.Run("returns only sessions for the specified user", func(t *testing.T) {
-		session1 := &v1alpha1.BreakglassSession{
+		session1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user1@example.com",
 				Cluster: "cluster-a",
 			},
 		}
-		session2 := &v1alpha1.BreakglassSession{
+		session2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-2", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user1@example.com",
 				Cluster: "cluster-b",
 			},
 		}
-		session3 := &v1alpha1.BreakglassSession{
+		session3 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-3", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user2@example.com",
 				Cluster: "cluster-a",
 			},
@@ -201,8 +201,8 @@ func TestSessionManager_GetUserBreakglassSessions(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
 			WithObjects(session1, session2, session3).
-			WithIndex(&v1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
-				bs := o.(*v1alpha1.BreakglassSession)
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
+				bs := o.(*breakglassv1alpha1.BreakglassSession)
 				if bs.Spec.User != "" {
 					return []string{bs.Spec.User}
 				}
@@ -232,16 +232,16 @@ func TestSessionManager_GetUserBreakglassSessions(t *testing.T) {
 	})
 
 	t.Run("returns sessions from multiple namespaces", func(t *testing.T) {
-		session1 := &v1alpha1.BreakglassSession{
+		session1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1", Namespace: "ns1"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user@example.com",
 				Cluster: "cluster-a",
 			},
 		}
-		session2 := &v1alpha1.BreakglassSession{
+		session2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-2", Namespace: "ns2"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user@example.com",
 				Cluster: "cluster-b",
 			},
@@ -250,8 +250,8 @@ func TestSessionManager_GetUserBreakglassSessions(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
 			WithObjects(session1, session2).
-			WithIndex(&v1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
-				bs := o.(*v1alpha1.BreakglassSession)
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(o client.Object) []string {
+				bs := o.(*breakglassv1alpha1.BreakglassSession)
 				if bs.Spec.User != "" {
 					return []string{bs.Spec.User}
 				}
@@ -279,8 +279,8 @@ func TestSessionManager_GetSessionsByState(t *testing.T) {
 	t.Run("empty list when no sessions in state", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
-			WithIndex(&v1alpha1.BreakglassSession{}, "status.state", func(o client.Object) []string {
-				bs := o.(*v1alpha1.BreakglassSession)
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", func(o client.Object) []string {
+				bs := o.(*breakglassv1alpha1.BreakglassSession)
 				if bs.Status.State != "" {
 					return []string{string(bs.Status.State)}
 				}
@@ -289,58 +289,58 @@ func TestSessionManager_GetSessionsByState(t *testing.T) {
 			Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 
-		sessions, err := mgr.GetSessionsByState(ctx, v1alpha1.SessionStateApproved)
+		sessions, err := mgr.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateApproved)
 		require.NoError(t, err)
 		assert.Empty(t, sessions)
 	})
 
 	t.Run("returns only sessions in specified state", func(t *testing.T) {
-		session1 := &v1alpha1.BreakglassSession{
+		session1 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-1", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user1@example.com",
 				Cluster: "cluster-a",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateApproved,
 			},
 		}
-		session2 := &v1alpha1.BreakglassSession{
+		session2 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-2", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user2@example.com",
 				Cluster: "cluster-b",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateApproved,
 			},
 		}
-		session3 := &v1alpha1.BreakglassSession{
+		session3 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-3", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user3@example.com",
 				Cluster: "cluster-a",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStatePending,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStatePending,
 			},
 		}
-		session4 := &v1alpha1.BreakglassSession{
+		session4 := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "session-4", Namespace: "default"},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user4@example.com",
 				Cluster: "cluster-c",
 			},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State: v1alpha1.SessionStateWaitingForScheduledTime,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateWaitingForScheduledTime,
 			},
 		}
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
 			WithObjects(session1, session2, session3, session4).
-			WithIndex(&v1alpha1.BreakglassSession{}, "status.state", func(o client.Object) []string {
-				bs := o.(*v1alpha1.BreakglassSession)
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", func(o client.Object) []string {
+				bs := o.(*breakglassv1alpha1.BreakglassSession)
 				if bs.Status.State != "" {
 					return []string{string(bs.Status.State)}
 				}
@@ -350,27 +350,27 @@ func TestSessionManager_GetSessionsByState(t *testing.T) {
 		mgr := NewSessionManagerWithClient(fakeClient)
 
 		// Get approved sessions
-		sessions, err := mgr.GetSessionsByState(ctx, v1alpha1.SessionStateApproved)
+		sessions, err := mgr.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateApproved)
 		require.NoError(t, err)
 		assert.Len(t, sessions, 2, "Should return 2 approved sessions")
 		for _, s := range sessions {
-			assert.Equal(t, v1alpha1.SessionStateApproved, s.Status.State)
+			assert.Equal(t, breakglassv1alpha1.SessionStateApproved, s.Status.State)
 		}
 
 		// Get pending sessions
-		sessions, err = mgr.GetSessionsByState(ctx, v1alpha1.SessionStatePending)
+		sessions, err = mgr.GetSessionsByState(ctx, breakglassv1alpha1.SessionStatePending)
 		require.NoError(t, err)
 		assert.Len(t, sessions, 1, "Should return 1 pending session")
 		assert.Equal(t, "session-3", sessions[0].Name)
 
 		// Get waiting for scheduled time sessions
-		sessions, err = mgr.GetSessionsByState(ctx, v1alpha1.SessionStateWaitingForScheduledTime)
+		sessions, err = mgr.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateWaitingForScheduledTime)
 		require.NoError(t, err)
 		assert.Len(t, sessions, 1, "Should return 1 waiting session")
 		assert.Equal(t, "session-4", sessions[0].Name)
 
 		// Get expired sessions (none exist)
-		sessions, err = mgr.GetSessionsByState(ctx, v1alpha1.SessionStateExpired)
+		sessions, err = mgr.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateExpired)
 		require.NoError(t, err)
 		assert.Empty(t, sessions, "Should return no expired sessions")
 	})
@@ -380,12 +380,12 @@ func TestSessionManager_UpdateBreakglassSession(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("successful update", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "default",
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:         "user@example.com",
 				Cluster:      "test-cluster",
 				GrantedGroup: "admin",
@@ -404,7 +404,7 @@ func TestSessionManager_UpdateBreakglassSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the update
-		updatedSession := &v1alpha1.BreakglassSession{}
+		updatedSession := &breakglassv1alpha1.BreakglassSession{}
 		err = fakeClient.Get(ctx, client.ObjectKey{Name: "test-session", Namespace: "default"}, updatedSession)
 		require.NoError(t, err)
 		assert.Equal(t, "Updated reason", updatedSession.Spec.RequestReason)
@@ -415,12 +415,12 @@ func TestSessionManager_UpdateBreakglassSessionStatus(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("successful status update", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "default",
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:         "user@example.com",
 				Cluster:      "test-cluster",
 				GrantedGroup: "admin",
@@ -430,12 +430,12 @@ func TestSessionManager_UpdateBreakglassSessionStatus(t *testing.T) {
 			WithScheme(Scheme).
 			WithObjects(session).
 			WithStatusSubresource(session).
-			WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
 			Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 
 		// Update status and pass as value
-		session.Status.State = v1alpha1.SessionStateApproved
+		session.Status.State = breakglassv1alpha1.SessionStateApproved
 		session.Status.Approver = "approver@example.com"
 
 		err := mgr.UpdateBreakglassSessionStatus(ctx, *session)
@@ -447,7 +447,7 @@ func TestSessionManager_DeleteBreakglassSession(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("successful delete", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-session",
 				Namespace: "default",
@@ -467,7 +467,7 @@ func TestSessionManager_DeleteBreakglassSession(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "non-existent",
 				Namespace: "default",
@@ -486,12 +486,12 @@ func TestSessionManager_AddBreakglassSession(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "new-session",
 				Namespace: "default",
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:         "user@example.com",
 				Cluster:      "test-cluster",
 				GrantedGroup: "admin",
@@ -502,7 +502,7 @@ func TestSessionManager_AddBreakglassSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify it was created
-		createdSession := &v1alpha1.BreakglassSession{}
+		createdSession := &breakglassv1alpha1.BreakglassSession{}
 		err = fakeClient.Get(ctx, client.ObjectKey{Name: "new-session", Namespace: "default"}, createdSession)
 		require.NoError(t, err)
 		assert.Equal(t, "user@example.com", createdSession.Spec.User)
@@ -518,12 +518,12 @@ func TestSessionManager_GetBreakglassSessionByName(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("found", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-session",
 				Namespace: "default",
 			},
-			Spec: v1alpha1.BreakglassSessionSpec{
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				User:    "user@example.com",
 				Cluster: "test-cluster",
 			},
@@ -531,7 +531,7 @@ func TestSessionManager_GetBreakglassSessionByName(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
 			WithObjects(session).
-			WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
 			Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 
@@ -544,7 +544,7 @@ func TestSessionManager_GetBreakglassSessionByName(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(Scheme).
-			WithIndex(&v1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexer).
 			Build()
 		mgr := NewSessionManagerWithClient(fakeClient)
 

--- a/pkg/breakglass/session_state_helpers_test.go
+++ b/pkg/breakglass/session_state_helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,50 +13,50 @@ import (
 func TestIsSessionPendingApproval_StateVariants(t *testing.T) {
 	tests := []struct {
 		name     string
-		state    v1alpha1.BreakglassSessionState
+		state    breakglassv1alpha1.BreakglassSessionState
 		expected bool
 	}{
 		{
 			name:     "pending state returns true",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: true,
 		},
 		{
 			name:     "approved state returns false",
-			state:    v1alpha1.SessionStateApproved,
+			state:    breakglassv1alpha1.SessionStateApproved,
 			expected: false,
 		},
 		{
 			name:     "rejected state returns false",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 		},
 		{
 			name:     "expired state returns false",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: false,
 		},
 		{
 			name:     "withdrawn state returns false",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 		},
 		{
 			name:     "timeout state returns false",
-			state:    v1alpha1.SessionStateTimeout,
+			state:    breakglassv1alpha1.SessionStateTimeout,
 			expected: false,
 		},
 		{
 			name:     "waiting state returns false",
-			state:    v1alpha1.SessionStateWaitingForScheduledTime,
+			state:    breakglassv1alpha1.SessionStateWaitingForScheduledTime,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -70,40 +70,40 @@ func TestIsSessionPendingApproval_StateVariants(t *testing.T) {
 func TestIsSessionRejected(t *testing.T) {
 	tests := []struct {
 		name     string
-		state    v1alpha1.BreakglassSessionState
+		state    breakglassv1alpha1.BreakglassSessionState
 		expected bool
 	}{
 		{
 			name:     "rejected state returns true",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: true,
 		},
 		{
 			name:     "pending state returns false",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: false,
 		},
 		{
 			name:     "approved state returns false",
-			state:    v1alpha1.SessionStateApproved,
+			state:    breakglassv1alpha1.SessionStateApproved,
 			expected: false,
 		},
 		{
 			name:     "expired state returns false",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: false,
 		},
 		{
 			name:     "withdrawn state returns false",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -117,35 +117,35 @@ func TestIsSessionRejected(t *testing.T) {
 func TestIsSessionWithdrawn(t *testing.T) {
 	tests := []struct {
 		name     string
-		state    v1alpha1.BreakglassSessionState
+		state    breakglassv1alpha1.BreakglassSessionState
 		expected bool
 	}{
 		{
 			name:     "withdrawn state returns true",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: true,
 		},
 		{
 			name:     "pending state returns false",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: false,
 		},
 		{
 			name:     "approved state returns false",
-			state:    v1alpha1.SessionStateApproved,
+			state:    breakglassv1alpha1.SessionStateApproved,
 			expected: false,
 		},
 		{
 			name:     "rejected state returns false",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -161,54 +161,54 @@ func TestIsSessionExpired(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		state     v1alpha1.BreakglassSessionState
+		state     breakglassv1alpha1.BreakglassSessionState
 		expiresAt *time.Time
 		expected  bool
 	}{
 		{
 			name:     "expired state returns true regardless of timestamp",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: true,
 		},
 		{
 			name:      "approved state with past expiry returns true",
-			state:     v1alpha1.SessionStateApproved,
+			state:     breakglassv1alpha1.SessionStateApproved,
 			expiresAt: func() *time.Time { t := now.Add(-1 * time.Hour); return &t }(),
 			expected:  true,
 		},
 		{
 			name:      "approved state with future expiry returns false",
-			state:     v1alpha1.SessionStateApproved,
+			state:     breakglassv1alpha1.SessionStateApproved,
 			expiresAt: func() *time.Time { t := now.Add(1 * time.Hour); return &t }(),
 			expected:  false,
 		},
 		{
 			name:     "approved state with zero expiry returns false",
-			state:    v1alpha1.SessionStateApproved,
+			state:    breakglassv1alpha1.SessionStateApproved,
 			expected: false,
 		},
 		{
 			name:      "pending state with past expiry returns false (not approved)",
-			state:     v1alpha1.SessionStatePending,
+			state:     breakglassv1alpha1.SessionStatePending,
 			expiresAt: func() *time.Time { t := now.Add(-1 * time.Hour); return &t }(),
 			expected:  false,
 		},
 		{
 			name:     "rejected state returns false",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 		},
 		{
 			name:     "withdrawn state returns false",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -249,8 +249,8 @@ func TestIsSessionRetained_TimeVariants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					RetainedUntil: metav1.NewTime(tt.retainedUntil),
 				},
 			}
@@ -266,62 +266,62 @@ func TestIsSessionValid(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		state              v1alpha1.BreakglassSessionState
+		state              breakglassv1alpha1.BreakglassSessionState
 		expiresAt          *time.Time
 		scheduledStartTime *time.Time
 		expected           bool
 	}{
 		{
 			name:      "approved session with valid expiry is valid",
-			state:     v1alpha1.SessionStateApproved,
+			state:     breakglassv1alpha1.SessionStateApproved,
 			expiresAt: func() *time.Time { t := now.Add(1 * time.Hour); return &t }(),
 			expected:  true,
 		},
 		{
 			name:     "pending session is valid",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: true,
 		},
 		{
 			name:     "rejected session is not valid",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 		},
 		{
 			name:     "withdrawn session is not valid",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 		},
 		{
 			name:     "expired session is not valid",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: false,
 		},
 		{
 			name:     "timeout session is not valid",
-			state:    v1alpha1.SessionStateTimeout,
+			state:    breakglassv1alpha1.SessionStateTimeout,
 			expected: false,
 		},
 		{
 			name:     "waiting for scheduled time is not valid",
-			state:    v1alpha1.SessionStateWaitingForScheduledTime,
+			state:    breakglassv1alpha1.SessionStateWaitingForScheduledTime,
 			expected: false,
 		},
 		{
 			name:      "approved session with past expiry is not valid",
-			state:     v1alpha1.SessionStateApproved,
+			state:     breakglassv1alpha1.SessionStateApproved,
 			expiresAt: func() *time.Time { t := now.Add(-1 * time.Hour); return &t }(),
 			expected:  false,
 		},
 		{
 			name:               "scheduled session with future start time is not valid",
-			state:              v1alpha1.SessionStateApproved,
+			state:              breakglassv1alpha1.SessionStateApproved,
 			scheduledStartTime: func() *time.Time { t := now.Add(1 * time.Hour); return &t }(),
 			expected:           false,
 		},
 		{
 			name:               "scheduled session with past start time is valid",
-			state:              v1alpha1.SessionStateApproved,
+			state:              breakglassv1alpha1.SessionStateApproved,
 			scheduledStartTime: func() *time.Time { t := now.Add(-1 * time.Hour); return &t }(),
 			expiresAt:          func() *time.Time { t := now.Add(1 * time.Hour); return &t }(),
 			expected:           true,
@@ -330,8 +330,8 @@ func TestIsSessionValid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -353,47 +353,47 @@ func TestIsSessionActive(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		state     v1alpha1.BreakglassSessionState
+		state     breakglassv1alpha1.BreakglassSessionState
 		expiresAt *time.Time
 		expected  bool
 	}{
 		{
 			name:      "approved session with valid expiry is active",
-			state:     v1alpha1.SessionStateApproved,
+			state:     breakglassv1alpha1.SessionStateApproved,
 			expiresAt: func() *time.Time { t := now.Add(1 * time.Hour); return &t }(),
 			expected:  true,
 		},
 		{
 			name:     "pending session is active",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: true,
 		},
 		{
 			name:     "rejected session is not active",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 		},
 		{
 			name:     "withdrawn session is not active",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 		},
 		{
 			name:     "expired session is not active",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: false,
 		},
 		{
 			name:     "timeout session is not active",
-			state:    v1alpha1.SessionStateTimeout,
+			state:    breakglassv1alpha1.SessionStateTimeout,
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
@@ -414,7 +414,7 @@ func TestDropK8sInternalFieldsSession(t *testing.T) {
 	})
 
 	t.Run("clears internal fields", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "test-session",
 				Namespace:       "default",
@@ -442,7 +442,7 @@ func TestDropK8sInternalFieldsSession(t *testing.T) {
 	})
 
 	t.Run("handles nil annotations", func(t *testing.T) {
-		session := &v1alpha1.BreakglassSession{
+		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "test-session",
 				Namespace:       "default",
@@ -460,12 +460,12 @@ func TestDropK8sInternalFieldsSession(t *testing.T) {
 // TestDropK8sInternalFieldsSessionList tests the dropK8sInternalFieldsSessionList function
 func TestDropK8sInternalFieldsSessionList(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
-		result := dropK8sInternalFieldsSessionList([]v1alpha1.BreakglassSession{})
+		result := dropK8sInternalFieldsSessionList([]breakglassv1alpha1.BreakglassSession{})
 		assert.Empty(t, result)
 	})
 
 	t.Run("clears fields from all sessions", func(t *testing.T) {
-		sessions := []v1alpha1.BreakglassSession{
+		sessions := []breakglassv1alpha1.BreakglassSession{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "session-1",

--- a/pkg/breakglass/session_state_test.go
+++ b/pkg/breakglass/session_state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,15 +28,15 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		session  v1alpha1.BreakglassSession
+		session  breakglassv1alpha1.BreakglassSession
 		expected bool
 		reason   string
 	}{
 		{
 			name: "withdrawn_session_not_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStateWithdrawn,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStateWithdrawn,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					ApprovedAt:    metav1.Time{}, // Not approved
 					RejectedAt:    metav1.Time{}, // Not rejected (empty)
@@ -48,9 +48,9 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 		},
 		{
 			name: "pending_session_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStatePending,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					ApprovedAt:    metav1.Time{}, // Not approved
 					RejectedAt:    metav1.Time{}, // Not rejected
@@ -62,9 +62,9 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 		},
 		{
 			name: "approved_session_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStateApproved,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStateApproved,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					ApprovedAt:    metav1.NewTime(now),
 					RejectedAt:    metav1.Time{}, // Not rejected
@@ -76,9 +76,9 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 		},
 		{
 			name: "rejected_session_not_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStateRejected,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStateRejected,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					ApprovedAt:    metav1.Time{},
 					RejectedAt:    metav1.NewTime(now),
@@ -90,9 +90,9 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 		},
 		{
 			name: "expired_session_not_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStateApproved,           // Must be Approved to check ExpiresAt
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStateApproved, // Must be Approved to check ExpiresAt
 					ExpiresAt:     metav1.NewTime(now.Add(-1 * time.Hour)), // Expired
 					ApprovedAt:    metav1.NewTime(now.Add(-2 * time.Hour)), // Approved earlier
 					RejectedAt:    metav1.Time{},
@@ -104,9 +104,9 @@ func TestIsSessionActive_WithdrawnSessionNotActive(t *testing.T) {
 		},
 		{
 			name: "approval_timeout_not_active",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:         v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStatePending,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					TimeoutAt:     metav1.NewTime(now.Add(-1 * time.Hour)), // Already timed out
 					ApprovedAt:    metav1.Time{},
@@ -141,15 +141,15 @@ func TestIsSessionPendingApproval_StateDoesntMatter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		session  v1alpha1.BreakglassSession
+		session  breakglassv1alpha1.BreakglassSession
 		expected bool
 		reason   string
 	}{
 		{
 			name: "withdrawn_NOT_pending_despite_timestamps",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateWithdrawn,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateWithdrawn,
 					ApprovedAt: metav1.Time{},                          // Not approved
 					RejectedAt: metav1.Time{},                          // Not rejected
 					TimeoutAt:  metav1.NewTime(now.Add(1 * time.Hour)), // Timeout in future
@@ -160,9 +160,9 @@ func TestIsSessionPendingApproval_StateDoesntMatter(t *testing.T) {
 		},
 		{
 			name: "pending_is_pending_approval",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStatePending,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.Time{},
 					TimeoutAt:  metav1.NewTime(now.Add(1 * time.Hour)),
@@ -173,9 +173,9 @@ func TestIsSessionPendingApproval_StateDoesntMatter(t *testing.T) {
 		},
 		{
 			name: "approved_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateApproved,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateApproved,
 					ApprovedAt: metav1.NewTime(now),
 					RejectedAt: metav1.Time{},
 					TimeoutAt:  metav1.NewTime(now.Add(1 * time.Hour)),
@@ -186,9 +186,9 @@ func TestIsSessionPendingApproval_StateDoesntMatter(t *testing.T) {
 		},
 		{
 			name: "rejected_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateRejected,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateRejected,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.NewTime(now),
 					TimeoutAt:  metav1.NewTime(now.Add(1 * time.Hour)),
@@ -199,9 +199,9 @@ func TestIsSessionPendingApproval_StateDoesntMatter(t *testing.T) {
 		},
 		{
 			name: "approval_timeout_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStatePending,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.Time{},
 					TimeoutAt:  metav1.NewTime(now.Add(-1 * time.Hour)), // Already timed out
@@ -235,18 +235,18 @@ func TestCreateSessionAfterWithdrawal_WithdrawnDoesNotBlock(t *testing.T) {
 	now := time.Now()
 
 	// Simulate a user's previous session that was withdrawn
-	withdrawnSession := v1alpha1.BreakglassSession{
+	withdrawnSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster-test-group-abc123",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:      "test-cluster",
 			User:         "user@test.com",
 			GrantedGroup: "test-group",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State:         v1alpha1.SessionStateWithdrawn,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStateWithdrawn,
 			ApprovedAt:    metav1.Time{}, // Never approved
 			RejectedAt:    metav1.Time{}, // Never rejected (empty)
 			ExpiresAt:     metav1.NewTime(now.Add(1 * time.Hour)),
@@ -262,8 +262,8 @@ func TestCreateSessionAfterWithdrawal_WithdrawnDoesNotBlock(t *testing.T) {
 	}
 
 	// Verify that filtering for active sessions would correctly exclude it
-	sessionList := []v1alpha1.BreakglassSession{withdrawnSession}
-	activeSessions := make([]v1alpha1.BreakglassSession, 0)
+	sessionList := []breakglassv1alpha1.BreakglassSession{withdrawnSession}
+	activeSessions := make([]breakglassv1alpha1.BreakglassSession, 0)
 	for _, s := range sessionList {
 		if IsSessionActive(s) {
 			activeSessions = append(activeSessions, s)
@@ -290,18 +290,18 @@ func TestCreateSessionAfterWithdrawal_WithdrawnDoesNotBlock(t *testing.T) {
 func TestWithdrawnSessionExcludedFromActiveButNotPending(t *testing.T) {
 	now := time.Now()
 
-	sessions := []v1alpha1.BreakglassSession{
+	sessions := []breakglassv1alpha1.BreakglassSession{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pending-session"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:     v1alpha1.SessionStatePending,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStatePending,
 				ExpiresAt: metav1.NewTime(now.Add(1 * time.Hour)),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "withdrawn-session"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:       v1alpha1.SessionStateWithdrawn,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:       breakglassv1alpha1.SessionStateWithdrawn,
 				WithdrawnAt: metav1.NewTime(now),
 				ExpiresAt:   metav1.NewTime(now.Add(1 * time.Hour)),
 				// Withdrawn is a terminal state - should not appear in pending or active
@@ -309,16 +309,16 @@ func TestWithdrawnSessionExcludedFromActiveButNotPending(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:      v1alpha1.SessionStateApproved,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateApproved,
 				ApprovedAt: metav1.NewTime(now),
 				ExpiresAt:  metav1.NewTime(now.Add(1 * time.Hour)),
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "rejected-session"},
-			Status: v1alpha1.BreakglassSessionStatus{
-				State:      v1alpha1.SessionStateRejected,
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateRejected,
 				RejectedAt: metav1.NewTime(now),
 				ExpiresAt:  metav1.NewTime(now.Add(1 * time.Hour)),
 			},
@@ -363,15 +363,15 @@ func TestIsSessionValid_EdgeCases(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		session  v1alpha1.BreakglassSession
+		session  breakglassv1alpha1.BreakglassSession
 		expected bool
 		reason   string
 	}{
 		{
 			name: "session_with_no_expiry_set",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:     v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:     breakglassv1alpha1.SessionStatePending,
 					ExpiresAt: metav1.Time{}, // Zero value - never expires
 				},
 			},
@@ -380,10 +380,10 @@ func TestIsSessionValid_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "session_expires_exactly_now",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateApproved, // Must be Approved to check ExpiresAt
-					ExpiresAt:  metav1.NewTime(now),           // Expires right now
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateApproved, // Must be Approved to check ExpiresAt
+					ExpiresAt:  metav1.NewTime(now),                     // Expires right now
 					ApprovedAt: metav1.NewTime(now.Add(-1 * time.Hour)),
 				},
 			},
@@ -392,12 +392,12 @@ func TestIsSessionValid_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "session_scheduled_in_future",
-			session: v1alpha1.BreakglassSession{
-				Spec: v1alpha1.BreakglassSessionSpec{
+			session: breakglassv1alpha1.BreakglassSession{
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
 					ScheduledStartTime: &metav1.Time{Time: now.Add(1 * time.Hour)},
 				},
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:     v1alpha1.SessionStateWaitingForScheduledTime,
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:     breakglassv1alpha1.SessionStateWaitingForScheduledTime,
 					ExpiresAt: metav1.NewTime(now.Add(2 * time.Hour)),
 				},
 			},
@@ -406,12 +406,12 @@ func TestIsSessionValid_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "session_scheduled_time_passed",
-			session: v1alpha1.BreakglassSession{
-				Spec: v1alpha1.BreakglassSessionSpec{
+			session: breakglassv1alpha1.BreakglassSession{
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
 					ScheduledStartTime: &metav1.Time{Time: now.Add(-1 * time.Hour)},
 				},
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:     v1alpha1.SessionStatePending,
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:     breakglassv1alpha1.SessionStatePending,
 					ExpiresAt: metav1.NewTime(now.Add(1 * time.Hour)),
 				},
 			},
@@ -420,12 +420,12 @@ func TestIsSessionValid_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "session_with_empty_scheduled_time",
-			session: v1alpha1.BreakglassSession{
-				Spec: v1alpha1.BreakglassSessionSpec{
+			session: breakglassv1alpha1.BreakglassSession{
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
 					ScheduledStartTime: nil, // Not set
 				},
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:     v1alpha1.SessionStatePending,
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:     breakglassv1alpha1.SessionStatePending,
 					ExpiresAt: metav1.NewTime(now.Add(1 * time.Hour)),
 				},
 			},
@@ -461,17 +461,17 @@ func TestRegressionScenario_409ConflictWithdrawnSession(t *testing.T) {
 	now := time.Now()
 
 	// Request A: A previous session the user made and then withdrew
-	requestA := v1alpha1.BreakglassSession{
+	requestA := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster-x-group-z-12345",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:      "cluster-x",
 			User:         "user-y",
 			GrantedGroup: "group-z",
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State:         v1alpha1.SessionStateWithdrawn,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStateWithdrawn,
 			ApprovedAt:    metav1.NewTime(now.Add(-30 * time.Minute)), // Was approved
 			RejectedAt:    metav1.Time{},                              // Never rejected
 			ExpiresAt:     metav1.NewTime(now.Add(30 * time.Minute)),
@@ -489,7 +489,7 @@ func TestRegressionScenario_409ConflictWithdrawnSession(t *testing.T) {
 	}
 
 	// Verify that the session state and timestamp configuration matches what we'd see in real scenario
-	if requestA.Status.State != v1alpha1.SessionStateWithdrawn {
+	if requestA.Status.State != breakglassv1alpha1.SessionStateWithdrawn {
 		t.Error("test setup error: session should be withdrawn")
 	}
 	if requestA.Status.ApprovedAt.IsZero() {
@@ -509,41 +509,41 @@ func TestRegressionScenario_409ConflictWithdrawnSession(t *testing.T) {
 // documents the logic: if EITHER condition is true, the API returns 409.
 //
 // Location: session_controller.go line 443
-// Code: if ses.Status.State == v1alpha1.SessionStateApproved || !ses.Status.ApprovedAt.IsZero()
+// Code: if ses.Status.State == breakglassv1alpha1.SessionStateApproved || !ses.Status.ApprovedAt.IsZero()
 func TestEdgeCase_ApprovedWithBothTimestamps(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
 		name             string
-		state            v1alpha1.BreakglassSessionState
+		state            breakglassv1alpha1.BreakglassSessionState
 		approvedAt       metav1.Time
 		expectedConflict bool
 		description      string
 	}{
 		{
 			name:             "both_state_and_timestamp_set",
-			state:            v1alpha1.SessionStateApproved,
+			state:            breakglassv1alpha1.SessionStateApproved,
 			approvedAt:       metav1.NewTime(now),
 			expectedConflict: true,
 			description:      "Normal approved session with both State and timestamp",
 		},
 		{
 			name:             "only_state_approved",
-			state:            v1alpha1.SessionStateApproved,
+			state:            breakglassv1alpha1.SessionStateApproved,
 			approvedAt:       metav1.Time{}, // Empty
 			expectedConflict: true,
 			description:      "Approved state is sufficient for 409 (defensive programming)",
 		},
 		{
 			name:             "only_timestamp_set",
-			state:            v1alpha1.SessionStatePending,
+			state:            breakglassv1alpha1.SessionStatePending,
 			approvedAt:       metav1.NewTime(now),
 			expectedConflict: true,
 			description:      "ApprovedAt timestamp alone is enough for 409 (state mismatch edge case)",
 		},
 		{
 			name:             "neither_set",
-			state:            v1alpha1.SessionStatePending,
+			state:            breakglassv1alpha1.SessionStatePending,
 			approvedAt:       metav1.Time{}, // Empty
 			expectedConflict: false,
 			description:      "Pending with no approval = not a conflict",
@@ -552,15 +552,15 @@ func TestEdgeCase_ApprovedWithBothTimestamps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:      tt.state,
 					ApprovedAt: tt.approvedAt,
 				},
 			}
 
 			// Simulate the conflict check from line 443
-			isConflict := (session.Status.State == v1alpha1.SessionStateApproved || !session.Status.ApprovedAt.IsZero())
+			isConflict := (session.Status.State == breakglassv1alpha1.SessionStateApproved || !session.Status.ApprovedAt.IsZero())
 
 			if isConflict != tt.expectedConflict {
 				t.Errorf("Expected conflict=%v but got %v. %s", tt.expectedConflict, isConflict, tt.description)
@@ -582,9 +582,9 @@ func TestEdgeCase_ApprovalAfterRejection(t *testing.T) {
 
 	// Scenario: Session was rejected, then somehow becomes approvable again
 	// (This shouldn't happen due to terminal state checks, but the code explicitly clears it)
-	session := v1alpha1.BreakglassSession{
-		Status: v1alpha1.BreakglassSessionStatus{
-			State:      v1alpha1.SessionStatePending,
+	session := breakglassv1alpha1.BreakglassSession{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:      breakglassv1alpha1.SessionStatePending,
 			RejectedAt: metav1.NewTime(now.Add(-1 * time.Hour)), // Previously rejected
 			ApprovedAt: metav1.Time{},                           // Not approved yet
 		},
@@ -593,7 +593,7 @@ func TestEdgeCase_ApprovalAfterRejection(t *testing.T) {
 	// Simulate approval clearing rejection (line 817)
 	session.Status.RejectedAt = metav1.Time{}
 	session.Status.ApprovedAt = metav1.Now()
-	session.Status.State = v1alpha1.SessionStateApproved
+	session.Status.State = breakglassv1alpha1.SessionStateApproved
 
 	// Verify clean state
 	if !session.Status.RejectedAt.IsZero() {
@@ -602,7 +602,7 @@ func TestEdgeCase_ApprovalAfterRejection(t *testing.T) {
 	if session.Status.ApprovedAt.IsZero() {
 		t.Error("ApprovedAt should be set after approval")
 	}
-	if session.Status.State != v1alpha1.SessionStateApproved {
+	if session.Status.State != breakglassv1alpha1.SessionStateApproved {
 		t.Errorf("State should be Approved, got %s", session.Status.State)
 	}
 
@@ -625,14 +625,14 @@ func TestEdgeCase_ScheduledSessionNotWaitingUntilActivation(t *testing.T) {
 	tests := []struct {
 		name          string
 		scheduledTime *metav1.Time
-		expectedState v1alpha1.BreakglassSessionState
+		expectedState breakglassv1alpha1.BreakglassSessionState
 		description   string
 		checkExpiry   func(time.Time, time.Time) bool // returns true if test passes
 	}{
 		{
 			name:          "scheduled_session_waits",
 			scheduledTime: &metav1.Time{Time: scheduledTime},
-			expectedState: v1alpha1.SessionStateWaitingForScheduledTime,
+			expectedState: breakglassv1alpha1.SessionStateWaitingForScheduledTime,
 			description:   "Session with scheduled time enters waiting state",
 			checkExpiry: func(expiresAt, scheduled time.Time) bool {
 				// Expiry should be ScheduledStartTime + validFor, NOT now + validFor
@@ -644,7 +644,7 @@ func TestEdgeCase_ScheduledSessionNotWaitingUntilActivation(t *testing.T) {
 		{
 			name:          "immediate_session_approved",
 			scheduledTime: nil, // No scheduled time
-			expectedState: v1alpha1.SessionStateApproved,
+			expectedState: breakglassv1alpha1.SessionStateApproved,
 			description:   "Session without scheduled time activates immediately",
 			checkExpiry: func(expiresAt, scheduled time.Time) bool {
 				// Expiry should be now + validFor (not from scheduled time)
@@ -656,25 +656,25 @@ func TestEdgeCase_ScheduledSessionNotWaitingUntilActivation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Spec: v1alpha1.BreakglassSessionSpec{
+			session := breakglassv1alpha1.BreakglassSession{
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
 					ScheduledStartTime: tt.scheduledTime,
 					MaxValidFor:        "1h",
 					RetainFor:          "168h",
 				},
-				Status: v1alpha1.BreakglassSessionStatus{
-					State: v1alpha1.SessionStatePending,
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State: breakglassv1alpha1.SessionStatePending,
 				},
 			}
 
 			// Simulate approval logic
 			if session.Spec.ScheduledStartTime != nil && !session.Spec.ScheduledStartTime.IsZero() {
-				session.Status.State = v1alpha1.SessionStateWaitingForScheduledTime
+				session.Status.State = breakglassv1alpha1.SessionStateWaitingForScheduledTime
 				session.Status.ExpiresAt = metav1.NewTime(session.Spec.ScheduledStartTime.Add(validFor))
 				session.Status.RetainedUntil = metav1.NewTime(session.Spec.ScheduledStartTime.Add(validFor).Add(retainFor))
 				session.Status.ActualStartTime = metav1.Time{}
 			} else {
-				session.Status.State = v1alpha1.SessionStateApproved
+				session.Status.State = breakglassv1alpha1.SessionStateApproved
 				session.Status.ExpiresAt = metav1.NewTime(now.Add(validFor))
 				session.Status.RetainedUntil = metav1.NewTime(now.Add(validFor).Add(retainFor))
 				session.Status.ActualStartTime = metav1.Now()
@@ -699,29 +699,29 @@ func TestEdgeCase_ScheduledSessionNotWaitingUntilActivation(t *testing.T) {
 // state checks.
 //
 // Location: session_controller.go line 789
-// Code: if currState == v1alpha1.SessionStateRejected || currState == v1alpha1.SessionStateWithdrawn || ...
+// Code: if currState == breakglassv1alpha1.SessionStateRejected || currState == breakglassv1alpha1.SessionStateWithdrawn || ...
 //
 // This is critical: these states should be immutable once reached.
 func TestEdgeCase_RejectedAndWithdrawnAreTerminal(t *testing.T) {
-	terminalStates := []v1alpha1.BreakglassSessionState{
-		v1alpha1.SessionStateRejected,
-		v1alpha1.SessionStateWithdrawn,
-		v1alpha1.SessionStateExpired,
-		v1alpha1.SessionStateTimeout,
+	terminalStates := []breakglassv1alpha1.BreakglassSessionState{
+		breakglassv1alpha1.SessionStateRejected,
+		breakglassv1alpha1.SessionStateWithdrawn,
+		breakglassv1alpha1.SessionStateExpired,
+		breakglassv1alpha1.SessionStateTimeout,
 	}
 
 	for _, terminalState := range terminalStates {
-		session := v1alpha1.BreakglassSession{
-			Status: v1alpha1.BreakglassSessionStatus{
+		session := breakglassv1alpha1.BreakglassSession{
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State: terminalState,
 			},
 		}
 
 		// Simulate the terminal state check (line 789)
-		isTerminal := (session.Status.State == v1alpha1.SessionStateRejected ||
-			session.Status.State == v1alpha1.SessionStateWithdrawn ||
-			session.Status.State == v1alpha1.SessionStateExpired ||
-			session.Status.State == v1alpha1.SessionStateTimeout)
+		isTerminal := (session.Status.State == breakglassv1alpha1.SessionStateRejected ||
+			session.Status.State == breakglassv1alpha1.SessionStateWithdrawn ||
+			session.Status.State == breakglassv1alpha1.SessionStateExpired ||
+			session.Status.State == breakglassv1alpha1.SessionStateTimeout)
 
 		if !isTerminal {
 			t.Errorf("State %s should be terminal", terminalState)
@@ -753,9 +753,9 @@ func TestEdgeCase_ApprovalTimeoutCleared(t *testing.T) {
 	now := time.Now()
 
 	// Session with pending approval that will timeout
-	session := v1alpha1.BreakglassSession{
-		Status: v1alpha1.BreakglassSessionStatus{
-			State:     v1alpha1.SessionStatePending,
+	session := breakglassv1alpha1.BreakglassSession{
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStatePending,
 			TimeoutAt: metav1.NewTime(now.Add(1 * time.Hour)), // Will timeout in 1 hour
 		},
 	}
@@ -783,66 +783,66 @@ func TestEdgeCase_NonzeroTimestampsInDifferentContexts(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		session     v1alpha1.BreakglassSession
-		check       func(v1alpha1.BreakglassSession) bool
+		session     breakglassv1alpha1.BreakglassSession
+		check       func(breakglassv1alpha1.BreakglassSession) bool
 		description string
 	}{
 		{
 			name: "pending_no_timestamps",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStatePending,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.Time{},
 					TimeoutAt:  metav1.Time{},
 				},
 			},
-			check: func(s v1alpha1.BreakglassSession) bool {
+			check: func(s breakglassv1alpha1.BreakglassSession) bool {
 				return s.Status.ApprovedAt.IsZero() && s.Status.RejectedAt.IsZero() && s.Status.TimeoutAt.IsZero()
 			},
 			description: "Pending session should have empty timestamps",
 		},
 		{
 			name: "approved_with_timestamp",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateApproved,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateApproved,
 					ApprovedAt: metav1.NewTime(now),
 					RejectedAt: metav1.Time{}, // Must be zero
 					TimeoutAt:  metav1.Time{}, // Must be zero
 				},
 			},
-			check: func(s v1alpha1.BreakglassSession) bool {
+			check: func(s breakglassv1alpha1.BreakglassSession) bool {
 				return !s.Status.ApprovedAt.IsZero() && s.Status.RejectedAt.IsZero() && s.Status.TimeoutAt.IsZero()
 			},
 			description: "Approved session must have ApprovedAt set and RejectedAt/TimeoutAt cleared",
 		},
 		{
 			name: "rejected_with_timestamp",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateRejected,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateRejected,
 					ApprovedAt: metav1.Time{}, // Must be zero
 					RejectedAt: metav1.NewTime(now),
 					TimeoutAt:  metav1.Time{}, // Must be zero
 				},
 			},
-			check: func(s v1alpha1.BreakglassSession) bool {
+			check: func(s breakglassv1alpha1.BreakglassSession) bool {
 				return s.Status.ApprovedAt.IsZero() && !s.Status.RejectedAt.IsZero() && s.Status.TimeoutAt.IsZero()
 			},
 			description: "Rejected session must have RejectedAt set and ApprovedAt/TimeoutAt cleared",
 		},
 		{
 			name: "withdrawn_no_rejection_timestamp",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateWithdrawn,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateWithdrawn,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.Time{}, // KEY: Empty, not set!
 					TimeoutAt:  metav1.Time{},
 				},
 			},
-			check: func(s v1alpha1.BreakglassSession) bool {
+			check: func(s breakglassv1alpha1.BreakglassSession) bool {
 				// Withdrawn session has empty RejectedAt (this was the bug!)
 				return s.Status.RejectedAt.IsZero() && !IsSessionActive(s)
 			},
@@ -871,15 +871,15 @@ func TestEdgeCase_PendingVsApprovedConflictMessages(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		session         v1alpha1.BreakglassSession
+		session         breakglassv1alpha1.BreakglassSession
 		expectedMessage string
 		description     string
 	}{
 		{
 			name: "approved_session_conflict",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStateApproved,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateApproved,
 					ApprovedAt: metav1.NewTime(now),
 				},
 			},
@@ -888,9 +888,9 @@ func TestEdgeCase_PendingVsApprovedConflictMessages(t *testing.T) {
 		},
 		{
 			name: "pending_session_conflict",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:      v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStatePending,
 					ApprovedAt: metav1.Time{},
 					RejectedAt: metav1.Time{},
 					TimeoutAt:  metav1.NewTime(now.Add(1 * time.Hour)), // Still pending
@@ -907,7 +907,7 @@ func TestEdgeCase_PendingVsApprovedConflictMessages(t *testing.T) {
 			var message string
 
 			// Line 443: approved check
-			if tt.session.Status.State == v1alpha1.SessionStateApproved || !tt.session.Status.ApprovedAt.IsZero() {
+			if tt.session.Status.State == breakglassv1alpha1.SessionStateApproved || !tt.session.Status.ApprovedAt.IsZero() {
 				message = "already approved"
 			} else if IsSessionPendingApproval(tt.session) {
 				message = "already requested"
@@ -942,31 +942,31 @@ func TestEdgeCase_PendingVsApprovedConflictMessages(t *testing.T) {
 func TestRegressionFix_WithdrawnSessionsShouldNotHaveRejectedAtSet(t *testing.T) {
 	tests := []struct {
 		name                 string
-		state                v1alpha1.BreakglassSessionState
+		state                breakglassv1alpha1.BreakglassSessionState
 		expectedRejectedAtOk bool
 		description          string
 	}{
 		{
 			name:                 "withdrawn_session_must_have_empty_rejectedat",
-			state:                v1alpha1.SessionStateWithdrawn,
+			state:                breakglassv1alpha1.SessionStateWithdrawn,
 			expectedRejectedAtOk: true, // Should be empty (true = IsZero() returns true)
 			description:          "User-cancelled sessions must NOT have RejectedAt set",
 		},
 		{
 			name:                 "rejected_session_must_have_rejectedat_set",
-			state:                v1alpha1.SessionStateRejected,
+			state:                breakglassv1alpha1.SessionStateRejected,
 			expectedRejectedAtOk: false, // Should be set (false = IsZero() returns false)
 			description:          "Approver-rejected sessions MUST have RejectedAt set",
 		},
 		{
 			name:                 "approved_session_must_have_empty_rejectedat",
-			state:                v1alpha1.SessionStateApproved,
+			state:                breakglassv1alpha1.SessionStateApproved,
 			expectedRejectedAtOk: true, // Should be empty
 			description:          "Approved sessions must NOT have RejectedAt set",
 		},
 		{
 			name:                 "pending_session_must_have_empty_rejectedat",
-			state:                v1alpha1.SessionStatePending,
+			state:                breakglassv1alpha1.SessionStatePending,
 			expectedRejectedAtOk: true, // Should be empty
 			description:          "Pending sessions must NOT have RejectedAt set",
 		},
@@ -974,14 +974,14 @@ func TestRegressionFix_WithdrawnSessionsShouldNotHaveRejectedAtSet(t *testing.T)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var session v1alpha1.BreakglassSession
+			var session breakglassv1alpha1.BreakglassSession
 			session.Status.State = tt.state
 
 			switch tt.state {
-			case v1alpha1.SessionStateRejected:
+			case breakglassv1alpha1.SessionStateRejected:
 				// When rejected by approver, set RejectedAt
 				session.Status.RejectedAt = metav1.Now()
-			case v1alpha1.SessionStateWithdrawn, v1alpha1.SessionStateApproved, v1alpha1.SessionStatePending:
+			case breakglassv1alpha1.SessionStateWithdrawn, breakglassv1alpha1.SessionStateApproved, breakglassv1alpha1.SessionStatePending:
 				// When withdrawn, approved or pending by user, RejectedAt should be empty
 				session.Status.RejectedAt = metav1.Time{}
 			}
@@ -1006,31 +1006,31 @@ func TestRetainedUntilSetForAllTerminalStates(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		state       v1alpha1.BreakglassSessionState
+		state       breakglassv1alpha1.BreakglassSessionState
 		rejectedAt  bool // true if RejectedAt should be set (only for Rejected state)
 		description string
 	}{
 		{
 			name:        "rejected_state_has_retaineduntil_and_rejectedat",
-			state:       v1alpha1.SessionStateRejected,
+			state:       breakglassv1alpha1.SessionStateRejected,
 			rejectedAt:  true,
 			description: "Rejected sessions MUST have both RejectedAt and RetainedUntil set",
 		},
 		{
 			name:        "withdrawn_state_has_retaineduntil_no_rejectedat",
-			state:       v1alpha1.SessionStateWithdrawn,
+			state:       breakglassv1alpha1.SessionStateWithdrawn,
 			rejectedAt:  false,
 			description: "Withdrawn sessions MUST have RetainedUntil but NOT RejectedAt",
 		},
 		{
 			name:        "expired_state_has_retaineduntil_no_rejectedat",
-			state:       v1alpha1.SessionStateExpired,
+			state:       breakglassv1alpha1.SessionStateExpired,
 			rejectedAt:  false,
 			description: "Expired sessions MUST have RetainedUntil but NOT RejectedAt",
 		},
 		{
 			name:        "timeout_state_has_retaineduntil_no_rejectedat",
-			state:       v1alpha1.SessionStateTimeout,
+			state:       breakglassv1alpha1.SessionStateTimeout,
 			rejectedAt:  false,
 			description: "Timeout sessions MUST have RetainedUntil but NOT RejectedAt",
 		},
@@ -1038,21 +1038,21 @@ func TestRetainedUntilSetForAllTerminalStates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Spec: v1alpha1.BreakglassSessionSpec{
+			session := breakglassv1alpha1.BreakglassSession{
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
 					RetainFor: "24h",
 				},
-				Status: v1alpha1.BreakglassSessionStatus{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State: tt.state,
 				},
 			}
 
 			// Simulate what the controller should do for each state
 			switch tt.state {
-			case v1alpha1.SessionStateRejected:
+			case breakglassv1alpha1.SessionStateRejected:
 				session.Status.RejectedAt = metav1.Now()
 				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
-			case v1alpha1.SessionStateWithdrawn, v1alpha1.SessionStateExpired, v1alpha1.SessionStateTimeout:
+			case breakglassv1alpha1.SessionStateWithdrawn, breakglassv1alpha1.SessionStateExpired, breakglassv1alpha1.SessionStateTimeout:
 				session.Status.RejectedAt = metav1.Time{}
 				session.Status.RetainedUntil = metav1.NewTime(now.Add(retainFor))
 			}
@@ -1082,43 +1082,43 @@ func TestIsSessionActive_ExcludesAllTerminalStates(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		state    v1alpha1.BreakglassSessionState
+		state    breakglassv1alpha1.BreakglassSessionState
 		expected bool
 		reason   string
 	}{
 		{
 			name:     "rejected_is_not_active",
-			state:    v1alpha1.SessionStateRejected,
+			state:    breakglassv1alpha1.SessionStateRejected,
 			expected: false,
 			reason:   "Rejected sessions are terminal and should not be active",
 		},
 		{
 			name:     "withdrawn_is_not_active",
-			state:    v1alpha1.SessionStateWithdrawn,
+			state:    breakglassv1alpha1.SessionStateWithdrawn,
 			expected: false,
 			reason:   "Withdrawn sessions are terminal and should not be active",
 		},
 		{
 			name:     "expired_is_not_active",
-			state:    v1alpha1.SessionStateExpired,
+			state:    breakglassv1alpha1.SessionStateExpired,
 			expected: false,
 			reason:   "Expired sessions are terminal and should not be active",
 		},
 		{
 			name:     "timeout_is_not_active",
-			state:    v1alpha1.SessionStateTimeout,
+			state:    breakglassv1alpha1.SessionStateTimeout,
 			expected: false,
 			reason:   "Timeout sessions are terminal and should not be active",
 		},
 		{
 			name:     "pending_is_active",
-			state:    v1alpha1.SessionStatePending,
+			state:    breakglassv1alpha1.SessionStatePending,
 			expected: true,
 			reason:   "Pending sessions are active and can be approved",
 		},
 		{
 			name:     "approved_is_active",
-			state:    v1alpha1.SessionStateApproved,
+			state:    breakglassv1alpha1.SessionStateApproved,
 			expected: true,
 			reason:   "Approved sessions are active",
 		},
@@ -1126,8 +1126,8 @@ func TestIsSessionActive_ExcludesAllTerminalStates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:         tt.state,
 					ExpiresAt:     metav1.NewTime(expiresAt),
 					RetainedUntil: metav1.NewTime(retainedUntil),
@@ -1135,7 +1135,7 @@ func TestIsSessionActive_ExcludesAllTerminalStates(t *testing.T) {
 			}
 
 			// Set appropriate timestamps based on state
-			if tt.state == v1alpha1.SessionStateApproved {
+			if tt.state == breakglassv1alpha1.SessionStateApproved {
 				session.Status.ApprovedAt = metav1.Now()
 			}
 
@@ -1161,7 +1161,7 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		state          v1alpha1.BreakglassSessionState
+		state          breakglassv1alpha1.BreakglassSessionState
 		approvedAt     metav1.Time // Represents time of approval
 		expiresAt      metav1.Time // Represents time of expiration
 		withdrawnAt    metav1.Time // Represents time of withdrawal
@@ -1172,7 +1172,7 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 	}{
 		{
 			name:           "rejected_overrides_valid_timestamps",
-			state:          v1alpha1.SessionStateRejected,
+			state:          breakglassv1alpha1.SessionStateRejected,
 			approvedAt:     metav1.NewTime(now.Add(-1 * time.Hour)), // Was approved long ago
 			expiresAt:      metav1.NewTime(now.Add(1 * time.Hour)),  // Won't expire for 1 hour
 			rejectedAt:     metav1.NewTime(now),                     // Just rejected
@@ -1182,7 +1182,7 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 		},
 		{
 			name:           "withdrawn_overrides_valid_timestamps",
-			state:          v1alpha1.SessionStateWithdrawn,
+			state:          breakglassv1alpha1.SessionStateWithdrawn,
 			approvedAt:     metav1.NewTime(now.Add(-1 * time.Hour)), // Was approved long ago
 			expiresAt:      metav1.NewTime(now.Add(1 * time.Hour)),  // Won't expire for 1 hour
 			withdrawnAt:    metav1.NewTime(now),                     // Just withdrawn
@@ -1192,7 +1192,7 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 		},
 		{
 			name:           "expired_overrides_approved_timestamp",
-			state:          v1alpha1.SessionStateExpired,
+			state:          breakglassv1alpha1.SessionStateExpired,
 			approvedAt:     metav1.NewTime(now.Add(-1 * time.Hour)), // Was approved long ago
 			expiresAt:      metav1.NewTime(now.Add(1 * time.Hour)),  // Timestamp suggests validity (but state is expired)
 			expectedValid:  false,
@@ -1201,14 +1201,14 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 		},
 		{
 			name:           "timeout_overrides_pending_timestamp",
-			state:          v1alpha1.SessionStateTimeout,
+			state:          breakglassv1alpha1.SessionStateTimeout,
 			expectedValid:  false,
 			expectedActive: false,
 			description:    "ApprovalTimeout state makes session invalid",
 		},
 		{
 			name:           "pending_is_active_despite_expired_timestamp",
-			state:          v1alpha1.SessionStatePending,
+			state:          breakglassv1alpha1.SessionStatePending,
 			expiresAt:      metav1.NewTime(now.Add(-1 * time.Hour)), // Old timestamp (shouldn't matter for Pending)
 			expectedValid:  true,
 			expectedActive: true,
@@ -1216,7 +1216,7 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 		},
 		{
 			name:           "approved_valid_with_current_timestamp",
-			state:          v1alpha1.SessionStateApproved,
+			state:          breakglassv1alpha1.SessionStateApproved,
 			approvedAt:     metav1.NewTime(now.Add(-1 * time.Hour)),
 			expiresAt:      metav1.NewTime(now.Add(1 * time.Hour)), // Won't expire for 1 hour
 			expectedValid:  true,
@@ -1227,8 +1227,8 @@ func TestStateIsUltimateAuthority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:       tt.state,
 					ApprovedAt:  tt.approvedAt,
 					ExpiresAt:   tt.expiresAt,
@@ -1268,14 +1268,14 @@ func TestTimestampPreservationAcrossStateTransitions(t *testing.T) {
 	tests := []struct {
 		name         string
 		description  string
-		validateFunc func(t *testing.T, session v1alpha1.BreakglassSession)
+		validateFunc func(t *testing.T, session breakglassv1alpha1.BreakglassSession)
 	}{
 		{
 			name:        "approved_then_withdrawn_preserves_approvedat",
 			description: "Withdrawn session should preserve ApprovedAt, ExpiresAt timestamps from when it was approved",
-			validateFunc: func(t *testing.T, session v1alpha1.BreakglassSession) {
+			validateFunc: func(t *testing.T, session breakglassv1alpha1.BreakglassSession) {
 				// Simulate: Session started as Pending, was approved, then withdrawn
-				session.Status.State = v1alpha1.SessionStateWithdrawn
+				session.Status.State = breakglassv1alpha1.SessionStateWithdrawn
 				session.Status.ApprovedAt = metav1.NewTime(baseTime.Add(-30 * time.Minute))
 				session.Status.WithdrawnAt = metav1.NewTime(baseTime)
 				session.Status.ExpiresAt = metav1.NewTime(baseTime.Add(30 * time.Minute))
@@ -1295,9 +1295,9 @@ func TestTimestampPreservationAcrossStateTransitions(t *testing.T) {
 		{
 			name:        "pending_then_rejected_has_rejectedat",
 			description: "Rejected session should have RejectedAt set (timestamps on Pending are empty)",
-			validateFunc: func(t *testing.T, session v1alpha1.BreakglassSession) {
+			validateFunc: func(t *testing.T, session breakglassv1alpha1.BreakglassSession) {
 				// Simulate: Session started as Pending, then rejected (no ApprovedAt needed)
-				session.Status.State = v1alpha1.SessionStateRejected
+				session.Status.State = breakglassv1alpha1.SessionStateRejected
 				session.Status.RejectedAt = metav1.NewTime(baseTime)
 
 				// Verify RejectedAt is set
@@ -1309,9 +1309,9 @@ func TestTimestampPreservationAcrossStateTransitions(t *testing.T) {
 		{
 			name:        "approved_then_expired_preserves_approvedat",
 			description: "Expired session should preserve ApprovedAt from approval time",
-			validateFunc: func(t *testing.T, session v1alpha1.BreakglassSession) {
+			validateFunc: func(t *testing.T, session breakglassv1alpha1.BreakglassSession) {
 				// Simulate: Session was approved, then expired
-				session.Status.State = v1alpha1.SessionStateExpired
+				session.Status.State = breakglassv1alpha1.SessionStateExpired
 				session.Status.ApprovedAt = metav1.NewTime(baseTime.Add(-1 * time.Hour))
 				session.Status.ExpiresAt = metav1.NewTime(baseTime) // Just expired
 
@@ -1328,7 +1328,7 @@ func TestTimestampPreservationAcrossStateTransitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{}
+			session := breakglassv1alpha1.BreakglassSession{}
 			tt.validateFunc(t, session)
 		})
 	}
@@ -1341,42 +1341,42 @@ func TestWithdrawnAtSemantics(t *testing.T) {
 
 	tests := []struct {
 		name                  string
-		state                 v1alpha1.BreakglassSessionState
+		state                 breakglassv1alpha1.BreakglassSessionState
 		withdrawnAt           metav1.Time
 		shouldHaveWithdrawnAt bool
 		description           string
 	}{
 		{
 			name:                  "withdrawn_has_withdrawnat",
-			state:                 v1alpha1.SessionStateWithdrawn,
+			state:                 breakglassv1alpha1.SessionStateWithdrawn,
 			withdrawnAt:           metav1.NewTime(now),
 			shouldHaveWithdrawnAt: true,
 			description:           "Withdrawn sessions MUST have WithdrawnAt set",
 		},
 		{
 			name:                  "rejected_has_no_withdrawnat",
-			state:                 v1alpha1.SessionStateRejected,
+			state:                 breakglassv1alpha1.SessionStateRejected,
 			withdrawnAt:           metav1.Time{},
 			shouldHaveWithdrawnAt: false,
 			description:           "Rejected sessions should NOT have WithdrawnAt set",
 		},
 		{
 			name:                  "approved_has_no_withdrawnat",
-			state:                 v1alpha1.SessionStateApproved,
+			state:                 breakglassv1alpha1.SessionStateApproved,
 			withdrawnAt:           metav1.Time{},
 			shouldHaveWithdrawnAt: false,
 			description:           "Approved sessions should NOT have WithdrawnAt set",
 		},
 		{
 			name:                  "pending_has_no_withdrawnat",
-			state:                 v1alpha1.SessionStatePending,
+			state:                 breakglassv1alpha1.SessionStatePending,
 			withdrawnAt:           metav1.Time{},
 			shouldHaveWithdrawnAt: false,
 			description:           "Pending sessions should NOT have WithdrawnAt set",
 		},
 		{
 			name:                  "expired_has_no_withdrawnat",
-			state:                 v1alpha1.SessionStateExpired,
+			state:                 breakglassv1alpha1.SessionStateExpired,
 			withdrawnAt:           metav1.Time{},
 			shouldHaveWithdrawnAt: false,
 			description:           "Expired sessions should NOT have WithdrawnAt set",
@@ -1385,8 +1385,8 @@ func TestWithdrawnAtSemantics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			session := v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
+			session := breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:       tt.state,
 					WithdrawnAt: tt.withdrawnAt,
 				},
@@ -1418,15 +1418,15 @@ func TestIsSessionPendingApproval_WithdrawnSessionsExcluded(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		session  v1alpha1.BreakglassSession
+		session  breakglassv1alpha1.BreakglassSession
 		expected bool
 		reason   string
 	}{
 		{
 			name: "withdrawn_session_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:       v1alpha1.SessionStateWithdrawn,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:       breakglassv1alpha1.SessionStateWithdrawn,
 					WithdrawnAt: metav1.NewTime(now.Add(-5 * time.Minute)),
 					ApprovedAt:  metav1.Time{},
 					RejectedAt:  metav1.Time{},
@@ -1438,9 +1438,9 @@ func TestIsSessionPendingApproval_WithdrawnSessionsExcluded(t *testing.T) {
 		},
 		{
 			name: "truly_pending_session",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:       v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:       breakglassv1alpha1.SessionStatePending,
 					WithdrawnAt: metav1.Time{}, // not withdrawn
 					ApprovedAt:  metav1.Time{}, // not approved
 					RejectedAt:  metav1.Time{}, // not rejected
@@ -1452,9 +1452,9 @@ func TestIsSessionPendingApproval_WithdrawnSessionsExcluded(t *testing.T) {
 		},
 		{
 			name: "pending_but_timed_out",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:       v1alpha1.SessionStatePending,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:       breakglassv1alpha1.SessionStatePending,
 					WithdrawnAt: metav1.Time{},
 					ApprovedAt:  metav1.Time{},
 					RejectedAt:  metav1.Time{},
@@ -1466,9 +1466,9 @@ func TestIsSessionPendingApproval_WithdrawnSessionsExcluded(t *testing.T) {
 		},
 		{
 			name: "rejected_session_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:       v1alpha1.SessionStateRejected,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:       breakglassv1alpha1.SessionStateRejected,
 					WithdrawnAt: metav1.Time{},
 					ApprovedAt:  metav1.Time{},
 					RejectedAt:  metav1.NewTime(now.Add(-5 * time.Minute)), // rejected
@@ -1480,9 +1480,9 @@ func TestIsSessionPendingApproval_WithdrawnSessionsExcluded(t *testing.T) {
 		},
 		{
 			name: "approved_session_not_pending",
-			session: v1alpha1.BreakglassSession{
-				Status: v1alpha1.BreakglassSessionStatus{
-					State:       v1alpha1.SessionStateApproved,
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:       breakglassv1alpha1.SessionStateApproved,
 					WithdrawnAt: metav1.Time{},
 					ApprovedAt:  metav1.NewTime(now.Add(-5 * time.Minute)), // approved
 					RejectedAt:  metav1.Time{},

--- a/pkg/breakglass/template_renderer_test.go
+++ b/pkg/breakglass/template_renderer_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
@@ -39,8 +39,8 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "simple variable substitution",
 			template: "Hello, {{ .session.name }}!",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "test-session",
 				},
 			},
@@ -49,11 +49,11 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "nested context access",
 			template: "Cluster: {{ .session.cluster }}, Namespace: {{ .target.namespace }}",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Cluster: "prod-cluster",
 				},
-				Target: v1alpha1.AuxiliaryResourceTargetContext{
+				Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 					Namespace: "debug-ns",
 				},
 			},
@@ -62,7 +62,7 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "user variables access",
 			template: "Size: {{ .vars.pvcSize }}, Class: {{ .vars.storageClass }}",
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"pvcSize":      "50Gi",
 					"storageClass": "csi-cinder",
@@ -73,8 +73,8 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "sprig functions - upper",
 			template: "{{ .session.name | upper }}",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "test-session",
 				},
 			},
@@ -83,8 +83,8 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "sprig functions - trunc",
 			template: "{{ .session.name | trunc 8 }}",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "very-long-session-name",
 				},
 			},
@@ -93,8 +93,8 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "sprig functions - quote",
 			template: "name: {{ .session.name | quote }}",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "test-session",
 				},
 			},
@@ -103,7 +103,7 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 		{
 			name:     "sprig functions - default",
 			template: "name: {{ .vars.missing | default \"default-value\" }}",
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{},
 			},
 			expected: "name: default-value",
@@ -113,7 +113,7 @@ func TestTemplateRenderer_RenderTemplateString(t *testing.T) {
 			template: `{{- if .vars.createPvc }}
 pvc: enabled
 {{- end }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"createPvc": "true",
 				},
@@ -126,7 +126,7 @@ pvc: enabled
 {{- range $k, $v := .labels }}
   {{ $k }}: {{ $v | quote }}
 {{- end }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Labels: map[string]string{
 					"app":     "test",
 					"version": "v1",
@@ -137,8 +137,8 @@ pvc: enabled
 		{
 			name:     "custom function - truncName",
 			template: "{{ truncName 10 .session.name }}",
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "very-long-session-name-that-exceeds-limit",
 				},
 			},
@@ -147,7 +147,7 @@ pvc: enabled
 		{
 			name:     "custom function - k8sName",
 			template: "{{ k8sName .vars.testName }}",
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{
 					"testName": "My Test_Name.123",
 				},
@@ -157,14 +157,14 @@ pvc: enabled
 		{
 			name:        "empty template",
 			template:    "",
-			context:     v1alpha1.AuxiliaryResourceContext{},
+			context:     breakglassv1alpha1.AuxiliaryResourceContext{},
 			expectError: true,
 			errorMsg:    "template string is empty",
 		},
 		{
 			name:        "invalid template syntax",
 			template:    "{{ .session.name",
-			context:     v1alpha1.AuxiliaryResourceContext{},
+			context:     breakglassv1alpha1.AuxiliaryResourceContext{},
 			expectError: true,
 			errorMsg:    "failed to parse template",
 		},
@@ -206,8 +206,8 @@ func TestTemplateRenderer_RenderMultiDocumentTemplate(t *testing.T) {
 kind: ConfigMap
 metadata:
   name: {{ .session.name }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "test-session",
 				},
 			},
@@ -225,8 +225,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-{{ .session.name }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
-				Session: v1alpha1.AuxiliaryResourceSessionContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
+				Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 					Name: "test",
 				},
 			},
@@ -246,7 +246,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-1`,
-			context:      v1alpha1.AuxiliaryResourceContext{},
+			context:      breakglassv1alpha1.AuxiliaryResourceContext{},
 			expectedDocs: 2, // Empty document should be skipped
 		},
 		{
@@ -257,7 +257,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: test-pvc
 {{- end }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{"createPvc": "true"},
 			},
 			expectedDocs: 1,
@@ -270,7 +270,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: test-pvc
 {{- end }}`,
-			context: v1alpha1.AuxiliaryResourceContext{
+			context: breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: map[string]string{"createPvc": "false"},
 			},
 			expectedDocs: 0,
@@ -299,14 +299,14 @@ metadata:
 func TestTemplateRenderer_ValidateTemplate(t *testing.T) {
 	renderer := NewTemplateRenderer()
 
-	sampleCtx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	sampleCtx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:        "validation-session",
 			Namespace:   "breakglass-system",
 			Cluster:     "validation-cluster",
 			RequestedBy: "validator@example.com",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "breakglass-debug",
 			ClusterName: "validation-cluster",
 		},
@@ -660,14 +660,14 @@ spec:
     requests:
       storage: {{ .vars.pvcSize }}`
 
-	ctx := v1alpha1.AuxiliaryResourceContext{
-		Session: v1alpha1.AuxiliaryResourceSessionContext{
+	ctx := breakglassv1alpha1.AuxiliaryResourceContext{
+		Session: breakglassv1alpha1.AuxiliaryResourceSessionContext{
 			Name:        "debug-session-12345",
 			Namespace:   "breakglass-system",
 			Cluster:     "prod-cluster",
 			RequestedBy: "user@example.com",
 		},
-		Target: v1alpha1.AuxiliaryResourceTargetContext{
+		Target: breakglassv1alpha1.AuxiliaryResourceTargetContext{
 			Namespace:   "breakglass-debug",
 			ClusterName: "prod-cluster",
 		},
@@ -736,7 +736,7 @@ spec:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := v1alpha1.AuxiliaryResourceContext{
+			ctx := breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: tt.vars,
 			}
 
@@ -955,7 +955,7 @@ func TestYamlQuoteInTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := v1alpha1.AuxiliaryResourceContext{
+			ctx := breakglassv1alpha1.AuxiliaryResourceContext{
 				Vars: tt.vars,
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	v1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -346,15 +346,15 @@ func Load(configPath ...string) (Config, error) {
 
 // GetUserIdentifierClaim returns the configured user identifier claim type.
 // Returns UserIdentifierClaimEmail as default if not configured or if an invalid value is set.
-func (c Config) GetUserIdentifierClaim() v1alpha1.UserIdentifierClaimType {
+func (c Config) GetUserIdentifierClaim() breakglassv1alpha1.UserIdentifierClaimType {
 	switch c.Kubernetes.UserIdentifierClaim {
-	case string(v1alpha1.UserIdentifierClaimEmail):
-		return v1alpha1.UserIdentifierClaimEmail
-	case string(v1alpha1.UserIdentifierClaimPreferredUsername):
-		return v1alpha1.UserIdentifierClaimPreferredUsername
-	case string(v1alpha1.UserIdentifierClaimSub):
-		return v1alpha1.UserIdentifierClaimSub
+	case string(breakglassv1alpha1.UserIdentifierClaimEmail):
+		return breakglassv1alpha1.UserIdentifierClaimEmail
+	case string(breakglassv1alpha1.UserIdentifierClaimPreferredUsername):
+		return breakglassv1alpha1.UserIdentifierClaimPreferredUsername
+	case string(breakglassv1alpha1.UserIdentifierClaimSub):
+		return breakglassv1alpha1.UserIdentifierClaimSub
 	default:
-		return v1alpha1.UserIdentifierClaimEmail
+		return breakglassv1alpha1.UserIdentifierClaimEmail
 	}
 }

--- a/pkg/config/identity_provider_reconciler_test.go
+++ b/pkg/config/identity_provider_reconciler_test.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	ctrltest "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // newTestScheme creates a scheme with v1alpha1 types registered for testing
 func newTestScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
+	err := breakglassv1alpha1.AddToScheme(scheme)
 	require.NoError(t, err, "failed to add v1alpha1 to scheme")
 	err = corev1.AddToScheme(scheme)
 	require.NoError(t, err, "failed to add corev1 to scheme")
@@ -84,12 +84,12 @@ func TestIdentityProviderReconciler_ReconcileSuccess(t *testing.T) {
 	scheme := newTestScheme(t)
 
 	// Create a test IdentityProvider
-	idp := &v1alpha1.IdentityProvider{
+	idp := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -151,12 +151,12 @@ func TestIdentityProviderReconciler_ReconcileReloadError(t *testing.T) {
 	log := zap.NewNop().Sugar()
 	scheme := newTestScheme(t)
 
-	idp := &v1alpha1.IdentityProvider{
+	idp := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -195,12 +195,12 @@ func TestIdentityProviderReconciler_ReconcileWithMultipleIDPs(t *testing.T) {
 	log := zap.NewNop().Sugar()
 	scheme := newTestScheme(t)
 
-	idp1 := &v1alpha1.IdentityProvider{
+	idp1 := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "idp-1",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -208,12 +208,12 @@ func TestIdentityProviderReconciler_ReconcileWithMultipleIDPs(t *testing.T) {
 		},
 	}
 
-	idp2 := &v1alpha1.IdentityProvider{
+	idp2 := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "idp-2",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -260,12 +260,12 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_NoProvider(t *testing.
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{}
-	idp.SetCondition(metav1.Condition{Type: string(v1alpha1.IdentityProviderConditionGroupSyncHealthy)})
+	idp := &breakglassv1alpha1.IdentityProvider{}
+	idp.SetCondition(metav1.Condition{Type: string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy)})
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
 
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	assert.Nil(t, condition)
 }
 
@@ -274,14 +274,14 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_UnknownProvider(t *tes
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			GroupSyncProvider: "unknown",
 		},
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "UnknownProvider", condition.Reason)
@@ -292,14 +292,14 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_KeycloakMissing(t *tes
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 		},
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "KeycloakMissing", condition.Reason)
@@ -310,10 +310,10 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_KeycloakIncomplete(t *
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
-			Keycloak: &v1alpha1.KeycloakGroupSync{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
 				BaseURL:  "",
 				Realm:    "realm",
 				ClientID: "client",
@@ -322,7 +322,7 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_KeycloakIncomplete(t *
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "KeycloakIncomplete", condition.Reason)
@@ -333,10 +333,10 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_ClientSecretRefMissing
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
-			Keycloak: &v1alpha1.KeycloakGroupSync{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
 				BaseURL:  "https://kc.example.com",
 				Realm:    "realm",
 				ClientID: "client",
@@ -345,7 +345,7 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_ClientSecretRefMissing
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "ClientSecretRefInvalid", condition.Reason)
@@ -359,14 +359,14 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretNotFound(t *test
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
-			Keycloak: &v1alpha1.KeycloakGroupSync{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
 				BaseURL:  "https://kc.example.com",
 				Realm:    "realm",
 				ClientID: "client",
-				ClientSecretRef: v1alpha1.SecretKeyReference{
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
 					Name:      "missing-secret",
 					Namespace: "default",
 				},
@@ -375,7 +375,7 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretNotFound(t *test
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "SecretNotFound", condition.Reason)
@@ -393,14 +393,14 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretKeyMissing(t *te
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
-			Keycloak: &v1alpha1.KeycloakGroupSync{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
 				BaseURL:  "https://kc.example.com",
 				Realm:    "realm",
 				ClientID: "client",
-				ClientSecretRef: v1alpha1.SecretKeyReference{
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
 					Name:      "kc-secret",
 					Namespace: "default",
 					Key:       "value",
@@ -410,7 +410,7 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretKeyMissing(t *te
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionFalse, condition.Status)
 	assert.Equal(t, "SecretKeyNotFound", condition.Reason)
@@ -428,14 +428,14 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_Healthy(t *testing.T) 
 		return nil
 	})
 
-	idp := &v1alpha1.IdentityProvider{
-		Spec: v1alpha1.IdentityProviderSpec{
-			GroupSyncProvider: v1alpha1.GroupSyncProviderKeycloak,
-			Keycloak: &v1alpha1.KeycloakGroupSync{
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
 				BaseURL:  "https://kc.example.com",
 				Realm:    "realm",
 				ClientID: "client",
-				ClientSecretRef: v1alpha1.SecretKeyReference{
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
 					Name:      "kc-secret",
 					Namespace: "default",
 					Key:       "value",
@@ -445,7 +445,7 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_Healthy(t *testing.T) 
 	}
 
 	reconciler.updateGroupSyncHealth(context.Background(), idp)
-	condition := findConditionByType(idp.Status.Conditions, string(v1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	assert.Equal(t, "GroupSyncOperational", condition.Reason)
@@ -491,12 +491,12 @@ func TestIdentityProviderReconciler_GetCachedIdentityProviders(t *testing.T) {
 	log := zap.NewNop().Sugar()
 	scheme := newTestScheme(t)
 
-	idp := &v1alpha1.IdentityProvider{
+	idp := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -526,12 +526,12 @@ func TestIdentityProviderReconciler_GetEnabledIdentityProviders(t *testing.T) {
 	log := zap.NewNop().Sugar()
 	scheme := newTestScheme(t)
 
-	idp := &v1alpha1.IdentityProvider{
+	idp := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
-			OIDC: v1alpha1.OIDCConfig{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
@@ -556,26 +556,26 @@ func TestIdentityProviderReconciler_DisabledIDPsFilteredFromCache(t *testing.T) 
 	log := zap.NewNop().Sugar()
 	scheme := newTestScheme(t)
 
-	enabledIDP := &v1alpha1.IdentityProvider{
+	enabledIDP := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "enabled-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Disabled: false,
-			OIDC: v1alpha1.OIDCConfig{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth.example.com",
 				ClientID:  "test-client",
 			},
 		},
 	}
 
-	disabledIDP := &v1alpha1.IdentityProvider{
+	disabledIDP := &breakglassv1alpha1.IdentityProvider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "disabled-idp",
 		},
-		Spec: v1alpha1.IdentityProviderSpec{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Disabled: true,
-			OIDC: v1alpha1.OIDCConfig{
+			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority: "https://auth2.example.com",
 				ClientID:  "test-client-2",
 			},

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 )
 
@@ -52,8 +52,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassSession", "spec.cluster", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.cluster", func(rawObj client.Object) []string {
-			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.Cluster != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Spec.Cluster != "" {
 				return []string{bs.Spec.Cluster}
 			}
 			return nil
@@ -63,8 +63,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassSession", "spec.user", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.user", func(rawObj client.Object) []string {
-			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.User != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "spec.user", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Spec.User != "" {
 				return []string{bs.Spec.User}
 			}
 			return nil
@@ -74,8 +74,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassSession", "spec.grantedGroup", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "spec.grantedGroup", func(rawObj client.Object) []string {
-			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Spec.GrantedGroup != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "spec.grantedGroup", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Spec.GrantedGroup != "" {
 				return []string{bs.Spec.GrantedGroup}
 			}
 			return nil
@@ -85,8 +85,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassSession", "metadata.name", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "metadata.name", func(rawObj client.Object) []string {
-			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Name != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "metadata.name", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Name != "" {
 				return []string{bs.Name}
 			}
 			return nil
@@ -96,8 +96,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassSession", "status.state", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassSession{}, "status.state", func(rawObj client.Object) []string {
-			if bs, ok := rawObj.(*v1alpha1.BreakglassSession); ok && bs.Status.State != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "status.state", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Status.State != "" {
 				return []string{string(bs.Status.State)}
 			}
 			return nil
@@ -107,8 +107,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("DebugSession", "spec.cluster", func() error {
-		return idx.IndexField(ctx, &v1alpha1.DebugSession{}, "spec.cluster", func(rawObj client.Object) []string {
-			if ds, ok := rawObj.(*v1alpha1.DebugSession); ok && ds.Spec.Cluster != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSession{}, "spec.cluster", func(rawObj client.Object) []string {
+			if ds, ok := rawObj.(*breakglassv1alpha1.DebugSession); ok && ds.Spec.Cluster != "" {
 				return []string{ds.Spec.Cluster}
 			}
 			return nil
@@ -118,8 +118,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("DebugSession", "status.state", func() error {
-		return idx.IndexField(ctx, &v1alpha1.DebugSession{}, "status.state", func(rawObj client.Object) []string {
-			if ds, ok := rawObj.(*v1alpha1.DebugSession); ok && ds.Status.State != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSession{}, "status.state", func(rawObj client.Object) []string {
+			if ds, ok := rawObj.(*breakglassv1alpha1.DebugSession); ok && ds.Status.State != "" {
 				return []string{string(ds.Status.State)}
 			}
 			return nil
@@ -129,8 +129,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("DebugSession", "status.participants.user", func() error {
-		return idx.IndexField(ctx, &v1alpha1.DebugSession{}, "status.participants.user", func(rawObj client.Object) []string {
-			ds, ok := rawObj.(*v1alpha1.DebugSession)
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSession{}, "status.participants.user", func(rawObj client.Object) []string {
+			ds, ok := rawObj.(*breakglassv1alpha1.DebugSession)
 			if !ok || ds == nil || len(ds.Status.Participants) == 0 {
 				return nil
 			}
@@ -150,8 +150,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassEscalation", "spec.allowed.cluster", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.allowed.cluster", func(rawObj client.Object) []string {
-			be, ok := rawObj.(*v1alpha1.BreakglassEscalation)
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, "spec.allowed.cluster", func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
 			if !ok || be == nil {
 				return nil
 			}
@@ -165,8 +165,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassEscalation", "spec.allowed.group", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.allowed.group", func(rawObj client.Object) []string {
-			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, "spec.allowed.group", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation); ok && be != nil {
 				return be.Spec.Allowed.Groups
 			}
 			return nil
@@ -176,8 +176,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassEscalation", "spec.escalatedGroup", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "spec.escalatedGroup", func(rawObj client.Object) []string {
-			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil && be.Spec.EscalatedGroup != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, "spec.escalatedGroup", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation); ok && be != nil && be.Spec.EscalatedGroup != "" {
 				return []string{be.Spec.EscalatedGroup}
 			}
 			return nil
@@ -187,8 +187,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("BreakglassEscalation", "metadata.name", func() error {
-		return idx.IndexField(ctx, &v1alpha1.BreakglassEscalation{}, "metadata.name", func(rawObj client.Object) []string {
-			if be, ok := rawObj.(*v1alpha1.BreakglassEscalation); ok && be != nil && be.Name != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, "metadata.name", func(rawObj client.Object) []string {
+			if be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation); ok && be != nil && be.Name != "" {
 				return []string{be.Name}
 			}
 			return nil
@@ -198,8 +198,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("ClusterConfig", "metadata.name", func() error {
-		return idx.IndexField(ctx, &v1alpha1.ClusterConfig{}, "metadata.name", func(rawObj client.Object) []string {
-			if cc, ok := rawObj.(*v1alpha1.ClusterConfig); ok && cc != nil && cc.Name != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.ClusterConfig{}, "metadata.name", func(rawObj client.Object) []string {
+			if cc, ok := rawObj.(*breakglassv1alpha1.ClusterConfig); ok && cc != nil && cc.Name != "" {
 				return []string{cc.Name}
 			}
 			return nil
@@ -209,8 +209,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 	}
 
 	if err := register("ClusterConfig", "spec.clusterID", func() error {
-		return idx.IndexField(ctx, &v1alpha1.ClusterConfig{}, "spec.clusterID", func(rawObj client.Object) []string {
-			if cc, ok := rawObj.(*v1alpha1.ClusterConfig); ok && cc != nil && cc.Spec.ClusterID != "" {
+		return idx.IndexField(ctx, &breakglassv1alpha1.ClusterConfig{}, "spec.clusterID", func(rawObj client.Object) []string {
+			if cc, ok := rawObj.(*breakglassv1alpha1.ClusterConfig); ok && cc != nil && cc.Spec.ClusterID != "" {
 				return []string{cc.Spec.ClusterID}
 			}
 			return nil

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // mockFieldIndexer is a test double for client.FieldIndexer
@@ -169,12 +169,12 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 	err := RegisterCommonFieldIndexes(ctx, indexer, logger)
 	require.NoError(t, err)
 
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:      "test-cluster",
 			User:         "test-user@example.com",
 			GrantedGroup: "admin-access",
@@ -189,7 +189,7 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 		assert.Equal(t, []string{"test-cluster"}, result)
 
 		// Test with empty cluster
-		emptySession := &v1alpha1.BreakglassSession{}
+		emptySession := &breakglassv1alpha1.BreakglassSession{}
 		result = fn(emptySession)
 		assert.Nil(t, result)
 	})
@@ -202,7 +202,7 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 		assert.Equal(t, []string{"test-user@example.com"}, result)
 
 		// Test with empty user
-		emptySession := &v1alpha1.BreakglassSession{}
+		emptySession := &breakglassv1alpha1.BreakglassSession{}
 		result = fn(emptySession)
 		assert.Nil(t, result)
 	})
@@ -215,7 +215,7 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 		assert.Equal(t, []string{"admin-access"}, result)
 
 		// Test with empty grantedGroup
-		emptySession := &v1alpha1.BreakglassSession{}
+		emptySession := &breakglassv1alpha1.BreakglassSession{}
 		result = fn(emptySession)
 		assert.Nil(t, result)
 	})
@@ -229,7 +229,7 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 		assert.Equal(t, []string{"test-session"}, result)
 
 		// Test with empty name
-		emptySession := &v1alpha1.BreakglassSession{}
+		emptySession := &breakglassv1alpha1.BreakglassSession{}
 		result = fn(emptySession)
 		assert.Nil(t, result)
 	})
@@ -243,17 +243,17 @@ func TestIndexerFunctions_DebugSession(t *testing.T) {
 	err := RegisterCommonFieldIndexes(ctx, indexer, logger)
 	require.NoError(t, err)
 
-	debugSession := &v1alpha1.DebugSession{
+	debugSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "debug-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DebugSessionSpec{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster: "debug-cluster",
 		},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
-			Participants: []v1alpha1.DebugSessionParticipant{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
 				{User: "user-a@example.com"},
 				{User: "user-b@example.com"},
 			},
@@ -267,7 +267,7 @@ func TestIndexerFunctions_DebugSession(t *testing.T) {
 		result := fn(debugSession)
 		assert.Equal(t, []string{"debug-cluster"}, result)
 
-		empty := &v1alpha1.DebugSession{}
+		empty := &breakglassv1alpha1.DebugSession{}
 		result = fn(empty)
 		assert.Nil(t, result)
 	})
@@ -277,9 +277,9 @@ func TestIndexerFunctions_DebugSession(t *testing.T) {
 		require.NotNil(t, fn)
 
 		result := fn(debugSession)
-		assert.Equal(t, []string{string(v1alpha1.DebugSessionStateActive)}, result)
+		assert.Equal(t, []string{string(breakglassv1alpha1.DebugSessionStateActive)}, result)
 
-		empty := &v1alpha1.DebugSession{}
+		empty := &breakglassv1alpha1.DebugSession{}
 		result = fn(empty)
 		assert.Nil(t, result)
 	})
@@ -291,7 +291,7 @@ func TestIndexerFunctions_DebugSession(t *testing.T) {
 		result := fn(debugSession)
 		assert.ElementsMatch(t, []string{"user-a@example.com", "user-b@example.com"}, result)
 
-		empty := &v1alpha1.DebugSession{}
+		empty := &breakglassv1alpha1.DebugSession{}
 		result = fn(empty)
 		assert.Nil(t, result)
 	})
@@ -305,14 +305,14 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 	err := RegisterCommonFieldIndexes(ctx, indexer, logger)
 	require.NoError(t, err)
 
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-escalation",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassEscalationSpec{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			EscalatedGroup: "elevated-access",
-			Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 				Clusters: []string{"cluster-a", "cluster-b"},
 				Groups:   []string{"developers@example.com", "ops@example.com"},
 			},
@@ -328,7 +328,7 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b", "cluster-c"}, result)
 
 		// Test with nil escalation
-		result = fn(&v1alpha1.BreakglassEscalation{})
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
 		assert.Empty(t, result)
 	})
 
@@ -340,7 +340,7 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.ElementsMatch(t, []string{"developers@example.com", "ops@example.com"}, result)
 
 		// Test with nil escalation
-		result = fn(&v1alpha1.BreakglassEscalation{})
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
 		assert.Nil(t, result)
 	})
 
@@ -352,7 +352,7 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.Equal(t, []string{"elevated-access"}, result)
 
 		// Test with empty escalatedGroup
-		emptyEsc := &v1alpha1.BreakglassEscalation{}
+		emptyEsc := &breakglassv1alpha1.BreakglassEscalation{}
 		result = fn(emptyEsc)
 		assert.Nil(t, result)
 	})
@@ -375,12 +375,12 @@ func TestIndexerFunctions_ClusterConfig(t *testing.T) {
 	err := RegisterCommonFieldIndexes(ctx, indexer, logger)
 	require.NoError(t, err)
 
-	clusterConfig := &v1alpha1.ClusterConfig{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster-config",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.ClusterConfigSpec{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			ClusterID: "cluster-id-123",
 		},
 	}
@@ -393,7 +393,7 @@ func TestIndexerFunctions_ClusterConfig(t *testing.T) {
 		assert.Equal(t, []string{"cluster-id-123"}, result)
 
 		// Test with empty clusterID
-		emptyCC := &v1alpha1.ClusterConfig{}
+		emptyCC := &breakglassv1alpha1.ClusterConfig{}
 		result = fn(emptyCC)
 		assert.Nil(t, result)
 	})
@@ -408,7 +408,7 @@ func TestIndexerFunctions_WrongType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a different object type that won't match type assertions
-	wrongObj := &v1alpha1.DenyPolicy{
+	wrongObj := &breakglassv1alpha1.DenyPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "wrong-type",
 		},
@@ -424,42 +424,42 @@ func TestIndexerFunctions_WrongType(t *testing.T) {
 func TestRegisterCommonFieldIndexes_WithFakeClient(t *testing.T) {
 	// Test with a real fake client to ensure indexes work end-to-end
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
+	err := breakglassv1alpha1.AddToScheme(scheme)
 	require.NoError(t, err)
 
 	// Create test objects
-	session := &v1alpha1.BreakglassSession{
+	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "indexed-session",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:      "indexed-cluster",
 			User:         "indexed-user@example.com",
 			GrantedGroup: "indexed-group",
 		},
 	}
 
-	escalation := &v1alpha1.BreakglassEscalation{
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "indexed-escalation",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.BreakglassEscalationSpec{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			EscalatedGroup: "indexed-escalated-group",
-			Allowed: v1alpha1.BreakglassEscalationAllowed{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 				Clusters: []string{"indexed-cluster"},
 				Groups:   []string{"indexed-allowed-group"},
 			},
 		},
 	}
 
-	clusterConfig := &v1alpha1.ClusterConfig{
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "indexed-cluster-config",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.ClusterConfigSpec{
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
 			ClusterID: "indexed-cluster-id",
 		},
 	}
@@ -467,8 +467,8 @@ func TestRegisterCommonFieldIndexes_WithFakeClient(t *testing.T) {
 	cli := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(session, escalation, clusterConfig).
-		WithIndex(&v1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
-			if s, ok := obj.(*v1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
 				return []string{s.Spec.Cluster}
 			}
 			return nil
@@ -477,7 +477,7 @@ func TestRegisterCommonFieldIndexes_WithFakeClient(t *testing.T) {
 
 	// Verify we can query by indexed field
 	ctx := context.Background()
-	var sessions v1alpha1.BreakglassSessionList
+	var sessions breakglassv1alpha1.BreakglassSessionList
 	err = cli.List(ctx, &sessions, client.MatchingFields{"spec.cluster": "indexed-cluster"})
 	require.NoError(t, err)
 	assert.Len(t, sessions.Items, 1)

--- a/pkg/policy/deny_test.go
+++ b/pkg/policy/deny_test.go
@@ -2175,8 +2175,8 @@ func TestEvaluatorPodSecurityOverrideCombinedOptions(t *testing.T) {
 		Pod:         complexPod,
 		PodSecurityOverrides: &breakglassv1alpha1.PodSecurityOverrides{
 			Enabled:         true,
-			MaxAllowedScore: ptr.To(60),                                                         // allows score 50 (20+30)
-			ExemptFactors:   []string{"hostNetwork"},                                            // bypasses block
+			MaxAllowedScore: ptr.To(60),                                                            // allows score 50 (20+30)
+			ExemptFactors:   []string{"hostNetwork"},                                               // bypasses block
 			NamespaceScope:  &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"monitoring"}}, // only in monitoring
 		},
 	})

--- a/pkg/utils/namespace_matcher.go
+++ b/pkg/utils/namespace_matcher.go
@@ -19,18 +19,18 @@ package utils
 import (
 	"path/filepath"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 // NamespaceMatcher provides namespace matching using patterns and label selectors.
 // It supports both glob-style pattern matching and Kubernetes-native label selection.
 type NamespaceMatcher struct {
-	filter *v1alpha1.NamespaceFilter
+	filter *breakglassv1alpha1.NamespaceFilter
 }
 
 // NewNamespaceMatcher creates a new NamespaceMatcher for the given filter.
 // If filter is nil, the matcher will match no namespaces.
-func NewNamespaceMatcher(filter *v1alpha1.NamespaceFilter) *NamespaceMatcher {
+func NewNamespaceMatcher(filter *breakglassv1alpha1.NamespaceFilter) *NamespaceMatcher {
 	return &NamespaceMatcher{filter: filter}
 }
 
@@ -117,7 +117,7 @@ func (m *NamespaceMatcher) matchesSelectorTerms(labels map[string]string) bool {
 
 // termMatches checks if a single selector term matches the labels.
 // All conditions within the term must match (AND semantics).
-func (m *NamespaceMatcher) termMatches(term v1alpha1.NamespaceSelectorTerm, labels map[string]string) bool {
+func (m *NamespaceMatcher) termMatches(term breakglassv1alpha1.NamespaceSelectorTerm, labels map[string]string) bool {
 	// Check matchLabels (all must match)
 	for key, value := range term.MatchLabels {
 		labelValue, exists := labels[key]
@@ -137,26 +137,26 @@ func (m *NamespaceMatcher) termMatches(term v1alpha1.NamespaceSelectorTerm, labe
 }
 
 // expressionMatches checks if a single expression matches the labels.
-func (m *NamespaceMatcher) expressionMatches(expr v1alpha1.NamespaceSelectorRequirement, labels map[string]string) bool {
+func (m *NamespaceMatcher) expressionMatches(expr breakglassv1alpha1.NamespaceSelectorRequirement, labels map[string]string) bool {
 	value, exists := labels[expr.Key]
 
 	switch expr.Operator {
-	case v1alpha1.NamespaceSelectorOpIn:
+	case breakglassv1alpha1.NamespaceSelectorOpIn:
 		if !exists {
 			return false
 		}
 		return contains(expr.Values, value)
 
-	case v1alpha1.NamespaceSelectorOpNotIn:
+	case breakglassv1alpha1.NamespaceSelectorOpNotIn:
 		if !exists {
 			return true // Key doesn't exist, so value is not in the set
 		}
 		return !contains(expr.Values, value)
 
-	case v1alpha1.NamespaceSelectorOpExists:
+	case breakglassv1alpha1.NamespaceSelectorOpExists:
 		return exists
 
-	case v1alpha1.NamespaceSelectorOpDoesNotExist:
+	case breakglassv1alpha1.NamespaceSelectorOpDoesNotExist:
 		return !exists
 
 	default:
@@ -184,7 +184,7 @@ type NamespaceAllowDenyMatcher struct {
 }
 
 // NewNamespaceAllowDenyMatcher creates a matcher with allow and deny filters.
-func NewNamespaceAllowDenyMatcher(allow, deny *v1alpha1.NamespaceFilter) *NamespaceAllowDenyMatcher {
+func NewNamespaceAllowDenyMatcher(allow, deny *breakglassv1alpha1.NamespaceFilter) *NamespaceAllowDenyMatcher {
 	return &NamespaceAllowDenyMatcher{
 		allow: NewNamespaceMatcher(allow),
 		deny:  NewNamespaceMatcher(deny),

--- a/pkg/utils/namespace_matcher_test.go
+++ b/pkg/utils/namespace_matcher_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func TestNamespaceMatcher_Matches(t *testing.T) {
 	tests := []struct {
 		name      string
-		filter    *v1alpha1.NamespaceFilter
+		filter    *breakglassv1alpha1.NamespaceFilter
 		namespace string
 		want      bool
 	}{
@@ -38,13 +38,13 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name:      "empty filter matches nothing",
-			filter:    &v1alpha1.NamespaceFilter{},
+			filter:    &breakglassv1alpha1.NamespaceFilter{},
 			namespace: "default",
 			want:      false,
 		},
 		{
 			name: "exact pattern match",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-system"},
 			},
 			namespace: "kube-system",
@@ -52,7 +52,7 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name: "glob pattern match",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			namespace: "app-frontend",
@@ -60,7 +60,7 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name: "glob pattern no match",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			namespace: "service-backend",
@@ -68,7 +68,7 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name: "multiple patterns - first matches",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*", "app-*"},
 			},
 			namespace: "kube-system",
@@ -76,7 +76,7 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name: "multiple patterns - second matches",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*", "app-*"},
 			},
 			namespace: "app-backend",
@@ -84,8 +84,8 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 		},
 		{
 			name: "selector terms ignored without labels",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -106,7 +106,7 @@ func TestNamespaceMatcher_Matches(t *testing.T) {
 func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 	tests := []struct {
 		name      string
-		filter    *v1alpha1.NamespaceFilter
+		filter    *breakglassv1alpha1.NamespaceFilter
 		namespace string
 		labels    map[string]string
 		want      bool
@@ -120,7 +120,7 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "pattern match takes precedence over labels",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "kube-system",
@@ -129,8 +129,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchLabels - exact match",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -140,8 +140,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchLabels - missing label",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -151,8 +151,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchLabels - wrong value",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -162,8 +162,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchLabels - multiple labels all match",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod", "team": "sre"}},
 				},
 			},
@@ -173,8 +173,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchLabels - multiple labels partial match fails",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod", "team": "sre"}},
 				},
 			},
@@ -184,11 +184,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - In operator",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "env", Operator: v1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
 						},
 					},
 				},
@@ -199,11 +199,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - In operator no match",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "env", Operator: v1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
 						},
 					},
 				},
@@ -214,11 +214,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - NotIn operator",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "env", Operator: v1alpha1.NamespaceSelectorOpNotIn, Values: []string{"prod", "staging"}},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOpNotIn, Values: []string{"prod", "staging"}},
 						},
 					},
 				},
@@ -229,11 +229,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - NotIn with missing key",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "env", Operator: v1alpha1.NamespaceSelectorOpNotIn, Values: []string{"prod"}},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOpNotIn, Values: []string{"prod"}},
 						},
 					},
 				},
@@ -244,11 +244,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - Exists operator",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "team", Operator: v1alpha1.NamespaceSelectorOpExists},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "team", Operator: breakglassv1alpha1.NamespaceSelectorOpExists},
 						},
 					},
 				},
@@ -259,11 +259,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - Exists operator no match",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "team", Operator: v1alpha1.NamespaceSelectorOpExists},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "team", Operator: breakglassv1alpha1.NamespaceSelectorOpExists},
 						},
 					},
 				},
@@ -274,11 +274,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - DoesNotExist operator",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "deprecated", Operator: v1alpha1.NamespaceSelectorOpDoesNotExist},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "deprecated", Operator: breakglassv1alpha1.NamespaceSelectorOpDoesNotExist},
 						},
 					},
 				},
@@ -289,11 +289,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "matchExpressions - DoesNotExist operator fails when key exists",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "deprecated", Operator: v1alpha1.NamespaceSelectorOpDoesNotExist},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "deprecated", Operator: breakglassv1alpha1.NamespaceSelectorOpDoesNotExist},
 						},
 					},
 				},
@@ -304,8 +304,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "multiple selector terms - OR semantics",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"team": "sre"}},
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
@@ -316,12 +316,12 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "combined matchLabels and matchExpressions - AND semantics within term",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
 						MatchLabels: map[string]string{"env": "prod"},
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "team", Operator: v1alpha1.NamespaceSelectorOpExists},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "team", Operator: breakglassv1alpha1.NamespaceSelectorOpExists},
 						},
 					},
 				},
@@ -332,12 +332,12 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "combined matchLabels and matchExpressions - partial match fails",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
 						MatchLabels: map[string]string{"env": "prod"},
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "team", Operator: v1alpha1.NamespaceSelectorOpExists},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "team", Operator: breakglassv1alpha1.NamespaceSelectorOpExists},
 						},
 					},
 				},
@@ -348,9 +348,9 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "pattern OR selector match",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -360,11 +360,11 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 		},
 		{
 			name: "nil labels treated as empty map",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{
-						MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-							{Key: "team", Operator: v1alpha1.NamespaceSelectorOpDoesNotExist},
+						MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+							{Key: "team", Operator: breakglassv1alpha1.NamespaceSelectorOpDoesNotExist},
 						},
 					},
 				},
@@ -387,8 +387,8 @@ func TestNamespaceMatcher_MatchesWithLabels(t *testing.T) {
 func TestNamespaceAllowDenyMatcher(t *testing.T) {
 	tests := []struct {
 		name      string
-		allow     *v1alpha1.NamespaceFilter
-		deny      *v1alpha1.NamespaceFilter
+		allow     *breakglassv1alpha1.NamespaceFilter
+		deny      *breakglassv1alpha1.NamespaceFilter
 		namespace string
 		labels    map[string]string
 		want      bool
@@ -403,7 +403,7 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		},
 		{
 			name: "allow pattern matches",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			deny:      nil,
@@ -413,7 +413,7 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		},
 		{
 			name: "allow pattern not matched",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			deny:      nil,
@@ -424,7 +424,7 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		{
 			name:  "deny overrides allow",
 			allow: nil,
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "kube-system",
@@ -433,10 +433,10 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		},
 		{
 			name: "allowed but also denied - deny wins",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"*"},
 			},
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "kube-system",
@@ -445,12 +445,12 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		},
 		{
 			name: "label-based allow with pattern deny",
-			allow: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			allow: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "production",
@@ -460,8 +460,8 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 		{
 			name:  "label-based deny blocks access",
 			allow: nil,
-			deny: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			deny: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"security": "restricted"}},
 				},
 			},
@@ -483,7 +483,7 @@ func TestNamespaceAllowDenyMatcher(t *testing.T) {
 func TestNamespaceFilter_IsEmpty(t *testing.T) {
 	tests := []struct {
 		name   string
-		filter *v1alpha1.NamespaceFilter
+		filter *breakglassv1alpha1.NamespaceFilter
 		want   bool
 	}{
 		{
@@ -493,20 +493,20 @@ func TestNamespaceFilter_IsEmpty(t *testing.T) {
 		},
 		{
 			name:   "empty filter",
-			filter: &v1alpha1.NamespaceFilter{},
+			filter: &breakglassv1alpha1.NamespaceFilter{},
 			want:   true,
 		},
 		{
 			name: "filter with patterns",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			want: false,
 		},
 		{
 			name: "filter with selector terms",
-			filter: &v1alpha1.NamespaceFilter{
-				SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+			filter: &breakglassv1alpha1.NamespaceFilter{
+				SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 					{MatchLabels: map[string]string{"env": "prod"}},
 				},
 			},
@@ -525,11 +525,11 @@ func TestNamespaceFilter_IsEmpty(t *testing.T) {
 // TestMatchesWithLabels_UnknownOperator tests that unknown operators return false
 func TestMatchesWithLabels_UnknownOperator(t *testing.T) {
 	// Create a filter with an unknown operator (bypassing enum validation for test)
-	filter := &v1alpha1.NamespaceFilter{
-		SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+	filter := &breakglassv1alpha1.NamespaceFilter{
+		SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 			{
-				MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-					{Key: "env", Operator: v1alpha1.NamespaceSelectorOperator("Unknown"), Values: []string{"prod"}},
+				MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+					{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOperator("Unknown"), Values: []string{"prod"}},
 				},
 			},
 		},
@@ -543,11 +543,11 @@ func TestMatchesWithLabels_UnknownOperator(t *testing.T) {
 
 // TestMatchesWithLabels_InOperatorMissingKey tests In operator with missing key
 func TestMatchesWithLabels_InOperatorMissingKey(t *testing.T) {
-	filter := &v1alpha1.NamespaceFilter{
-		SelectorTerms: []v1alpha1.NamespaceSelectorTerm{
+	filter := &breakglassv1alpha1.NamespaceFilter{
+		SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
 			{
-				MatchExpressions: []v1alpha1.NamespaceSelectorRequirement{
-					{Key: "env", Operator: v1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
+				MatchExpressions: []breakglassv1alpha1.NamespaceSelectorRequirement{
+					{Key: "env", Operator: breakglassv1alpha1.NamespaceSelectorOpIn, Values: []string{"prod", "staging"}},
 				},
 			},
 		},
@@ -619,7 +619,7 @@ func TestNewNamespaceAllowDenyMatcher_NilFilters(t *testing.T) {
 func TestNamespaceMatcher_MatchesAny(t *testing.T) {
 	tests := []struct {
 		name   string
-		filter *v1alpha1.NamespaceFilter
+		filter *breakglassv1alpha1.NamespaceFilter
 		want   bool
 	}{
 		{
@@ -629,12 +629,12 @@ func TestNamespaceMatcher_MatchesAny(t *testing.T) {
 		},
 		{
 			name:   "empty filter matches any",
-			filter: &v1alpha1.NamespaceFilter{},
+			filter: &breakglassv1alpha1.NamespaceFilter{},
 			want:   true,
 		},
 		{
 			name: "filter with patterns does not match any",
-			filter: &v1alpha1.NamespaceFilter{
+			filter: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			want: false,
@@ -662,8 +662,8 @@ func TestNamespaceMatcher_NilFilter(t *testing.T) {
 func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 	tests := []struct {
 		name      string
-		allow     *v1alpha1.NamespaceFilter
-		deny      *v1alpha1.NamespaceFilter
+		allow     *breakglassv1alpha1.NamespaceFilter
+		deny      *breakglassv1alpha1.NamespaceFilter
 		namespace string
 		want      bool
 	}{
@@ -676,7 +676,7 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		},
 		{
 			name: "allow pattern matches",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			deny:      nil,
@@ -685,7 +685,7 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		},
 		{
 			name: "allow pattern not matched",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
 			deny:      nil,
@@ -695,7 +695,7 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		{
 			name:  "deny overrides allow",
 			allow: nil,
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "kube-system",
@@ -703,10 +703,10 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		},
 		{
 			name: "allowed but also denied - deny wins",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"*"},
 			},
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "kube-system",
@@ -714,10 +714,10 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		},
 		{
 			name: "allowed namespace not denied",
-			allow: &v1alpha1.NamespaceFilter{
+			allow: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"app-*"},
 			},
-			deny: &v1alpha1.NamespaceFilter{
+			deny: &breakglassv1alpha1.NamespaceFilter{
 				Patterns: []string{"kube-*"},
 			},
 			namespace: "app-production",
@@ -725,8 +725,8 @@ func TestNamespaceAllowDenyMatcher_IsAllowed(t *testing.T) {
 		},
 		{
 			name:      "empty filters allow all",
-			allow:     &v1alpha1.NamespaceFilter{},
-			deny:      &v1alpha1.NamespaceFilter{},
+			allow:     &breakglassv1alpha1.NamespaceFilter{},
+			deny:      &breakglassv1alpha1.NamespaceFilter{},
 			namespace: "random-namespace",
 			want:      true,
 		},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
@@ -27,7 +27,7 @@ func CreateScheme() (*runtime.Scheme, error) {
 	}
 
 	// Add custom breakglass CRD types (v1alpha1)
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
+	if err := breakglassv1alpha1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("failed to add v1alpha1 CRDs to scheme: %w", err)
 	}
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -47,42 +47,42 @@ func TestCreateScheme(t *testing.T) {
 
 	t.Run("scheme contains v1alpha1 types", func(t *testing.T) {
 		// Check that BreakglassSession is known to the scheme
-		gvk := v1alpha1.GroupVersion.WithKind("BreakglassSession")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("BreakglassSession")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize BreakglassSession")
 		}
 	})
 
 	t.Run("scheme contains IdentityProvider type", func(t *testing.T) {
-		gvk := v1alpha1.GroupVersion.WithKind("IdentityProvider")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("IdentityProvider")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize IdentityProvider")
 		}
 	})
 
 	t.Run("scheme contains ClusterConfig type", func(t *testing.T) {
-		gvk := v1alpha1.GroupVersion.WithKind("ClusterConfig")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("ClusterConfig")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize ClusterConfig")
 		}
 	})
 
 	t.Run("scheme contains BreakglassEscalation type", func(t *testing.T) {
-		gvk := v1alpha1.GroupVersion.WithKind("BreakglassEscalation")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("BreakglassEscalation")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize BreakglassEscalation")
 		}
 	})
 
 	t.Run("scheme contains DenyPolicy type", func(t *testing.T) {
-		gvk := v1alpha1.GroupVersion.WithKind("DenyPolicy")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("DenyPolicy")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize DenyPolicy")
 		}
 	})
 
 	t.Run("scheme contains MailProvider type", func(t *testing.T) {
-		gvk := v1alpha1.GroupVersion.WithKind("MailProvider")
+		gvk := breakglassv1alpha1.GroupVersion.WithKind("MailProvider")
 		if !scheme.Recognizes(gvk) {
 			t.Errorf("scheme does not recognize MailProvider")
 		}
@@ -124,7 +124,7 @@ func TestParseDuration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test the canonical ParseDuration in api/v1alpha1 package
-			got, err := v1alpha1.ParseDuration(tt.input)
+			got, err := breakglassv1alpha1.ParseDuration(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseDuration(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 				return

--- a/pkg/webhook/ephemeral.go
+++ b/pkg/webhook/ephemeral.go
@@ -10,16 +10,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 )
 
 // DebugSessionHandler defines the interface for debug session operations
 type DebugSessionHandler interface {
-	FindActiveSession(ctx context.Context, user, cluster string) (*v1alpha1.DebugSession, error)
+	FindActiveSession(ctx context.Context, user, cluster string) (*breakglassv1alpha1.DebugSession, error)
 	ValidateEphemeralContainerRequest(
 		ctx context.Context,
-		ds *v1alpha1.DebugSession,
+		ds *breakglassv1alpha1.DebugSession,
 		namespace, podName, image string,
 		capabilities []string,
 		runAsNonRoot bool,

--- a/pkg/webhook/ephemeral_test.go
+++ b/pkg/webhook/ephemeral_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
 func TestFindNewEphemeralContainers(t *testing.T) {
@@ -194,18 +194,18 @@ func TestIsRunAsNonRoot(t *testing.T) {
 
 // mockDebugHandler implements DebugSessionHandler for testing
 type mockDebugHandler struct {
-	session     *v1alpha1.DebugSession
+	session     *breakglassv1alpha1.DebugSession
 	findErr     error
 	validateErr error
 }
 
-func (m *mockDebugHandler) FindActiveSession(ctx context.Context, user, cluster string) (*v1alpha1.DebugSession, error) {
+func (m *mockDebugHandler) FindActiveSession(ctx context.Context, user, cluster string) (*breakglassv1alpha1.DebugSession, error) {
 	return m.session, m.findErr
 }
 
 func (m *mockDebugHandler) ValidateEphemeralContainerRequest(
 	ctx context.Context,
-	ds *v1alpha1.DebugSession,
+	ds *breakglassv1alpha1.DebugSession,
 	namespace, podName, image string,
 	capabilities []string,
 	runAsNonRoot bool,
@@ -244,10 +244,10 @@ func (m *mockDecoder) DecodeRaw(rawObj runtime.RawExtension, into runtime.Object
 func TestEphemeralContainerWebhook_Handle(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
-	validSession := &v1alpha1.DebugSession{
+	validSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-session"},
-		Status: v1alpha1.DebugSessionStatus{
-			State: v1alpha1.DebugSessionStateActive,
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
 		},
 	}
 
@@ -259,7 +259,7 @@ func TestEphemeralContainerWebhook_Handle(t *testing.T) {
 		oldPod         *corev1.Pod
 		decodeErr      error
 		oldDecodeErr   error
-		session        *v1alpha1.DebugSession
+		session        *breakglassv1alpha1.DebugSession
 		findErr        error
 		validateErr    error
 		expectAllowed  bool

--- a/pkg/webhook/error_scenarios_test.go
+++ b/pkg/webhook/error_scenarios_test.go
@@ -15,7 +15,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/policy"
@@ -25,13 +25,13 @@ import (
 
 var errorScenarioIndexFns = map[string]client.IndexerFunc{
 	"spec.user": func(o client.Object) []string {
-		return []string{o.(*v1alpha1.BreakglassSession).Spec.User}
+		return []string{o.(*breakglassv1alpha1.BreakglassSession).Spec.User}
 	},
 	"spec.cluster": func(o client.Object) []string {
-		return []string{o.(*v1alpha1.BreakglassSession).Spec.Cluster}
+		return []string{o.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
 	},
 	"spec.grantedGroup": func(o client.Object) []string {
-		return []string{o.(*v1alpha1.BreakglassSession).Spec.GrantedGroup}
+		return []string{o.(*breakglassv1alpha1.BreakglassSession).Spec.GrantedGroup}
 	},
 }
 
@@ -39,7 +39,7 @@ var errorScenarioIndexFns = map[string]client.IndexerFunc{
 func TestHandleAuthorize_MalformedJSON(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -72,7 +72,7 @@ func TestHandleAuthorize_MalformedJSON(t *testing.T) {
 func TestHandleAuthorize_NilResourceAttributes(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -112,7 +112,7 @@ func TestHandleAuthorize_NilResourceAttributes(t *testing.T) {
 func TestHandleAuthorize_SpecialCharactersInReason(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -156,7 +156,7 @@ func TestHandleAuthorize_SpecialCharactersInReason(t *testing.T) {
 func TestHandleAuthorize_EmptyUserField(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -200,7 +200,7 @@ func TestHandleAuthorize_EmptyUserField(t *testing.T) {
 func TestHandleAuthorize_ConcurrentRequests(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -253,7 +253,7 @@ func TestHandleAuthorize_ConcurrentRequests(t *testing.T) {
 func TestHandleAuthorize_InvalidResourceName(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -298,7 +298,7 @@ func TestHandleAuthorize_InvalidResourceName(t *testing.T) {
 func TestHandleAuthorize_InvalidGroupFormat(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -338,7 +338,7 @@ func TestHandleAuthorize_InvalidGroupFormat(t *testing.T) {
 func TestHandleAuthorize_BothAttributeTypesPresent(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -386,7 +386,7 @@ func TestHandleAuthorize_BothAttributeTypesPresent(t *testing.T) {
 func TestHandleAuthorize_UnicodeCharactersInUser(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -430,7 +430,7 @@ func TestHandleAuthorize_UnicodeCharactersInUser(t *testing.T) {
 func TestHandleAuthorize_MissingContentType(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range errorScenarioIndexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 

--- a/pkg/webhook/manager.go
+++ b/pkg/webhook/manager.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"github.com/telekom/k8s-breakglass/pkg/cert"
 	"github.com/telekom/k8s-breakglass/pkg/cli"
@@ -112,37 +112,37 @@ func Setup(
 
 	// Register validating webhooks (conditionally based on enableValidatingWebhooks)
 	if enableValidatingWebhooks {
-		if err := registerWebhook(&v1alpha1.BreakglassSession{}, "BreakglassSession", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.BreakglassSession{}, "BreakglassSession", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.BreakglassEscalation{}, "BreakglassEscalation", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.BreakglassEscalation{}, "BreakglassEscalation", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.ClusterConfig{}, "ClusterConfig", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.ClusterConfig{}, "ClusterConfig", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.IdentityProvider{}, "IdentityProvider", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.IdentityProvider{}, "IdentityProvider", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.MailProvider{}, "MailProvider", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.MailProvider{}, "MailProvider", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.DenyPolicy{}, "DenyPolicy", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.DenyPolicy{}, "DenyPolicy", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.DebugSession{}, "DebugSession", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.DebugSession{}, "DebugSession", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.DebugSessionTemplate{}, "DebugSessionTemplate", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.DebugSessionTemplate{}, "DebugSessionTemplate", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.DebugPodTemplate{}, "DebugPodTemplate", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.DebugPodTemplate{}, "DebugPodTemplate", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.AuditConfig{}, "AuditConfig", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.AuditConfig{}, "AuditConfig", mgr, log); err != nil {
 			return err
 		}
-		if err := registerWebhook(&v1alpha1.DebugSessionClusterBinding{}, "DebugSessionClusterBinding", mgr, log); err != nil {
+		if err := registerWebhook(&breakglassv1alpha1.DebugSessionClusterBinding{}, "DebugSessionClusterBinding", mgr, log); err != nil {
 			return err
 		}
 

--- a/pkg/webhook/multi_idp_integration_test.go
+++ b/pkg/webhook/multi_idp_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,41 +13,41 @@ import (
 // TestMultiIDP_HappyPath_ValidIssuerMatch tests complete flow with valid IDP issuer matching
 func TestMultiIDP_HappyPath_ValidIssuerMatch(t *testing.T) {
 	// Setup: Create sessions for different IDPs
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
-	ldapSession := v1alpha1.BreakglassSession{
+	ldapSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-ldap"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://ldap.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test: User authenticates via Keycloak, should match Keycloak session only
-	sessions := []v1alpha1.BreakglassSession{keycloakSession, ldapSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{keycloakSession, ldapSession}
 	issuer := "https://keycloak.corp.com"
 
 	// Simulate getSessionsWithIDPMismatchInfo logic
-	var matchedSessions []v1alpha1.BreakglassSession
-	var mismatchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
+	var mismatchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
@@ -68,40 +68,40 @@ func TestMultiIDP_HappyPath_ValidIssuerMatch(t *testing.T) {
 // accept any IDP (backward compatibility for single-IDP deployments)
 func TestMultiIDP_HappyPath_BackwardCompatibility(t *testing.T) {
 	// Setup: Create session with AllowIDPMismatch=true (legacy single-IDP deployment)
-	legacySession := v1alpha1.BreakglassSession{
+	legacySession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-legacy"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:          "prod-cluster",
 			User:             "user@example.com",
 			GrantedGroup:     "admin",
 			AllowIDPMismatch: true, // Backward compatibility flag
 			// No IDP issuer set
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test: User authenticates via Keycloak, both sessions should match
-	sessions := []v1alpha1.BreakglassSession{legacySession, keycloakSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{legacySession, keycloakSession}
 	issuer := "https://keycloak.corp.com"
 
 	// Simulate getSessionsWithIDPMismatchInfo logic
-	var matchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
@@ -118,27 +118,27 @@ func TestMultiIDP_HappyPath_BackwardCompatibility(t *testing.T) {
 // TestMultiIDP_BadPath_NoMatchingIssuer tests authorization failure when no IDP issuer matches
 func TestMultiIDP_BadPath_NoMatchingIssuer(t *testing.T) {
 	// Setup: Create sessions for specific IDPs
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test: User authenticates via unknown IDP (not in any session)
-	sessions := []v1alpha1.BreakglassSession{keycloakSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{keycloakSession}
 	issuer := "https://unknown-idp.corp.com"
 
 	// Simulate getSessionsWithIDPMismatchInfo logic
-	var matchedSessions []v1alpha1.BreakglassSession
-	var mismatchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
+	var mismatchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
@@ -156,9 +156,9 @@ func TestMultiIDP_BadPath_NoMatchingIssuer(t *testing.T) {
 // TestMultiIDP_BadPath_IssuerMismatchErrorInfo tests that mismatch error provides useful information
 func TestMultiIDP_BadPath_IssuerMismatchErrorInfo(t *testing.T) {
 	// Setup: Create multiple sessions with different IDPs
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
@@ -166,14 +166,14 @@ func TestMultiIDP_BadPath_IssuerMismatchErrorInfo(t *testing.T) {
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
-	ldapSession := v1alpha1.BreakglassSession{
+	ldapSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-ldap"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
@@ -181,18 +181,18 @@ func TestMultiIDP_BadPath_IssuerMismatchErrorInfo(t *testing.T) {
 			IdentityProviderIssuer: "https://ldap.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test: User authenticates via unknown IDP, should get error with available options
-	sessions := []v1alpha1.BreakglassSession{keycloakSession, ldapSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{keycloakSession, ldapSession}
 	userIssuer := "https://unknown-idp.corp.com"
 
 	// Simulate getSessionsWithIDPMismatchInfo logic to build error message
 	var mismatchedIDPs []string
-	var matchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if userIssuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != userIssuer {
@@ -212,11 +212,11 @@ func TestMultiIDP_BadPath_IssuerMismatchErrorInfo(t *testing.T) {
 // TestMultiIDP_BadPath_EmptySessionList tests handling when no sessions exist
 func TestMultiIDP_BadPath_EmptySessionList(t *testing.T) {
 	// Setup: No sessions
-	sessions := []v1alpha1.BreakglassSession{}
+	sessions := []breakglassv1alpha1.BreakglassSession{}
 	issuer := "https://keycloak.corp.com"
 
 	// Simulate getSessionsWithIDPMismatchInfo logic
-	var matchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
@@ -233,27 +233,27 @@ func TestMultiIDP_BadPath_EmptySessionList(t *testing.T) {
 // TestMultiIDP_BadPath_NoIssuerInSAR tests handling when SAR has no issuer (no JWT)
 func TestMultiIDP_BadPath_NoIssuerInSAR(t *testing.T) {
 	// Setup: Create session requiring specific IDP
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test: SAR has NO issuer (no JWT or auth middleware failure)
-	sessions := []v1alpha1.BreakglassSession{keycloakSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{keycloakSession}
 	issuer := "" // Empty issuer from SAR
 
 	// Simulate getSessionsWithIDPMismatchInfo logic
-	var matchedSessions []v1alpha1.BreakglassSession
-	var mismatchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
+	var mismatchedSessions []breakglassv1alpha1.BreakglassSession
 
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
@@ -272,52 +272,52 @@ func TestMultiIDP_BadPath_NoIssuerInSAR(t *testing.T) {
 func TestMultiIDP_HappyPath_MultipleValidIssuers(t *testing.T) {
 	// Setup: Create a flexible session (AllowIDPMismatch=true) for backward compat
 	// and new multi-IDP sessions
-	flexibleSession := v1alpha1.BreakglassSession{
+	flexibleSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-flexible"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:          "prod-cluster",
 			User:             "user@example.com",
 			GrantedGroup:     "admin",
 			AllowIDPMismatch: true, // Accepts any IDP
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
-	keycloakSession := v1alpha1.BreakglassSession{
+	keycloakSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-kc"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://keycloak.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
-	ldapSession := v1alpha1.BreakglassSession{
+	ldapSession := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-ldap"},
-		Spec: v1alpha1.BreakglassSessionSpec{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
 			Cluster:                "prod-cluster",
 			User:                   "user@example.com",
 			GrantedGroup:           "admin",
 			IdentityProviderIssuer: "https://ldap.corp.com",
 			AllowIDPMismatch:       false,
 		},
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
 	// Test Case 1: User with Keycloak should match both flexible and keycloak sessions
-	sessions := []v1alpha1.BreakglassSession{flexibleSession, keycloakSession, ldapSession}
+	sessions := []breakglassv1alpha1.BreakglassSession{flexibleSession, keycloakSession, ldapSession}
 	issuer := "https://keycloak.corp.com"
 
-	var matchedSessions []v1alpha1.BreakglassSession
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
 	for _, s := range sessions {
 		if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
 			// Skip mismatched
@@ -359,7 +359,7 @@ func TestMultiIDP_IntegrationFlow_SessionCreationToAuthorization(t *testing.T) {
 	// 6. SAR is authorized or denied
 
 	// Step 1-2: Session creation sets AllowIDPMismatch
-	sessionSpec := v1alpha1.BreakglassSessionSpec{
+	sessionSpec := breakglassv1alpha1.BreakglassSessionSpec{
 		Cluster:      "prod-cluster",
 		User:         "user@example.com",
 		GrantedGroup: "admin",
@@ -373,11 +373,11 @@ func TestMultiIDP_IntegrationFlow_SessionCreationToAuthorization(t *testing.T) {
 	sessionSpec.IdentityProviderName = "keycloak"
 	sessionSpec.IdentityProviderIssuer = "https://keycloak.corp.com"
 
-	session := v1alpha1.BreakglassSession{
+	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session-test"},
 		Spec:       sessionSpec,
-		Status: v1alpha1.BreakglassSessionStatus{
-			State: v1alpha1.SessionStateApproved,
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
 
@@ -386,7 +386,7 @@ func TestMultiIDP_IntegrationFlow_SessionCreationToAuthorization(t *testing.T) {
 		"Session should have AllowIDPMismatch=true when no IDP restrictions")
 
 	// Step 3: Approver already approved (simulated)
-	assert.Equal(t, v1alpha1.SessionStateApproved, session.Status.State)
+	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, session.Status.State)
 
 	// Step 4-5: User SAR comes with issuer, webhook filters
 	sar := &authorizationv1.SubjectAccessReview{
@@ -405,8 +405,8 @@ func TestMultiIDP_IntegrationFlow_SessionCreationToAuthorization(t *testing.T) {
 	}
 
 	// Filter sessions
-	var matchedSessions []v1alpha1.BreakglassSession
-	sessions := []v1alpha1.BreakglassSession{session}
+	var matchedSessions []breakglassv1alpha1.BreakglassSession
+	sessions := []breakglassv1alpha1.BreakglassSession{session}
 
 	for _, s := range sessions {
 		if userIssuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != userIssuer {

--- a/pkg/webhook/ratelimit_test.go
+++ b/pkg/webhook/ratelimit_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
-	"github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/policy"
@@ -32,7 +32,7 @@ func TestWebhookRateLimiting(t *testing.T) {
 	setupWebhookController := func(t *testing.T) *WebhookController {
 		builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 		for k, fn := range sessionIndexFnsWebhook {
-			builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+			builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 		}
 		cli := builder.Build()
 
@@ -136,7 +136,7 @@ func TestWebhookRateLimiting(t *testing.T) {
 		// Using default SAR config (1000 req/s, burst 5000) is too high and timing-dependent
 		builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 		for k, fn := range sessionIndexFnsWebhook {
-			builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+			builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 		}
 		cli := builder.Build()
 
@@ -213,7 +213,7 @@ func TestWebhookControllerWithNilRateLimiter(t *testing.T) {
 	// Create controller manually without rate limiter to test nil handling
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	for k, fn := range sessionIndexFnsWebhook {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 
@@ -243,14 +243,14 @@ func BenchmarkWebhookWithRateLimiter(b *testing.B) {
 	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
 	indexFns := map[string]client.IndexerFunc{
 		"spec.user": func(o client.Object) []string {
-			return []string{o.(*v1alpha1.BreakglassSession).Spec.User}
+			return []string{o.(*breakglassv1alpha1.BreakglassSession).Spec.User}
 		},
 		"spec.cluster": func(o client.Object) []string {
-			return []string{o.(*v1alpha1.BreakglassSession).Spec.Cluster}
+			return []string{o.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
 		},
 	}
 	for k, fn := range indexFns {
-		builder = builder.WithIndex(&v1alpha1.BreakglassSession{}, k, fn)
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, k, fn)
 	}
 	cli := builder.Build()
 


### PR DESCRIPTION
## Description

PR #429 (`chore: consolidate scheme, standardize import alias, add godoc`) missed renaming import aliases in 77 files and introduced struct tag alignment inconsistencies in 3 files. This breaks CI on main and all open PRs.

## Root Cause

1. 77 Go files still use bare `v1alpha1`, explicit `v1alpha1`, `apiv1alpha1`, or `v1` aliases for the breakglass API import, but the `importas` linter now requires `breakglassv1alpha1`
2. 3 test files have `go fmt` struct tag alignment issues from the mass rename
3. 1 test file (`debug_session_api_test.go`) still referenced the old `telekomv1alpha1` alias (compilation error)

## Changes

- Renames all 77 remaining import aliases to `breakglassv1alpha1` (matching `.golangci.yml` importas config)
- Fixes `go fmt` struct tag alignment in 3 test files
- Fixes stale `telekomv1alpha1` references in `debug_session_api_test.go`
- Preserves reflect-based type name strings (`*v1alpha1.Type:field` keys in indexer tests)

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- `go fmt ./...` reports 0 files needing formatting
- All 27 test packages pass
- 81 files changed, 4198 insertions = 4198 deletions (pure rename, zero functional changes)
