### PR TITLE
fix(e2e): ensure Keycloak pod is Ready before OIDC tests and extend rotation timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1389,6 +1389,23 @@ jobs:
             exit 1
           fi
 
+          # Wait for Keycloak pod to be Ready in-cluster.
+          # The port-forward confirms localhost connectivity, but the Keycloak pod
+          # itself may still be starting or recovering from a restart. The controller
+          # reaches Keycloak via the in-cluster service URL, so we must ensure the pod
+          # is Ready before the tests create ClusterConfig objects that trigger OIDC
+          # discovery requests. Without this, the rotation tests (OT-007, OT-008) fail
+          # with "connection refused" on breakglass-keycloak.breakglass-system.svc.cluster.local:8443.
+          echo "Waiting for Keycloak pod to be Ready in-cluster (up to 120s)..."
+          if ! kubectl wait pod -n breakglass-system -l app=keycloak \
+              --for=condition=Ready --timeout=120s 2>&1; then
+            echo "ERROR: Keycloak pod not Ready after 120s"
+            kubectl get pods -n breakglass-system -l app=keycloak -o wide 2>&1 || true
+            kubectl describe pod -n breakglass-system -l app=keycloak 2>&1 || true
+            exit 1
+          fi
+          echo "✓ Keycloak pod is Ready in-cluster"
+
           # Wait for API to be reachable
           for i in {1..20}; do
             if curl -s http://localhost:8080/api/config > /dev/null 2>&1; then

--- a/e2e/api/oidc_offline_token_test.go
+++ b/e2e/api/oidc_offline_token_test.go
@@ -538,7 +538,10 @@ func TestOIDC_OfflineToken_Rotation_PersistsNewToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for Ready — this triggers token exchange and rotation persist.
-	err = waitForClusterConfigConditionReady(t, ctx, cli, ccName, namespace, 90*time.Second)
+	// Use a generous timeout: the controller reaches Keycloak via the in-cluster service
+	// URL, and Keycloak may need up to ~60s to recover after a pod restart. 150s gives
+	// enough headroom while keeping the test within its 5-minute context budget.
+	err = waitForClusterConfigConditionReady(t, ctx, cli, ccName, namespace, 150*time.Second)
 	require.NoError(t, err, "CC with rotation enabled should become Ready")
 
 	// Poll for the rotated key to appear in the secret (best-effort write may be async).


### PR DESCRIPTION
## Summary

Fixes the recurring `OIDC Comprehensive E2E Tests` CI failure on `main` caused by `TestOIDC_OfflineToken_Rotation_PersistsNewToken` (OT-007) timing out with:

```
timed out waiting for ClusterConfig breakglass-system/ot007-rotate-... to become Ready
OIDCDiscoveryFailed: ...dial tcp 10.96.8.224:8443: connect: connection refused
```

## Root Cause

The CI step validated Keycloak reachability via `localhost:8443` (port-forward) but never confirmed the **Keycloak pod itself was Ready inside the cluster**. The controller reaches Keycloak via the in-cluster service URL (`breakglass-keycloak.breakglass-system.svc.cluster.local:8443`), not via the port-forward. When the Keycloak pod restarts or is not yet healthy, the controller receives `connection refused` on every OIDC discovery attempt and the ClusterConfig never becomes Ready within the 90s timeout.

This affected OT-007 specifically because it runs 7th in the test sequence — after ~2.5 minutes of accumulated load — giving Keycloak enough time to restart from resource pressure.

## Changes

### `ci.yml` — Primary fix
After confirming `localhost:8443` is reachable, add `kubectl wait --for=condition=Ready` on the Keycloak pod (up to 120s) before running the test suite. This ensures the pod is truly Ready in-cluster before any test creates a `ClusterConfig` that triggers OIDC discovery requests.

### `e2e/api/oidc_offline_token_test.go` — Defence in depth
Increase `waitForClusterConfigConditionReady` timeout in OT-007 from 90s → 150s. Keycloak pod restarts take ~30-60s in Kind; 150s provides enough headroom while staying within the 5-minute test context budget. This makes the test resilient to transient pod hiccups that happen *during* the test run (after the pre-check).

## Verification

- `make test`: all 34 packages pass ✓
- `make lint`: 0 issues ✓
- No generated files modified
- No new files added (no SPDX headers needed)