### PR TITLE
fix: refresh OIDC approver token before approve/reject in E2E tests

### DIFF
--- a/e2e/debug_session_e2e_test.go
+++ b/e2e/debug_session_e2e_test.go
@@ -688,6 +688,12 @@ func TestDebugSession_E2E_ManualApprovalWorkflow(t *testing.T) {
 
 	// Approve session via API if pending approval - must use approver client
 	if session.Status.State == breakglassv1alpha1.DebugSessionStatePendingApproval {
+		// Refresh the approver token right before the API call: WaitForDebugSessionStateAny can
+		// block for up to 60-89 seconds while the session is provisioned, which is long enough
+		// for the OIDC token (typically 5 min TTL) to expire and cause a 401 UNAUTHORIZED.
+		freshTC := helpers.NewTestContext(t, ctx)
+		approverAPI.AuthToken = freshTC.GetApproverToken()
+
 		err = approverAPI.ApproveDebugSession(ctx, t, session.Name, "Approved by E2E test")
 		require.NoError(t, err, "Failed to approve session via API")
 
@@ -780,6 +786,12 @@ func TestDebugSession_E2E_RejectionWorkflow(t *testing.T) {
 	session = helpers.WaitForDebugSessionStateAny(t, ctx, cli, session.Name, session.Namespace, defaultTimeout)
 
 	// Reject the session via API - must use approver client
+	// Refresh the approver token right before the API call: WaitForDebugSessionStateAny can
+	// block for up to 60-89 seconds while the session is provisioned, which is long enough
+	// for the OIDC token (typically 5 min TTL) to expire and cause a 401 UNAUTHORIZED.
+	freshTC := helpers.NewTestContext(t, ctx)
+	approverAPI.AuthToken = freshTC.GetApproverToken()
+
 	err = approverAPI.RejectDebugSession(ctx, t, session.Name, "Insufficient justification provided")
 	require.NoError(t, err, "Failed to reject session via API")
 


### PR DESCRIPTION
## Summary

- Fixes a consistent flake in `TestDebugSession_E2E_ManualApprovalWorkflow` and `TestDebugSession_E2E_RejectionWorkflow` where the approver API call fails with `401 UNAUTHORIZED`.

## Root Cause

`setupApproverClient(t)` is called at the start of each test, obtaining an OIDC token. Then `WaitForDebugSessionStateAny` blocks for up to 60–89 seconds while the session is provisioned. The OIDC token TTL is typically 5 minutes, but in the CI environment it can be shorter. By the time `ApproveDebugSession` / `RejectDebugSession` is called, the token has expired, causing:

```
status=401, body={"error":"Token verification failed. Please re-authenticate.","code":"UNAUTHORIZED"}
```

## Fix

Right before each `approverAPI.Approve/RejectDebugSession()` call, obtain a fresh token:

```go
freshTC := helpers.NewTestContext(t, ctx)
approverAPI.AuthToken = freshTC.GetApproverToken()
```

`TestContext.GetApproverToken()` checks the token cache TTL (4 min) and fetches a new token from Keycloak if needed, so it is safe to call multiple times and will not cause unnecessary round-trips.

## Files Changed

- `e2e/debug_session_e2e_test.go` — added token refresh before approve (line ~696) and before reject (line ~791)