### PR TITLE
fix(e2e): prevent session name collision in CrossUserAuthorization test

### DIFF
--- a/e2e/api/debug_session_api_test.go
+++ b/e2e/api/debug_session_api_test.go
@@ -3978,6 +3978,9 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Requester should not be able to self-approve")
 	})
 
+	// Ensure Unix timestamp advances between session creations to avoid name collisions.
+	// The server generates session names using time.Now().Unix() (see debug_session_api.go).
+	time.Sleep(1100 * time.Millisecond)
 	t.Run("ApproverCannotTerminateOthersSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4009,6 +4012,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Non-owner should not be able to terminate")
 	})
 
+	time.Sleep(1100 * time.Millisecond)
 	t.Run("ApproverCannotRenewOthersSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4040,6 +4044,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Non-owner should not be able to renew")
 	})
 
+	time.Sleep(1100 * time.Millisecond)
 	t.Run("RequesterCannotRejectOwnSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4065,6 +4070,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		// Log the result for analysis
 	})
 
+	time.Sleep(1100 * time.Millisecond)
 	t.Run("UnauthorizedUserCannotAccessSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4086,10 +4092,9 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		_, err = unauthClient.GetDebugSession(ctx, t, session.Name)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "401")
-		// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-		time.Sleep(1100 * time.Millisecond)
 	})
 
+	time.Sleep(1100 * time.Millisecond)
 	t.Run("ApproverCanViewAllSessions", func(t *testing.T) {
 		// Create a session owned by requester
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{

--- a/e2e/api/debug_session_api_test.go
+++ b/e2e/api/debug_session_api_test.go
@@ -3752,8 +3752,7 @@ func TestDebugSessionAPICreateOptionalParams(t *testing.T) {
 		assert.Contains(t, session.Spec.InvitedParticipants, "user1@example.com")
 		assert.Contains(t, session.Spec.InvitedParticipants, "user2@example.com")
 		t.Logf("Created session with invited participants: %v", session.Spec.InvitedParticipants)
-		// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-		time.Sleep(1100 * time.Millisecond)
+		helpers.WaitForNextUnixSecond()
 	})
 
 	t.Run("CreateWithNodeSelector", func(t *testing.T) {
@@ -3779,8 +3778,7 @@ func TestDebugSessionAPICreateOptionalParams(t *testing.T) {
 		// Verify node selector was set
 		assert.Equal(t, "linux", session.Spec.NodeSelector["kubernetes.io/os"])
 		t.Logf("Created session with node selector: %v", session.Spec.NodeSelector)
-		// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-		time.Sleep(1100 * time.Millisecond)
+		helpers.WaitForNextUnixSecond()
 	})
 
 	t.Run("CreateWithSchedulingOption", func(t *testing.T) {
@@ -3803,8 +3801,7 @@ func TestDebugSessionAPICreateOptionalParams(t *testing.T) {
 
 		assert.Equal(t, "priority", session.Spec.SelectedSchedulingOption)
 		t.Logf("Created session with scheduling option: %s", session.Spec.SelectedSchedulingOption)
-		// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-		time.Sleep(1100 * time.Millisecond)
+		helpers.WaitForNextUnixSecond()
 	})
 
 	t.Run("CreateWithInvalidSchedulingOption", func(t *testing.T) {
@@ -3818,9 +3815,7 @@ func TestDebugSessionAPICreateOptionalParams(t *testing.T) {
 
 		_, status, err := apiClient.CreateDebugSession(ctx, t, req)
 		t.Logf("Create with invalid scheduling option: status=%d, err=%v", status, err)
-		// Should either fail validation or use default
-		// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-		time.Sleep(1100 * time.Millisecond)
+		helpers.WaitForNextUnixSecond()
 	})
 
 	t.Run("CreateWithLongReason", func(t *testing.T) {
@@ -3839,8 +3834,7 @@ func TestDebugSessionAPICreateOptionalParams(t *testing.T) {
 			cleanup.Add(&breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{Name: session.Name, Namespace: session.Namespace},
 			})
-			// Wait to ensure next subtest gets a different timestamp (session names use Unix seconds)
-			time.Sleep(1100 * time.Millisecond)
+			helpers.WaitForNextUnixSecond()
 		}
 	})
 
@@ -3978,9 +3972,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Requester should not be able to self-approve")
 	})
 
-	// Ensure Unix timestamp advances between session creations to avoid name collisions.
-	// The server generates session names using time.Now().Unix() (see debug_session_api.go).
-	time.Sleep(1100 * time.Millisecond)
+	helpers.WaitForNextUnixSecond()
 	t.Run("ApproverCannotTerminateOthersSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4012,7 +4004,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Non-owner should not be able to terminate")
 	})
 
-	time.Sleep(1100 * time.Millisecond)
+	helpers.WaitForNextUnixSecond()
 	t.Run("ApproverCannotRenewOthersSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4044,7 +4036,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, status, "Non-owner should not be able to renew")
 	})
 
-	time.Sleep(1100 * time.Millisecond)
+	helpers.WaitForNextUnixSecond()
 	t.Run("RequesterCannotRejectOwnSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4070,7 +4062,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		// Log the result for analysis
 	})
 
-	time.Sleep(1100 * time.Millisecond)
+	helpers.WaitForNextUnixSecond()
 	t.Run("UnauthorizedUserCannotAccessSession", func(t *testing.T) {
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{
 			TemplateRef:       sessionTemplateName,
@@ -4094,7 +4086,7 @@ func TestDebugSessionAPICrossUserAuthorization(t *testing.T) {
 		assert.Contains(t, err.Error(), "401")
 	})
 
-	time.Sleep(1100 * time.Millisecond)
+	helpers.WaitForNextUnixSecond()
 	t.Run("ApproverCanViewAllSessions", func(t *testing.T) {
 		// Create a session owned by requester
 		session, _, err := requesterClient.CreateDebugSession(ctx, t, DebugSessionCreateRequest{

--- a/e2e/helpers/util.go
+++ b/e2e/helpers/util.go
@@ -110,3 +110,13 @@ func PastTime(d time.Duration) metav1.Time {
 func GenerateUniqueName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, uuid.New().String()[:8])
 }
+
+// WaitForNextUnixSecond blocks until time.Now().Unix() increments, ensuring
+// that consecutive session names (which embed Unix seconds) are unique.
+// It polls in short intervals so it only sleeps as long as actually needed.
+func WaitForNextUnixSecond() {
+	target := time.Now().Unix() + 1
+	for time.Now().Unix() < target {
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix flaky `TestDebugSessionAPICrossUserAuthorization` E2E test that intermittently fails with 409 CONFLICT

## Root Cause
The server generates debug session names using `time.Now().Unix()` (seconds precision). When subtests create sessions within the same second, they collide. The first subtest (`RequesterCannotApproveOwnSession`) always succeeds, but subsequent subtests fail with "session already exists".

## Fix
Add `time.Sleep(1100 * time.Millisecond)` between subtests that create sessions, ensuring the Unix timestamp advances. This pattern was already used inside one subtest (`UnauthorizedUserCannotAccessSession`) — now applied consistently before all session-creating subtests.

## Evidence
- CI run [24338837518](https://github.com/telekom/k8s-breakglass/actions/runs/24338837518) on main: `TestDebugSessionAPICrossUserAuthorization` failed with 5 subtests getting 409 CONFLICT
- Same commit passed on a different run [24338828934](https://github.com/telekom/k8s-breakglass/actions/runs/24338828934), confirming flake