### PR TITLE
fix: use allowlist for SanitizeReasonText to prevent XSS bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,7 +659,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Approver logging now uses counts instead of identities to reduce PII exposure
 - Standardized error wrapping to use `fmt.Errorf("...: %w", err)` pattern
 - Centralized frontend duration parsing and reason sanitization utilities for consistent validation
-- Enforced server-side 1024-character limit for session request reasons
+- Enforced server-side 500-character limit for session request reasons (reduced from 1024; applies uniformly to request, approval, and rejection reasons via `SanitizeReasonText`)
 - DebugSession lookups now use indexed field selectors for cluster, state, and participant filters
 - Bumped controller-runtime to v0.23.0 and adopted typed webhooks with `events.k8s.io` RBAC for event recording
 - Switched internal event emission to the `events.k8s.io` recorder API

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -243,7 +243,7 @@ Authorization: Bearer <token>
 - JSON bodies must contain only known field names; requests with unknown or typo'd fields are rejected with `422 Unprocessable Entity`
 - JSON bodies must contain exactly one JSON object; trailing data is rejected
 - `reason` is optional unless the escalation's `requestReason.mandatory` is `true`.
-- `reason` must be at most 1024 characters after trimming.
+- `reason` must be at most 500 characters after trimming.
 - `user` must match the authenticated identity in the request token; mismatches are rejected.
 
 **Status Code:** `201 Created`

--- a/e2e/api/debug_session_api_test.go
+++ b/e2e/api/debug_session_api_test.go
@@ -1025,7 +1025,7 @@ func TestDebugSessionAPIJoinLeave(t *testing.T) {
 		TemplateRef: sessionTemplateName,
 		Cluster:     clusterName,
 		Namespace:   namespace,
-		Reason:      "Join/Leave test",
+		Reason:      "Join-Leave test",
 	})
 	require.NoError(t, err, "Failed to create debug session via API")
 	t.Logf("Created debug session via API: %s", session.Name)
@@ -3077,7 +3077,7 @@ func TestDebugSessionAPIJoinLeavePermutations(t *testing.T) {
 		TemplateRef:       sessionTemplateName,
 		Cluster:           clusterName,
 		RequestedDuration: "1h",
-		Reason:            "Join/Leave permutation test",
+		Reason:            "Join-Leave permutation test",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, session)

--- a/e2e/api/multi_idp_authorization_test.go
+++ b/e2e/api/multi_idp_authorization_test.go
@@ -149,7 +149,7 @@ func (s *MultiIDPAuthorizationSuite) TestEmployeeAccessEmployeeOnlyCluster() {
 		Cluster: spokeCluster,
 		User:    helpers.MultiClusterTestUsers.Employee.Email,
 		Group:   "breakglass-employee-access",
-		Reason:  "E2E Test: Employee IDP access verification",
+		Reason:  "E2E Test - Employee IDP access verification",
 	})
 	s.Require().NoError(err, "Employee should be able to create session via API")
 	s.cleanup.Add(session)
@@ -196,7 +196,7 @@ func (s *MultiIDPAuthorizationSuite) TestContractorDeniedOnEmployeeOnlyCluster()
 		Cluster: spokeCluster,
 		User:    helpers.MultiClusterTestUsers.Contractor1.Email,
 		Group:   "breakglass-employee-access", // Employee-only escalation
-		Reason:  "E2E Test: Contractor denied verification",
+		Reason:  "E2E Test - Contractor denied verification",
 	})
 
 	// The session creation might be rejected by webhook or API
@@ -270,7 +270,7 @@ func (s *MultiIDPAuthorizationSuite) TestContractorAccessContractorCluster() {
 		Cluster: spokeCluster,
 		User:    helpers.MultiClusterTestUsers.Contractor1.Email,
 		Group:   "breakglass-contractor-access",
-		Reason:  "E2E Test: Contractor IDP access verification",
+		Reason:  "E2E Test - Contractor IDP access verification",
 	})
 	s.Require().NoError(err, "Contractor should be able to create session for contractor-allowed cluster")
 	s.cleanup.Add(session)
@@ -319,7 +319,7 @@ func (s *MultiIDPAuthorizationSuite) TestIDPMismatchDenied() {
 		Cluster: spokeCluster,
 		User:    helpers.MultiClusterTestUsers.Employee.Email,
 		Group:   "breakglass-employee-access",
-		Reason:  "E2E Test: IDP mismatch verification",
+		Reason:  "E2E Test - IDP mismatch verification",
 	})
 	s.Require().NoError(err)
 	s.cleanup.Add(session)

--- a/e2e/api/oidc_integration_flow_test.go
+++ b/e2e/api/oidc_integration_flow_test.go
@@ -152,7 +152,7 @@ func TestOIDCFullIntegrationFlow(t *testing.T) {
 		Cluster: oidcClusterName,
 		User:    sessionUser,
 		Group:   escalation.Spec.EscalatedGroup,
-		Reason:  "CC-OIDC-INT-001: Full OIDC integration test",
+		Reason:  "CC-OIDC-INT-001 Full OIDC integration test",
 	}, helpers.WaitForStateTimeout)
 	require.NoError(t, err, "Failed to create session via API")
 	cleanup.Add(session)

--- a/e2e/api/security_isolation_test.go
+++ b/e2e/api/security_isolation_test.go
@@ -73,7 +73,7 @@ func TestCrossClusterSessionIsolation(t *testing.T) {
 		Cluster: clusterA,
 		User:    sessionUser,
 		Group:   escalation.Spec.EscalatedGroup,
-		Reason:  "SEC-001: Cross-cluster isolation test",
+		Reason:  "SEC-001 - Cross-cluster isolation test",
 	}, helpers.WaitForStateTimeout)
 	require.NoError(t, err)
 	cleanup.Add(session)
@@ -140,7 +140,7 @@ func TestExpiredSessionRaceCondition(t *testing.T) {
 		Cluster: clusterName,
 		User:    sessionUser,
 		Group:   escalation.Spec.EscalatedGroup,
-		Reason:  "SEC-002: Expired session race condition test",
+		Reason:  "SEC-002 - Expired session race condition test",
 	}, helpers.WaitForStateTimeout)
 	require.NoError(t, err)
 	cleanup.Add(session)
@@ -210,7 +210,7 @@ func TestDifferentUserSameGroup(t *testing.T) {
 		Cluster: clusterName,
 		User:    userA.Email,
 		Group:   escalation.Spec.EscalatedGroup,
-		Reason:  "SEC-003: User isolation test",
+		Reason:  "SEC-003 - User isolation test",
 	}, helpers.WaitForStateTimeout)
 	require.NoError(t, err)
 	cleanup.Add(session)
@@ -273,7 +273,7 @@ func TestSameUserDifferentGroup(t *testing.T) {
 		Cluster: clusterName,
 		User:    user,
 		Group:   escalationGroupX.Spec.EscalatedGroup,
-		Reason:  "SEC-004: Group isolation test",
+		Reason:  "SEC-004 - Group isolation test",
 	}, helpers.WaitForStateTimeout)
 	require.NoError(t, err)
 	cleanup.Add(session)

--- a/e2e/api/spoke_hub_authorization_test.go
+++ b/e2e/api/spoke_hub_authorization_test.go
@@ -195,7 +195,7 @@ func (s *SpokeHubAuthorizationSuite) TestUserWithApprovedSessionAllowed() {
 		Cluster: spokeCluster,
 		User:    testUser.Email,
 		Group:   "breakglass-pods-reader",
-		Reason:  "E2E Test: Complete user journey - investigating pod issues",
+		Reason:  "E2E Test - Complete user journey - investigating pod issues",
 	})
 	s.Require().NoError(err, "Employee should be able to create session via API")
 	s.cleanup.Add(session)
@@ -264,7 +264,7 @@ func (s *SpokeHubAuthorizationSuite) TestSessionClusterScopeEnforced() {
 		Cluster: spokeA,
 		User:    testUser.Email,
 		Group:   "breakglass-pods-admin",
-		Reason:  "E2E Test: Cluster scope verification",
+		Reason:  "E2E Test - Cluster scope verification",
 	})
 	s.Require().NoError(err)
 	s.cleanup.Add(session)
@@ -328,7 +328,7 @@ func (s *SpokeHubAuthorizationSuite) TestDenyPolicyEnforcedOnSpoke() {
 		Cluster: spokeCluster,
 		User:    testUser.Email,
 		Group:   "breakglass-limited-access",
-		Reason:  "E2E Test: DenyPolicy enforcement verification",
+		Reason:  "E2E Test - DenyPolicy enforcement verification",
 	})
 	s.Require().NoError(err)
 	s.cleanup.Add(session)
@@ -413,7 +413,7 @@ func (s *SpokeHubAuthorizationSuite) TestExpiredSessionDenied() {
 		Cluster: spokeCluster,
 		User:    testUser.Email,
 		Group:   "breakglass-read-only",
-		Reason:  "E2E Test: Session expiry verification",
+		Reason:  "E2E Test - Session expiry verification",
 	})
 	s.Require().NoError(err, "Failed to create session via API")
 	s.cleanup.Add(session)
@@ -530,7 +530,7 @@ func (s *SpokeHubAuthorizationSuite) TestMultipleUsersIndependentSessions() {
 		Cluster: spokeCluster,
 		User:    testUser.Email,
 		Group:   "breakglass-emergency-admin",
-		Reason:  "E2E Test: Multi-user session isolation",
+		Reason:  "E2E Test - Multi-user session isolation",
 	})
 	s.Require().NoError(err)
 	s.cleanup.Add(session)

--- a/e2e/api/use_cases_test.go
+++ b/e2e/api/use_cases_test.go
@@ -92,7 +92,7 @@ func TestUseCasePodShellAccess(t *testing.T) {
 			Cluster: clusterName,
 			User:    helpers.GetTestUserEmail(),
 			Group:   escalation.Spec.EscalatedGroup,
-			Reason:  "INC-12345: Debug pod networking issue",
+			Reason:  "INC-12345 Debug pod networking issue",
 		})
 		require.NoError(t, err, "Failed to create pod exec session via API")
 		require.NotEmpty(t, session.Name, "Session name should be returned")
@@ -259,7 +259,7 @@ func TestUseCaseWorkloadScaling(t *testing.T) {
 			Cluster: clusterName,
 			User:    helpers.GetTestUserEmail(),
 			Group:   escalation.Spec.EscalatedGroup,
-			Reason:  "INC-99999: Scale up due to traffic surge",
+			Reason:  "INC-99999 Scale up due to traffic surge",
 		}, helpers.WaitForStateTimeout)
 		require.NoError(t, err, "Failed to create session via API")
 		cleanup.Add(session)
@@ -352,7 +352,7 @@ func TestUseCaseResourceDeletion(t *testing.T) {
 			Cluster: clusterName,
 			User:    helpers.GetTestUserEmail(),
 			Group:   escalation.Spec.EscalatedGroup,
-			Reason:  "INC-88888: Delete stuck terminating pods",
+			Reason:  "INC-88888 Delete stuck terminating pods",
 		}, helpers.WaitForStateTimeout)
 		require.NoError(t, err, "Failed to create session via API")
 		cleanup.Add(session)
@@ -421,7 +421,7 @@ func TestUseCaseM2MAutomatedAccess(t *testing.T) {
 			Cluster: clusterName,
 			User:    helpers.TestUsers.Requester.Email,
 			Group:   escalation.Spec.EscalatedGroup,
-			Reason:  "CI/CD pipeline run #1234",
+			Reason:  "CI-CD pipeline run 1234",
 		}, helpers.WaitForStateTimeout)
 		require.NoError(t, err, "Failed to create session via API")
 		cleanup.Add(session)
@@ -491,7 +491,7 @@ func TestUseCaseBISDebugging(t *testing.T) {
 			Cluster: clusterName,
 			User:    helpers.GetTestUserEmail(),
 			Group:   escalation.Spec.EscalatedGroup,
-			Reason:  "BISWI-567: Investigate data sync issue",
+			Reason:  "BISWI-567 Investigate data sync issue",
 		}, helpers.WaitForStateTimeout)
 		require.NoError(t, err, "Failed to create session via API")
 		cleanup.Add(session)

--- a/e2e/template_string_format_e2e_test.go
+++ b/e2e/template_string_format_e2e_test.go
@@ -119,7 +119,7 @@ spec:
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: kind:Pod format",
+		Reason:            "E2E test - kind Pod format",
 	})
 	defer func() { _ = cli.Delete(ctx, session) }()
 
@@ -217,7 +217,7 @@ spec:
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: full Deployment manifest",
+		Reason:            "E2E test - full Deployment manifest",
 	})
 	defer func() { _ = cli.Delete(ctx, session) }()
 
@@ -376,7 +376,7 @@ spec:
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: workload type mismatch",
+		Reason:            "E2E test - workload type mismatch",
 	})
 	if err != nil {
 		// If API rejects it, that's also acceptable
@@ -444,7 +444,7 @@ func TestTemplateStringFormat_E2E_BareSpecBackwardCompatible(t *testing.T) {
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: bare PodSpec backward compat",
+		Reason:            "E2E test - bare PodSpec backward compat",
 	})
 	defer func() { _ = cli.Delete(ctx, session) }()
 
@@ -536,7 +536,7 @@ spec:
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: full DaemonSet manifest",
+		Reason:            "E2E test - full DaemonSet manifest",
 	})
 	defer func() { _ = cli.Delete(ctx, session) }()
 
@@ -652,7 +652,7 @@ spec:
 		TemplateRef:       sessionTemplate.Name,
 		Cluster:           helpers.GetTestClusterName(),
 		RequestedDuration: "30m",
-		Reason:            "E2E test: kind:Pod with overrides",
+		Reason:            "E2E test - kind Pod with overrides",
 	})
 	defer func() { _ = cli.Delete(ctx, session) }()
 

--- a/frontend/tests/e2e/request-session.spec.ts
+++ b/frontend/tests/e2e/request-session.spec.ts
@@ -71,7 +71,7 @@ test.describe.serial("Request Session via UI", () => {
     }
 
     // Enter reason
-    const reason = "UI E2E Test: Debugging production issue #12345";
+    const reason = "UI E2E Test - Debugging production issue 12345";
     await fillScaleTextarea(page, '[data-testid="reason-input"]', reason);
 
     // Select duration (if available) - this is a text field, not a dropdown

--- a/pkg/breakglass/clusteruser.go
+++ b/pkg/breakglass/clusteruser.go
@@ -3,6 +3,7 @@ package breakglass
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -23,7 +24,7 @@ type BreakglassSessionRequest struct {
 	GroupName   string `json:"group,omitempty"`
 	// Reason is an optional free-text field supplied by the requester. Its requirement and description
 	// are driven by the escalation's RequestReason configuration.
-	// Max 1024 characters, sanitized on server-side to prevent injection attacks.
+	// Max 500 characters, sanitized on server-side to prevent injection attacks.
 	Reason string `json:"reason,omitempty"`
 	// Duration is the requested duration in seconds. Must not exceed the escalation's maxValidFor.
 	// Optional; if not provided, uses escalation's maxValidFor.
@@ -32,15 +33,17 @@ type BreakglassSessionRequest struct {
 	ScheduledStartTime string `json:"scheduledStartTime,omitempty"`
 }
 
-const MaxReasonLength = 1024
+const MaxReasonLength = 500
+
+// allowedReasonChars is an allowlist pattern that matches characters NOT permitted in reason text.
+// Only alphanumeric characters, spaces, and basic punctuation (.,;:!?'-) are permitted.
+// Everything else is stripped to prevent XSS and injection attacks.
+var allowedReasonChars = regexp.MustCompile(`[^a-zA-Z0-9 .,;:!?'\-]`)
 
 // SanitizeReason sanitizes the reason field to prevent injection attacks.
-// Trims whitespace and removes dangerous HTML/JS/TS patterns while preserving safe content.
+// Trims whitespace, strips non-allowlisted characters, and enforces maximum length.
 func (r *BreakglassSessionRequest) SanitizeReason() error {
-	sanitized, err := SanitizeReasonText(r.Reason)
-	if err != nil {
-		return err
-	}
+	sanitized := SanitizeReasonText(r.Reason)
 	if utf8.RuneCountInString(sanitized) > MaxReasonLength {
 		return fmt.Errorf("reason must be at most %d characters", MaxReasonLength)
 	}
@@ -48,95 +51,21 @@ func (r *BreakglassSessionRequest) SanitizeReason() error {
 	return nil
 }
 
-// dangerousPatterns contains patterns that could be used for injection attacks.
-var dangerousPatterns = []string{
-	"<script", "</script",
-	"<iframe", "</iframe",
-	"javascript:", "data:text/html",
-	"onerror=", "onload=", "onclick=", "onmouseover=",
-	"<svg", "</svg",
-	"<object", "</object",
-	"<embed", "</embed",
-	"<link", "</link",
-	"<style", "</style",
-	"<img", "</img",
-	"<frame", "</frame",
-	"<frameset", "</frameset",
-	"<base",
-	"<form", "</form",
-	"<input", "</input",
-	"<button", "</button",
-	"<textarea", "</textarea",
-	"<select", "</select",
-	"<option", "</option",
-	"<label",
-	"<legend",
-	"<fieldset",
-	"eval(", "expression(", "vbscript:",
-	"<!--", "-->", // HTML comments can hide malicious content
-	"<?php", "<?=", "?>", // PHP injection
-	"<%", "%>", // ASP injection
-}
-
-// SanitizeReasonText sanitizes a reason string to prevent injection attacks.
-// Trims whitespace and removes dangerous HTML/JS/TS patterns while preserving safe content.
-// This is a standalone function that can be used for any reason field.
-func SanitizeReasonText(reason string) (string, error) {
-	// Trim whitespace
-	reason = strings.TrimSpace(reason)
-
-	// Check each pattern in a case-insensitive manner
-	// We iterate multiple times until no more patterns are found to handle nested cases
-	for {
-		foundPattern := false
-		for _, pattern := range dangerousPatterns {
-			// Find pattern case-insensitively by searching in the original string
-			// We need to find the byte position in the original string, not the lowercased one
-			idx := indexCaseInsensitive(reason, pattern)
-			if idx >= 0 {
-				// Strip out the dangerous pattern and everything after it
-				reason = reason[:idx]
-				reason = strings.TrimSpace(reason)
-				foundPattern = true
-				break // Restart the loop with the modified string
-			}
-		}
-		if !foundPattern {
-			break
-		}
-	}
-
-	return reason, nil
-}
-
-// indexCaseInsensitive finds the byte index of pattern in s using case-insensitive matching.
-// Returns -1 if not found. This returns the index in the ORIGINAL string s, which is required
-// for safe slicing.
+// SanitizeReasonText sanitizes a reason string to prevent injection attacks using an allowlist approach.
+// Only alphanumeric characters, spaces, and basic punctuation (.,;:!?'-) are permitted.
+// All other characters — including HTML tags, script injection markers, Unicode specials,
+// and URL-encoded bypass attempts — are stripped. Leading/trailing whitespace is trimmed.
 //
-// IMPORTANT: We cannot use strings.Index(strings.ToLower(s), strings.ToLower(pattern)) because
-// ToLower can change byte lengths for certain Unicode characters (e.g., some multi-byte chars).
-// Using an index from the lowercased string to slice the original would cause panics or
-// incorrect results. This was discovered via fuzz testing.
-func indexCaseInsensitive(s, pattern string) int {
-	if len(pattern) == 0 {
-		return 0
-	}
-	if len(s) < len(pattern) {
-		return -1
-	}
-
-	// Iterate through each possible starting position using range to ensure
-	// we start at valid UTF-8 character boundaries.
-	// strings.EqualFold handles Unicode case folding correctly.
-	for i := range s {
-		if i+len(pattern) > len(s) {
-			break // No room for pattern to fit, exit early
-		}
-		if strings.EqualFold(s[i:i+len(pattern)], pattern) {
-			return i
-		}
-	}
-	return -1
+// This allowlist approach is more robust than a blacklist because it cannot be bypassed
+// via encoding tricks, novel HTML tags, or patterns not yet in the deny list.
+func SanitizeReasonText(reason string) string {
+	// Trim leading/trailing whitespace first
+	reason = strings.TrimSpace(reason)
+	// Strip any character not in the allowlist
+	reason = allowedReasonChars.ReplaceAllString(reason, "")
+	// Re-trim in case stripping left new leading/trailing spaces
+	reason = strings.TrimSpace(reason)
+	return reason
 }
 
 // ValidateDuration validates that the requested duration is within acceptable bounds.

--- a/pkg/breakglass/clusteruser.go
+++ b/pkg/breakglass/clusteruser.go
@@ -35,26 +35,30 @@ type BreakglassSessionRequest struct {
 
 const MaxReasonLength = 500
 
-// allowedReasonChars is an allowlist pattern that matches characters NOT permitted in reason text.
-// Only alphanumeric characters, spaces, and basic punctuation (.,;:!?'-) are permitted.
+// disallowedReasonChars is an allowlist pattern that matches characters NOT permitted in reason text.
+// Only alphanumeric characters, spaces, and basic punctuation (.,;!?'-) are permitted.
+// The colon (:) is intentionally excluded to prevent javascript: and data: scheme injection.
 // Everything else is stripped to prevent XSS and injection attacks.
-var allowedReasonChars = regexp.MustCompile(`[^a-zA-Z0-9 .,;:!?'\-]`)
+var disallowedReasonChars = regexp.MustCompile(`[^a-zA-Z0-9 .,;!?'\-]`)
 
 // SanitizeReason sanitizes the reason field to prevent injection attacks.
-// Trims whitespace, strips non-allowlisted characters, and enforces maximum length.
+// Returns an error if the raw input (after trimming whitespace) exceeds MaxReasonLength characters,
+// then strips non-allowlisted characters via SanitizeReasonText.
 func (r *BreakglassSessionRequest) SanitizeReason() error {
-	sanitized := SanitizeReasonText(r.Reason)
-	if utf8.RuneCountInString(sanitized) > MaxReasonLength {
+	trimmed := strings.TrimSpace(r.Reason)
+	if utf8.RuneCountInString(trimmed) > MaxReasonLength {
 		return fmt.Errorf("reason must be at most %d characters", MaxReasonLength)
 	}
-	r.Reason = sanitized
+	r.Reason = SanitizeReasonText(r.Reason)
 	return nil
 }
 
 // SanitizeReasonText sanitizes a reason string to prevent injection attacks using an allowlist approach.
-// Only alphanumeric characters, spaces, and basic punctuation (.,;:!?'-) are permitted.
+// Only alphanumeric characters, spaces, and basic punctuation (.,;!?'-) are permitted.
+// The colon (:) is intentionally excluded to prevent javascript: and data: URI scheme injection.
 // All other characters — including HTML tags, script injection markers, Unicode specials,
 // and URL-encoded bypass attempts — are stripped. Leading/trailing whitespace is trimmed.
+// Inputs longer than MaxReasonLength runes are truncated to that limit.
 //
 // This allowlist approach is more robust than a blacklist because it cannot be bypassed
 // via encoding tricks, novel HTML tags, or patterns not yet in the deny list.
@@ -62,9 +66,14 @@ func SanitizeReasonText(reason string) string {
 	// Trim leading/trailing whitespace first
 	reason = strings.TrimSpace(reason)
 	// Strip any character not in the allowlist
-	reason = allowedReasonChars.ReplaceAllString(reason, "")
+	reason = disallowedReasonChars.ReplaceAllString(reason, "")
 	// Re-trim in case stripping left new leading/trailing spaces
 	reason = strings.TrimSpace(reason)
+	// Truncate to MaxReasonLength to enforce a consistent upper bound for all callers
+	if utf8.RuneCountInString(reason) > MaxReasonLength {
+		runes := []rune(reason)
+		reason = string(runes[:MaxReasonLength])
+	}
 	return reason
 }
 

--- a/pkg/breakglass/clusteruser_test.go
+++ b/pkg/breakglass/clusteruser_test.go
@@ -106,8 +106,8 @@ func TestBreakglassSessionRequest_SanitizeReason(t *testing.T) {
 		},
 		{
 			name:    "reason with basic punctuation preserved",
-			input:   "Debugging prod issue: server down. Please help!",
-			want:    "Debugging prod issue: server down. Please help!",
+			input:   "Debugging prod issue - server down. Please help!",
+			want:    "Debugging prod issue - server down. Please help!",
 			wantErr: false,
 		},
 	}
@@ -299,7 +299,7 @@ func TestBreakglassSessionRequest_CombinedValidation(t *testing.T) {
 }
 
 // TestSanitizeReasonText tests the standalone SanitizeReasonText function.
-// Verifies allowlist behavior: only alphanumeric, spaces, and .,;:!?'- are permitted.
+// Verifies allowlist behavior: only alphanumeric, spaces, and .,;!?'- are permitted (colon excluded).
 func TestSanitizeReasonText(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -323,8 +323,8 @@ func TestSanitizeReasonText(t *testing.T) {
 		},
 		{
 			name:     "basic punctuation preserved",
-			input:    "Prod is down: needs fix. Please help!",
-			expected: "Prod is down: needs fix. Please help!",
+			input:    "Prod is down - needs fix. Please help!",
+			expected: "Prod is down - needs fix. Please help!",
 		},
 		{
 			name:     "XSS: script tag stripped",
@@ -343,8 +343,13 @@ func TestSanitizeReasonText(t *testing.T) {
 		},
 		{
 			name:     "XSS: javascript protocol stripped",
-			input:    "Click here: javascript:alert(1)",
-			expected: "Click here: javascript:alert1",
+			input:    "Click here javascript alert(1)",
+			expected: "Click here javascript alert1",
+		},
+		{
+			name:     "XSS: javascript colon stripped",
+			input:    "javascript:alert(1)",
+			expected: "javascriptalert1",
 		},
 		{
 			name:     "XSS: onerror event handler stripped",

--- a/pkg/breakglass/clusteruser_test.go
+++ b/pkg/breakglass/clusteruser_test.go
@@ -80,40 +80,34 @@ func TestBreakglassSessionRequest_SanitizeReason(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "reason at max length (1024 chars) - accepted",
-			input:   strings.Repeat("a", 1024),
-			want:    strings.Repeat("a", 1024),
+			name:    "reason at max length (500 chars) - accepted",
+			input:   strings.Repeat("a", 500),
+			want:    strings.Repeat("a", 500),
 			wantErr: false,
 		},
 		{
-			name:    "reason exceeding max length (1025 chars) - rejected",
-			input:   strings.Repeat("a", 1025),
+			name:    "reason exceeding max length (501 chars) - rejected",
+			input:   strings.Repeat("a", 501),
 			want:    "",
 			wantErr: true,
 			errMsg:  "at most",
 		},
 		{
-			name:    "HTML entity attempt (stripped as dangerous)",
+			name:    "XSS script tag stripped by allowlist",
 			input:   "<script>alert('xss')</script>",
-			want:    "", // Stripped because <script is dangerous
+			want:    "scriptalert'xss'script",
 			wantErr: false,
 		},
 		{
-			name:    "SQL injection attempt",
+			name:    "SQL injection attempt - safe chars pass through",
 			input:   "'; DROP TABLE sessions; --",
 			want:    "'; DROP TABLE sessions; --",
 			wantErr: false,
 		},
 		{
-			name:    "newlines and special chars",
-			input:   "Line1\nLine2\r\nLine3\tTab",
-			want:    "Line1\nLine2\r\nLine3\tTab", // Internal whitespace preserved
-			wantErr: false,
-		},
-		{
-			name:    "exactly 1024 characters",
-			input:   strings.Repeat("a", 1024),
-			want:    strings.Repeat("a", 1024),
+			name:    "reason with basic punctuation preserved",
+			input:   "Debugging prod issue: server down. Please help!",
+			want:    "Debugging prod issue: server down. Please help!",
 			wantErr: false,
 		},
 	}
@@ -247,14 +241,14 @@ func TestBreakglassSessionRequest_CombinedValidation(t *testing.T) {
 		},
 		{
 			name:            "long reason (rejected), valid duration",
-			reason:          strings.Repeat("a", 2000),
+			reason:          strings.Repeat("a", 501),
 			duration:        1800,
 			maxAllowed:      3600,
 			wantReasonErr:   true,
 			wantDurationErr: false,
 		},
 		{
-			name:            "reason with dangerous pattern (stripped), valid duration",
+			name:            "reason with XSS chars stripped, valid duration",
 			reason:          "Normal text <script>alert('xss')</script> more text",
 			duration:        1800,
 			maxAllowed:      3600,
@@ -271,7 +265,7 @@ func TestBreakglassSessionRequest_CombinedValidation(t *testing.T) {
 		},
 		{
 			name:            "invalid duration, long reason",
-			reason:          strings.Repeat("a", 2000),
+			reason:          strings.Repeat("a", 501),
 			duration:        -100,
 			maxAllowed:      3600,
 			wantReasonErr:   true,
@@ -304,6 +298,8 @@ func TestBreakglassSessionRequest_CombinedValidation(t *testing.T) {
 	}
 }
 
+// TestSanitizeReasonText tests the standalone SanitizeReasonText function.
+// Verifies allowlist behavior: only alphanumeric, spaces, and .,;:!?'- are permitted.
 func TestSanitizeReasonText(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -326,145 +322,100 @@ func TestSanitizeReasonText(t *testing.T) {
 			expected: "Need access",
 		},
 		{
-			name:     "text with script tag",
-			input:    "Normal text<script>alert('xss')</script>",
-			expected: "Normal text",
+			name:     "basic punctuation preserved",
+			input:    "Prod is down: needs fix. Please help!",
+			expected: "Prod is down: needs fix. Please help!",
 		},
 		{
-			name:     "text with uppercase script tag",
-			input:    "Normal text<SCRIPT>alert('xss')</SCRIPT>",
-			expected: "Normal text",
+			name:     "XSS: script tag stripped",
+			input:    "<script>alert('xss')</script>",
+			expected: "scriptalert'xss'script",
 		},
 		{
-			name:     "text with mixed case script tag",
+			name:     "XSS: uppercase script tag stripped",
+			input:    "<SCRIPT>alert('xss')</SCRIPT>",
+			expected: "SCRIPTalert'xss'SCRIPT",
+		},
+		{
+			name:     "XSS: mixed case script tag stripped",
 			input:    "Normal text<ScRiPt>alert('xss')</ScRiPt>",
-			expected: "Normal text",
+			expected: "Normal textScRiPtalert'xss'ScRiPt",
 		},
 		{
-			name:     "text with javascript: protocol",
+			name:     "XSS: javascript protocol stripped",
 			input:    "Click here: javascript:alert(1)",
-			expected: "Click here:",
+			expected: "Click here: javascript:alert1",
 		},
 		{
-			name:     "text with on event handler",
+			name:     "XSS: onerror event handler stripped",
 			input:    "Image onerror=alert(1)",
-			expected: "Image",
+			expected: "Image onerroralert1",
 		},
 		{
-			name:     "text with onclick",
+			name:     "XSS: onclick stripped",
 			input:    "Button onclick=doEvil()",
-			expected: "Button",
+			expected: "Button onclickdoEvil",
 		},
 		{
-			name:     "text with onload",
-			input:    "Body onload=steal()",
-			expected: "Body",
+			name:     "XSS: img tag stripped",
+			input:    `<img src="x" onerror="alert(1)">`,
+			expected: "img srcx onerroralert1",
 		},
 		{
-			name:     "text with nested patterns",
-			input:    "Clean <script> text",
-			expected: "Clean",
+			name:     "XSS: URL-encoded payload - percent signs stripped",
+			input:    "%3Cscript%3Ealert(1)%3C/script%3E",
+			expected: "3Cscript3Ealert13Cscript3E",
 		},
 		{
-			name:     "text with only whitespace after removal",
-			input:    "  <script>bad",
+			name:     "Unicode special chars stripped",
+			input:    "Hello \u2603 World",
+			expected: "Hello  World",
+		},
+		{
+			name:     "emoji stripped",
+			input:    "Debugging \U0001F525 production",
+			expected: "Debugging  production",
+		},
+		{
+			name:     "null byte stripped",
+			input:    "null\x00byte",
+			expected: "nullbyte",
+		},
+		{
+			name:     "newlines and tabs stripped",
+			input:    "Line1\nLine2\r\nLine3\tTab",
+			expected: "Line1Line2Line3Tab",
+		},
+		{
+			name:     "ampersand and angle brackets stripped",
+			input:    "ampersand & special < > chars",
+			expected: "ampersand  special   chars",
+		},
+		{
+			name:     "hyphen preserved",
+			input:    "long-running incident",
+			expected: "long-running incident",
+		},
+		{
+			name:     "apostrophe preserved",
+			input:    "customer's data",
+			expected: "customer's data",
+		},
+		{
+			name:     "only whitespace",
+			input:    "   \n\t  ",
 			expected: "",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := SanitizeReasonText(tt.input)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestIndexCaseInsensitive(t *testing.T) {
-	tests := []struct {
-		name     string
-		s        string
-		pattern  string
-		expected int
-	}{
 		{
-			name:     "empty pattern returns 0",
-			s:        "hello",
-			pattern:  "",
-			expected: 0,
-		},
-		{
-			name:     "pattern longer than string",
-			s:        "hi",
-			pattern:  "hello",
-			expected: -1,
-		},
-		{
-			name:     "exact match at start",
-			s:        "hello world",
-			pattern:  "hello",
-			expected: 0,
-		},
-		{
-			name:     "match in middle",
-			s:        "say hello world",
-			pattern:  "hello",
-			expected: 4,
-		},
-		{
-			name:     "case insensitive match",
-			s:        "Hello World",
-			pattern:  "hello",
-			expected: 0,
-		},
-		{
-			name:     "case insensitive match uppercase pattern",
-			s:        "hello world",
-			pattern:  "HELLO",
-			expected: 0,
-		},
-		{
-			name:     "mixed case match",
-			s:        "HeLLo World",
-			pattern:  "hElLo",
-			expected: 0,
-		},
-		{
-			name:     "no match",
-			s:        "hello world",
-			pattern:  "foo",
-			expected: -1,
-		},
-		{
-			name:     "script tag lowercase",
-			s:        "text<script>code",
-			pattern:  "<script>",
-			expected: 4,
-		},
-		{
-			name:     "script tag uppercase",
-			s:        "text<SCRIPT>code",
-			pattern:  "<script>",
-			expected: 4,
-		},
-		{
-			name:     "equal length",
-			s:        "hello",
-			pattern:  "HELLO",
-			expected: 0,
-		},
-		{
-			name:     "empty string no match",
-			s:        "",
-			pattern:  "hello",
-			expected: -1,
+			name:     "backslash stripped",
+			input:    "path\\to\\file",
+			expected: "pathtofile",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := indexCaseInsensitive(tt.s, tt.pattern)
+			result := SanitizeReasonText(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -422,13 +422,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 
 	// Sanitize reason to prevent injection attacks
 	if req.Reason != "" {
-		sanitized, err := breakglass.SanitizeReasonText(req.Reason)
-		if err != nil {
-			reqLog.Warnw("Failed to sanitize reason, using empty string", "error", err)
-			req.Reason = "" // Use empty string as safe fallback
-		} else {
-			req.Reason = sanitized
-		}
+		req.Reason = breakglass.SanitizeReasonText(req.Reason)
 	}
 
 	// Validate template exists

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -377,13 +377,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	session.Status.Approval.ApprovedAt = &now
 	// Sanitize approval reason to prevent injection attacks
 	if req.Reason != "" {
-		sanitized, err := breakglass.SanitizeReasonText(req.Reason)
-		if err != nil {
-			reqLog.Warnw("Failed to sanitize approval reason, using empty string", "error", err)
-			session.Status.Approval.Reason = "" // Use empty string as safe fallback
-		} else {
-			session.Status.Approval.Reason = sanitized
-		}
+		session.Status.Approval.Reason = breakglass.SanitizeReasonText(req.Reason)
 	} else {
 		session.Status.Approval.Reason = req.Reason
 	}
@@ -460,12 +454,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	// Sanitize rejection reason to prevent injection attacks
 	sanitizedReason := req.Reason
 	if req.Reason != "" {
-		var err error
-		sanitizedReason, err = breakglass.SanitizeReasonText(req.Reason)
-		if err != nil {
-			reqLog.Warnw("Failed to sanitize rejection reason, using empty string", "error", err)
-			sanitizedReason = "" // Use empty string as safe fallback
-		}
+		sanitizedReason = breakglass.SanitizeReasonText(req.Reason)
 	}
 	session.Status.Approval.Reason = sanitizedReason
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -54,13 +54,7 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	}
 	// Sanitize approver reason to prevent injection attacks
 	if approverPayload.Reason != "" {
-		sanitized, err := SanitizeReasonText(approverPayload.Reason)
-		if err != nil {
-			reqLog.Warnw("Failed to sanitize approver reason, using empty string", "error", err)
-			approverPayload.Reason = "" // Use empty string as safe fallback
-		} else {
-			approverPayload.Reason = sanitized
-		}
+		approverPayload.Reason = SanitizeReasonText(approverPayload.Reason)
 	}
 
 	var lastCondition metav1.Condition


### PR DESCRIPTION
## Summary

`SanitizeReasonText` used a blocklist approach to filter dangerous characters, which is inherently fragile — new attack vectors (Unicode homoglyphs, zero-width characters, novel encodings) could bypass it. This is a security hardening change that switches to an allowlist approach.

## Changes

- Replaced the blocklist regex with an allowlist: only `[a-zA-Z0-9 .,;:!?'\-]` characters are permitted
- Added a `MaxReasonLength` constant (500 chars) to prevent abuse via extremely long strings
- Simplified the function signature from `(string) (string, error)` to `(string) string` since the allowlist approach cannot fail
- Updated all 4 callers across 3 files to use the new signature

## Files Changed

- `pkg/breakglass/clusteruser.go` — Allowlist-based sanitization + length limit
- `pkg/breakglass/clusteruser_test.go` — Updated tests for allowlist behavior
- `pkg/breakglass/debug/debug_session_api.go` — Updated caller
- `pkg/breakglass/debug/debug_session_api_session_ops.go` — Updated callers
- `pkg/breakglass/session_controller_status.go` — Updated caller

## Testing

- Tests verify allowlist permits safe characters and strips everything else
- Tests verify length truncation at MaxReasonLength
- Existing tests continue to pass