### PR TITLE
fix: address pre-existing code quality issues

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -42,6 +42,13 @@ export default defineConfigWithVueTs(
       "vue/v-on-event-hyphenation": "off",
       "vue/no-deprecated-slot-attribute": "off",
       "no-console": ["error", { allow: ["warn", "error"] }],
+      // Allow variables/functions prefixed with underscore to be unused.
+      // This is the idiomatic TypeScript convention for intentionally-unused
+      // but retained symbols (e.g. placeholder computed values, future-use helpers).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { varsIgnorePattern: "^_", argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
     },
   },
   {

--- a/frontend/mock-api/data.mjs
+++ b/frontend/mock-api/data.mjs
@@ -891,7 +891,6 @@ export function renewDebugSession(name, extendBy = "1h") {
   return session;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function listDebugSessionTemplates(_userGroups = []) {
   // In real API, this filters by user's group membership
   // For mock, we return all templates

--- a/frontend/src/components/BreakglassSessionCard.vue
+++ b/frontend/src/components/BreakglassSessionCard.vue
@@ -68,7 +68,6 @@ const retained = computed(
     props.breakglass.status?.retainedUntil !== undefined &&
     Date.parse(props.breakglass.status.retainedUntil) - props.time > 0,
 );
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _approved = computed(
   () =>
     props.breakglass.status?.expiresAt !== null &&
@@ -131,7 +130,6 @@ const requestedAt = computed(() => {
   return null;
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _approver = computed(() => {
   // Prefer explicit approver field
   if (props.breakglass.status) {

--- a/frontend/src/components/common/ChipRow.vue
+++ b/frontend/src/components/common/ChipRow.vue
@@ -16,8 +16,7 @@ export type ChipItem = {
   truncate?: boolean;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const props = withDefaults(
+withDefaults(
   defineProps<{
     /** Array of chip items to display */
     items?: ChipItem[];

--- a/frontend/src/views/DebugSessionDetails.vue
+++ b/frontend/src/views/DebugSessionDetails.vue
@@ -260,7 +260,6 @@ async function handleJoin() {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function _handleLeave() {
   try {
     await debugSessionService.leaveSession(sessionName.value);

--- a/pkg/breakglass/group_checker.go
+++ b/pkg/breakglass/group_checker.go
@@ -8,7 +8,6 @@ import (
 
 	"go.uber.org/zap"
 	authenticationv1 "k8s.io/api/authentication/v1"
-	authenticationv1alpha1 "k8s.io/api/authentication/v1alpha1"
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -169,16 +168,18 @@ func getUserGroupsInternal(ctx context.Context, cug ClusterUserGroup, configPath
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
+	// SelfSubjectReview API availability by Kubernetes version:
+	//   v1alpha1 (K8s 1.24, now EOL) — dropped from this fallback chain
+	//   v1beta1  (K8s 1.25–1.27)     — kept as fallback for compatibility
+	//   v1       (K8s 1.28+)         — stable, tried first
 	var res runtime.Object
 	res, err = client.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
 
 	if err != nil && k8serrors.IsNotFound(err) {
-		zap.S().Warn("Falling back to Beta API for SelfSubjectReview")
+		// Fallback to v1beta1 for Kubernetes 1.25–1.27 clusters where v1 is not yet available.
+		// v1beta1 SelfSubjectReview was promoted to GA (v1) in Kubernetes 1.28.
+		zap.S().Warn("Falling back to authentication.k8s.io/v1beta1 SelfSubjectReview (cluster predates K8s 1.28)")
 		res, err = client.AuthenticationV1beta1().SelfSubjectReviews().Create(ctx, &authenticationv1beta1.SelfSubjectReview{}, metav1.CreateOptions{})
-		if err != nil && k8serrors.IsNotFound(err) {
-			zap.S().Warn("Falling back to Alpha API for SelfSubjectReview")
-			res, err = client.AuthenticationV1alpha1().SelfSubjectReviews().Create(ctx, &authenticationv1alpha1.SelfSubjectReview{}, metav1.CreateOptions{})
-		}
 	}
 
 	if err != nil {
@@ -234,14 +235,11 @@ func GetUserGroupsWithConfig(ctx context.Context, cug ClusterUserGroup, configPa
 
 func getUserInfo(obj runtime.Object) (authenticationv1.UserInfo, error) {
 	switch val := obj.(type) {
-	case *authenticationv1alpha1.SelfSubjectReview:
-		zap.S().Debug("Parsing user info from v1alpha1.SelfSubjectReview")
+	case *authenticationv1.SelfSubjectReview:
+		zap.S().Debug("Parsing user info from v1.SelfSubjectReview")
 		return val.Status.UserInfo, nil
 	case *authenticationv1beta1.SelfSubjectReview:
 		zap.S().Debug("Parsing user info from v1beta1.SelfSubjectReview")
-		return val.Status.UserInfo, nil
-	case *authenticationv1.SelfSubjectReview:
-		zap.S().Debug("Parsing user info from v1.SelfSubjectReview")
 		return val.Status.UserInfo, nil
 	default:
 		zap.S().Errorw("Unexpected response type for user info extraction", "type", fmt.Sprintf("%T", obj))

--- a/pkg/breakglass/group_checker_test.go
+++ b/pkg/breakglass/group_checker_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	authenticationv1 "k8s.io/api/authentication/v1"
-	authenticationv1alpha1 "k8s.io/api/authentication/v1alpha1"
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1332,20 +1331,6 @@ func TestGetUserInfo(t *testing.T) {
 			},
 			expectedGroups: []string{"beta-admin", "beta-users"},
 			expectedUser:   "test-user-beta",
-			expectError:    false,
-		},
-		{
-			name: "v1alpha1 SelfSubjectReview",
-			input: &authenticationv1alpha1.SelfSubjectReview{
-				Status: authenticationv1alpha1.SelfSubjectReviewStatus{
-					UserInfo: authenticationv1.UserInfo{
-						Username: "test-user-alpha",
-						Groups:   []string{"alpha-admin", "alpha-users"},
-					},
-				},
-			},
-			expectedGroups: []string{"alpha-admin", "alpha-users"},
-			expectedUser:   "test-user-alpha",
 			expectError:    false,
 		},
 		{

--- a/pkg/cluster/circuitbreaker.go
+++ b/pkg/cluster/circuitbreaker.go
@@ -527,19 +527,14 @@ func IsTransientError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	// net.Error — only treat as transient when it's a timeout or temporary condition.
+	// net.Error — only treat as transient when it's a timeout.
 	// Other net.Error values (e.g., DNS resolution failures for invalid hosts) are
 	// configuration issues that should not trip the breaker.
+	// Note: net.Error.Temporary() was deprecated in Go 1.18 with no direct replacement;
+	// concrete error types (net.OpError, url.Error) are handled below via errors.As.
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		if netErr.Timeout() {
-			return true
-		}
-		// Check deprecated Temporary() as a fallback for legacy error types.
-		type temporaryError interface {
-			Temporary() bool
-		}
-		if te, ok := netErr.(temporaryError); ok && te.Temporary() { //nolint:staticcheck // Temporary() is deprecated but still useful for legacy types
 			return true
 		}
 	}

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -29,7 +29,7 @@ type authorizeState struct {
 	// Immutable inputs
 	startTime   time.Time
 	clusterName string
-	ctx         context.Context //nolint:containedctx // scoped to a single request; passed to helpers
+	ctx         context.Context //nolint:containedctx // request-scoped context: authorizeState is created per HTTP request and passed to private helpers; storing ctx here avoids threading it through every helper signature while keeping it out of global state
 	reqLog      *zap.SugaredLogger
 	phases      *SARPhaseTracker
 


### PR DESCRIPTION
## Summary

Fixes four pre-existing code quality issues identified during code review:

### 1. Remove deprecated `authentication/v1alpha1` usage (`pkg/breakglass/group_checker.go`)
- Dropped the `v1alpha1` fallback from the `SelfSubjectReview` API chain (Kubernetes 1.24 is EOL since July 2023)
- Kept the `v1beta1` fallback for K8s 1.25–1.27 clusters where `v1` is not yet available
- Moved `v1` to the top of the `getUserInfo` switch statement (preferred path first)
- Added Kubernetes version comments documenting API availability
- Updated test: removed `v1alpha1` test case from `TestGetUserInfo`

### 2. Remove deprecated `net.Error.Temporary()` check (`pkg/cluster/circuitbreaker.go`)
- Removed the local `temporaryError` interface and the `Temporary()` assertion that triggered `//nolint:staticcheck`
- The concrete error types (`*net.OpError`, `*url.Error`) are already handled below via `errors.As`, making the `Temporary()` check redundant
- Added a comment explaining why `Temporary()` was removed (deprecated in Go 1.18, no direct replacement)

### 3. Configure ESLint to allow underscore-prefixed unused vars (`frontend/eslint.config.mjs`)
- Added `@typescript-eslint/no-unused-vars` rule with `varsIgnorePattern: "^_"` — the idiomatic TypeScript convention for intentionally-retained-but-unused symbols
- Removed 4 per-line `// eslint-disable-next-line @typescript-eslint/no-unused-vars` suppressions from:
  - `DebugSessionDetails.vue`: `_handleLeave`
  - `BreakglassSessionCard.vue`: `_approved`, `_approver`
  - `ChipRow.vue`: `props` (false positive from `withDefaults(defineProps<...>())`)

### 4. Improve `nolint:containedctx` justification (`pkg/webhook/authorize_helpers.go`)
- Expanded the inline comment to explain *why* `context.Context` is stored in the struct: `authorizeState` is per-HTTP-request and avoids threading `ctx` through every private helper signature

## Testing
- `go build ./...` ✓
- `go vet ./pkg/breakglass/... ./pkg/cluster/... ./pkg/webhook/...` ✓
- `staticcheck ./pkg/breakglass/ ./pkg/cluster/ ./pkg/webhook/` ✓
- `go test ./pkg/breakglass/... ./pkg/cluster/... ./pkg/webhook/... ./pkg/api/...` ✓ (all pass)
- `golangci-lint` 0 issues (verified pre-change; changes reduce suppressed warnings)