### PR TITLE
fix: add server-side pagination to list endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Server-side pagination for all list endpoints (K7, K17)**: All `GET` list endpoints (`/api/breakglassSessions`, `/api/breakglassEscalations`, `/api/debugSessions`, `/api/debugSessions/templates`, `/api/debugSessions/podTemplates`, `/api/clusterBindings`, `/api/clusterBindings/forCluster/:cluster`) now support `?limit=N` (default 100, max 500) and `?continue=<token>` query parameters following Kubernetes LIST semantics. Responses include a `metadata.continue` (or top-level `continue`) field with an opaque token for retrieving the next page. The shared pagination helper lives in `pkg/utils/pagination.go`.
+
 ### Changed
 
 - **Frontend: upgrade Vite 7 → 8 and @vitejs/plugin-legacy 7 → 8** (PR #562): Major version bumps — Vite 8 replaces Rollup with Rolldown and removes esbuild in favor of Oxc. `@vitejs/plugin-vue` patch bumped to 6.0.5. No breaking changes to the frontend build configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Server-side pagination for all list endpoints (K7, K17)**: All `GET` list endpoints (`/api/breakglassSessions`, `/api/breakglassEscalations`, `/api/debugSessions`, `/api/debugSessions/templates`, `/api/debugSessions/podTemplates`, `/api/clusterBindings`, `/api/clusterBindings/forCluster/:cluster`) now support `?limit=N` (default 100, max 500) and `?continue=<token>` query parameters following Kubernetes LIST semantics. Responses include a `metadata.continue` (or top-level `continue`) field with an opaque token for retrieving the next page. The shared pagination helper lives in `pkg/utils/pagination.go`.
+- **Server-side pagination for all list endpoints (K7, K17)**: All `GET` list endpoints (`/api/breakglassSessions`, `/api/breakglassEscalations`, `/api/debugSessions`, `/api/debugSessions/templates`, `/api/debugSessions/podTemplates`, `/api/clusterBindings`, `/api/clusterBindings/forCluster/:cluster`) now support `?limit=N` (default 100, max 500) and `?continue=<token>` query parameters. The `continue` token is an opaque, base64-encoded integer offset — it is not compatible with Kubernetes watch semantics and does not carry a `resourceVersion`. Responses include a `metadata.continue` (or top-level `continue`) field with an opaque token for retrieving the next page. The shared pagination helper lives in `pkg/utils/pagination.go`.
 
 ### Changed
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -590,37 +590,43 @@ Authorization: Bearer <token>
 
 **Status Code:** `200 OK`
 
-**Response:** Array of `BreakglassEscalation` resources filtered by user's groups:
+**Response:** Paginated envelope containing `BreakglassEscalation` resources filtered by user's groups. The `metadata.continue` field is non-empty when additional pages are available.
 
 ```json
-[
-  {
-    "apiVersion": "breakglass.t-caas.telekom.com/v1alpha1",
-    "kind": "BreakglassEscalation",
-    "metadata": {
-      "name": "cluster-admin-escalation",
-      "namespace": "breakglass-system",
-      "uid": "...",
-      "creationTimestamp": "2024-01-01T00:00:00Z"
-    },
-    "spec": {
-      "displayName": "Cluster Admin Access",
-      "description": "Temporary cluster admin access for incident response",
-      "escalatedGroup": "cluster-admin",
-      "maxValidFor": "2h",
-      "approvers": {
-        "users": ["admin@example.com"],
-        "groups": ["admins"]
+{
+  "items": [
+    {
+      "apiVersion": "breakglass.t-caas.telekom.com/v1alpha1",
+      "kind": "BreakglassEscalation",
+      "metadata": {
+        "name": "cluster-admin-escalation",
+        "namespace": "breakglass-system",
+        "uid": "...",
+        "creationTimestamp": "2024-01-01T00:00:00Z"
       },
-      "requestReason": {
-        "mandatory": true,
-        "description": "Please provide the incident ticket ID"
-      },
-      "blockSelfApproval": true,
-      "allowedApproverDomains": ["example.com"]
+      "spec": {
+        "displayName": "Cluster Admin Access",
+        "description": "Temporary cluster admin access for incident response",
+        "escalatedGroup": "cluster-admin",
+        "maxValidFor": "2h",
+        "approvers": {
+          "users": ["admin@example.com"],
+          "groups": ["admins"]
+        },
+        "requestReason": {
+          "mandatory": true,
+          "description": "Please provide the incident ticket ID"
+        },
+        "blockSelfApproval": true,
+        "allowedApproverDomains": ["example.com"]
+      }
     }
+  ],
+  "metadata": {
+    "continue": "",
+    "total": 1
   }
-]
+}
 ```
 
 ## Webhook Authorization API

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -74,7 +74,7 @@ Paginated responses include a continuation field alongside the items. When there
 ### Example
 
 ```bash
-# First page (100 items)
+# First page (50 items)
 curl -H "Authorization: Bearer <token>" \
   "https://breakglass.example.com/api/debugSessions?limit=50"
 # Response: { "sessions": [...], "total": 320, "continue": "MTAwMA==" }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -50,7 +50,7 @@ Common error codes: `UNAUTHORIZED`, `FORBIDDEN`, `BAD_REQUEST`, `NOT_FOUND`
 
 ## Pagination
 
-All list endpoints support server-side pagination using Kubernetes LIST semantics.
+All list endpoints support server-side pagination using an offset-based continue token. The `continue` token is an opaque, base64-encoded integer offset; it is not compatible with Kubernetes watch semantics and does not reflect resource versions.
 
 ### Query Parameters
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,6 +48,42 @@ The API uses standard HTTP status codes with the following conventions:
 
 Common error codes: `UNAUTHORIZED`, `FORBIDDEN`, `BAD_REQUEST`, `NOT_FOUND`
 
+## Pagination
+
+All list endpoints support server-side pagination using Kubernetes LIST semantics.
+
+### Query Parameters
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `limit` | integer | `100` | `500` | Maximum number of items to return per page |
+| `continue` | string | — | — | Opaque token returned by a previous response to fetch the next page |
+
+### Response Fields
+
+Paginated responses include a continuation field alongside the items. When there are more items available, the field is non-empty. When the last page has been reached, the field is absent or empty.
+
+- `GET /api/breakglassSessions` → `metadata.continue` (and `metadata.total`)
+- `GET /api/breakglassEscalations` → `metadata.continue` (and `metadata.total`)
+- `GET /api/debugSessions` → top-level `continue` (and `total`)
+- `GET /api/debugSessions/templates` → top-level `continue` (and `total`)
+- `GET /api/debugSessions/podTemplates` → top-level `continue` (and `total`)
+- `GET /api/clusterBindings` → top-level `continue` (and `total`)
+- `GET /api/clusterBindings/forCluster/:cluster` → top-level `continue` (and `total`)
+
+### Example
+
+```bash
+# First page (100 items)
+curl -H "Authorization: Bearer <token>" \
+  "https://breakglass.example.com/api/debugSessions?limit=50"
+# Response: { "sessions": [...], "total": 320, "continue": "MTAwMA==" }
+
+# Next page using continue token
+curl -H "Authorization: Bearer <token>" \
+  "https://breakglass.example.com/api/debugSessions?limit=50&continue=MTAwMA=="
+```
+
 ## Identity Provider Configuration
 
 ### Overview
@@ -171,34 +207,42 @@ Authorization: Bearer <token>
 | `approvedByMe` | boolean | Sessions the user has already approved |
 | `activeOnly` | boolean | Only return active (currently running) sessions |
 | `state` | string | Accepts a single value, comma-separated list, or repeated parameter. Supported tokens: `pending`, `approved`, `active`, `waiting`, `waitingforscheduledtime`, `rejected`, `withdrawn`, `expired`, `timeout`. |
+| `limit` | integer | Max items per page (default: 100, max: 500) |
+| `continue` | string | Opaque continuation token from a previous response |
 
-**Response:** Array of `BreakglassSession` resources filtered by query parameters:
+**Response:**
 
 ```json
-[
-  {
-    "apiVersion": "breakglass.t-caas.telekom.com/v1alpha1",
-    "kind": "BreakglassSession",
-    "metadata": {
-      "name": "session-abc123",
-      "namespace": "breakglass-system",
-      "uid": "...",
-      "creationTimestamp": "2024-01-15T10:30:00Z"
-    },
-    "spec": {
-      "cluster": "prod-cluster-1",
-      "user": "user@example.com",
-      "grantedGroup": "cluster-admin",
-      "requestReason": "Emergency access for incident response"
-    },
-    "status": {
-      "state": "Pending",
-      "expiresAt": null,
-      "approver": "",
-      "approvers": []
+{
+  "items": [
+    {
+      "apiVersion": "breakglass.t-caas.telekom.com/v1alpha1",
+      "kind": "BreakglassSession",
+      "metadata": {
+        "name": "session-abc123",
+        "namespace": "breakglass-system",
+        "uid": "...",
+        "creationTimestamp": "2024-01-15T10:30:00Z"
+      },
+      "spec": {
+        "cluster": "prod-cluster-1",
+        "user": "user@example.com",
+        "grantedGroup": "cluster-admin",
+        "requestReason": "Emergency access for incident response"
+      },
+      "status": {
+        "state": "Pending",
+        "expiresAt": null,
+        "approver": "",
+        "approvers": []
+      }
     }
+  ],
+  "metadata": {
+    "continue": "MTAwMA==",
+    "total": 320
   }
-]
+}
 ```
 
 **Examples:**

--- a/e2e/api/escalation_api_test.go
+++ b/e2e/api/escalation_api_test.go
@@ -124,13 +124,15 @@ func (c *EscalationAPIClient) ListEscalationsWithOptions(ctx context.Context, t 
 		return nil, resp.StatusCode, fmt.Errorf("failed to list escalations: status=%d, body=%s", resp.StatusCode, string(body))
 	}
 
-	// API returns array of BreakglassEscalation objects directly
-	var escalations []breakglassv1alpha1.BreakglassEscalation
-	if err := json.Unmarshal(body, &escalations); err != nil {
+	// The API returns a paginated envelope: {"items": [...], "metadata": {"continue": "...", "total": N}}
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("failed to parse escalations: %w", err)
 	}
 
-	return escalations, resp.StatusCode, nil
+	return envelope.Items, resp.StatusCode, nil
 }
 
 // ListEscalationsForCluster lists all escalations for a specific cluster

--- a/e2e/cli/cli_e2e_test.go
+++ b/e2e/cli/cli_e2e_test.go
@@ -21,7 +21,7 @@ import (
 func TestCLIListSessions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/breakglassSessions" {
-			_ = json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassSession{
+			sessions := []breakglassv1alpha1.BreakglassSession{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "session-1",
@@ -37,7 +37,8 @@ func TestCLIListSessions(t *testing.T) {
 						ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
 					},
 				},
-			})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": sessions})
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)

--- a/e2e/helpers/api.go
+++ b/e2e/helpers/api.go
@@ -455,12 +455,15 @@ func (c *APIClient) ListSessions(ctx context.Context) ([]breakglassv1alpha1.Brea
 		return nil, fmt.Errorf("failed to list sessions: status=%d, body=%s", resp.StatusCode, string(body))
 	}
 
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+	// The API returns a paginated envelope: {"items": [...], "metadata": {"continue": "...", "total": N}}
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassSession `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
 		return nil, fmt.Errorf("failed to decode sessions: %w", err)
 	}
 
-	return sessions, nil
+	return envelope.Items, nil
 }
 
 // GetSession gets a specific session via the REST API

--- a/e2e/helpers/api.go
+++ b/e2e/helpers/api.go
@@ -442,29 +442,49 @@ func (c *APIClient) CancelSessionViaAPI(ctx context.Context, t *testing.T, sessi
 	return nil
 }
 
-// ListSessions lists all sessions via the REST API.
-// Uses limit=500 (max page size) to ensure all sessions are returned in test scenarios.
+// ListSessions lists all sessions via the REST API, following pagination continuation tokens.
 func (c *APIClient) ListSessions(ctx context.Context) ([]breakglassv1alpha1.BreakglassSession, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, sessionsBasePath+"?limit=500", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list sessions: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	var all []breakglassv1alpha1.BreakglassSession
+	continueToken := ""
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to list sessions: status=%d, body=%s", resp.StatusCode, string(body))
+	for {
+		path := sessionsBasePath
+		if continueToken != "" {
+			path += "?continue=" + continueToken
+		}
+
+		resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list sessions: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to list sessions: status=%d, body=%s", resp.StatusCode, string(body))
+		}
+
+		// The API returns a paginated envelope: {"items": [...], "metadata": {"continue": "...", "total": N}}
+		var envelope struct {
+			Items    []breakglassv1alpha1.BreakglassSession `json:"items"`
+			Metadata struct {
+				Continue string `json:"continue"`
+			} `json:"metadata"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to decode sessions: %w", err)
+		}
+		_ = resp.Body.Close()
+
+		all = append(all, envelope.Items...)
+		if envelope.Metadata.Continue == "" {
+			break
+		}
+		continueToken = envelope.Metadata.Continue
 	}
 
-	// The API returns a paginated envelope: {"items": [...], "metadata": {"continue": "...", "total": N}}
-	var envelope struct {
-		Items []breakglassv1alpha1.BreakglassSession `json:"items"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("failed to decode sessions: %w", err)
-	}
-
-	return envelope.Items, nil
+	return all, nil
 }
 
 // GetSession gets a specific session via the REST API

--- a/e2e/helpers/api.go
+++ b/e2e/helpers/api.go
@@ -442,9 +442,10 @@ func (c *APIClient) CancelSessionViaAPI(ctx context.Context, t *testing.T, sessi
 	return nil
 }
 
-// ListSessions lists all sessions via the REST API
+// ListSessions lists all sessions via the REST API.
+// Uses limit=500 (max page size) to ensure all sessions are returned in test scenarios.
 func (c *APIClient) ListSessions(ctx context.Context) ([]breakglassv1alpha1.BreakglassSession, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, sessionsBasePath, nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, sessionsBasePath+"?limit=500", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sessions: %w", err)
 	}

--- a/frontend/mock-api/server.mjs
+++ b/frontend/mock-api/server.mjs
@@ -48,12 +48,12 @@ app.get("/api/config/idps", (_req, res) => {
 });
 
 app.get("/api/breakglassEscalations", (_req, res) => {
-  res.json(breakglassEscalations);
+  res.json({ items: breakglassEscalations, metadata: {} });
 });
 
 app.get("/api/breakglassSessions", (req, res) => {
   const sessions = listSessions(req.query || {});
-  res.json(sessions);
+  res.json({ items: sessions, metadata: {} });
 });
 
 app.post("/api/breakglassSessions", (req, res) => {

--- a/frontend/src/services/breakglass.spec.ts
+++ b/frontend/src/services/breakglass.spec.ts
@@ -39,18 +39,20 @@ describe("BreakglassService", () => {
 
   it("maps withdrawn and rejected sessions using status.state", async () => {
     mockClient.get.mockResolvedValueOnce({
-      data: [
-        {
-          metadata: { name: "withdrawn1" },
-          spec: { grantedGroup: "g1", cluster: "c1" },
-          status: { state: "Withdrawn" },
-        },
-        {
-          metadata: { name: "rejected1" },
-          spec: { grantedGroup: "g2", cluster: "c2" },
-          status: { state: "Rejected" },
-        },
-      ],
+      data: {
+        items: [
+          {
+            metadata: { name: "withdrawn1" },
+            spec: { grantedGroup: "g1", cluster: "c1" },
+            status: { state: "Withdrawn" },
+          },
+          {
+            metadata: { name: "rejected1" },
+            spec: { grantedGroup: "g2", cluster: "c2" },
+            status: { state: "Rejected" },
+          },
+        ],
+      },
     });
 
     const sessions = await service.fetchHistoricalSessions();
@@ -72,13 +74,15 @@ describe("BreakglassService", () => {
 
   it("explodes escalations and parses duration strings for all supported units", async () => {
     mockClient.get.mockResolvedValueOnce({
-      data: [
-        { spec: { allowed: { groups: ["ops"], clusters: ["alpha"] }, escalatedGroup: "ops", maxValidFor: "15s" } },
-        { spec: { allowed: { groups: ["db"], clusters: ["beta"] }, escalatedGroup: "db", maxValidFor: "10m" } },
-        { spec: { allowed: { groups: ["sec"], clusters: ["gamma"] }, escalatedGroup: "sec", maxValidFor: "2h" } },
-        { spec: { allowed: { groups: ["sre"], clusters: ["delta"] }, escalatedGroup: "sre", maxValidFor: "1d" } },
-        { spec: { allowed: { groups: ["qa"], clusters: ["epsilon"] }, escalatedGroup: "qa", maxValidFor: "999x" } },
-      ],
+      data: {
+        items: [
+          { spec: { allowed: { groups: ["ops"], clusters: ["alpha"] }, escalatedGroup: "ops", maxValidFor: "15s" } },
+          { spec: { allowed: { groups: ["db"], clusters: ["beta"] }, escalatedGroup: "db", maxValidFor: "10m" } },
+          { spec: { allowed: { groups: ["sec"], clusters: ["gamma"] }, escalatedGroup: "sec", maxValidFor: "2h" } },
+          { spec: { allowed: { groups: ["sre"], clusters: ["delta"] }, escalatedGroup: "sre", maxValidFor: "1d" } },
+          { spec: { allowed: { groups: ["qa"], clusters: ["epsilon"] }, escalatedGroup: "qa", maxValidFor: "999x" } },
+        ],
+      },
     });
 
     const escalations = await (
@@ -97,25 +101,29 @@ describe("BreakglassService", () => {
     // fetchAvailableEscalations -> returns one available escalation
     mockClient.get
       .mockResolvedValueOnce({
-        data: [
-          { spec: { allowed: { groups: ["test-user"], clusters: ["c1"] }, escalatedGroup: "g1", maxValidFor: "1h" } },
-        ],
+        data: {
+          items: [
+            { spec: { allowed: { groups: ["test-user"], clusters: ["c1"] }, escalatedGroup: "g1", maxValidFor: "1h" } },
+          ],
+        },
       })
       // fetchActiveSessions -> returns approved session with nested metadata/spec/status
       .mockResolvedValueOnce({
-        data: [
-          {
-            metadata: { name: "s1" },
-            spec: { grantedGroup: "g1", cluster: "c1" },
-            status: { expiresAt: new Date().toISOString(), state: "Approved" },
-          },
-        ],
+        data: {
+          items: [
+            {
+              metadata: { name: "s1" },
+              spec: { grantedGroup: "g1", cluster: "c1" },
+              status: { expiresAt: new Date().toISOString(), state: "Approved" },
+            },
+          ],
+        },
       })
       // fetchMyOutstandingRequests -> none
-      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: { items: [] } })
       // fetchHistoricalSessions -> rejected and withdrawn (two sequential GETs inside helper)
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: [] });
+      .mockResolvedValueOnce({ data: { items: [] } })
+      .mockResolvedValueOnce({ data: { items: [] } });
 
     const service = new BreakglassService({ getAccessToken: async () => "t" } as unknown as FakeAuth);
     const res = await service.getBreakglasses();
@@ -130,29 +138,35 @@ describe("BreakglassService", () => {
     const timestamp = new Date().toISOString();
     mockClient.get
       .mockResolvedValueOnce({
-        data: [
-          { spec: { allowed: { groups: ["ops"], clusters: ["alpha"] }, escalatedGroup: "ops", maxValidFor: "30m" } },
-          { spec: { allowed: { groups: ["sec"], clusters: ["beta"] }, escalatedGroup: "sec" } },
-        ],
+        data: {
+          items: [
+            { spec: { allowed: { groups: ["ops"], clusters: ["alpha"] }, escalatedGroup: "ops", maxValidFor: "30m" } },
+            { spec: { allowed: { groups: ["sec"], clusters: ["beta"] }, escalatedGroup: "sec" } },
+          ],
+        },
       })
-      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: { items: [] } })
       .mockResolvedValueOnce({
-        data: [
-          {
-            metadata: { name: "pending-1", creationTimestamp: timestamp },
-            spec: { grantedGroup: "ops", cluster: "alpha" },
-            status: { expiresAt: timestamp, state: "Pending" },
-          },
-        ],
+        data: {
+          items: [
+            {
+              metadata: { name: "pending-1", creationTimestamp: timestamp },
+              spec: { grantedGroup: "ops", cluster: "alpha" },
+              status: { expiresAt: timestamp, state: "Pending" },
+            },
+          ],
+        },
       })
       .mockResolvedValueOnce({
-        data: [
-          {
-            metadata: { name: "history-1" },
-            spec: { grantedGroup: "sec", cluster: "beta" },
-            status: { state: "Withdrawn" },
-          },
-        ],
+        data: {
+          items: [
+            {
+              metadata: { name: "history-1" },
+              spec: { grantedGroup: "sec", cluster: "beta" },
+              status: { state: "Withdrawn" },
+            },
+          ],
+        },
       });
 
     const breakglasses = await service.getBreakglasses();
@@ -340,7 +354,7 @@ describe("BreakglassService", () => {
   });
 
   it("fetches outstanding requests and rethrows errors", async () => {
-    mockClient.get.mockResolvedValueOnce({ data: [{ metadata: { name: "req" } }] });
+    mockClient.get.mockResolvedValueOnce({ data: { items: [{ metadata: { name: "req" } }] } });
     const outstanding = await service.fetchMyOutstandingRequests();
     expect(mockClient.get).toHaveBeenCalledWith("/breakglassSessions", {
       params: { mine: true, approver: false, state: "pending" },
@@ -353,13 +367,15 @@ describe("BreakglassService", () => {
 
   it("normalizes approved sessions when fetching active sessions", async () => {
     mockClient.get.mockResolvedValueOnce({
-      data: [
-        {
-          metadata: { name: "sess" },
-          spec: { grantedGroup: "ops", cluster: "c-1" },
-          status: { expiresAt: new Date().toISOString(), state: "Approved" },
-        },
-      ],
+      data: {
+        items: [
+          {
+            metadata: { name: "sess" },
+            spec: { grantedGroup: "ops", cluster: "c-1" },
+            status: { expiresAt: new Date().toISOString(), state: "Approved" },
+          },
+        ],
+      },
     });
 
     const sessions = await service.fetchActiveSessions();
@@ -377,24 +393,28 @@ describe("BreakglassService", () => {
   it("enriches pending sessions with approval reasons when escalation config matches", async () => {
     mockClient.get
       .mockResolvedValueOnce({
-        data: [
-          {
-            metadata: { name: "pending" },
-            spec: { cluster: "c-1", grantedGroup: "ops" },
-          },
-        ],
+        data: {
+          items: [
+            {
+              metadata: { name: "pending" },
+              spec: { cluster: "c-1", grantedGroup: "ops" },
+            },
+          ],
+        },
       })
       .mockResolvedValueOnce({
-        data: [
-          {
-            spec: {
-              allowed: { groups: ["ops"], clusters: ["c-1"] },
-              approvers: { groups: ["sec"] },
-              escalatedGroup: "ops",
-              approvalReason: { mandatory: true, description: "Need manager approval" },
+        data: {
+          items: [
+            {
+              spec: {
+                allowed: { groups: ["ops"], clusters: ["c-1"] },
+                approvers: { groups: ["sec"] },
+                escalatedGroup: "ops",
+                approvalReason: { mandatory: true, description: "Need manager approval" },
+              },
             },
-          },
-        ],
+          ],
+        },
       });
 
     const pending = await service.fetchPendingSessionsForApproval();
@@ -404,7 +424,7 @@ describe("BreakglassService", () => {
 
   it("continues when available escalations cannot be fetched", async () => {
     mockClient.get
-      .mockResolvedValueOnce({ data: [{ metadata: { name: "pending" }, spec: {} }] })
+      .mockResolvedValueOnce({ data: { items: [{ metadata: { name: "pending" }, spec: {} }] } })
       .mockRejectedValueOnce(new Error("config down"));
 
     const pending = await service.fetchPendingSessionsForApproval();
@@ -413,7 +433,7 @@ describe("BreakglassService", () => {
   });
 
   it("searches sessions with arbitrary parameters and handles failures", async () => {
-    mockClient.get.mockResolvedValueOnce({ data: [{ metadata: { name: "s" } }] });
+    mockClient.get.mockResolvedValueOnce({ data: { items: [{ metadata: { name: "s" } }] } });
     const results = await service.searchSessions({ mine: true, state: "approved" });
     expect(results).toHaveLength(1);
 
@@ -449,15 +469,17 @@ describe("BreakglassService", () => {
     const now = Date.now();
     mockClient.get
       .mockResolvedValueOnce({
-        data: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }],
+        data: { items: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }] },
       })
       .mockResolvedValueOnce({
-        data: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }],
+        data: { items: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }] },
       })
       .mockResolvedValueOnce({
-        data: [
-          { metadata: { name: "hist" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { state: "Rejected" } },
-        ],
+        data: {
+          items: [
+            { metadata: { name: "hist" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { state: "Rejected" } },
+          ],
+        },
       });
 
     const sessions = await service.fetchMySessions();
@@ -469,10 +491,12 @@ describe("BreakglassService", () => {
 
   it("returns deduplicated sessions approved by the user", async () => {
     mockClient.get.mockResolvedValueOnce({
-      data: [
-        { metadata: { name: "same" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: 1 } },
-        { metadata: { name: "same" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: 1 } },
-      ],
+      data: {
+        items: [
+          { metadata: { name: "same" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: 1 } },
+          { metadata: { name: "same" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: 1 } },
+        ],
+      },
     });
 
     const sessions = await service.fetchSessionsIApproved();

--- a/frontend/src/services/breakglass.spec.ts
+++ b/frontend/src/services/breakglass.spec.ts
@@ -469,10 +469,18 @@ describe("BreakglassService", () => {
     const now = Date.now();
     mockClient.get
       .mockResolvedValueOnce({
-        data: { items: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }] },
+        data: {
+          items: [
+            { metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } },
+          ],
+        },
       })
       .mockResolvedValueOnce({
-        data: { items: [{ metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } }] },
+        data: {
+          items: [
+            { metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { expiresAt: now } },
+          ],
+        },
       })
       .mockResolvedValueOnce({
         data: {

--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -18,13 +18,13 @@ export type SessionSearchParams = {
 
 export default class BreakglassService {
   public async fetchMyOutstandingRequests(): Promise<SessionCR[]> {
-    // Use RESTful endpoint with filtering
     debug("BreakglassService.fetchMyOutstandingRequests", "Fetching outstanding requests");
     try {
-      const r = await this.client.get("/breakglassSessions", {
-        params: { mine: true, approver: false, state: "pending" },
+      const sessions = await this.fetchAllPages<SessionCR>("/breakglassSessions", {
+        mine: true,
+        approver: false,
+        state: "pending",
       });
-      const sessions = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchMyOutstandingRequests", "Fetched outstanding requests", {
         count: sessions.length,
       });
@@ -32,7 +32,7 @@ export default class BreakglassService {
     } catch (e) {
       handleAxiosError("BreakglassService.fetchMyOutstandingRequests", e, "Failed to fetch outstanding requests");
       debug("BreakglassService.fetchMyOutstandingRequests", "Request failed", { errorMessage: (e as Error)?.message });
-      throw e; // Re-throw so UI can show error state
+      throw e;
     }
   }
   private client: AxiosInstance;
@@ -45,6 +45,19 @@ export default class BreakglassService {
     // Note: Error handling is done in individual methods to provide context-specific messages.
     // Do NOT add a response interceptor that calls handleAxiosError here, as it would cause
     // duplicate error toasts (interceptor + method catch block).
+  }
+
+  private async fetchAllPages<T>(url: string, params: Record<string, unknown>): Promise<T[]> {
+    const all: T[] = [];
+    let continueToken: string | undefined = undefined;
+    do {
+      const requestParams = continueToken ? { ...params, continue: continueToken } : params;
+      const r = await this.client.get(url, { params: requestParams });
+      const items = Array.isArray(r.data?.items) ? (r.data.items as T[]) : [];
+      all.push(...items);
+      continueToken = r.data?.metadata?.continue || "";
+    } while (continueToken);
+    return all;
   }
 
   // Backend endpoints:
@@ -107,10 +120,11 @@ export default class BreakglassService {
   public async fetchActiveSessions(): Promise<ActiveBreakglass[]> {
     try {
       debug("BreakglassService.fetchActiveSessions", "Fetching active sessions");
-      const r = await this.client.get("/breakglassSessions", {
-        params: { state: "approved", mine: true, approver: false },
+      const data = await this.fetchAllPages<SessionCR>("/breakglassSessions", {
+        state: "approved",
+        mine: true,
+        approver: false,
       });
-      const data = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchActiveSessions", "Fetched active sessions", { count: data.length });
       // Normalize approved sessions to a shape that includes metadata/spec/status so
       // callers (getBreakglasses) can build sessionActive/sessionPending consistently.
@@ -139,10 +153,11 @@ export default class BreakglassService {
   public async fetchPendingSessionsForApproval(): Promise<SessionCR[]> {
     try {
       debug("BreakglassService.fetchPendingSessionsForApproval", "Fetching pending sessions for approval");
-      const r = await this.client.get("/breakglassSessions", {
-        params: { state: "pending", approver: true, mine: false },
+      const data = await this.fetchAllPages<SessionCR>("/breakglassSessions", {
+        state: "pending",
+        approver: true,
+        mine: false,
       });
-      const data = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchPendingSessionsForApproval", "Fetched pending sessions", { count: data.length });
 
       // Backend now returns sessions with approvalReason populated from session.spec.approvalReasonConfig
@@ -210,10 +225,7 @@ export default class BreakglassService {
   public async searchSessions(params: SessionSearchParams = {}): Promise<SessionCR[]> {
     try {
       debug("BreakglassService.searchSessions", "Searching sessions", { params });
-      const response = await this.client.get("/breakglassSessions", {
-        params,
-      });
-      const results = Array.isArray(response.data?.items) ? (response.data.items as SessionCR[]) : [];
+      const results = await this.fetchAllPages<SessionCR>("/breakglassSessions", params as Record<string, unknown>);
       debug("BreakglassService.searchSessions", "Search complete", { count: results.length });
       return results;
     } catch (e) {
@@ -347,10 +359,11 @@ export default class BreakglassService {
   public async fetchHistoricalSessions(): Promise<ActiveBreakglass[]> {
     try {
       debug("BreakglassService.fetchHistoricalSessions", "Fetching historical sessions");
-      const response = await this.client.get("/breakglassSessions", {
-        params: { state: "rejected,withdrawn", mine: true, approver: false },
+      const all = await this.fetchAllPages<SessionCR>("/breakglassSessions", {
+        state: "rejected,withdrawn",
+        mine: true,
+        approver: false,
       });
-      const all = Array.isArray(response.data?.items) ? response.data.items : [];
       debug("BreakglassService.fetchHistoricalSessions", "Fetched historical sessions", { count: all.length });
       return all.map((ses: SessionCR) => ({
         name: ses?.metadata?.name || "",
@@ -377,13 +390,11 @@ export default class BreakglassService {
   public async fetchMySessions(): Promise<ActiveBreakglass[]> {
     try {
       debug("BreakglassService.fetchMySessions", "Fetching my sessions");
-      const [activeResp, timedOutResp, historical] = await Promise.all([
-        this.client.get("/breakglassSessions", { params: { mine: true, approver: false, state: "approved" } }),
-        this.client.get("/breakglassSessions", { params: { mine: true, approver: false, state: "timeout" } }),
+      const [approved, timedOut, historical] = await Promise.all([
+        this.fetchAllPages<SessionCR>("/breakglassSessions", { mine: true, approver: false, state: "approved" }),
+        this.fetchAllPages<SessionCR>("/breakglassSessions", { mine: true, approver: false, state: "timeout" }),
         this.fetchHistoricalSessions(),
       ]);
-      const approved = Array.isArray(activeResp.data?.items) ? activeResp.data.items : [];
-      const timedOut = Array.isArray(timedOutResp.data?.items) ? timedOutResp.data.items : [];
 
       // Normalize entries to ActiveBreakglass shape
       const approvedNormalized = approved.map((ses: unknown) => this.normalizeSessionRecord(ses as SessionCR));
@@ -410,10 +421,12 @@ export default class BreakglassService {
   public async fetchSessionsIApproved(): Promise<ActiveBreakglass[]> {
     try {
       debug("BreakglassService.fetchSessionsIApproved", "Fetching sessions I approved");
-      const response = await this.client.get("/breakglassSessions", {
-        params: { state: "approved,timeout", mine: false, approver: false, approvedByMe: true },
+      const data = await this.fetchAllPages<SessionCR>("/breakglassSessions", {
+        state: "approved,timeout",
+        mine: false,
+        approver: false,
+        approvedByMe: true,
       });
-      const data = Array.isArray(response.data?.items) ? response.data.items : [];
 
       const combined = data.map((ses: unknown) => this.normalizeSessionRecord(ses as SessionCR));
       const seen = new Map<string, ActiveBreakglass>();

--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -24,7 +24,7 @@ export default class BreakglassService {
       const r = await this.client.get("/breakglassSessions", {
         params: { mine: true, approver: false, state: "pending" },
       });
-      const sessions = Array.isArray(r.data) ? (r.data as SessionCR[]) : [];
+      const sessions = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchMyOutstandingRequests", "Fetched outstanding requests", {
         count: sessions.length,
       });
@@ -56,7 +56,7 @@ export default class BreakglassService {
       const r = await this.client.get("/breakglassEscalations");
       // Each escalation spec has: allowed (clusters, groups), approvers (users, groups), escalatedGroup, maxValidFor, retainFor, idleTimeout, clusterConfigRefs, denyPolicyRefs
       // We explode multi-cluster escalations into individual entries per cluster so UI can show sessions per cluster.
-      const data = Array.isArray(r.data) ? r.data : [];
+      const data = Array.isArray(r.data?.items) ? r.data.items : [];
       const output: AvailableBreakglass[] = [];
       data.forEach((item: Record<string, unknown>) => {
         const spec = (item?.spec || {}) as Record<string, unknown>;
@@ -110,7 +110,7 @@ export default class BreakglassService {
       const r = await this.client.get("/breakglassSessions", {
         params: { state: "approved", mine: true, approver: false },
       });
-      const data = Array.isArray(r.data) ? (r.data as SessionCR[]) : [];
+      const data = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchActiveSessions", "Fetched active sessions", { count: data.length });
       // Normalize approved sessions to a shape that includes metadata/spec/status so
       // callers (getBreakglasses) can build sessionActive/sessionPending consistently.
@@ -142,7 +142,7 @@ export default class BreakglassService {
       const r = await this.client.get("/breakglassSessions", {
         params: { state: "pending", approver: true, mine: false },
       });
-      const data = Array.isArray(r.data) ? (r.data as SessionCR[]) : [];
+      const data = Array.isArray(r.data?.items) ? (r.data.items as SessionCR[]) : [];
       debug("BreakglassService.fetchPendingSessionsForApproval", "Fetched pending sessions", { count: data.length });
 
       // Backend now returns sessions with approvalReason populated from session.spec.approvalReasonConfig
@@ -213,7 +213,7 @@ export default class BreakglassService {
       const response = await this.client.get("/breakglassSessions", {
         params,
       });
-      const results = Array.isArray(response.data) ? (response.data as SessionCR[]) : [];
+      const results = Array.isArray(response.data?.items) ? (response.data.items as SessionCR[]) : [];
       debug("BreakglassService.searchSessions", "Search complete", { count: results.length });
       return results;
     } catch (e) {
@@ -350,7 +350,7 @@ export default class BreakglassService {
       const response = await this.client.get("/breakglassSessions", {
         params: { state: "rejected,withdrawn", mine: true, approver: false },
       });
-      const all = Array.isArray(response.data) ? response.data : [];
+      const all = Array.isArray(response.data?.items) ? response.data.items : [];
       debug("BreakglassService.fetchHistoricalSessions", "Fetched historical sessions", { count: all.length });
       return all.map((ses: SessionCR) => ({
         name: ses?.metadata?.name || "",
@@ -382,8 +382,8 @@ export default class BreakglassService {
         this.client.get("/breakglassSessions", { params: { mine: true, approver: false, state: "timeout" } }),
         this.fetchHistoricalSessions(),
       ]);
-      const approved = Array.isArray(activeResp.data) ? activeResp.data : [];
-      const timedOut = Array.isArray(timedOutResp.data) ? timedOutResp.data : [];
+      const approved = Array.isArray(activeResp.data?.items) ? activeResp.data.items : [];
+      const timedOut = Array.isArray(timedOutResp.data?.items) ? timedOutResp.data.items : [];
 
       // Normalize entries to ActiveBreakglass shape
       const approvedNormalized = approved.map((ses: unknown) => this.normalizeSessionRecord(ses as SessionCR));
@@ -413,7 +413,7 @@ export default class BreakglassService {
       const response = await this.client.get("/breakglassSessions", {
         params: { state: "approved,timeout", mine: false, approver: false, approvedByMe: true },
       });
-      const data = Array.isArray(response.data) ? response.data : [];
+      const data = Array.isArray(response.data?.items) ? response.data.items : [];
 
       const combined = data.map((ses: unknown) => this.normalizeSessionRecord(ses as SessionCR));
       const seen = new Map<string, ActiveBreakglass>();

--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -51,8 +51,8 @@ export default class BreakglassService {
     const all: T[] = [];
     let continueToken: string | undefined = undefined;
     do {
-      const requestParams = continueToken ? { ...params, continue: continueToken } : params;
-      const r = await this.client.get(url, { params: requestParams });
+      const requestParams: Record<string, unknown> = continueToken ? { ...params, continue: continueToken } : params;
+      const r: AxiosResponse = await this.client.get(url, { params: requestParams });
       const items = Array.isArray(r.data?.items) ? (r.data.items as T[]) : [];
       all.push(...items);
       continueToken = r.data?.metadata?.continue || "";

--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -66,7 +66,8 @@ export default class BreakglassService {
   private async fetchAvailableEscalations(): Promise<AvailableBreakglass[]> {
     try {
       debug("BreakglassService.fetchAvailableEscalations", "Fetching available escalations");
-      const r = await this.client.get("/breakglassEscalations");
+      const requestParams: Record<string, string> = { limit: "100" };
+      const r: AxiosResponse = await this.client.get("/breakglassEscalations", { params: requestParams });
       // Each escalation spec has: allowed (clusters, groups), approvers (users, groups), escalatedGroup, maxValidFor, retainFor, idleTimeout, clusterConfigRefs, denyPolicyRefs
       // We explode multi-cluster escalations into individual entries per cluster so UI can show sessions per cluster.
       const data = Array.isArray(r.data?.items) ? r.data.items : [];

--- a/frontend/src/services/breakglassSession.ts
+++ b/frontend/src/services/breakglassSession.ts
@@ -38,7 +38,7 @@ export default class BreakglassSessionService {
     }
   }
 
-  public async getSessionStatus(request: BreakglassSessionRequest) {
+  public async getSessionStatus(request: BreakglassSessionRequest, continueToken?: string) {
     // RESTful: GET /breakglassSessions?user=...&cluster=...&group=...&name=...
     try {
       const params: Record<string, string | boolean> = {};
@@ -51,6 +51,7 @@ export default class BreakglassSessionService {
       // Default client-side policy: mine defaults to true, approver defaults to false
       params.mine = request.mine === undefined ? true : request.mine;
       params.approver = request.approver === undefined ? false : request.approver;
+      if (continueToken) params.continue = continueToken;
       return await this.client.get("/breakglassSessions", { params });
     } catch (e) {
       handleAxiosError("BreakglassSessionService.getSessionStatus", e, "Failed to fetch session status");

--- a/frontend/src/views/BreakglassSessionReview.vue
+++ b/frontend/src/views/BreakglassSessionReview.vue
@@ -132,7 +132,7 @@ async function getActiveBreakglasses() {
     const response = await service.getSessionStatus(params);
     if (response.status === 200) {
       state.getBreakglassesMsg = "";
-      state.breakglasses = response.data;
+      state.breakglasses = Array.isArray(response.data?.items) ? response.data.items : [];
     }
   } catch (errResponse: unknown) {
     const axiosLike = errResponse as AxiosLikeError;

--- a/frontend/src/views/BreakglassSessionReview.vue
+++ b/frontend/src/views/BreakglassSessionReview.vue
@@ -129,11 +129,20 @@ async function getActiveBreakglasses() {
       mine: routeApprover.value ? false : true,
       approver: routeApprover.value ? true : false,
     };
-    const response = await service.getSessionStatus(params);
-    if (response.status === 200) {
-      state.getBreakglassesMsg = "";
-      state.breakglasses = Array.isArray(response.data?.items) ? response.data.items : [];
-    }
+    const all: SessionCR[] = [];
+    let continueToken: string | undefined = undefined;
+    do {
+      const response = await service.getSessionStatus(params, continueToken);
+      if (response.status === 200) {
+        state.getBreakglassesMsg = "";
+        const items: SessionCR[] = Array.isArray(response.data?.items) ? response.data.items : [];
+        all.push(...items);
+        continueToken = response.data?.metadata?.continue || "";
+      } else {
+        break;
+      }
+    } while (continueToken);
+    state.breakglasses = all;
   } catch (errResponse: unknown) {
     const axiosLike = errResponse as AxiosLikeError;
     if (axiosLike?.response?.status === 401 || axiosLike?.status === 401) {

--- a/frontend/tests/unit/breakglassService.spec.ts
+++ b/frontend/tests/unit/breakglassService.spec.ts
@@ -116,4 +116,72 @@ describe("BreakglassService", () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe("pagination", () => {
+    it("fetchMyOutstandingRequests walks all pages", async () => {
+      const page1 = { metadata: { name: "s1" }, spec: { grantedGroup: "g", cluster: "c" }, status: {} };
+      const page2 = { metadata: { name: "s2" }, spec: { grantedGroup: "g", cluster: "c" }, status: {} };
+      mockGet
+        .mockResolvedValueOnce({ data: { items: [page1], metadata: { continue: "tok1" } } })
+        .mockResolvedValueOnce({ data: { items: [page2], metadata: { continue: "" } } });
+
+      const result = await service.fetchMyOutstandingRequests();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ metadata: { name: "s1" } });
+      expect(result[1]).toMatchObject({ metadata: { name: "s2" } });
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("fetchActiveSessions walks all pages", async () => {
+      const page1 = { metadata: { name: "a1" }, spec: { grantedGroup: "grp", cluster: "cl" }, status: { state: "Approved" } };
+      const page2 = { metadata: { name: "a2" }, spec: { grantedGroup: "grp", cluster: "cl" }, status: { state: "Approved" } };
+      mockGet
+        .mockResolvedValueOnce({ data: { items: [page1], metadata: { continue: "next" } } })
+        .mockResolvedValueOnce({ data: { items: [page2], metadata: { continue: "" } } });
+
+      const result = await service.fetchActiveSessions();
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("a1");
+      expect(result[1].name).toBe("a2");
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("searchSessions walks all pages", async () => {
+      const s1 = { metadata: { name: "q1" }, spec: {}, status: {} };
+      const s2 = { metadata: { name: "q2" }, spec: {}, status: {} };
+      mockGet
+        .mockResolvedValueOnce({ data: { items: [s1], metadata: { continue: "c1" } } })
+        .mockResolvedValueOnce({ data: { items: [s2], metadata: { continue: "" } } });
+
+      const result = await service.searchSessions({ state: "pending" });
+      expect(result).toHaveLength(2);
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("fetchHistoricalSessions walks all pages", async () => {
+      const h1 = { metadata: { name: "h1" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Rejected" } };
+      const h2 = { metadata: { name: "h2" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Withdrawn" } };
+      mockGet
+        .mockResolvedValueOnce({ data: { items: [h1], metadata: { continue: "p2" } } })
+        .mockResolvedValueOnce({ data: { items: [h2], metadata: { continue: "" } } });
+
+      const result = await service.fetchHistoricalSessions();
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe("h1");
+      expect(result[1].name).toBe("h2");
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it("fetchSessionsIApproved walks all pages", async () => {
+      const a1 = { metadata: { name: "ia1" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Approved" } };
+      const a2 = { metadata: { name: "ia2" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Timeout" } };
+      mockGet
+        .mockResolvedValueOnce({ data: { items: [a1], metadata: { continue: "tok" } } })
+        .mockResolvedValueOnce({ data: { items: [a2], metadata: { continue: "" } } });
+
+      const result = await service.fetchSessionsIApproved();
+      expect(result).toHaveLength(2);
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/frontend/tests/unit/breakglassService.spec.ts
+++ b/frontend/tests/unit/breakglassService.spec.ts
@@ -133,8 +133,16 @@ describe("BreakglassService", () => {
     });
 
     it("fetchActiveSessions walks all pages", async () => {
-      const page1 = { metadata: { name: "a1" }, spec: { grantedGroup: "grp", cluster: "cl" }, status: { state: "Approved" } };
-      const page2 = { metadata: { name: "a2" }, spec: { grantedGroup: "grp", cluster: "cl" }, status: { state: "Approved" } };
+      const page1 = {
+        metadata: { name: "a1" },
+        spec: { grantedGroup: "grp", cluster: "cl" },
+        status: { state: "Approved" },
+      };
+      const page2 = {
+        metadata: { name: "a2" },
+        spec: { grantedGroup: "grp", cluster: "cl" },
+        status: { state: "Approved" },
+      };
       mockGet
         .mockResolvedValueOnce({ data: { items: [page1], metadata: { continue: "next" } } })
         .mockResolvedValueOnce({ data: { items: [page2], metadata: { continue: "" } } });
@@ -160,7 +168,11 @@ describe("BreakglassService", () => {
 
     it("fetchHistoricalSessions walks all pages", async () => {
       const h1 = { metadata: { name: "h1" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Rejected" } };
-      const h2 = { metadata: { name: "h2" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Withdrawn" } };
+      const h2 = {
+        metadata: { name: "h2" },
+        spec: { grantedGroup: "g", cluster: "c" },
+        status: { state: "Withdrawn" },
+      };
       mockGet
         .mockResolvedValueOnce({ data: { items: [h1], metadata: { continue: "p2" } } })
         .mockResolvedValueOnce({ data: { items: [h2], metadata: { continue: "" } } });
@@ -173,7 +185,11 @@ describe("BreakglassService", () => {
     });
 
     it("fetchSessionsIApproved walks all pages", async () => {
-      const a1 = { metadata: { name: "ia1" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Approved" } };
+      const a1 = {
+        metadata: { name: "ia1" },
+        spec: { grantedGroup: "g", cluster: "c" },
+        status: { state: "Approved" },
+      };
       const a2 = { metadata: { name: "ia2" }, spec: { grantedGroup: "g", cluster: "c" }, status: { state: "Timeout" } };
       mockGet
         .mockResolvedValueOnce({ data: { items: [a1], metadata: { continue: "tok" } } })

--- a/frontend/tests/unit/views/BreakglassSessionReview.spec.ts
+++ b/frontend/tests/unit/views/BreakglassSessionReview.spec.ts
@@ -101,14 +101,17 @@ describe("BreakglassSessionReview", () => {
     await createWrapper();
 
     expect(mockGetSessionStatus).toHaveBeenCalledTimes(1);
-    expect(mockGetSessionStatus).toHaveBeenCalledWith({
-      name: undefined,
-      cluster: undefined,
-      user: undefined,
-      group: undefined,
-      mine: true,
-      approver: false,
-    });
+    expect(mockGetSessionStatus).toHaveBeenCalledWith(
+      {
+        name: undefined,
+        cluster: undefined,
+        user: undefined,
+        group: undefined,
+        mine: true,
+        approver: false,
+      },
+      undefined,
+    );
   });
 
   it("uses approver mode params when route query has approver=true", async () => {
@@ -120,6 +123,7 @@ describe("BreakglassSessionReview", () => {
         mine: false,
         approver: true,
       }),
+      undefined,
     );
   });
 

--- a/pkg/api/api_end_to_end_test.go
+++ b/pkg/api/api_end_to_end_test.go
@@ -241,9 +241,15 @@ func (env *apiEndToEndEnv) listSessions(t *testing.T) []breakglassv1alpha1.Break
 	t.Helper()
 	rr := env.doRequest(t, http.MethodGet, sessionsBasePath, nil)
 	require.Equal(t, http.StatusOK, rr.Code)
-	var sessions []breakglassv1alpha1.BreakglassSession
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &sessions))
-	return sessions
+	var envelope struct {
+		Items    []breakglassv1alpha1.BreakglassSession `json:"items"`
+		Metadata struct {
+			Continue string `json:"continue"`
+			Total    int    `json:"total"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &envelope))
+	return envelope.Items
 }
 
 func (env *apiEndToEndEnv) approveSession(t *testing.T, name string) {

--- a/pkg/bgctl/client/debug.go
+++ b/pkg/bgctl/client/debug.go
@@ -28,6 +28,7 @@ type DebugSessionListOptions struct {
 
 type DebugSessionSummary struct {
 	Name                 string                                   `json:"name"`
+	Namespace            string                                   `json:"namespace"`
 	TemplateRef          string                                   `json:"templateRef"`
 	Cluster              string                                   `json:"cluster"`
 	RequestedBy          string                                   `json:"requestedBy"`
@@ -473,6 +474,7 @@ type DebugPodTemplateService struct {
 // DebugPodTemplateSummary represents a pod template summary from the API
 type DebugPodTemplateSummary struct {
 	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
 	DisplayName string `json:"displayName"`
 	Description string `json:"description,omitempty"`
 	Containers  int    `json:"containers"`

--- a/pkg/bgctl/client/escalations.go
+++ b/pkg/bgctl/client/escalations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
@@ -17,14 +18,29 @@ func (c *Client) Escalations() *EscalationService {
 }
 
 func (e *EscalationService) List(ctx context.Context) ([]breakglassv1alpha1.BreakglassEscalation, error) {
-	endpoint := "api/breakglassEscalations"
-	var envelope struct {
-		Items []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+	var all []breakglassv1alpha1.BreakglassEscalation
+	continueToken := ""
+	for {
+		endpoint := "api/breakglassEscalations"
+		if continueToken != "" {
+			endpoint = fmt.Sprintf("%s?continue=%s", endpoint, url.QueryEscape(continueToken))
+		}
+		var envelope struct {
+			Items    []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+			Metadata struct {
+				Continue string `json:"continue"`
+			} `json:"metadata"`
+		}
+		if err := e.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
+			return nil, err
+		}
+		all = append(all, envelope.Items...)
+		if envelope.Metadata.Continue == "" {
+			break
+		}
+		continueToken = envelope.Metadata.Continue
 	}
-	if err := e.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
-		return nil, err
-	}
-	return envelope.Items, nil
+	return all, nil
 }
 
 func (e *EscalationService) Get(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassEscalation, error) {

--- a/pkg/bgctl/client/escalations.go
+++ b/pkg/bgctl/client/escalations.go
@@ -18,11 +18,13 @@ func (c *Client) Escalations() *EscalationService {
 
 func (e *EscalationService) List(ctx context.Context) ([]breakglassv1alpha1.BreakglassEscalation, error) {
 	endpoint := "api/breakglassEscalations"
-	var escs []breakglassv1alpha1.BreakglassEscalation
-	if err := e.client.do(ctx, http.MethodGet, endpoint, nil, &escs); err != nil {
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+	}
+	if err := e.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
 		return nil, err
 	}
-	return escs, nil
+	return envelope.Items, nil
 }
 
 func (e *EscalationService) Get(ctx context.Context, name string) (*breakglassv1alpha1.BreakglassEscalation, error) {

--- a/pkg/bgctl/client/escalations_test.go
+++ b/pkg/bgctl/client/escalations_test.go
@@ -49,7 +49,8 @@ func TestEscalationsList(t *testing.T) {
 		require.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(escalations)
+		envelope := map[string]interface{}{"items": escalations}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 
@@ -81,7 +82,8 @@ func TestEscalationsGet(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(escalations)
+		envelope := map[string]interface{}{"items": escalations}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 
@@ -109,7 +111,8 @@ func TestEscalationsGet_NotFound(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(escalations)
+		envelope := map[string]interface{}{"items": escalations}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 
@@ -143,7 +146,8 @@ func TestEscalationsListClusters(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(escalations)
+		envelope := map[string]interface{}{"items": escalations}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 
@@ -162,7 +166,8 @@ func TestEscalationsListClusters(t *testing.T) {
 func TestEscalationsListClusters_Empty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassEscalation{})
+		envelope := map[string]interface{}{"items": []breakglassv1alpha1.BreakglassEscalation{}}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 

--- a/pkg/bgctl/client/sessions.go
+++ b/pkg/bgctl/client/sessions.go
@@ -72,11 +72,13 @@ func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]b
 	if encoded := params.Encode(); encoded != "" {
 		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &sessions); err != nil {
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassSession `json:"items"`
+	}
+	if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
 		return nil, err
 	}
-	return sessions, nil
+	return envelope.Items, nil
 }
 
 // SessionGetResponse wraps the session with authorization metadata

--- a/pkg/bgctl/client/sessions.go
+++ b/pkg/bgctl/client/sessions.go
@@ -43,42 +43,62 @@ type SessionActionRequest struct {
 }
 
 func (s *SessionService) List(ctx context.Context, opts SessionListOptions) ([]breakglassv1alpha1.BreakglassSession, error) {
-	endpoint := "api/breakglassSessions"
-	params := url.Values{}
+	baseParams := url.Values{}
 	if opts.Cluster != "" {
-		params.Set("cluster", opts.Cluster)
+		baseParams.Set("cluster", opts.Cluster)
 	}
 	if opts.User != "" {
-		params.Set("user", opts.User)
+		baseParams.Set("user", opts.User)
 	}
 	if opts.Group != "" {
-		params.Set("group", opts.Group)
+		baseParams.Set("group", opts.Group)
 	}
 	if opts.Mine {
-		params.Set("mine", "true")
+		baseParams.Set("mine", "true")
 	}
 	if opts.Approver {
-		params.Set("approver", "true")
+		baseParams.Set("approver", "true")
 	}
 	if opts.ApprovedByMe {
-		params.Set("approvedByMe", "true")
+		baseParams.Set("approvedByMe", "true")
 	}
 	if opts.ActiveOnly {
-		params.Set("activeOnly", "true")
+		baseParams.Set("activeOnly", "true")
 	}
 	if len(opts.State) > 0 {
-		params.Set("state", strings.Join(opts.State, ","))
+		baseParams.Set("state", strings.Join(opts.State, ","))
 	}
-	if encoded := params.Encode(); encoded != "" {
-		endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+
+	var all []breakglassv1alpha1.BreakglassSession
+	continueToken := ""
+	for {
+		params := url.Values{}
+		for k, v := range baseParams {
+			params[k] = v
+		}
+		if continueToken != "" {
+			params.Set("continue", continueToken)
+		}
+		endpoint := "api/breakglassSessions"
+		if encoded := params.Encode(); encoded != "" {
+			endpoint = fmt.Sprintf("%s?%s", endpoint, encoded)
+		}
+		var envelope struct {
+			Items    []breakglassv1alpha1.BreakglassSession `json:"items"`
+			Metadata struct {
+				Continue string `json:"continue"`
+			} `json:"metadata"`
+		}
+		if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
+			return nil, err
+		}
+		all = append(all, envelope.Items...)
+		if envelope.Metadata.Continue == "" {
+			break
+		}
+		continueToken = envelope.Metadata.Continue
 	}
-	var envelope struct {
-		Items []breakglassv1alpha1.BreakglassSession `json:"items"`
-	}
-	if err := s.client.do(ctx, http.MethodGet, endpoint, nil, &envelope); err != nil {
-		return nil, err
-	}
-	return envelope.Items, nil
+	return all, nil
 }
 
 // SessionGetResponse wraps the session with authorization metadata

--- a/pkg/bgctl/client/sessions_test.go
+++ b/pkg/bgctl/client/sessions_test.go
@@ -31,7 +31,8 @@ func TestSessionsList(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(sessions)
+		envelope := map[string]interface{}{"items": sessions}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 
@@ -259,7 +260,8 @@ func TestSessionsList_WithFilters(t *testing.T) {
 		require.Equal(t, "true", query.Get("activeOnly"))
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(sessions)
+		envelope := map[string]interface{}{"items": sessions}
+		_ = json.NewEncoder(w).Encode(envelope)
 	}))
 	defer server.Close()
 

--- a/pkg/bgctl/cmd/escalation_test.go
+++ b/pkg/bgctl/cmd/escalation_test.go
@@ -140,7 +140,8 @@ func setupMockEscalationServer(t *testing.T) *httptest.Server {
 		switch r.URL.Path {
 		case "/api/breakglassEscalations":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(escalations)
+			envelope := map[string]interface{}{"items": escalations}
+			_ = json.NewEncoder(w).Encode(envelope)
 		default:
 			http.NotFound(w, r)
 		}

--- a/pkg/breakglass/clusterconfig/binding_api.go
+++ b/pkg/breakglass/clusterconfig/binding_api.go
@@ -29,6 +29,7 @@ import (
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,7 +183,23 @@ func (c *ClusterBindingAPIController) handleListClusterBindings(ctx *gin.Context
 		return responses[i].Name < responses[j].Name
 	})
 
-	ctx.JSON(http.StatusOK, responses)
+	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
+	if lerr != nil {
+		apiresponses.RespondBadRequest(ctx, lerr.Error())
+		return
+	}
+	offset, oerr := utils.ParseContinueToken(ctx.Query("continue"))
+	if oerr != nil {
+		apiresponses.RespondBadRequest(ctx, oerr.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(responses, limit, offset)
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"items":    page,
+		"total":    len(responses),
+		"continue": nextToken,
+	})
 }
 
 // handleGetClusterBinding returns a single cluster binding by namespace and name
@@ -253,7 +270,23 @@ func (c *ClusterBindingAPIController) handleListBindingsForCluster(ctx *gin.Cont
 		return matchingBindings[i].Name < matchingBindings[j].Name
 	})
 
-	ctx.JSON(http.StatusOK, matchingBindings)
+	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
+	if lerr != nil {
+		apiresponses.RespondBadRequest(ctx, lerr.Error())
+		return
+	}
+	offset, oerr := utils.ParseContinueToken(ctx.Query("continue"))
+	if oerr != nil {
+		apiresponses.RespondBadRequest(ctx, oerr.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(matchingBindings, limit, offset)
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"items":    page,
+		"total":    len(matchingBindings),
+		"continue": nextToken,
+	})
 }
 
 // bindingMatchesCluster checks if a binding applies to the given cluster

--- a/pkg/breakglass/clusterconfig/binding_api_test.go
+++ b/pkg/breakglass/clusterconfig/binding_api_test.go
@@ -36,6 +36,24 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
+// pagedBindingResponse mirrors the paginated JSON envelope returned by the
+// cluster binding list endpoints: {"items": [...], "total": N, "continue": "..."}
+type pagedBindingResponse struct {
+	Items    []ClusterBindingResponse `json:"items"`
+	Total    int                      `json:"total"`
+	Continue string                   `json:"continue"`
+}
+
+// decodeBindingPage decodes a paged cluster binding response body and returns items.
+func decodeBindingPage(t *testing.T, body []byte) []ClusterBindingResponse {
+	t.Helper()
+	var paged pagedBindingResponse
+	if err := json.Unmarshal(body, &paged); err != nil {
+		t.Fatalf("Failed to decode paginated binding response: %v", err)
+	}
+	return paged.Items
+}
+
 func init() {
 	gin.SetMode(gin.TestMode)
 }
@@ -168,9 +186,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 2)
 		// Should be sorted by namespace then name
@@ -195,9 +211,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 		assert.Len(t, response, 0)
 	})
 
@@ -218,9 +232,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.NotNil(t, response[0].TemplateRef)
 		assert.Equal(t, "template-1", response[0].TemplateRef.Name)
@@ -244,9 +256,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Equal(t, map[string]string{"env": "prod"}, response[0].TemplateSelector)
 		assert.Equal(t, map[string]string{"tier": "production"}, response[0].ClusterSelector)
@@ -457,9 +467,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "explicit-binding", response[0].Name)
@@ -485,9 +493,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "selector-binding", response[0].Name)
@@ -551,9 +557,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 		assert.Len(t, response, 0)
 	})
 }
@@ -873,9 +877,7 @@ func TestClusterBindingAPIController_Integration(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 		assert.Len(t, response, 1)
 		assert.Equal(t, "integration-test-binding", response[0].Name)
 	})
@@ -1086,9 +1088,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "visible-binding", response[0].Name)
@@ -1112,9 +1112,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 2)
 		// Check both bindings are present
@@ -1140,9 +1138,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "hidden-binding", response[0].Name)
@@ -1232,9 +1228,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 4)
 	})
@@ -1256,9 +1250,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		// Only active-binding should be returned
 		assert.Len(t, response, 1)
@@ -1313,9 +1305,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		// Only active bindings (including hidden active)
 		assert.Len(t, response, 2)
@@ -1468,9 +1458,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster_EmptyList(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 0)
 	})
@@ -1495,9 +1483,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster_EmptyList(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingPage(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "cluster-a-binding", response[0].Name)

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/naming"
 	"github.com/telekom/k8s-breakglass/pkg/system"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -228,6 +229,7 @@ type CreateNodeDebugPodRequest struct {
 type DebugSessionListResponse struct {
 	Sessions []DebugSessionSummary `json:"sessions"`
 	Total    int                   `json:"total"`
+	Continue string                `json:"continue,omitempty"`
 }
 
 // DebugSessionSummary represents a summarized debug session for list responses
@@ -366,9 +368,22 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 		})
 	}
 
+	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
+	if lerr != nil {
+		apiresponses.RespondBadRequest(ctx, lerr.Error())
+		return
+	}
+	offset, oerr := utils.ParseContinueToken(ctx.Query("continue"))
+	if oerr != nil {
+		apiresponses.RespondBadRequest(ctx, oerr.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(summaries, limit, offset)
+
 	ctx.JSON(http.StatusOK, DebugSessionListResponse{
-		Sessions: summaries,
+		Sessions: page,
 		Total:    len(summaries),
+		Continue: nextToken,
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -236,6 +236,7 @@ type DebugSessionListResponse struct {
 // DebugSessionSummary represents a summarized debug session for list responses
 type DebugSessionSummary struct {
 	Name                   string                                   `json:"name"`
+	Namespace              string                                   `json:"namespace"`
 	TemplateRef            string                                   `json:"templateRef"`
 	Cluster                string                                   `json:"cluster"`
 	RequestedBy            string                                   `json:"requestedBy"`
@@ -354,6 +355,7 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 		}
 		summaries = append(summaries, DebugSessionSummary{
 			Name:                   s.Name,
+			Namespace:              s.Namespace,
 			TemplateRef:            s.Spec.TemplateRef,
 			Cluster:                s.Spec.Cluster,
 			RequestedBy:            s.Spec.RequestedBy,
@@ -380,7 +382,10 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 		if !ti.Equal(tj) {
 			return ti.After(tj)
 		}
-		return summaries[i].Name < summaries[j].Name
+		if summaries[i].Name != summaries[j].Name {
+			return summaries[i].Name < summaries[j].Name
+		}
+		return summaries[i].Namespace < summaries[j].Namespace
 	})
 
 	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -367,6 +368,20 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 			AllowedPodOperations:   s.Status.AllowedPodOperations,
 		})
 	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		var ti, tj time.Time
+		if summaries[i].StartsAt != nil {
+			ti = summaries[i].StartsAt.Time
+		}
+		if summaries[j].StartsAt != nil {
+			tj = summaries[j].StartsAt.Time
+		}
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return summaries[i].Name < summaries[j].Name
+	})
 
 	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
 	if lerr != nil {

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -475,6 +475,7 @@ func (c *DebugSessionAPIController) handleListPodTemplates(ctx *gin.Context) {
 	for _, t := range templateList.Items {
 		templates = append(templates, DebugPodTemplateResponse{
 			Name:        t.Name,
+			Namespace:   t.Namespace,
 			DisplayName: t.Spec.DisplayName,
 			Description: t.Spec.Description,
 			Containers:  len(t.Spec.Template.Spec.Containers),
@@ -482,7 +483,10 @@ func (c *DebugSessionAPIController) handleListPodTemplates(ctx *gin.Context) {
 	}
 
 	sort.Slice(templates, func(i, j int) bool {
-		return templates[i].Name < templates[j].Name
+		if templates[i].Name != templates[j].Name {
+			return templates[i].Name < templates[j].Name
+		}
+		return templates[i].Namespace < templates[j].Namespace
 	})
 
 	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -480,9 +480,22 @@ func (c *DebugSessionAPIController) handleListPodTemplates(ctx *gin.Context) {
 		})
 	}
 
+	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
+	if lerr != nil {
+		apiresponses.RespondBadRequest(ctx, lerr.Error())
+		return
+	}
+	offset, oerr := utils.ParseContinueToken(ctx.Query("continue"))
+	if oerr != nil {
+		apiresponses.RespondBadRequest(ctx, oerr.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(templates, limit, offset)
+
 	ctx.JSON(http.StatusOK, gin.H{
-		"templates": templates,
+		"templates": page,
 		"total":     len(templates),
+		"continue":  nextToken,
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -479,6 +480,10 @@ func (c *DebugSessionAPIController) handleListPodTemplates(ctx *gin.Context) {
 			Containers:  len(t.Spec.Template.Spec.Containers),
 		})
 	}
+
+	sort.Slice(templates, func(i, j int) bool {
+		return templates[i].Name < templates[j].Name
+	})
 
 	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
 	if lerr != nil {

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -82,6 +82,7 @@ type NamespaceSelectorRequirementResponse struct {
 // DebugPodTemplateResponse represents a pod template in API responses
 type DebugPodTemplateResponse struct {
 	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
 	DisplayName string `json:"displayName"`
 	Description string `json:"description,omitempty"`
 	Containers  int    `json:"containers"`

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -12,6 +12,7 @@ import (
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"github.com/telekom/k8s-breakglass/pkg/system"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -345,9 +346,22 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 		return templates[i].Name < templates[j].Name
 	})
 
+	limit, lerr := utils.ParsePageLimit(ctx.Query("limit"))
+	if lerr != nil {
+		apiresponses.RespondBadRequest(ctx, lerr.Error())
+		return
+	}
+	offset, oerr := utils.ParseContinueToken(ctx.Query("continue"))
+	if oerr != nil {
+		apiresponses.RespondBadRequest(ctx, oerr.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(templates, limit, offset)
+
 	ctx.JSON(http.StatusOK, gin.H{
-		"templates": templates,
+		"templates": page,
 		"total":     len(templates),
+		"continue":  nextToken,
 	})
 }
 

--- a/pkg/breakglass/escalation/escalation_controller.go
+++ b/pkg/breakglass/escalation/escalation_controller.go
@@ -3,6 +3,7 @@ package escalation
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -184,6 +185,9 @@ func (ec *BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 
 	reqLog.Debugw("Returning escalations response (filtered, hidden groups removed)", "responseCount", len(response))
 	cleaned := dropK8sInternalFieldsEscalationList(response)
+	sort.Slice(cleaned, func(i, j int) bool {
+		return cleaned[i].Name < cleaned[j].Name
+	})
 
 	limit, err := utils.ParsePageLimit(c.Query("limit"))
 	if err != nil {

--- a/pkg/breakglass/escalation/escalation_controller.go
+++ b/pkg/breakglass/escalation/escalation_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/system"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 )
 
 type BreakglassEscalationController struct {
@@ -182,7 +183,27 @@ func (ec *BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 	}
 
 	reqLog.Debugw("Returning escalations response (filtered, hidden groups removed)", "responseCount", len(response))
-	c.JSON(http.StatusOK, dropK8sInternalFieldsEscalationList(response))
+	cleaned := dropK8sInternalFieldsEscalationList(response)
+
+	limit, err := utils.ParsePageLimit(c.Query("limit"))
+	if err != nil {
+		apiresponses.RespondBadRequest(c, err.Error())
+		return
+	}
+	offset, err := utils.ParseContinueToken(c.Query("continue"))
+	if err != nil {
+		apiresponses.RespondBadRequest(c, err.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(cleaned, limit, offset)
+
+	c.JSON(http.StatusOK, gin.H{
+		"items": page,
+		"metadata": gin.H{
+			"continue": nextToken,
+			"total":    len(cleaned),
+		},
+	})
 }
 
 func (*BreakglassEscalationController) BasePath() string {

--- a/pkg/breakglass/escalation/escalation_controller.go
+++ b/pkg/breakglass/escalation/escalation_controller.go
@@ -186,7 +186,10 @@ func (ec *BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 	reqLog.Debugw("Returning escalations response (filtered, hidden groups removed)", "responseCount", len(response))
 	cleaned := dropK8sInternalFieldsEscalationList(response)
 	sort.Slice(cleaned, func(i, j int) bool {
-		return cleaned[i].Name < cleaned[j].Name
+		if cleaned[i].Name != cleaned[j].Name {
+			return cleaned[i].Name < cleaned[j].Name
+		}
+		return cleaned[i].Namespace < cleaned[j].Namespace
 	})
 
 	limit, err := utils.ParsePageLimit(c.Query("limit"))

--- a/pkg/breakglass/escalation/escalation_controller_handlers_test.go
+++ b/pkg/breakglass/escalation/escalation_controller_handlers_test.go
@@ -82,10 +82,17 @@ func TestHandleGetEscalations_ReturnsEscalationsForTokenGroups(t *testing.T) {
 		t.Fatalf("expected 200 OK, got %d", w.Result().StatusCode)
 	}
 
-	var out []breakglassv1alpha1.BreakglassEscalation
-	if err := json.NewDecoder(w.Result().Body).Decode(&out); err != nil {
+	var paged struct {
+		Items    []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+		Metadata struct {
+			Continue string `json:"continue"`
+			Total    int    `json:"total"`
+		} `json:"metadata"`
+	}
+	if err := json.NewDecoder(w.Result().Body).Decode(&paged); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
+	out := paged.Items
 
 	// Only esc1 should be returned because the token groups include system:authenticated
 	if len(out) != 1 {

--- a/pkg/breakglass/escalation/hidden_from_ui_test.go
+++ b/pkg/breakglass/escalation/hidden_from_ui_test.go
@@ -75,10 +75,16 @@ func TestHiddenFromUI_EscalationResponse_GroupsRemoved(t *testing.T) {
 		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
 	}
 
-	// Parse response
-	var escList []breakglassv1alpha1.BreakglassEscalation
-	err := json.Unmarshal(w.Body.Bytes(), &escList)
+	var paged struct {
+		Items    []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+		Metadata struct {
+			Continue string `json:"continue"`
+			Total    int    `json:"total"`
+		} `json:"metadata"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &paged)
 	require.NoError(t, err)
+	escList := paged.Items
 
 	if len(escList) != 1 {
 		t.Fatalf("expected 1 escalation, got %d", len(escList))

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -716,14 +716,17 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	// Enrich sessions with approvalReason from matching escalations
 	enriched := wc.enrichSessionsWithApprovalReason(ctx, filtered, reqLog)
 
-	// Sort by creation timestamp (newest first), then by name for stable ordering
+	// Sort by creation timestamp (newest first), then by name and namespace for deterministic pagination ordering
 	sort.Slice(enriched, func(i, j int) bool {
 		ti := enriched[i].CreationTimestamp.Time
 		tj := enriched[j].CreationTimestamp.Time
 		if !ti.Equal(tj) {
 			return ti.After(tj)
 		}
-		return enriched[i].Name < enriched[j].Name
+		if enriched[i].Name != enriched[j].Name {
+			return enriched[i].Name < enriched[j].Name
+		}
+		return enriched[i].Namespace < enriched[j].Namespace
 	})
 
 	limit, err := utils.ParsePageLimit(c.Query("limit"))

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -714,6 +715,16 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 
 	// Enrich sessions with approvalReason from matching escalations
 	enriched := wc.enrichSessionsWithApprovalReason(ctx, filtered, reqLog)
+
+	// Sort by creation timestamp (newest first), then by name for stable ordering
+	sort.Slice(enriched, func(i, j int) bool {
+		ti := enriched[i].CreationTimestamp.Time
+		tj := enriched[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return enriched[i].Name < enriched[j].Name
+	})
 
 	limit, err := utils.ParsePageLimit(c.Query("limit"))
 	if err != nil {

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -715,8 +715,26 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	// Enrich sessions with approvalReason from matching escalations
 	enriched := wc.enrichSessionsWithApprovalReason(ctx, filtered, reqLog)
 
-	reqLog.Infow("Returning filtered breakglass sessions", "count", len(enriched))
-	c.JSON(http.StatusOK, enriched)
+	limit, err := utils.ParsePageLimit(c.Query("limit"))
+	if err != nil {
+		apiresponses.RespondBadRequest(c, err.Error())
+		return
+	}
+	offset, err := utils.ParseContinueToken(c.Query("continue"))
+	if err != nil {
+		apiresponses.RespondBadRequest(c, err.Error())
+		return
+	}
+	page, nextToken := utils.Paginate(enriched, limit, offset)
+
+	reqLog.Infow("Returning filtered breakglass sessions", "count", len(page), "total", len(enriched), "offset", offset, "limit", limit)
+	c.JSON(http.StatusOK, gin.H{
+		"items": page,
+		"metadata": gin.H{
+			"continue": nextToken,
+			"total":    len(enriched),
+		},
+	})
 }
 
 // SessionApprovalMeta contains authorization metadata for a session

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -27,6 +27,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// pagedSessionsResponse mirrors the paginated JSON envelope returned by the
+// session list endpoint: {"items": [...], "metadata": {"continue": "...", "total": N}}
+type pagedSessionsResponse struct {
+	Items    []breakglassv1alpha1.BreakglassSession `json:"items"`
+	Metadata struct {
+		Continue string `json:"continue"`
+		Total    int    `json:"total"`
+	} `json:"metadata"`
+}
+
+// decodeSessionPage decodes a paged sessions response body and returns items.
+// It calls t.Helper() so failures are attributed to the caller.
+func decodeSessionPage(t *testing.T, body io.Reader) []breakglassv1alpha1.BreakglassSession {
+	t.Helper()
+	var paged pagedSessionsResponse
+	if err := json.NewDecoder(body).Decode(&paged); err != nil {
+		t.Fatalf("Failed to decode paginated session response: %v", err)
+	}
+	return paged.Items
+}
+
 type FakeMailSender struct {
 	LastRecivers          []string
 	LastSubject, LastBody string
@@ -210,11 +231,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 		if response.StatusCode != http.StatusOK {
 			t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 		}
-		respSessions := []breakglassv1alpha1.BreakglassSession{}
-		err := json.NewDecoder(response.Body).Decode(&respSessions)
-		if err != nil {
-			t.Fatalf("Failed to decode response body %v", err)
-		}
+		respSessions := decodeSessionPage(t, response.Body)
 		if l := len(respSessions); l != 1 {
 			t.Fatalf("Expected one breakglass session to be created go %d instead. (%#v)", l, respSessions)
 		}
@@ -373,9 +390,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
 	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(response.Body).Decode(&respSessions); err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions = decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one created session, got %#v", respSessions)
 	}
@@ -399,9 +414,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
 	respSessions = []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(response.Body).Decode(&respSessions); err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions = decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one session after approve, got %#v", respSessions)
 	}
@@ -438,9 +451,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
 	respSessions = []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(response.Body).Decode(&respSessions); err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions = decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one session after invalid reject attempt, got %#v", respSessions)
 	}
@@ -581,10 +592,7 @@ func TestCreateSessionWithoutEscalationReturns401(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Expected OK getting sessions, got %d", resp.StatusCode)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
-		t.Fatalf("failed to decode sessions: %v", err)
-	}
+	sessions := decodeSessionPage(t, resp.Body)
 	if len(sessions) != 0 {
 		t.Fatalf("expected 0 sessions after refused create, got %d", len(sessions))
 	}
@@ -1191,11 +1199,7 @@ func TestFilterBreakglassSessionsByUser(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.User != "user1@example.com" {
 		t.Fatalf("Expected one session for user1@example.com, got: %#v", respSessions)
 	}
@@ -1853,11 +1857,7 @@ func TestFilterBreakglassSessionsByClusterQueryParam(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.Cluster != "clusterA" {
 		t.Fatalf("Expected one session for clusterA, got: %#v", respSessions)
 	}
@@ -1914,11 +1914,7 @@ func TestFilterBreakglassSessionsByUserQueryParam(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.User != "alice@example.com" {
 		t.Fatalf("Expected one session for alice@example.com, got: %#v", respSessions)
 	}
@@ -1975,11 +1971,7 @@ func TestFilterBreakglassSessionsByGroupQueryParam(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.GrantedGroup != "admins" {
 		t.Fatalf("Expected one session for group admins, got: %#v", respSessions)
 	}
@@ -2138,11 +2130,7 @@ func TestFilterBreakglassSessionsByClusterAndUserQueryParams(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.User != "u1@example.com" || respSessions[0].Spec.Cluster != "c1" {
 		t.Fatalf("Expected one session for c1/u1, got: %#v", respSessions)
 	}
@@ -2233,9 +2221,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 		t.Fatalf("expected 200 fetching sessions, got %d", res.StatusCode)
 	}
 	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(res.Body).Decode(&respSessions); err != nil {
-		t.Fatalf("failed to decode sessions: %v", err)
-	}
+	respSessions = decodeSessionPage(t, res.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("expected one session, got %#v", respSessions)
 	}
@@ -2264,9 +2250,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 		t.Fatalf("expected 200 fetching sessions after approve, got %d", res.StatusCode)
 	}
 	respSessions = []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(res.Body).Decode(&respSessions); err != nil {
-		t.Fatalf("failed to decode sessions after approve: %v", err)
-	}
+	respSessions = decodeSessionPage(t, res.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("expected one session after approve, got %#v", respSessions)
 	}
@@ -2335,10 +2319,7 @@ func TestLongReasonStored(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 fetching sessions, got %d", res.StatusCode)
 	}
-	sessions := []breakglassv1alpha1.BreakglassSession{}
-	if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-		t.Fatalf("decode failed: %v", err)
-	}
+	sessions := decodeSessionPage(t, res.Body)
 	if len(sessions) != 0 {
 		t.Fatalf("expected 0 sessions, got %d", len(sessions))
 	}
@@ -2438,8 +2419,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
-	var sessions []breakglassv1alpha1.BreakglassSession
-	_ = json.NewDecoder(w.Result().Body).Decode(&sessions)
+	sessions := decodeSessionPage(t, w.Result().Body)
 	if len(sessions) != 1 {
 		t.Fatalf("expected session present")
 	}
@@ -2458,7 +2438,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	sessions = []breakglassv1alpha1.BreakglassSession{}
-	_ = json.NewDecoder(w.Result().Body).Decode(&sessions)
+	sessions = decodeSessionPage(t, w.Result().Body)
 	if sessions[0].Status.State != breakglassv1alpha1.SessionStateRejected {
 		t.Fatalf("expected state rejected, got %s", sessions[0].Status.State)
 	}
@@ -2514,11 +2494,7 @@ func TestFilterBreakglassSessionsByClusterAndGroupQueryParams(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.Cluster != "cluster1" || respSessions[0].Spec.GrantedGroup != "ops" {
 		t.Fatalf("Expected one session for cluster1/ops, got: %#v", respSessions)
 	}
@@ -2574,11 +2550,7 @@ func TestFilterBreakglassSessionsByUserAndGroupQueryParams(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.User != "sam@example.com" || respSessions[0].Spec.GrantedGroup != "ops" {
 		t.Fatalf("Expected one session for sam/ops, got: %#v", respSessions)
 	}
@@ -2634,11 +2606,7 @@ func TestFilterBreakglassSessionsByClusterUserGroupQueryParams(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	err := json.NewDecoder(response.Body).Decode(&respSessions)
-	if err != nil {
-		t.Fatalf("Failed to decode response body %v", err)
-	}
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 || respSessions[0].Spec.Cluster != "z1" || respSessions[0].Spec.User != "p@example.com" || respSessions[0].Spec.GrantedGroup != "wheel" {
 		t.Fatalf("Expected one session for z1/p/wheel, got: %#v", respSessions)
 	}
@@ -2747,10 +2715,7 @@ func TestFilterBreakglassSessionsByState(t *testing.T) {
 		if response.StatusCode != http.StatusOK {
 			t.Fatalf("Expected status OK (200) got '%d' instead for state %s", response.StatusCode, state)
 		}
-		respSessions := []breakglassv1alpha1.BreakglassSession{}
-		if err := json.NewDecoder(response.Body).Decode(&respSessions); err != nil {
-			t.Fatalf("Failed to decode response body for state %s: %v", state, err)
-		}
+		respSessions := decodeSessionPage(t, response.Body)
 		return respSessions
 	}
 
@@ -2819,10 +2784,7 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 		if res.StatusCode != http.StatusOK {
 			t.Fatalf("expected 200 OK, got %d", res.StatusCode)
 		}
-		var sessions []breakglassv1alpha1.BreakglassSession
-		if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-			t.Fatalf("failed to decode response: %v", err)
-		}
+		sessions := decodeSessionPage(t, res.Body)
 		if len(sessions) != len(want) {
 			t.Fatalf("expected %d sessions, got %d: %#v", len(want), len(sessions), sessions)
 		}
@@ -2902,10 +2864,7 @@ func TestFilterBreakglassSessionsApprovedByMe(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", res.StatusCode)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	sessions := decodeSessionPage(t, res.Body)
 	if len(sessions) != 2 {
 		t.Fatalf("expected two sessions approved by me, got %#v", sessions)
 	}
@@ -2981,10 +2940,7 @@ func TestApproverCanSeePendingSessions(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", res.StatusCode)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-		t.Fatalf("failed decode response: %v", err)
-	}
+	sessions := decodeSessionPage(t, res.Body)
 	if len(sessions) != 1 || sessions[0].Name != "approver-sess-1" {
 		t.Fatalf("expected approver to see the pending session, got: %#v", sessions)
 	}
@@ -3103,10 +3059,7 @@ func TestClusterConfig_BlockSelfApproval_PreventsSelfApproval(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", res.StatusCode)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-		t.Fatalf("failed decode response: %v", err)
-	}
+	sessions := decodeSessionPage(t, res.Body)
 	if len(sessions) != 0 {
 		t.Fatalf("expected no sessions visible due to blockSelfApproval, got: %#v", sessions)
 	}
@@ -3174,10 +3127,7 @@ func TestClusterConfig_AllowedApproverDomains_AllowsDomain(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", res.StatusCode)
 	}
-	var sessions []breakglassv1alpha1.BreakglassSession
-	if err := json.NewDecoder(res.Body).Decode(&sessions); err != nil {
-		t.Fatalf("failed decode response: %v", err)
-	}
+	sessions := decodeSessionPage(t, res.Body)
 	if len(sessions) != 1 || sessions[0].Name != "domain-approve-sess" {
 		t.Fatalf("expected approver with allowed domain to see session, got: %#v", sessions)
 	}
@@ -3276,10 +3226,7 @@ func TestFilterBreakglassSessions_ExhaustivePermutations(t *testing.T) {
 		if res.StatusCode != http.StatusOK {
 			t.Fatalf("case %s: expected 200 OK, got %d", tc.name, res.StatusCode)
 		}
-		var got []breakglassv1alpha1.BreakglassSession
-		if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
-			t.Fatalf("case %s: failed to decode response: %v", tc.name, err)
-		}
+		got := decodeSessionPage(t, res.Body)
 		// build name set
 		gotNames := map[string]struct{}{}
 		for _, s := range got {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -389,8 +389,7 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	respSessions = decodeSessionPage(t, response.Body)
+	respSessions := decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one created session, got %#v", respSessions)
 	}
@@ -413,7 +412,6 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions = []breakglassv1alpha1.BreakglassSession{}
 	respSessions = decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one session after approve, got %#v", respSessions)
@@ -450,7 +448,6 @@ func TestApproveSetsApproverMetadata(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
-	respSessions = []breakglassv1alpha1.BreakglassSession{}
 	respSessions = decodeSessionPage(t, response.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("Expected one session after invalid reject attempt, got %#v", respSessions)
@@ -2220,8 +2217,7 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 fetching sessions, got %d", res.StatusCode)
 	}
-	respSessions := []breakglassv1alpha1.BreakglassSession{}
-	respSessions = decodeSessionPage(t, res.Body)
+	respSessions := decodeSessionPage(t, res.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("expected one session, got %#v", respSessions)
 	}
@@ -2249,7 +2245,6 @@ func TestRequestAndApproveWithReasons(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 fetching sessions after approve, got %d", res.StatusCode)
 	}
-	respSessions = []breakglassv1alpha1.BreakglassSession{}
 	respSessions = decodeSessionPage(t, res.Body)
 	if len(respSessions) != 1 {
 		t.Fatalf("expected one session after approve, got %#v", respSessions)
@@ -2437,7 +2432,6 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
 	w = httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
-	sessions = []breakglassv1alpha1.BreakglassSession{}
 	sessions = decodeSessionPage(t, w.Result().Body)
 	if sessions[0].Status.State != breakglassv1alpha1.SessionStateRejected {
 		t.Fatalf("expected state rejected, got %s", sessions[0].Status.State)

--- a/pkg/utils/pagination.go
+++ b/pkg/utils/pagination.go
@@ -18,7 +18,7 @@ const (
 )
 
 // ParsePageLimit parses the ?limit query parameter string.
-// Returns DefaultPageSize if the string is empty or invalid.
+// Returns DefaultPageSize if the string is empty.
 // Returns an error if the value is present but not a positive integer or exceeds MaxPageSize.
 func ParsePageLimit(limitStr string) (int, error) {
 	if limitStr == "" {

--- a/pkg/utils/pagination.go
+++ b/pkg/utils/pagination.go
@@ -65,7 +65,12 @@ func EncodeContinueToken(offset int) string {
 
 // Paginate applies limit and offset to items and returns the current page and the next
 // continue token. The returned token is empty if there are no more items after this page.
+// Invalid inputs (non-positive limit or negative offset) return an empty page with no token.
 func Paginate[T any](items []T, limit, offset int) (page []T, nextToken string) {
+	if limit <= 0 || offset < 0 {
+		return []T{}, ""
+	}
+
 	total := len(items)
 
 	// Offset past end of list → empty page, no continuation.

--- a/pkg/utils/pagination.go
+++ b/pkg/utils/pagination.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+)
+
+const (
+	// DefaultPageSize is the default number of items returned per page.
+	DefaultPageSize = 100
+	// MaxPageSize is the maximum number of items that can be requested per page.
+	MaxPageSize = 500
+)
+
+// ParsePageLimit parses the ?limit query parameter string.
+// Returns DefaultPageSize if the string is empty or invalid.
+// Returns an error if the value is present but not a positive integer or exceeds MaxPageSize.
+func ParsePageLimit(limitStr string) (int, error) {
+	if limitStr == "" {
+		return DefaultPageSize, nil
+	}
+	n, err := strconv.Atoi(limitStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid limit parameter %q: must be a positive integer: %w", limitStr, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("invalid limit parameter %d: must be a positive integer", n)
+	}
+	if n > MaxPageSize {
+		return 0, fmt.Errorf("invalid limit parameter %d: exceeds maximum allowed page size of %d", n, MaxPageSize)
+	}
+	return n, nil
+}
+
+// ParseContinueToken decodes a base64-encoded continue token to an integer offset.
+// An empty token is treated as offset 0 (beginning of the list).
+// Returns an error if the token is non-empty but cannot be decoded.
+func ParseContinueToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("invalid continue token: %w", err)
+	}
+	offset, err := strconv.Atoi(string(decoded))
+	if err != nil {
+		return 0, fmt.Errorf("invalid continue token: encoded value is not an integer: %w", err)
+	}
+	if offset < 0 {
+		return 0, fmt.Errorf("invalid continue token: offset must be non-negative")
+	}
+	return offset, nil
+}
+
+// EncodeContinueToken encodes an integer offset as an opaque base64 continue token.
+func EncodeContinueToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// Paginate applies limit and offset to items and returns the current page and the next
+// continue token. The returned token is empty if there are no more items after this page.
+func Paginate[T any](items []T, limit, offset int) (page []T, nextToken string) {
+	total := len(items)
+
+	// Offset past end of list → empty page, no continuation.
+	if offset >= total {
+		return []T{}, ""
+	}
+
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	page = items[offset:end]
+
+	// If there are more items after this page, encode the next offset.
+	if end < total {
+		nextToken = EncodeContinueToken(end)
+	}
+
+	return page, nextToken
+}

--- a/pkg/utils/pagination_test.go
+++ b/pkg/utils/pagination_test.go
@@ -198,6 +198,34 @@ func TestPaginate_EmptySlice(t *testing.T) {
 	}
 }
 
+func TestPaginate_InvalidInputs(t *testing.T) {
+	items := makeInts(10)
+
+	page, nextToken := utils.Paginate(items, 0, 0)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items for limit=0, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken for limit=0, got %q", nextToken)
+	}
+
+	page, nextToken = utils.Paginate(items, -1, 0)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items for limit=-1, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken for limit=-1, got %q", nextToken)
+	}
+
+	page, nextToken = utils.Paginate(items, 10, -1)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items for offset=-1, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken for offset=-1, got %q", nextToken)
+	}
+}
+
 func TestPaginate_DefaultPaginationContinuation(t *testing.T) {
 	// Verify the full walk of 250 items in pages of 100.
 	items := makeInts(250)

--- a/pkg/utils/pagination_test.go
+++ b/pkg/utils/pagination_test.go
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/telekom/k8s-breakglass/pkg/utils"
+)
+
+// ---- ParsePageLimit ----
+
+func TestParsePageLimit_Empty(t *testing.T) {
+	limit, err := utils.ParsePageLimit("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if limit != utils.DefaultPageSize {
+		t.Errorf("expected %d, got %d", utils.DefaultPageSize, limit)
+	}
+}
+
+func TestParsePageLimit_Valid(t *testing.T) {
+	limit, err := utils.ParsePageLimit("50")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if limit != 50 {
+		t.Errorf("expected 50, got %d", limit)
+	}
+}
+
+func TestParsePageLimit_Max(t *testing.T) {
+	limit, err := utils.ParsePageLimit("500")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if limit != utils.MaxPageSize {
+		t.Errorf("expected %d, got %d", utils.MaxPageSize, limit)
+	}
+}
+
+func TestParsePageLimit_ExceedsMax(t *testing.T) {
+	_, err := utils.ParsePageLimit("501")
+	if err == nil {
+		t.Error("expected error for limit exceeding MaxPageSize")
+	}
+}
+
+func TestParsePageLimit_Zero(t *testing.T) {
+	_, err := utils.ParsePageLimit("0")
+	if err == nil {
+		t.Error("expected error for limit=0")
+	}
+}
+
+func TestParsePageLimit_Negative(t *testing.T) {
+	_, err := utils.ParsePageLimit("-1")
+	if err == nil {
+		t.Error("expected error for negative limit")
+	}
+}
+
+func TestParsePageLimit_NonNumeric(t *testing.T) {
+	_, err := utils.ParsePageLimit("abc")
+	if err == nil {
+		t.Error("expected error for non-numeric limit")
+	}
+}
+
+// ---- ParseContinueToken / EncodeContinueToken ----
+
+func TestParseContinueToken_Empty(t *testing.T) {
+	offset, err := utils.ParseContinueToken("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if offset != 0 {
+		t.Errorf("expected offset 0, got %d", offset)
+	}
+}
+
+func TestParseContinueToken_RoundTrip(t *testing.T) {
+	token := utils.EncodeContinueToken(100)
+	offset, err := utils.ParseContinueToken(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if offset != 100 {
+		t.Errorf("expected offset 100, got %d", offset)
+	}
+}
+
+func TestParseContinueToken_InvalidBase64(t *testing.T) {
+	_, err := utils.ParseContinueToken("not-valid-base64!!!")
+	if err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestParseContinueToken_ValidBase64NonInteger(t *testing.T) {
+	// base64("hello") is a valid base64 string but decodes to non-integer
+	_, err := utils.ParseContinueToken("aGVsbG8=")
+	if err == nil {
+		t.Error("expected error for base64-encoded non-integer")
+	}
+}
+
+// ---- Paginate ----
+
+func makeInts(n int) []int {
+	s := make([]int, n)
+	for i := range s {
+		s[i] = i
+	}
+	return s
+}
+
+func TestPaginate_FirstPage(t *testing.T) {
+	items := makeInts(250)
+	page, nextToken := utils.Paginate(items, 100, 0)
+	if len(page) != 100 {
+		t.Errorf("expected 100 items, got %d", len(page))
+	}
+	if nextToken == "" {
+		t.Error("expected non-empty nextToken")
+	}
+	// Verify the token decodes to 100
+	offset, err := utils.ParseContinueToken(nextToken)
+	if err != nil {
+		t.Fatalf("token decode error: %v", err)
+	}
+	if offset != 100 {
+		t.Errorf("expected next offset 100, got %d", offset)
+	}
+}
+
+func TestPaginate_MiddlePage(t *testing.T) {
+	items := makeInts(250)
+	page, nextToken := utils.Paginate(items, 100, 100)
+	if len(page) != 100 {
+		t.Errorf("expected 100 items, got %d", len(page))
+	}
+	if nextToken == "" {
+		t.Error("expected non-empty nextToken for middle page")
+	}
+	offset, err := utils.ParseContinueToken(nextToken)
+	if err != nil {
+		t.Fatalf("token decode error: %v", err)
+	}
+	if offset != 200 {
+		t.Errorf("expected next offset 200, got %d", offset)
+	}
+}
+
+func TestPaginate_LastPage_NoToken(t *testing.T) {
+	items := makeInts(250)
+	page, nextToken := utils.Paginate(items, 100, 200)
+	if len(page) != 50 {
+		t.Errorf("expected 50 items on last page, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken on last page, got %q", nextToken)
+	}
+}
+
+func TestPaginate_ExactPage_NoToken(t *testing.T) {
+	items := makeInts(100)
+	page, nextToken := utils.Paginate(items, 100, 0)
+	if len(page) != 100 {
+		t.Errorf("expected 100 items, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken when items exactly fit one page, got %q", nextToken)
+	}
+}
+
+func TestPaginate_OffsetBeyondEnd(t *testing.T) {
+	items := makeInts(10)
+	page, nextToken := utils.Paginate(items, 100, 20)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items for offset beyond end, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken, got %q", nextToken)
+	}
+}
+
+func TestPaginate_EmptySlice(t *testing.T) {
+	page, nextToken := utils.Paginate([]int{}, 100, 0)
+	if len(page) != 0 {
+		t.Errorf("expected 0 items for empty slice, got %d", len(page))
+	}
+	if nextToken != "" {
+		t.Errorf("expected empty nextToken, got %q", nextToken)
+	}
+}
+
+func TestPaginate_DefaultPaginationContinuation(t *testing.T) {
+	// Verify the full walk of 250 items in pages of 100.
+	items := makeInts(250)
+	limit := utils.DefaultPageSize
+	offset := 0
+	pageCount := 0
+	totalItems := 0
+
+	for {
+		page, nextToken := utils.Paginate(items, limit, offset)
+		totalItems += len(page)
+		pageCount++
+
+		if nextToken == "" {
+			break
+		}
+		var err error
+		offset, err = utils.ParseContinueToken(nextToken)
+		if err != nil {
+			t.Fatalf("token decode error: %v", err)
+		}
+	}
+
+	if pageCount != 3 {
+		t.Errorf("expected 3 pages for 250 items with limit 100, got %d", pageCount)
+	}
+	if totalItems != 250 {
+		t.Errorf("expected 250 total items, got %d", totalItems)
+	}
+}


### PR DESCRIPTION
## Summary

All list endpoints returned unbounded result sets, which could cause performance issues and potential OOM conditions in clusters with many resources. A previous PR (#577) attempted this but was closed without merging.

## Changes

- Added a generic \`Paginate[T]\` helper in \`pkg/utils/pagination.go\` that uses \`limit\` and \`continue\` query parameters (default limit=100, max=500) with opaque base64-encoded offset tokens
- Applied pagination to 7 list endpoints across the API
- Results are sorted before pagination for stable page boundaries (sessions by creation timestamp descending then name; escalations by name; debug sessions by start time descending then name; templates by name)
- Updated API documentation with accurate pagination description (offset-based, not Kubernetes watch semantics)
- Added CHANGELOG entry

## Files Changed

- \`pkg/utils/pagination.go\` — Generic pagination helper (\`limit\`/\`continue\` parameters, base64-encoded offset tokens)
- \`pkg/utils/pagination_test.go\` — Comprehensive pagination tests
- \`pkg/breakglass/clusterconfig/binding_api.go\` — Paginated binding list
- \`pkg/breakglass/debug/debug_session_api.go\` — Paginated session list
- \`pkg/breakglass/debug/debug_session_api_resolution.go\` — Paginated resolution list
- \`pkg/breakglass/debug/debug_session_api_templates.go\` — Paginated template list
- \`pkg/breakglass/escalation/escalation_controller.go\` — Paginated escalation list
- \`pkg/breakglass/session_controller_status.go\` — Paginated status list
- \`docs/api-reference.md\` — Pagination documentation
- \`CHANGELOG.md\` — Entry for pagination feature

## Testing

- Comprehensive unit tests for \`Paginate[T]\` covering edge cases (empty input, out-of-range offsets, boundary conditions)
- Existing tests updated to decode paginated \`{items, metadata}\` / \`{items, total, continue}\` envelope formats
- All \`pkg/breakglass/...\` tests pass