### PR TITLE
feat: add NetworkPolicy to Helm chart for default ingress restriction

### DIFF
--- a/charts/escalation-config/templates/networkpolicy.yaml
+++ b/charts/escalation-config/templates/networkpolicy.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-breakglass
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: breakglass
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: breakglass
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- /* Allow ingress on the HTTP/API + frontend port */}}
+    - ports:
+        - port: {{ .Values.networkPolicy.apiPort }}
+          protocol: TCP
+      {{- if .Values.networkPolicy.ingressNamespaceSelector }}
+      from:
+        - namespaceSelector:
+            matchLabels:
+{{ toYaml .Values.networkPolicy.ingressNamespaceSelector | indent 14 }}
+      {{- end }}
+    {{- /* Allow ingress on the metrics port */}}
+    - ports:
+        - port: {{ .Values.networkPolicy.metricsPort }}
+          protocol: TCP
+      {{- if .Values.networkPolicy.metricsNamespaceSelector }}
+      from:
+        - namespaceSelector:
+            matchLabels:
+{{ toYaml .Values.networkPolicy.metricsNamespaceSelector | indent 14 }}
+      {{- end }}
+    {{- /* Allow ingress on the webhook port */}}
+    - ports:
+        - port: {{ .Values.networkPolicy.webhookPort }}
+          protocol: TCP
+    {{- /* Allow ingress on the health probe port */}}
+    - ports:
+        - port: {{ .Values.networkPolicy.healthPort }}
+          protocol: TCP
+    {{- /* Additional custom ingress rules */}}
+    {{- if .Values.networkPolicy.additionalIngressRules }}
+{{ toYaml .Values.networkPolicy.additionalIngressRules | indent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/escalation-config/templates/networkpolicy.yaml
+++ b/charts/escalation-config/templates/networkpolicy.yaml
@@ -15,7 +15,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    {{- /* Allow ingress on the HTTP/API + frontend port */}}
     - ports:
         - port: {{ .Values.networkPolicy.apiPort }}
           protocol: TCP
@@ -25,7 +24,6 @@ spec:
             matchLabels:
 {{ toYaml .Values.networkPolicy.ingressNamespaceSelector | indent 14 }}
       {{- end }}
-    {{- /* Allow ingress on the metrics port */}}
     - ports:
         - port: {{ .Values.networkPolicy.metricsPort }}
           protocol: TCP
@@ -35,15 +33,17 @@ spec:
             matchLabels:
 {{ toYaml .Values.networkPolicy.metricsNamespaceSelector | indent 14 }}
       {{- end }}
-    {{- /* Allow ingress on the webhook port */}}
+    {{- if .Values.networkPolicy.webhookMetricsPort }}
+    - ports:
+        - port: {{ .Values.networkPolicy.webhookMetricsPort }}
+          protocol: TCP
+    {{- end }}
     - ports:
         - port: {{ .Values.networkPolicy.webhookPort }}
           protocol: TCP
-    {{- /* Allow ingress on the health probe port */}}
     - ports:
         - port: {{ .Values.networkPolicy.healthPort }}
           protocol: TCP
-    {{- /* Additional custom ingress rules */}}
     {{- if .Values.networkPolicy.additionalIngressRules }}
 {{ toYaml .Values.networkPolicy.additionalIngressRules | indent 4 }}
     {{- end }}

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -522,7 +522,7 @@
         "enabled": {
           "type": "boolean",
           "description": "Create a NetworkPolicy with default deny-all ingress and explicit allow rules.",
-          "default": true
+          "default": false
         },
         "apiPort": {
           "type": "integer",
@@ -536,6 +536,13 @@
           "description": "Container port for Prometheus metrics.",
           "default": 8081,
           "minimum": 1,
+          "maximum": 65535
+        },
+        "webhookMetricsPort": {
+          "type": "integer",
+          "description": "Container port for webhook metrics.",
+          "default": 8083,
+          "minimum": 0,
           "maximum": 65535
         },
         "webhookPort": {

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -515,6 +515,61 @@
         }
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy for the breakglass controller pods.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create a NetworkPolicy with default deny-all ingress and explicit allow rules.",
+          "default": true
+        },
+        "apiPort": {
+          "type": "integer",
+          "description": "Container port for the HTTP API and frontend.",
+          "default": 8080,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "metricsPort": {
+          "type": "integer",
+          "description": "Container port for Prometheus metrics.",
+          "default": 8081,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "webhookPort": {
+          "type": "integer",
+          "description": "Container port for the Kubernetes authorization webhook.",
+          "default": 9443,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "healthPort": {
+          "type": "integer",
+          "description": "Container port for liveness and readiness probes.",
+          "default": 8082,
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "ingressNamespaceSelector": {
+          "type": "object",
+          "description": "Namespace label selector restricting ingress on the API port. Empty allows all namespaces.",
+          "additionalProperties": { "type": "string" }
+        },
+        "metricsNamespaceSelector": {
+          "type": "object",
+          "description": "Namespace label selector restricting ingress on the metrics port. Empty allows all namespaces.",
+          "additionalProperties": { "type": "string" }
+        },
+        "additionalIngressRules": {
+          "type": "array",
+          "description": "Additional custom NetworkPolicy ingress rules appended to the defaults.",
+          "items": { "type": "object" },
+          "default": []
+        }
+      }
+    },
     "denyPolicies": {
       "type": "array",
       "description": "List of DenyPolicy resources to create.",

--- a/charts/escalation-config/values.yaml
+++ b/charts/escalation-config/values.yaml
@@ -5,12 +5,12 @@
 # When enabled, a default deny-all ingress policy is applied and
 # only the listed ports are explicitly allowed.
 networkPolicy:
-  # enabled controls whether the NetworkPolicy is created. Default: true.
-  enabled: true
+  enabled: false
   # apiPort is the container port for the HTTP API and frontend. Default: 8080.
   apiPort: 8080
   # metricsPort is the container port for Prometheus metrics. Default: 8081.
   metricsPort: 8081
+  webhookMetricsPort: 8083
   # webhookPort is the container port for the Kubernetes authorization webhook. Default: 9443.
   webhookPort: 9443
   # healthPort is the container port for liveness/readiness probes. Default: 8082.

--- a/charts/escalation-config/values.yaml
+++ b/charts/escalation-config/values.yaml
@@ -1,3 +1,45 @@
+# ==========================================
+# NetworkPolicy Configuration
+# ==========================================
+# Controls ingress traffic to the breakglass controller pods.
+# When enabled, a default deny-all ingress policy is applied and
+# only the listed ports are explicitly allowed.
+networkPolicy:
+  # enabled controls whether the NetworkPolicy is created. Default: true.
+  enabled: true
+  # apiPort is the container port for the HTTP API and frontend. Default: 8080.
+  apiPort: 8080
+  # metricsPort is the container port for Prometheus metrics. Default: 8081.
+  metricsPort: 8081
+  # webhookPort is the container port for the Kubernetes authorization webhook. Default: 9443.
+  webhookPort: 9443
+  # healthPort is the container port for liveness/readiness probes. Default: 8082.
+  healthPort: 8082
+  # ingressNamespaceSelector restricts the API/frontend port to pods from namespaces
+  # matching the given labels. If empty, ingress is allowed from all namespaces.
+  # Example:
+  #   ingressNamespaceSelector:
+  #     kubernetes.io/metadata.name: ingress-nginx
+  ingressNamespaceSelector: {}
+  # metricsNamespaceSelector restricts the metrics port to pods from namespaces
+  # matching the given labels. If empty, ingress is allowed from all namespaces.
+  # Example:
+  #   metricsNamespaceSelector:
+  #     kubernetes.io/metadata.name: monitoring
+  metricsNamespaceSelector: {}
+  # additionalIngressRules allows appending custom ingress rules beyond the defaults.
+  # Each entry follows the NetworkPolicy ingress rule format.
+  # Example:
+  #   additionalIngressRules:
+  #     - from:
+  #         - podSelector:
+  #             matchLabels:
+  #               app: custom-scraper
+  #       ports:
+  #         - port: 9090
+  #           protocol: TCP
+  additionalIngressRules: []
+
 cluster:
   clusterID: tenant-b-virtual-test
   tenant: tenant-b


### PR DESCRIPTION
## Summary

The Helm chart for k8s-breakglass had no NetworkPolicy, meaning any pod in the cluster could reach the breakglass API server by default. This is a security hardening gap — production deployments should restrict ingress to only authorized sources.

## Changes

- Added a `NetworkPolicy` template to the escalation-config Helm chart
- The policy denies all ingress by default and allows configurable ingress rules
- Added corresponding values and JSON schema for configuration
- NetworkPolicy creation is optional and disabled by default to avoid breaking existing deployments

## Files Changed

- `charts/escalation-config/templates/networkpolicy.yaml` — NetworkPolicy template
- `charts/escalation-config/values.yaml` — Default NetworkPolicy configuration
- `charts/escalation-config/values.schema.json` — Schema validation for NetworkPolicy values

## Testing

- Helm template rendering verified
- Schema validation ensures correct value types