### PR TITLE
docs(prompts): sharpen reviewer personas to catch all Copilot review …

### DIFF
--- a/.github/prompts/review-ci-testing.md
+++ b/.github/prompts/review-ci-testing.md
@@ -42,6 +42,11 @@ and that CI configuration is correct.
 - Verify that negative tests (expected failures) assert the specific error
   type or message, not just `err != nil`.
 - Check for assertions on mock call counts when order/frequency matters.
+- **Count-only assertions**: Flag tests that assert only `.length`,
+  `.toHaveLength()`, or element count without verifying the *content* of
+  the results. Asserting "4 items rendered" passes even when the wrong 4
+  items are shown. Tests for filtering, searching, or sorting must verify
+  the actual values (names, IDs, text content) of retained items.
 - **Blank-identifier suppression**: Flag Go tests that assign function
   return values to `_` (blank identifier) instead of asserting them.
   `_ = someFunction()` always passes regardless of the result — use

--- a/.github/prompts/review-docs-consistency.md
+++ b/.github/prompts/review-docs-consistency.md
@@ -43,6 +43,11 @@ consistent, and synchronized with the actual code.
 - Check that godoc comments on exported types and functions describe the
   current behavior, not a previous iteration.
 - Flag TODO / FIXME comments that reference completed work.
+- **Generated artifact freshness**: When a Go doc comment on a CRD type
+  or field is modified, verify that `make manifests` has been re-run so
+  the generated CRD YAML (`config/crd/bases/`) reflects the updated
+  description. A Go comment saying "must not be set" while the CRD YAML
+  still says "are ignored" is a consistency violation.
 - **Enforcement-mechanism attribution**: Comments describing validation or
   rejection must name the specific mechanism — "rejected by CEL rule at
   admission time", "rejected by Go webhook validation", or "enforced by

--- a/.github/prompts/review-edge-cases.md
+++ b/.github/prompts/review-edge-cases.md
@@ -32,6 +32,14 @@ that would slip past routine test coverage.
     comparison logic?
   - Session expiry in the far future (year 9999) or far past.
   - Clock skew between replicas > idle timeout duration.
+- **State × time interactions**: For functions that branch on both session
+  state and timestamp (e.g., `isSessionExpired`), test the cross-product:
+  - Zero `ExpiresAt` on an Approved session — should it expire or not?
+  - Nil/zero `StartedAt` with a valid `ExpiresAt` — does expiry still work?
+  - Non-Approved states (Pending, Rejected, Withdrawn, Timeout) with a
+    past `ExpiresAt` — the function must return false for these states.
+  - Near-future boundary (a few seconds out) — verify no time-of-check /
+    time-of-use race in the test itself (use a small offset, not exact now).
 - Counter boundaries:
   - `activityCount` at `math.MaxInt64` — does incrementing overflow?
   - Counter reset to 0 on status patch failure — is this handled?

--- a/.github/prompts/review-frontend-ui.md
+++ b/.github/prompts/review-frontend-ui.md
@@ -12,6 +12,12 @@ incidents — clarity and accessibility are critical.
 - **Keyboard navigation**: Every interactive element (buttons, links, form
   controls, filters) must be reachable and operable via keyboard alone.
   Check for proper `tabindex`, `:focus-visible` styles, and no focus traps.
+- **Roving tabindex after filtering**: When a list or grid uses roving
+  `tabindex` (one item has `tabindex="0"`, rest have `tabindex="-1"`),
+  verify the focused-item logic handles filtering. If the currently
+  selected item is filtered out of the visible list, `tabindex="0"` must
+  fall back to the first visible item — otherwise NO item is tabbable
+  and keyboard users are trapped.
 - **Screen reader support**: Verify `aria-label`, `aria-describedby`,
   `aria-live` regions for dynamic content (session status changes,
   notifications, filter results).
@@ -30,6 +36,14 @@ incidents — clarity and accessibility are critical.
 - Check that component props have explicit TypeScript interfaces defined.
 - Verify emits are typed using the `defineEmits<>()` syntax.
 - Flag unused imports and variables.
+- **Identifier spelling**: Check component names, route constants, and
+  variable names for typos — especially names derived from domain terms
+  (e.g., `Breakglass` not `Breaglass`). Lazy-loaded route constants must
+  match the actual component name exactly.
+- **DRY type definitions**: Flag interfaces or types defined locally in a
+  component that duplicate or closely mirror types already exported from
+  shared model files (`@/model/`, `@/api/`). Use imports with type
+  aliases when the local name differs from the canonical one.
 
 ### 3. Vue 3 Composition API Patterns
 

--- a/.github/prompts/review-integration-wiring.md
+++ b/.github/prompts/review-integration-wiring.md
@@ -73,6 +73,11 @@ is defined but never used, or used but never initialized.
   6. Frontend (if displayed in `frontend/src/`)
   7. CLI (`pkg/bgctl/cmd/`)
 - Flag fields that are defined but never read by any controller or handler.
+- **Generated artifact staleness**: If a Go doc comment on a CRD field is
+  modified (description change, validation wording), verify `make manifests`
+  was re-run. Compare the CRD YAML description against the Go comment —
+  a mismatch means the generated file is stale. Apply the same check after
+  CEL rule changes, marker annotation edits, or `+kubebuilder` tag changes.
 
 ### 8. Error Path Completeness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,18 +107,18 @@ The 16 reviewer personas cover every issue class found by automated reviewers
 - **Performance** catches webhook latency regressions, unbounded memory, high-cardinality metrics
 
 **Correctness** (4 personas):
-- **Integration wiring** catches new code that is defined but never called or connected, state pipeline overwrites, dead channel branches, error swallowing at shutdown
+- **Integration wiring** catches new code that is defined but never called or connected, state pipeline overwrites, dead channel branches, error swallowing at shutdown, **stale generated CRD descriptions after Go comment changes**
 - **API & CRD** catches missing validation markers, backwards-compatibility breaks
-- **Edge cases** catches untested boundary conditions, zero-value bugs, clock skew issues
+- **Edge cases** catches untested boundary conditions, zero-value bugs, clock skew issues, **state × time interaction gaps** (e.g., missing edge-case tests for expiry functions across session states and timestamp combinations)
 - **QA regression** catches state machine violations, data migration gaps, rollback hazards
 
 **Security & documentation** (3 personas):
 - **Security** catches privilege escalation, credential leaks, input injection, CSRF gaps
-- **Docs consistency** catches field name mismatches, missing metrics docs, duplicate headings, duplicate comment lines, log-level claim inaccuracies, function-description table drift
-- **CI & testing** catches coverage gaps, wrong test names in docs, missing enum cases
+- **Docs consistency** catches field name mismatches, missing metrics docs, duplicate headings, duplicate comment lines, log-level claim inaccuracies, function-description table drift, **generated artifact staleness** (Go comment ↔ CRD YAML description divergence)
+- **CI & testing** catches coverage gaps, wrong test names in docs, missing enum cases, **count-only assertions** (tests asserting `.length` without verifying item content)
 
 **User-facing** (5 personas):
-- **Frontend UI** catches missing session states in filters, accessibility gaps, XSS risks
+- **Frontend UI** catches missing session states in filters, accessibility gaps, XSS risks, **roving tabindex bugs after filtering**, **duplicate type definitions** that mirror shared models, **identifier misspellings** in route constants and component names
 - **CLI usability** catches unclear error messages, missing completions, flag inconsistencies
 - **REST API** catches validation gaps, inconsistent response formats, auth bypasses, 401-vs-403 misuse
 - **Helm chart** catches RBAC drift, stale CRDs, upgrade failures, missing security contexts


### PR DESCRIPTION
…gaps

Add rules derived from 6 unresolved Copilot review findings:

- review-frontend-ui: identifier spelling, DRY type definitions, roving tabindex fallback after filtering
- review-ci-testing: count-only assertion anti-pattern
- review-edge-cases: state × time interaction test matrix
- review-docs-consistency: generated artifact freshness (Go comment vs CRD YAML description)
- review-integration-wiring: stale generated CRD detection
- AGENTS.md: updated persona summaries with new capabilities

<!--
SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration / CI change
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link related issues: "Fixes #123" or "Relates to #123" -->

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] I have made corresponding changes to the documentation
- [ ] `CHANGELOG.md` updated under `[Unreleased]` for user-facing changes
- [ ] My changes generate no new warnings
- [ ] REUSE SPDX license header compliance check passes (`reuse lint`)

### If CRD / API types changed

- [ ] Ran `make generate && make manifests` and committed generated files

### If Helm chart affected

- [ ] Updated `charts/escalation-config/` templates and values
- [ ] Ran `helm lint charts/escalation-config` and `helm template test charts/escalation-config`

### If Frontend changed

- [ ] TypeScript type-check passes (`cd frontend && npm run typecheck`)
- [ ] Frontend tests pass (`cd frontend && npm test`)

## Component Affected

- [ ] Backend (Go)
- [ ] Frontend (Vue 3 / TypeScript)
- [ ] API / CRDs
- [ ] Helm chart
- [ ] CI / Workflows
- [ ] E2E tests
- [ ] Documentation only

## Testing

<!-- Describe how you tested your changes -->

### Test environment

- Kubernetes version:
- Test type: (unit / e2e / manual)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional context about the PR -->
