### PR TITLE
fix: return 429 Too Many Requests for JWKS rate-limited auth failures

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -469,6 +469,25 @@ func authErrorMessageForJWKSLoad(err error) string {
 	}
 }
 
+func retryAfterFromRateLimitedError(err error) string {
+	const prefix = "retry after "
+	msg := err.Error()
+	idx := strings.LastIndex(msg, prefix)
+	if idx < 0 {
+		return "10"
+	}
+	durationStr := msg[idx+len(prefix):]
+	d, parseErr := time.ParseDuration(durationStr)
+	if parseErr != nil || d <= 0 {
+		return "10"
+	}
+	secs := int(d.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	return fmt.Sprintf("%d", secs)
+}
+
 func (a *AuthHandler) authenticate(c *gin.Context) bool {
 	if c.Request.Method == http.MethodOptions {
 		return true
@@ -539,7 +558,11 @@ func (a *AuthHandler) authenticate(c *gin.Context) bool {
 			metrics.JWTValidationRequests.WithLabelValues("unknown", mode).Inc()
 			metrics.JWTValidationFailure.WithLabelValues("unknown", "jwks_load_failed").Inc()
 
-			RespondUnauthorizedWithMessage(c, authErrorMessageForJWKSLoad(err))
+			if errors.Is(err, errJWKSFetchRateLimited) {
+				RespondTooManyRequestsWithRetryAfter(c, retryAfterFromRateLimitedError(err), authErrorMessageForJWKSLoad(err))
+			} else {
+				RespondUnauthorizedWithMessage(c, authErrorMessageForJWKSLoad(err))
+			}
 			c.Abort()
 			return false
 		}

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -61,6 +62,19 @@ var (
 	errUnknownIdentityProvider = errors.New("invalid or unknown identity provider")
 	errJWKSFetchRateLimited    = errors.New("jwks fetch rate limited")
 )
+
+// jwksFetchRateLimitedError is a typed error that carries the exact duration
+// a caller should wait before retrying. It wraps errJWKSFetchRateLimited so
+// that errors.Is checks continue to work unchanged.
+type jwksFetchRateLimitedError struct {
+	RetryAfter time.Duration
+}
+
+func (e *jwksFetchRateLimitedError) Error() string {
+	return fmt.Sprintf("%s: retry after %s", errJWKSFetchRateLimited, e.RetryAfter.Truncate(time.Millisecond))
+}
+
+func (e *jwksFetchRateLimitedError) Unwrap() error { return errJWKSFetchRateLimited }
 
 // jwksCacheEntry holds the JWKS and its position in the LRU list
 type jwksCacheEntry struct {
@@ -284,7 +298,7 @@ func (a *AuthHandler) loadJWKSForIssuer(ctx context.Context, issuer string) (*jw
 			elapsed := time.Since(t)
 			if elapsed < jwksFetchMinInterval {
 				retryAfter := jwksFetchMinInterval - elapsed
-				return nil, fmt.Errorf("%w: retry after %s", errJWKSFetchRateLimited, retryAfter.Truncate(time.Millisecond))
+				return nil, &jwksFetchRateLimitedError{RetryAfter: retryAfter}
 			}
 		}
 	}
@@ -470,22 +484,15 @@ func authErrorMessageForJWKSLoad(err error) string {
 }
 
 func retryAfterFromRateLimitedError(err error) string {
-	const prefix = "retry after "
-	msg := err.Error()
-	idx := strings.LastIndex(msg, prefix)
-	if idx < 0 {
-		return "10"
+	var rle *jwksFetchRateLimitedError
+	if errors.As(err, &rle) && rle.RetryAfter > 0 {
+		secs := int(math.Ceil(rle.RetryAfter.Seconds()))
+		if secs < 1 {
+			secs = 1
+		}
+		return fmt.Sprintf("%d", secs)
 	}
-	durationStr := msg[idx+len(prefix):]
-	d, parseErr := time.ParseDuration(durationStr)
-	if parseErr != nil || d <= 0 {
-		return "10"
-	}
-	secs := int(d.Seconds())
-	if secs < 1 {
-		secs = 1
-	}
-	return fmt.Sprintf("%d", secs)
+	return fmt.Sprintf("%d", int(jwksFetchMinInterval.Seconds()))
 }
 
 func (a *AuthHandler) authenticate(c *gin.Context) bool {
@@ -556,11 +563,11 @@ func (a *AuthHandler) authenticate(c *gin.Context) bool {
 		if err != nil {
 			a.log.Debugw("failed to get JWKS for issuer", "issuer", issuer, "error", err)
 			metrics.JWTValidationRequests.WithLabelValues("unknown", mode).Inc()
-			metrics.JWTValidationFailure.WithLabelValues("unknown", "jwks_load_failed").Inc()
-
 			if errors.Is(err, errJWKSFetchRateLimited) {
+				metrics.JWTValidationFailure.WithLabelValues("unknown", "jwks_load_rate_limited").Inc()
 				RespondTooManyRequestsWithRetryAfter(c, retryAfterFromRateLimitedError(err), authErrorMessageForJWKSLoad(err))
 			} else {
+				metrics.JWTValidationFailure.WithLabelValues("unknown", "jwks_load_failed").Inc()
 				RespondUnauthorizedWithMessage(c, authErrorMessageForJWKSLoad(err))
 			}
 			c.Abort()

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -791,6 +791,86 @@ func TestAuthErrorMessageForJWKSLoad(t *testing.T) {
 	}
 }
 
+func TestRetryAfterFromRateLimitedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "standard rate limited error with seconds duration",
+			err:  fmt.Errorf("%w: retry after 9s", errJWKSFetchRateLimited),
+			want: "9",
+		},
+		{
+			name: "rate limited with sub-second remainder rounds up to 1",
+			err:  fmt.Errorf("%w: retry after 500ms", errJWKSFetchRateLimited),
+			want: "1",
+		},
+		{
+			name: "rate limited with mixed duration",
+			err:  fmt.Errorf("%w: retry after 4.999s", errJWKSFetchRateLimited),
+			want: "4",
+		},
+		{
+			name: "error without retry after segment returns default",
+			err:  errJWKSFetchRateLimited,
+			want: "10",
+		},
+		{
+			name: "wrapped error preserves retry after",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("%w: retry after 7s", errJWKSFetchRateLimited)),
+			want: "7",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, retryAfterFromRateLimitedError(tt.err))
+		})
+	}
+}
+
+func TestAuthenticate_RateLimitedJWKS_Returns429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	auth := &AuthHandler{
+		log:         zaptest.NewLogger(t).Sugar(),
+		jwksCache:   make(map[string]*list.Element),
+		jwksLRUList: list.New(),
+		idpLoader:   config.NewIdentityProviderLoader(fakeClient),
+	}
+	auth.jwksFetchLimiter.Store("https://idp.example.com", time.Now())
+
+	router := gin.New()
+	router.Use(auth.Middleware())
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	claims := jwt.MapClaims{
+		"iss": "https://idp.example.com",
+		"sub": "user@example.com",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := tok.SignedString([]byte("secret"))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	retryAfter := w.Header().Get("Retry-After")
+	assert.NotEmpty(t, retryAfter, "Retry-After header must be set")
+	assert.Contains(t, w.Body.String(), `"TOO_MANY_REQUESTS"`)
+}
+
 // --- SEC-005: Audience claim validation ---
 
 func TestAuthMiddleware_AudienceValidation(t *testing.T) {

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -799,27 +799,27 @@ func TestRetryAfterFromRateLimitedError(t *testing.T) {
 	}{
 		{
 			name: "standard rate limited error with seconds duration",
-			err:  fmt.Errorf("%w: retry after 9s", errJWKSFetchRateLimited),
+			err:  &jwksFetchRateLimitedError{RetryAfter: 9 * time.Second},
 			want: "9",
 		},
 		{
 			name: "rate limited with sub-second remainder rounds up to 1",
-			err:  fmt.Errorf("%w: retry after 500ms", errJWKSFetchRateLimited),
+			err:  &jwksFetchRateLimitedError{RetryAfter: 500 * time.Millisecond},
 			want: "1",
 		},
 		{
-			name: "rate limited with mixed duration",
-			err:  fmt.Errorf("%w: retry after 4.999s", errJWKSFetchRateLimited),
-			want: "4",
+			name: "rate limited with fractional seconds rounds up via Ceil",
+			err:  &jwksFetchRateLimitedError{RetryAfter: 4999 * time.Millisecond},
+			want: "5",
 		},
 		{
-			name: "error without retry after segment returns default",
+			name: "error without typed rate limit info returns default from jwksFetchMinInterval",
 			err:  errJWKSFetchRateLimited,
 			want: "10",
 		},
 		{
-			name: "wrapped error preserves retry after",
-			err:  fmt.Errorf("outer: %w", fmt.Errorf("%w: retry after 7s", errJWKSFetchRateLimited)),
+			name: "wrapped typed error preserves retry after",
+			err:  fmt.Errorf("outer: %w", &jwksFetchRateLimitedError{RetryAfter: 7 * time.Second}),
 			want: "7",
 		},
 	}

--- a/pkg/api/responses.go
+++ b/pkg/api/responses.go
@@ -129,6 +129,19 @@ func RespondInternalErrorSimple(c *gin.Context, message string) {
 	})
 }
 
+// RespondTooManyRequestsWithRetryAfter sends a 429 Too Many Requests response
+// with a Retry-After header indicating when the client should retry.
+func RespondTooManyRequestsWithRetryAfter(c *gin.Context, retryAfter string, message string) {
+	if message == "" {
+		message = "too many requests"
+	}
+	c.Header("Retry-After", retryAfter)
+	c.JSON(http.StatusTooManyRequests, APIError{
+		Error: message,
+		Code:  "TOO_MANY_REQUESTS",
+	})
+}
+
 // RespondBadGateway sends a 502 Bad Gateway response.
 // Useful when proxying upstream services.
 func RespondBadGateway(c *gin.Context, message string) {


### PR DESCRIPTION
## Summary

When the JWKS endpoint was rate-limited during token validation, the auth middleware returned HTTP 401 (Unauthorized) instead of HTTP 429 (Too Many Requests). This caused clients to interpret a transient rate-limit condition as an authentication failure, potentially triggering unnecessary re-authentication flows or confusing error messages.

## Changes

- Added rate-limit error detection in the JWKS token validation path
- When a rate-limit is detected, returns 429 with a `Retry-After` header instead of 401
- Added a new `TooManyRequestsResponse` helper in `pkg/api/responses.go`

## Files Changed

- `pkg/api/auth.go` — Rate-limit detection + 429 response in auth middleware
- `pkg/api/auth_test.go` — Tests for rate-limited JWKS scenarios
- `pkg/api/responses.go` — New `TooManyRequestsResponse` helper

## Testing

- Unit tests verify 429 response code and Retry-After header when JWKS is rate-limited
- Existing auth tests continue to pass