### PR TITLE
fix: add retry with backoff to E2E OIDC token acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dockerfile: fragile single-file COPY** ([#474](https://github.com/telekom/k8s-breakglass/issues/474) partial): Changed `COPY cmd/main.go cmd/main.go` to `COPY cmd/ cmd/` so new files added to `cmd/` are automatically included in builds
 - **Makefile: test flag deduplication** ([#474](https://github.com/telekom/k8s-breakglass/issues/474) partial): Factored duplicated `-race -count=…` flags into `GO_TEST_FLAGS` variable used by `test`, `test-controller`, and `test-cli` targets; fixed e2e exclusion grep `grep -v /e2e` → `grep -vE '/e2e($|/)'` to prevent false exclusion; `GO_TEST_COUNT` defaults to `1` and supports empty override to re-enable caching
 - **Metrics: `MetricsHandler()` now uses correct registry** ([#465](https://github.com/telekom/k8s-breakglass/issues/465)): Fixed to serve from `ctrlmetrics.Registry` which contains all breakglass metrics, instead of the default registry which was empty
-- **E2E: retry OIDC token acquisition with backoff**: `GetToken()` in `e2e/helpers/auth.go` now retries up to 5 times with exponential backoff (2 s → 16 s) when Keycloak is temporarily unreachable, reducing false-negative E2E failures from transient Keycloak pod restarts
+- **E2E: retry OIDC token acquisition with backoff** ([#476](https://github.com/telekom/k8s-breakglass/issues/476)): `GetToken()` in `e2e/helpers/auth.go` now retries up to 5 times with exponential backoff (2 s → 16 s) when Keycloak is temporarily unreachable, reducing false-negative E2E failures from transient Keycloak pod restarts
 
 ### Removed
 

--- a/e2e/helpers/auth.go
+++ b/e2e/helpers/auth.go
@@ -62,9 +62,10 @@ func DefaultOIDCProvider() *OIDCTokenProvider {
 }
 
 // tokenRequestError is returned when Keycloak rejects the token request
-// with a non-200 HTTP status. The StatusCode field allows callers to
-// distinguish retryable (5xx / connection errors) from non-retryable (4xx)
-// failures.
+// with a non-2xx HTTP status. The StatusCode field allows callers to
+// distinguish potentially retryable 5xx failures from non-retryable 4xx
+// failures. Connection-level errors are returned as wrapped errors
+// without a StatusCode.
 type tokenRequestError struct {
 	StatusCode int
 	Message    string
@@ -103,8 +104,10 @@ func (p *OIDCTokenProvider) GetToken(t *testing.T, ctx context.Context, username
 	backoff := p.initialBackoff()
 
 	var lastErr error
+	actualAttempts := 0
 retryLoop:
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		actualAttempts = attempt
 		token, lastErr = p.getTokenViaHTTP(ctx, username, password)
 		if lastErr == nil && token != "" {
 			if attempt > 1 {
@@ -136,7 +139,7 @@ retryLoop:
 		}
 	}
 
-	require.NoError(t, lastErr, "Failed to get OIDC token after %d attempts", maxAttempts)
+	require.NoErrorf(t, lastErr, "Failed to get OIDC token after %d attempts", actualAttempts)
 	require.NotEmpty(t, token, "Token is empty")
 
 	return token

--- a/e2e/helpers/auth_test.go
+++ b/e2e/helpers/auth_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestGetToken_RetriesTransientFailures verifies that GetToken retries on
-// connection-level errors and 5xx responses before eventually succeeding.
+// transient 5xx responses before eventually succeeding.
 func TestGetToken_RetriesTransientFailures(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,8 +50,8 @@ func TestGetToken_RetriesTransientFailures(t *testing.T) {
 	assert.Equal(t, int32(3), calls.Load(), "expected 3 HTTP calls (2 failures + 1 success)")
 }
 
-// TestGetToken_NoRetryOn401 verifies that GetToken does NOT retry when
-// Keycloak returns 401 (bad credentials).
+// TestGetToken_NoRetryOn401 verifies that getTokenViaHTTP returns a
+// non-retryable tokenRequestError for 401 (bad credentials).
 func TestGetToken_NoRetryOn401(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -66,8 +66,8 @@ func TestGetToken_NoRetryOn401(t *testing.T) {
 		ClientID:     "test-client",
 	}
 
-	// Test the underlying getTokenViaHTTP — GetToken calls require.NoError
-	// which would abort the test before we can assert retry counts.
+	// Call getTokenViaHTTP directly so we can inspect the error;
+	// GetToken calls require.NoError which would abort the test.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -138,10 +138,11 @@ func TestGetToken_retryableVsNonRetryable(t *testing.T) {
 	}
 }
 
-// TestGetToken_ContextCancellation verifies that GetToken's retry loop
-// respects context cancellation during the backoff wait, exiting promptly
-// instead of sleeping through all retry attempts.
-// We test via GetToken on a real *testing.T and assert it fails fast.
+// TestGetToken_ContextCancellation verifies that the retry loop used by
+// GetToken respects context cancellation during the backoff wait, exiting
+// promptly instead of sleeping through all retry attempts.
+// This test re-implements the retry loop to call getTokenViaHTTP directly,
+// avoiding GetToken's require.NoError which would abort the test.
 func TestGetToken_ContextCancellation(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

Adds retry logic with exponential backoff to E2E OIDC token acquisition to fix transient Keycloak unavailability flakes.

## Problem

PRs #495 and #498 Single-Cluster E2E tests fail with:
```
failed to request token: Post "https://localhost:8443/...": dial tcp [::1]:8443: connect: connection refused
```

Keycloak pod restarts during E2E cluster setup cause transient unavailability. `GetToken()` made a single HTTP request with no retry logic.

## Fix

`GetToken()` in `e2e/helpers/auth.go` now retries the HTTP token request up to 5 times with exponential backoff (2s, 4s, 8s, 16s). Each retry attempt is logged via `t.Logf()`. Context cancellation is respected between retries.

## Changes

- `e2e/helpers/auth.go`: Added retry loop with exponential backoff to `GetToken()`
- `CHANGELOG.md`: Added entry under `### Fixed`