### PR TITLE
fix: remove offline_access scope to prevent refresh token issuance in breakglass sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep refresh tokens stripped when browser storage fails, redact approval-page HTTP errors, and cap mock dataset scaling.
 
-- Disable automatic silent renewal and iframe-based session extension for frontend OIDC sessions. Production always uses session storage and purges legacy persistent OIDC artifacts; development-only persistent local storage remains an explicit opt-in.
+- Disable automatic silent renewal and iframe-based session extension for frontend OIDC sessions. Production uses session storage or an in-memory fallback when browser storage is unavailable, resets stale persistent preferences, and makes a best-effort purge of legacy persistent OIDC artifacts; development-only persistent local storage remains an explicit opt-in.
 
 - Avoid duplicate approval-page error logging and preserve one contextual toast for unexpected approval failures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep refresh tokens stripped when browser storage fails, redact approval-page HTTP errors, and cap mock dataset scaling.
 
+- Disable automatic silent renewal and iframe-based session extension for frontend OIDC sessions. Production always uses session storage and purges legacy persistent OIDC artifacts; development-only persistent local storage remains an explicit opt-in.
+
 - Avoid duplicate approval-page error logging and preserve one contextual toast for unexpected approval failures.
 
 - Preserve contextual diagnostics when debug template output validation rejects unsafe actions.
@@ -411,7 +413,7 @@ non-buggy case:
 - **BreakglassEscalation admission validation**: Escalation duration fields now reject non-positive or malformed values consistently, `idleTimeout` and `approvalTimeout` are checked against the effective `maxValidFor`, and invalid cluster glob patterns are rejected before they can affect session admission.
 - **OIDC upstream response handling**: OIDC discovery, JWKS, userinfo, token, and Keycloak API reads now enforce bounded response bodies, preventing oversized identity-provider responses from exhausting controller memory. (#1131)
 - **BreakglassSession approver IDP enforcement**: Approval and rejection requests now enforce `BreakglassEscalation.spec.allowedIdentityProvidersForApprovers`, denying approvers whose authenticated IdentityProvider is missing or not allowed.
-- **Frontend debug logging hardening**: Production builds no longer enable verbose debug logging from URL or localStorage flags, group and claim refresh diagnostics log only counts and claim keys instead of sensitive group memberships or full profile claims, and stale OIDC refresh tokens are removed from browser session state before silent renew.
+- **Frontend debug logging hardening**: Production builds no longer enable verbose debug logging from URL or localStorage flags, group and claim refresh diagnostics log only counts and claim keys instead of sensitive group memberships or full profile claims, and stale OIDC refresh tokens are removed from browser session state when users are loaded.
 - **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed, scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present, and checks approval/rejection authorization before body validation or state-specific errors so unrelated callers cannot infer session details.
 - **DebugSession leave access revocation**: Debug session participant indexes, webhook pod-operation authorization, and kubectl-debug active-session lookup now ignore participants after `status.participants[].leftAt` is set, ensuring leaving a session revokes debug pod access immediately.
 - **DebugSession renewal authorization**: Debug session renewals now require the requester or an active `owner`/`participant` status entry; `viewer` entries and participants with `leftAt` set can no longer extend session lifetime.

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -245,7 +245,7 @@ The following patterns are stripped from text fields:
 ### OIDC Best Practices
 
 1. **Use short-lived tokens** - Configure your IDP to issue tokens with 5-15 minute expiry
-2. **Enable token refresh** - Allow token refresh for long-running sessions
+2. **Disable UI refresh tokens** - Do not issue `offline_access` or refresh tokens for breakglass UI sessions; use short access-token lifetimes and require explicit re-authentication instead
 3. **Validate audiences** - Ensure tokens are issued for the breakglass client
 4. **Use HTTPS** - Always use TLS for OIDC communication
 5. **Keep `hardenedIDPHints` enabled** (default) - Prevents disclosure of configured identity provider names and URLs in webhook error messages. See [Configuration Reference](configuration-reference.md#hardenedidphints-optional) for details.

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -189,7 +189,7 @@ This requires a matching audience protocol mapper in your identity provider (e.g
 
 ### Token Storage in the Browser
 
-The frontend stores OIDC tokens in the browser's **`sessionStorage`** by default (via `oidc-client-ts`). The `AuthService` layer supports `localStorage` as an alternative (e.g., for a future "Remember me" toggle), but no user-facing control is currently exposed — all tokens remain in `sessionStorage`.
+The frontend stores OIDC tokens in the browser's **`sessionStorage`** by default (via `oidc-client-ts`). The `AuthService` layer supports `localStorage` as an alternative (e.g., for a future "Remember me" toggle), but no user-facing control is currently exposed — all tokens remain in `sessionStorage`. Production builds also force session storage when a stale persistent preference is present and purge or ignore legacy localStorage OIDC artifacts, including IDP-name hints used for re-authentication.
 
 **Why not `httpOnly` cookies?**
 

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -230,15 +230,16 @@ This requires a matching audience protocol mapper in your identity provider (e.g
 
 ### Token Storage in the Browser
 
-The browser frontend uses `sessionStorage` through `oidc-client-ts`. Access
-tokens remain readable by same-origin JavaScript and are explicitly attached as
-Bearer tokens to API requests. Session storage limits persistence and prevents
-other origins from reading it; it does not protect tokens from compromised
-same-origin scripts. Browser-local cached runtime configuration is bootstrap
-state, not the server's issuer authorization policy.
-Production builds also force session storage when a stale persistent preference is
-present and purge or ignore legacy localStorage OIDC artifacts, including IDP
-name hints used for re-authentication.
+The browser frontend uses `sessionStorage` through `oidc-client-ts` by default.
+Development builds may explicitly opt into persistent `localStorage` storage;
+that mode is warned about because browser scripts can read it. Production builds
+always use `sessionStorage`, reset a stale persistent preference, and purge or
+ignore legacy localStorage OIDC artifacts, including IDP name hints used for
+reauthentication. Access tokens remain readable by same-origin JavaScript and
+are explicitly attached as Bearer tokens to API requests. Session storage limits
+persistence and prevents other origins from reading it; it does not protect
+tokens from compromised same-origin scripts. Browser-local cached runtime
+configuration is bootstrap state, not the server's issuer authorization policy.
 
 CSP restricts script sources and reduces injection opportunities, but cannot
 guarantee that every XSS payload is blocked. Keep access tokens short-lived
@@ -530,7 +531,7 @@ Every lookup failure is observable, so the fallback is never silent:
 The breakglass frontend is **not vulnerable to CSRF** because it uses **OIDC Bearer token authentication** rather than cookie-based sessions:
 
 - All API requests include an `Authorization: Bearer <token>` header injected by the HTTP client interceptor (`frontend/src/services/httpClient.ts`).
-- OIDC access tokens are stored in the browser's `sessionStorage` via `oidc-client-ts`, **not** in cookies.
+- OIDC access tokens default to browser `sessionStorage` via `oidc-client-ts`, **not** cookies; development-only persistent `localStorage` is an explicit opt-in and production always uses session storage.
 - The browser never automatically attaches credentials to cross-origin requests, so a malicious site cannot forge authenticated API calls.
 
 This architecture inherently mitigates CSRF because:

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -233,8 +233,9 @@ This requires a matching audience protocol mapper in your identity provider (e.g
 The browser frontend uses `sessionStorage` through `oidc-client-ts` by default.
 Development builds may explicitly opt into persistent `localStorage` storage;
 that mode is warned about because browser scripts can read it. Production builds
-always use `sessionStorage`, reset a stale persistent preference, and purge or
-ignore legacy localStorage OIDC artifacts, including IDP name hints used for
+use `sessionStorage` or an in-memory fallback when browser storage is
+unavailable, reset a stale persistent preference, and make a best-effort purge
+of legacy localStorage OIDC artifacts, including IDP name hints used for
 reauthentication. Access tokens remain readable by same-origin JavaScript and
 are explicitly attached as Bearer tokens to API requests. Session storage limits
 persistence and prevents other origins from reading it; it does not protect
@@ -531,7 +532,7 @@ Every lookup failure is observable, so the fallback is never silent:
 The breakglass frontend is **not vulnerable to CSRF** because it uses **OIDC Bearer token authentication** rather than cookie-based sessions:
 
 - All API requests include an `Authorization: Bearer <token>` header injected by the HTTP client interceptor (`frontend/src/services/httpClient.ts`).
-- OIDC access tokens default to browser `sessionStorage` via `oidc-client-ts`, **not** cookies; development-only persistent `localStorage` is an explicit opt-in and production always uses session storage.
+- OIDC access tokens default to browser `sessionStorage` via `oidc-client-ts`, **not** cookies; development-only persistent `localStorage` is an explicit opt-in and production uses session storage or an in-memory fallback when browser storage is unavailable.
 - The browser never automatically attaches credentials to cross-origin requests, so a malicious site cannot forge authenticated API calls.
 
 This architecture inherently mitigates CSRF because:

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -291,7 +291,7 @@ The following patterns are stripped from text fields:
 ### OIDC Best Practices
 
 1. **Use short-lived tokens** - Configure your IDP to issue tokens with 5-15 minute expiry
-2. **Enable token refresh** - Allow token refresh for long-running sessions
+2. **Disable UI refresh tokens** - Do not issue `offline_access` or refresh tokens for breakglass UI sessions; use short access-token lifetimes and require explicit re-authentication instead
 3. **Validate audiences** - Ensure tokens are issued for the breakglass client
 4. **Use HTTPS** - Always use TLS for OIDC communication
 5. **Keep `hardenedIDPHints` enabled** (default) - Prevents disclosure of configured identity provider names and URLs in webhook error messages. See [Configuration Reference](configuration-reference.md#hardenedidphints-optional) for details.

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -236,6 +236,9 @@ Bearer tokens to API requests. Session storage limits persistence and prevents
 other origins from reading it; it does not protect tokens from compromised
 same-origin scripts. Browser-local cached runtime configuration is bootstrap
 state, not the server's issuer authorization policy.
+Production builds also force session storage when a stale persistent preference is
+present and purge or ignore legacy localStorage OIDC artifacts, including IDP
+name hints used for re-authentication.
 
 CSP restricts script sources and reduces injection opportunities, but cannot
 guarantee that every XSS payload is blocked. Keep access tokens short-lived

--- a/frontend/src/components/AutoLogoutWarning.ts
+++ b/frontend/src/components/AutoLogoutWarning.ts
@@ -1,3 +1,0 @@
-import AutoLogoutWarning from "./AutoLogoutWarning.vue";
-
-export default AutoLogoutWarning;

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -81,7 +81,7 @@ export default {
     }
 
     async function reauthenticate() {
-      if (!auth || renewing.value) return;
+      if (renewing.value) return;
       renewing.value = true;
       try {
         const path = window.location.pathname + window.location.search + window.location.hash;

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -198,6 +198,7 @@ export default {
 
       if (nearestExpiryMs === null) {
         show.value = false;
+        dismissed.value = false;
         return;
       }
 

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -65,7 +65,8 @@ export default {
 
     function getCurrentIdentityProviderName(): string | undefined {
       const sessionStorageValue = getStorageItem(getBrowserStorage("sessionStorage"), "oidc_idp_name");
-      return auth.getIdentityProviderName() ?? sessionStorageValue ?? undefined;
+      const localStorageValue = getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name");
+      return auth.getIdentityProviderName() ?? sessionStorageValue ?? localStorageValue ?? undefined;
     }
 
     async function reauthenticate() {

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -122,24 +122,6 @@ export default {
       }
     }
 
-    function getStorageLength(storage: Storage): number {
-      try {
-        return storage.length;
-      } catch (err) {
-        warn("AutoLogoutWarning", "Unable to enumerate browser storage", err);
-        return 0;
-      }
-    }
-
-    function getStorageKey(storage: Storage, index: number): string | null {
-      try {
-        return storage.key(index);
-      } catch (err) {
-        warn("AutoLogoutWarning", "Unable to read browser storage key", err);
-        return null;
-      }
-    }
-
     function shouldReadLocalOIDCStorage(): boolean {
       if (import.meta.env.PROD) {
         return false;
@@ -158,37 +140,13 @@ export default {
       return storages;
     }
 
-    function getTrustedOIDCUserKeyPrefixes(): string[] {
-      const prefixes = new Set<string>();
-      const configuredAuthority = auth.userManager.settings.authority;
-      if (configuredAuthority) {
-        prefixes.add(`oidc.user:${configuredAuthority}:`);
-      }
-      prefixes.add("oidc.user:/api/oidc/authority:");
-      return Array.from(prefixes);
-    }
-
-    function isTrustedOIDCUserKey(key: string, trustedPrefixes: readonly string[]): boolean {
-      return trustedPrefixes.some((prefix) => key.startsWith(prefix));
-    }
-
     function getStoredOIDCUserValues(): string[] {
-      const defaultStorageKey =
-        "oidc.user:" + auth.userManager.settings.authority + ":" + auth.userManager.settings.client_id;
-      const trustedPrefixes = getTrustedOIDCUserKeyPrefixes();
       const values: string[] = [];
       const seenValues = new Set<string>();
+      const activeKeys = auth.getActiveOIDCUserStorageKeys();
 
       for (const storage of getAvailableOIDCStorages()) {
-        const keys = new Set<string>([defaultStorageKey]);
-        for (let index = 0; index < getStorageLength(storage); index += 1) {
-          const key = getStorageKey(storage, index);
-          if (key && isTrustedOIDCUserKey(key, trustedPrefixes)) {
-            keys.add(key);
-          }
-        }
-
-        for (const key of keys) {
+        for (const key of activeKeys) {
           const value = getStorageItem(storage, key);
           if (value && !seenValues.has(value)) {
             seenValues.add(value);

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -42,6 +42,8 @@ import { inject, onMounted, onUnmounted, ref } from "vue";
 import { AuthKey } from "@/keys";
 import { warn } from "@/services/logger";
 
+const TOKEN_PERSISTENCE_KEY = "breakglass_oidc_token_persistence";
+
 export default {
   name: "AutoLogoutWarning",
   setup() {
@@ -65,7 +67,9 @@ export default {
 
     function getCurrentIdentityProviderName(): string | undefined {
       const sessionStorageValue = getStorageItem(getBrowserStorage("sessionStorage"), "oidc_idp_name");
-      const localStorageValue = getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name");
+      const localStorageValue = shouldReadLocalOIDCStorage()
+        ? getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name")
+        : undefined;
       return auth.getIdentityProviderName() ?? sessionStorageValue ?? localStorageValue ?? undefined;
     }
 
@@ -132,12 +136,21 @@ export default {
       }
     }
 
+    function shouldReadLocalOIDCStorage(): boolean {
+      if (import.meta.env.PROD) {
+        return false;
+      }
+      return getStorageItem(getBrowserStorage("localStorage"), TOKEN_PERSISTENCE_KEY) === "persistent";
+    }
+
     function getAvailableOIDCStorages(): Storage[] {
       const storages: Storage[] = [];
       const sessionStorage = getBrowserStorage("sessionStorage");
-      const localStorage = getBrowserStorage("localStorage");
       if (sessionStorage) storages.push(sessionStorage);
-      if (localStorage) storages.push(localStorage);
+      if (shouldReadLocalOIDCStorage()) {
+        const localStorage = getBrowserStorage("localStorage");
+        if (localStorage) storages.push(localStorage);
+      }
       return storages;
     }
 

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -64,7 +64,8 @@ export default {
     }
 
     function getCurrentIdentityProviderName(): string | undefined {
-      return auth.getIdentityProviderName() ?? sessionStorage.getItem("oidc_idp_name") ?? undefined;
+      const sessionStorageValue = getStorageItem(getBrowserStorage("sessionStorage"), "oidc_idp_name");
+      return auth.getIdentityProviderName() ?? sessionStorageValue ?? undefined;
     }
 
     async function reauthenticate() {
@@ -88,18 +89,69 @@ export default {
       show.value = false;
     }
 
+    function getBrowserStorage(name: "sessionStorage" | "localStorage"): Storage | undefined {
+      if (typeof window === "undefined") {
+        return undefined;
+      }
+      try {
+        return window[name];
+      } catch (err) {
+        warn("AutoLogoutWarning", `Unable to access browser ${name}`, err);
+        return undefined;
+      }
+    }
+
+    function getStorageItem(storage: Storage | undefined, key: string): string | null {
+      if (!storage) {
+        return null;
+      }
+      try {
+        return storage.getItem(key);
+      } catch (err) {
+        warn("AutoLogoutWarning", "Unable to read browser storage item", err);
+        return null;
+      }
+    }
+
+    function getStorageLength(storage: Storage): number {
+      try {
+        return storage.length;
+      } catch (err) {
+        warn("AutoLogoutWarning", "Unable to enumerate browser storage", err);
+        return 0;
+      }
+    }
+
+    function getStorageKey(storage: Storage, index: number): string | null {
+      try {
+        return storage.key(index);
+      } catch (err) {
+        warn("AutoLogoutWarning", "Unable to read browser storage key", err);
+        return null;
+      }
+    }
+
     function getAvailableOIDCStorages(): Storage[] {
       const storages: Storage[] = [];
-      if (typeof window === "undefined") {
-        return storages;
-      }
-      if (typeof window.sessionStorage !== "undefined") {
-        storages.push(window.sessionStorage);
-      }
-      if (typeof window.localStorage !== "undefined") {
-        storages.push(window.localStorage);
-      }
+      const sessionStorage = getBrowserStorage("sessionStorage");
+      const localStorage = getBrowserStorage("localStorage");
+      if (sessionStorage) storages.push(sessionStorage);
+      if (localStorage) storages.push(localStorage);
       return storages;
+    }
+
+    function getTrustedOIDCUserKeyPrefixes(): string[] {
+      const prefixes = new Set<string>();
+      const configuredAuthority = auth.userManager.settings.authority;
+      if (configuredAuthority) {
+        prefixes.add(`oidc.user:${configuredAuthority}:`);
+      }
+      prefixes.add("oidc.user:/api/oidc/authority:");
+      return Array.from(prefixes);
+    }
+
+    function isTrustedOIDCUserKey(key: string): boolean {
+      return getTrustedOIDCUserKeyPrefixes().some((prefix) => key.startsWith(prefix));
     }
 
     function getStoredOIDCUserValues(): string[] {
@@ -110,15 +162,15 @@ export default {
 
       for (const storage of getAvailableOIDCStorages()) {
         const keys = new Set<string>([defaultStorageKey]);
-        for (let index = 0; index < storage.length; index += 1) {
-          const key = storage.key(index);
-          if (key?.startsWith("oidc.user:")) {
+        for (let index = 0; index < getStorageLength(storage); index += 1) {
+          const key = getStorageKey(storage, index);
+          if (key && isTrustedOIDCUserKey(key)) {
             keys.add(key);
           }
         }
 
         for (const key of keys) {
-          const value = storage.getItem(key);
+          const value = getStorageItem(storage, key);
           if (value && !seenValues.has(value)) {
             seenValues.add(value);
             values.push(value);

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -51,6 +51,7 @@ export default {
     const renewing = ref(false);
     const dismissed = ref(false);
     let timer: number | null = null;
+    const warnedStorageAccess = new Set<"sessionStorage" | "localStorage">();
     const requireAuth = () => {
       const injectedAuth = inject(AuthKey);
       if (!injectedAuth) {
@@ -101,7 +102,10 @@ export default {
       try {
         return window[name];
       } catch (err) {
-        warn("AutoLogoutWarning", `Unable to access browser ${name}`, err);
+        if (!warnedStorageAccess.has(name)) {
+          warnedStorageAccess.add(name);
+          warn("AutoLogoutWarning", `Unable to access browser ${name}`, err);
+        }
         return undefined;
       }
     }

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -52,6 +52,8 @@ export default {
     const dismissed = ref(false);
     let timer: number | null = null;
     const warnedStorageAccess = new Set<"sessionStorage" | "localStorage">();
+    const warnedStorageItemReads = new Set<string>();
+    const warnedOIDCParseValues = new Set<string>();
     const requireAuth = () => {
       const injectedAuth = inject(AuthKey);
       if (!injectedAuth) {
@@ -67,9 +69,13 @@ export default {
     }
 
     function getCurrentIdentityProviderName(): string | undefined {
-      const sessionStorageValue = getStorageItem(getBrowserStorage("sessionStorage"), "oidc_idp_name");
+      const sessionStorageValue = getStorageItem(
+        getBrowserStorage("sessionStorage"),
+        "oidc_idp_name",
+        "sessionStorage",
+      );
       const localStorageValue = shouldReadLocalOIDCStorage()
-        ? getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name")
+        ? getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name", "localStorage")
         : undefined;
       return auth.getIdentityProviderName() ?? sessionStorageValue ?? localStorageValue ?? undefined;
     }
@@ -110,14 +116,18 @@ export default {
       }
     }
 
-    function getStorageItem(storage: Storage | undefined, key: string): string | null {
+    function getStorageItem(storage: Storage | undefined, key: string, storageName: string): string | null {
       if (!storage) {
         return null;
       }
       try {
         return storage.getItem(key);
       } catch (err) {
-        warn("AutoLogoutWarning", "Unable to read browser storage item", err);
+        const warningKey = `${storageName}:${key}`;
+        if (!warnedStorageItemReads.has(warningKey)) {
+          warnedStorageItemReads.add(warningKey);
+          warn("AutoLogoutWarning", "Unable to read browser storage item", err);
+        }
         return null;
       }
     }
@@ -126,18 +136,26 @@ export default {
       if (import.meta.env.PROD) {
         return false;
       }
-      return getStorageItem(getBrowserStorage("localStorage"), TOKEN_PERSISTENCE_KEY) === "persistent";
+      return getStorageItem(getBrowserStorage("localStorage"), TOKEN_PERSISTENCE_KEY, "localStorage") === "persistent";
     }
 
-    function getAvailableOIDCStorages(): Storage[] {
-      const storages: Storage[] = [];
+    function getAvailableOIDCStorages(): Array<{ name: "sessionStorage" | "localStorage"; storage: Storage }> {
+      const storages: Array<{ name: "sessionStorage" | "localStorage"; storage: Storage }> = [];
       const sessionStorage = getBrowserStorage("sessionStorage");
-      if (sessionStorage) storages.push(sessionStorage);
+      if (sessionStorage) storages.push({ name: "sessionStorage", storage: sessionStorage });
       if (shouldReadLocalOIDCStorage()) {
         const localStorage = getBrowserStorage("localStorage");
-        if (localStorage) storages.push(localStorage);
+        if (localStorage) storages.push({ name: "localStorage", storage: localStorage });
       }
       return storages;
+    }
+
+    function fingerprintStoredValue(value: string): string {
+      let hash = 0;
+      for (let index = 0; index < value.length; index += 1) {
+        hash = (hash * 31 + value.charCodeAt(index)) | 0;
+      }
+      return `${value.length}:${hash}`;
     }
 
     function getStoredOIDCUserValues(): string[] {
@@ -145,9 +163,9 @@ export default {
       const seenValues = new Set<string>();
       const activeKeys = auth.getActiveOIDCUserStorageKeys();
 
-      for (const storage of getAvailableOIDCStorages()) {
+      for (const { name, storage } of getAvailableOIDCStorages()) {
         for (const key of activeKeys) {
-          const value = getStorageItem(storage, key);
+          const value = getStorageItem(storage, key, name);
           if (value && !seenValues.has(value)) {
             seenValues.add(value);
             values.push(value);
@@ -170,7 +188,11 @@ export default {
             }
           }
         } catch (e) {
-          warn("AutoLogoutWarning", "Failed to parse OIDC user data from browser storage", e);
+          const warningKey = fingerprintStoredValue(userStr);
+          if (!warnedOIDCParseValues.has(warningKey)) {
+            warnedOIDCParseValues.add(warningKey);
+            warn("AutoLogoutWarning", "Failed to parse OIDC user data from browser storage", e);
+          }
         }
       }
 

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -150,13 +150,14 @@ export default {
       return Array.from(prefixes);
     }
 
-    function isTrustedOIDCUserKey(key: string): boolean {
-      return getTrustedOIDCUserKeyPrefixes().some((prefix) => key.startsWith(prefix));
+    function isTrustedOIDCUserKey(key: string, trustedPrefixes: readonly string[]): boolean {
+      return trustedPrefixes.some((prefix) => key.startsWith(prefix));
     }
 
     function getStoredOIDCUserValues(): string[] {
       const defaultStorageKey =
         "oidc.user:" + auth.userManager.settings.authority + ":" + auth.userManager.settings.client_id;
+      const trustedPrefixes = getTrustedOIDCUserKeyPrefixes();
       const values: string[] = [];
       const seenValues = new Set<string>();
 
@@ -164,7 +165,7 @@ export default {
         const keys = new Set<string>([defaultStorageKey]);
         for (let index = 0; index < getStorageLength(storage); index += 1) {
           const key = getStorageKey(storage, index);
-          if (key && isTrustedOIDCUserKey(key)) {
+          if (key && isTrustedOIDCUserKey(key, trustedPrefixes)) {
             keys.add(key);
           }
         }

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -15,17 +15,17 @@
         @scale-close="dismiss"
       >
         <p class="warning-copy">
-          Your session will expire shortly. Click stay logged in to silently renew, or log out if you are finished.
+          Your session will expire shortly. Re-authenticate to continue, or log out if you are finished.
         </p>
         <div class="warning-actions">
           <scale-button
             variant="primary"
             size="small"
             :loading="renewing"
-            data-testid="stay-logged-in-button"
-            @click="stayLoggedIn"
+            data-testid="reauthenticate-button"
+            @click="reauthenticate"
           >
-            Stay logged in
+            Re-authenticate
           </scale-button>
           <scale-button variant="secondary" size="small" data-testid="dismiss-button" @click="dismiss"
             >Dismiss</scale-button
@@ -41,7 +41,6 @@
 import { inject, onMounted, onUnmounted, ref } from "vue";
 import { AuthKey } from "@/keys";
 import { warn } from "@/services/logger";
-import { getStoredOIDCUser } from "@/services/auth";
 
 export default {
   name: "AutoLogoutWarning",
@@ -64,15 +63,21 @@ export default {
       auth.logout();
     }
 
-    async function stayLoggedIn() {
+    function getCurrentIdentityProviderName(): string | undefined {
+      return auth.getIdentityProviderName() ?? sessionStorage.getItem("oidc_idp_name") ?? undefined;
+    }
+
+    async function reauthenticate() {
       if (!auth || renewing.value) return;
       renewing.value = true;
       try {
-        await auth.userManager.signinSilent();
+        const path = window.location.pathname + window.location.search + window.location.hash;
+        const idpName = getCurrentIdentityProviderName();
+        await auth.login(idpName ? { path, idpName } : { path });
         show.value = false;
         dismissed.value = false;
       } catch (err) {
-        warn("AutoLogoutWarning", "Silent renew failed", err);
+        warn("AutoLogoutWarning", "Re-authentication failed", err);
       } finally {
         renewing.value = false;
       }
@@ -83,46 +88,86 @@ export default {
       show.value = false;
     }
 
+    function getAvailableOIDCStorages(): Storage[] {
+      const storages: Storage[] = [];
+      if (typeof window === "undefined") {
+        return storages;
+      }
+      if (typeof window.sessionStorage !== "undefined") {
+        storages.push(window.sessionStorage);
+      }
+      if (typeof window.localStorage !== "undefined") {
+        storages.push(window.localStorage);
+      }
+      return storages;
+    }
+
+    function getStoredOIDCUserValues(): string[] {
+      const defaultStorageKey =
+        "oidc.user:" + auth.userManager.settings.authority + ":" + auth.userManager.settings.client_id;
+      const values: string[] = [];
+      const seenValues = new Set<string>();
+
+      for (const storage of getAvailableOIDCStorages()) {
+        const keys = new Set<string>([defaultStorageKey]);
+        for (let index = 0; index < storage.length; index += 1) {
+          const key = storage.key(index);
+          if (key?.startsWith("oidc.user:")) {
+            keys.add(key);
+          }
+        }
+
+        for (const key of keys) {
+          const value = storage.getItem(key);
+          if (value && !seenValues.has(value)) {
+            seenValues.add(value);
+            values.push(value);
+          }
+        }
+      }
+
+      return values;
+    }
+
     function checkExpiring() {
-      const userStr = getStoredOIDCUser(auth.userManager.settings.authority, auth.userManager.settings.client_id);
-      if (!userStr) {
+      let nearestExpiryMs: number | null = null;
+      for (const userStr of getStoredOIDCUserValues()) {
+        try {
+          const parsed = JSON.parse(userStr) as { expires_at?: unknown } | null;
+          if (parsed && typeof parsed.expires_at === "number") {
+            const expiresIn = parsed.expires_at * 1000 - Date.now();
+            if (expiresIn > 0 && (nearestExpiryMs === null || expiresIn < nearestExpiryMs)) {
+              nearestExpiryMs = expiresIn;
+            }
+          }
+        } catch (e) {
+          warn("AutoLogoutWarning", "Failed to parse OIDC user data from browser storage", e);
+        }
+      }
+
+      if (nearestExpiryMs === null) {
         show.value = false;
-        dismissed.value = false;
         return;
       }
 
-      try {
-        const parsed = JSON.parse(userStr);
-        if (!parsed?.expires_at) {
-          show.value = false;
-          dismissed.value = false;
-          return;
-        }
-
-        const expiresIn = parsed.expires_at * 1000 - Date.now();
-        if (expiresIn < WARNING_THRESHOLD_MS && expiresIn > 0 && !dismissed.value) {
-          show.value = true;
-        } else {
-          show.value = false;
-          if (expiresIn > WARNING_THRESHOLD_MS) {
-            dismissed.value = false;
-          }
-        }
-      } catch (e) {
-        show.value = false;
-        dismissed.value = false;
-        warn("AutoLogoutWarning", "Failed to parse OIDC user data from browser storage", e);
+      if (nearestExpiryMs < WARNING_THRESHOLD_MS) {
+        show.value = !dismissed.value;
+        return;
       }
+
+      show.value = false;
+      dismissed.value = false;
     }
 
     onMounted(() => {
+      checkExpiring();
       timer = window.setInterval(checkExpiring, 5000);
     });
     onUnmounted(() => {
       if (timer) clearInterval(timer);
     });
 
-    return { show, logout, stayLoggedIn, dismiss, renewing };
+    return { show, logout, reauthenticate, dismiss, renewing };
   },
 };
 </script>

--- a/frontend/src/components/AutoLogoutWarning.vue
+++ b/frontend/src/components/AutoLogoutWarning.vue
@@ -77,7 +77,7 @@ export default {
       const localStorageValue = shouldReadLocalOIDCStorage()
         ? getStorageItem(getBrowserStorage("localStorage"), "breakglass_current_idp_name", "localStorage")
         : undefined;
-      return auth.getIdentityProviderName() ?? sessionStorageValue ?? localStorageValue ?? undefined;
+      return auth.getIdentityProviderName?.() ?? sessionStorageValue ?? localStorageValue ?? undefined;
     }
 
     async function reauthenticate() {
@@ -161,7 +161,7 @@ export default {
     function getStoredOIDCUserValues(): string[] {
       const values: string[] = [];
       const seenValues = new Set<string>();
-      const activeKeys = auth.getActiveOIDCUserStorageKeys();
+      const activeKeys = auth.getActiveOIDCUserStorageKeys?.() ?? [];
 
       for (const { name, storage } of getAvailableOIDCStorages()) {
         for (const key of activeKeys) {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -59,8 +59,13 @@ describe("AuthService", () => {
       expect(authService.userManager.settings.userStore).toBeDefined();
     });
 
-    it("should enable automatic silent renew", () => {
-      expect(authService.userManager.settings.automaticSilentRenew).toBe(true);
+    it("should disable automatic silent renew for security", () => {
+      expect(authService.userManager.settings.automaticSilentRenew).toBe(false);
+    });
+
+    it("should not include offline_access in scope", () => {
+      expect(authService.userManager.settings.scope).toBeDefined();
+      expect(authService.userManager.settings.scope).not.toContain("offline_access");
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -518,10 +518,7 @@ describe("AuthService", () => {
 
     it("returns the active identity provider key from session state", () => {
       sessionStorage.setItem("oidc_idp_name", "corp");
-      sessionStorage.setItem(
-        "breakglass_active_oidc_user_storage_key",
-        "oidc.user:/api/oidc/authority:corp-ui",
-      );
+      sessionStorage.setItem("breakglass_active_oidc_user_storage_key", "oidc.user:/api/oidc/authority:corp-ui");
 
       expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:/api/oidc/authority:corp-ui"]);
     });

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/services/logger", () => ({
 }));
 
 import AuthService, { useUser, AuthRedirect, AuthSilentRedirect, __authTestHooks } from "./auth";
-import type { User, UserManager } from "oidc-client-ts";
+import { User, type UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
 import type { MultiIDPConfig } from "@/model/multiIDP";
@@ -343,34 +343,16 @@ describe("AuthService", () => {
   });
 
   describe("trySilentRenew()", () => {
-    it("removes stale refresh tokens from stored users before silent renew", async () => {
-      const mockUser = new User({
-        profile: {
-          email: "test@example.com",
-          sub: "12345",
-          iss: "https://example.com",
-          aud: "test-client",
-          exp: Math.floor(Date.now() / 1000) + 3600,
-          iat: Math.floor(Date.now() / 1000),
-        },
-        session_state: "",
-        access_token: "access-token",
-        token_type: "Bearer",
-        userState: null,
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-        refresh_token: "stale-refresh-token",
-      });
-
-      const getUserSpy = vi.spyOn(authService.userManager, "getUser").mockResolvedValue(mockUser);
+    it("does not invoke real OIDC silent renewal or mutate stored users", async () => {
+      const getUserSpy = vi.spyOn(authService.userManager, "getUser");
       const storeUserSpy = vi.spyOn(authService.userManager, "storeUser").mockResolvedValue(undefined);
       const signinSilentSpy = vi.spyOn(authService.userManager, "signinSilent").mockResolvedValue(null);
 
-      await authService.trySilentRenew();
+      await expect(authService.trySilentRenew()).resolves.toBe(false);
 
-      expect(getUserSpy).toHaveBeenCalled();
-      expect(storeUserSpy).toHaveBeenCalledWith(expect.objectContaining({ access_token: "access-token" }));
-      expect(storeUserSpy.mock.calls[0]?.[0]?.refresh_token).toBeUndefined();
-      expect(signinSilentSpy).toHaveBeenCalled();
+      expect(getUserSpy).not.toHaveBeenCalled();
+      expect(storeUserSpy).not.toHaveBeenCalled();
+      expect(signinSilentSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -569,7 +551,7 @@ describe("AuthService", () => {
           registerUserManagerEvents: (manager: UserManager) => void;
         }
       ).registerUserManagerEvents(manager);
-      expect(userRef.value).toStrictEqual(loadedUser);
+      await vi.waitFor(() => expect(userRef.value).toStrictEqual(loadedUser));
 
       expiredHandler?.();
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/services/logger", () => ({
 }));
 
 import AuthService, { useUser, AuthRedirect, AuthSilentRedirect } from "./auth";
-import { User } from "oidc-client-ts";
+import type { User, UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
 import type { MultiIDPConfig } from "@/model/multiIDP";
@@ -477,6 +477,51 @@ describe("AuthService", () => {
       expect(userRef).toBeDefined();
       // userRef.value is initially undefined until user logs in
       expect(userRef.value === undefined || typeof userRef.value === "object").toBe(true);
+    });
+  });
+
+  describe("OIDC user manager events", () => {
+    it("clears reactive and persisted user state when the access token expires", async () => {
+      const userRef = useUser();
+      const loadedUser = {
+        profile: {
+          email: "test@example.com",
+          sub: "12345",
+          iss: "https://example.com",
+          aud: "test-client",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          iat: Math.floor(Date.now() / 1000),
+        },
+        access_token: "access-token",
+        expired: false,
+      } as User;
+      let expiredHandler: (() => void) | undefined;
+      const removeUser = vi.fn().mockResolvedValue(undefined);
+      const manager = {
+        removeUser,
+        events: {
+          addUserLoaded: (handler: (loaded: User) => void) => handler(loadedUser),
+          addUserUnloaded: vi.fn(),
+          addAccessTokenExpiring: vi.fn(),
+          addAccessTokenExpired: (handler: () => void) => {
+            expiredHandler = handler;
+          },
+          addSilentRenewError: vi.fn(),
+          addUserSignedOut: vi.fn(),
+        },
+      } as unknown as UserManager;
+
+      (
+        authService as unknown as {
+          registerUserManagerEvents: (manager: UserManager) => void;
+        }
+      ).registerUserManagerEvents(manager);
+      expect(userRef.value).toStrictEqual(loadedUser);
+
+      expiredHandler?.();
+
+      expect(userRef.value).toBeUndefined();
+      await vi.waitFor(() => expect(removeUser).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -277,7 +277,7 @@ describe("AuthService", () => {
 
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
-      expect(localStorage.getItem("breakglass_current_idp_name")).toBe(idpName);
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -484,7 +484,20 @@ describe("AuthService", () => {
   });
 
   describe("getIdentityProviderName()", () => {
-    it("falls back to the persisted identity provider name", () => {
+    it("falls back to the session persisted identity provider name", () => {
+      sessionStorage.setItem("oidc_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBe("corp");
+    });
+
+    it("ignores stale local persisted identity provider names by default", () => {
+      localStorage.setItem("breakglass_current_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBeUndefined();
+    });
+
+    it("uses local persisted identity provider names only when persistent storage is active", () => {
+      localStorage.setItem(TOKEN_PERSISTENCE_KEY, "persistent");
       localStorage.setItem("breakglass_current_idp_name", "corp");
 
       expect(authService.getIdentityProviderName()).toBe("corp");

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/services/logger", () => ({
   error: vi.fn(),
 }));
 
-import AuthService, { useUser, AuthRedirect, AuthSilentRedirect } from "./auth";
+import AuthService, { useUser, AuthRedirect, AuthSilentRedirect, __authTestHooks } from "./auth";
 import type { User, UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
@@ -612,6 +612,16 @@ describe("AuthService", () => {
       expect(token?.split(".")[2]).toBe("bW9jay1zaWduYXR1cmU");
       expect(await mockAuthService.getUserEmail()).toBe("mock.user@breakglass.dev");
       expect(mockAuthService.getIdentityProviderName()).toBe("production-keycloak");
+    });
+
+    it("stores empty browser storage values instead of clearing the key", () => {
+      expect(__authTestHooks).toBeDefined();
+
+      __authTestHooks!.setBrowserStorageItem("sessionStorage", "empty-storage-value", "");
+      expect(sessionStorage.getItem("empty-storage-value")).toBe("");
+
+      __authTestHooks!.setBrowserStorageItem("sessionStorage", "empty-storage-value", undefined);
+      expect(sessionStorage.getItem("empty-storage-value")).toBeNull();
     });
 
     it("issues synthetic access tokens and email with default profile", async () => {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -264,7 +264,10 @@ describe("AuthService", () => {
 
       const fakeManager = {
         signinRedirect: vi.fn().mockResolvedValue(undefined),
-        settings: {},
+        settings: {
+          authority: "/api/oidc/authority",
+          client_id: "corp-ui",
+        },
       } as unknown as ReturnType<AuthService["getOrCreateUserManagerForIDP"]>;
       const managerSpy = vi
         .spyOn(
@@ -278,6 +281,9 @@ describe("AuthService", () => {
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
       expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+      expect(sessionStorage.getItem("breakglass_active_oidc_user_storage_key")).toBe(
+        "oidc.user:/api/oidc/authority:corp-ui",
+      );
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -479,6 +485,7 @@ describe("AuthService", () => {
       await authService.logout();
       expect(signoutSpy).toHaveBeenCalled();
       expect(sessionStorage.getItem("oidc_idp_name")).toBeNull();
+      expect(sessionStorage.getItem("breakglass_active_oidc_user_storage_key")).toBeNull();
       expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
     });
   });
@@ -501,6 +508,22 @@ describe("AuthService", () => {
       localStorage.setItem("breakglass_current_idp_name", "corp");
 
       expect(authService.getIdentityProviderName()).toBe("corp");
+    });
+  });
+
+  describe("getActiveOIDCUserStorageKeys()", () => {
+    it("returns the default OIDC user key when no identity provider is active", () => {
+      expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:https://example.com:test-client"]);
+    });
+
+    it("returns the active identity provider key from session state", () => {
+      sessionStorage.setItem("oidc_idp_name", "corp");
+      sessionStorage.setItem(
+        "breakglass_active_oidc_user_storage_key",
+        "oidc.user:/api/oidc/authority:corp-ui",
+      );
+
+      expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:/api/oidc/authority:corp-ui"]);
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -71,6 +71,13 @@ describe("AuthService", () => {
     it("does not request offline_access refresh-token scope", () => {
       expect(authService.userManager.settings.scope).toBe("openid profile email");
     });
+
+    it("does not silently renew real OIDC sessions", async () => {
+      const signinSilentSpy = vi.spyOn(authService.userManager, "signinSilent");
+
+      await expect(authService.trySilentRenew()).resolves.toBe(false);
+      expect(signinSilentSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("getUser()", () => {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -277,6 +277,7 @@ describe("AuthService", () => {
 
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBe(idpName);
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -472,9 +473,21 @@ describe("AuthService", () => {
   describe("logout()", () => {
     it("should call userManager.signoutRedirect", async () => {
       const signoutSpy = vi.spyOn(authService.userManager, "signoutRedirect").mockResolvedValue(undefined);
+      sessionStorage.setItem("oidc_idp_name", "corp");
+      localStorage.setItem("breakglass_current_idp_name", "corp");
 
       await authService.logout();
       expect(signoutSpy).toHaveBeenCalled();
+      expect(sessionStorage.getItem("oidc_idp_name")).toBeNull();
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+    });
+  });
+
+  describe("getIdentityProviderName()", () => {
+    it("falls back to the persisted identity provider name", () => {
+      localStorage.setItem("breakglass_current_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBe("corp");
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -59,8 +59,13 @@ describe("AuthService", () => {
       expect(authService.userManager.settings.userStore).toBeDefined();
     });
 
-    it("should enable automatic silent renew", () => {
-      expect(authService.userManager.settings.automaticSilentRenew).toBe(true);
+    it("should disable automatic silent renew for security", () => {
+      expect(authService.userManager.settings.automaticSilentRenew).toBe(false);
+    });
+
+    it("should not include offline_access in scope", () => {
+      expect(authService.userManager.settings.scope).toBeDefined();
+      expect(authService.userManager.settings.scope).not.toContain("offline_access");
     });
 
     it("does not request offline_access refresh-token scope", () => {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/services/logger", () => ({
 }));
 
 import AuthService, { useUser, AuthRedirect, AuthSilentRedirect, __authTestHooks } from "./auth";
-import type { User, UserManager } from "oidc-client-ts";
+import { User, type UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
 import type { MultiIDPConfig } from "@/model/multiIDP";
@@ -345,34 +345,16 @@ describe("AuthService", () => {
   });
 
   describe("trySilentRenew()", () => {
-    it("removes stale refresh tokens from stored users before silent renew", async () => {
-      const mockUser = new User({
-        profile: {
-          email: "test@example.com",
-          sub: "12345",
-          iss: "https://example.com",
-          aud: "test-client",
-          exp: Math.floor(Date.now() / 1000) + 3600,
-          iat: Math.floor(Date.now() / 1000),
-        },
-        session_state: "",
-        access_token: "access-token",
-        token_type: "Bearer",
-        userState: null,
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-        refresh_token: "stale-refresh-token",
-      });
-
-      const getUserSpy = vi.spyOn(authService.userManager, "getUser").mockResolvedValue(mockUser);
+    it("does not invoke real OIDC silent renewal or mutate stored users", async () => {
+      const getUserSpy = vi.spyOn(authService.userManager, "getUser");
       const storeUserSpy = vi.spyOn(authService.userManager, "storeUser").mockResolvedValue(undefined);
       const signinSilentSpy = vi.spyOn(authService.userManager, "signinSilent").mockResolvedValue(null);
 
-      await authService.trySilentRenew();
+      await expect(authService.trySilentRenew()).resolves.toBe(false);
 
-      expect(getUserSpy).toHaveBeenCalled();
-      expect(storeUserSpy).toHaveBeenCalledWith(expect.objectContaining({ access_token: "access-token" }));
-      expect(storeUserSpy.mock.calls[0]?.[0]?.refresh_token).toBeUndefined();
-      expect(signinSilentSpy).toHaveBeenCalled();
+      expect(getUserSpy).not.toHaveBeenCalled();
+      expect(storeUserSpy).not.toHaveBeenCalled();
+      expect(signinSilentSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -571,7 +553,7 @@ describe("AuthService", () => {
           registerUserManagerEvents: (manager: UserManager) => void;
         }
       ).registerUserManagerEvents(manager);
-      expect(userRef.value).toStrictEqual(loadedUser);
+      await vi.waitFor(() => expect(userRef.value).toStrictEqual(loadedUser));
 
       expiredHandler?.();
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/services/logger", () => ({
 }));
 
 import AuthService, { useUser, AuthRedirect, AuthSilentRedirect } from "./auth";
-import { User } from "oidc-client-ts";
+import type { User, UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
 import type { MultiIDPConfig } from "@/model/multiIDP";
@@ -479,6 +479,51 @@ describe("AuthService", () => {
       expect(userRef).toBeDefined();
       // userRef.value is initially undefined until user logs in
       expect(userRef.value === undefined || typeof userRef.value === "object").toBe(true);
+    });
+  });
+
+  describe("OIDC user manager events", () => {
+    it("clears reactive and persisted user state when the access token expires", async () => {
+      const userRef = useUser();
+      const loadedUser = {
+        profile: {
+          email: "test@example.com",
+          sub: "12345",
+          iss: "https://example.com",
+          aud: "test-client",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          iat: Math.floor(Date.now() / 1000),
+        },
+        access_token: "access-token",
+        expired: false,
+      } as User;
+      let expiredHandler: (() => void) | undefined;
+      const removeUser = vi.fn().mockResolvedValue(undefined);
+      const manager = {
+        removeUser,
+        events: {
+          addUserLoaded: (handler: (loaded: User) => void) => handler(loadedUser),
+          addUserUnloaded: vi.fn(),
+          addAccessTokenExpiring: vi.fn(),
+          addAccessTokenExpired: (handler: () => void) => {
+            expiredHandler = handler;
+          },
+          addSilentRenewError: vi.fn(),
+          addUserSignedOut: vi.fn(),
+        },
+      } as unknown as UserManager;
+
+      (
+        authService as unknown as {
+          registerUserManagerEvents: (manager: UserManager) => void;
+        }
+      ).registerUserManagerEvents(manager);
+      expect(userRef.value).toStrictEqual(loadedUser);
+
+      expiredHandler?.();
+
+      expect(userRef.value).toBeUndefined();
+      await vi.waitFor(() => expect(removeUser).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -546,9 +546,9 @@ describe("AuthService", () => {
         },
       } as unknown as UserManager;
 
-      (authService as unknown as { registerUserManagerEvents: (manager: UserManager) => void }).registerUserManagerEvents(
-        manager,
-      );
+      (
+        authService as unknown as { registerUserManagerEvents: (manager: UserManager) => void }
+      ).registerUserManagerEvents(manager);
 
       const loadedUser = { refresh_token: "stale-refresh-token" } as User;
       userLoadedHandler?.(loadedUser);

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -518,6 +518,48 @@ describe("AuthService", () => {
   });
 
   describe("OIDC user manager events", () => {
+    it("clears selected OIDC hints when sanitized storage cleanup fails", async () => {
+      sessionStorage.setItem("oidc_idp_name", "corp");
+      sessionStorage.setItem("oidc_direct_authority", "https://direct.corp");
+      sessionStorage.setItem("breakglass_active_oidc_user_storage_key", "oidc.user:/api/oidc/authority:corp-ui");
+
+      let userLoadedHandler: ((user: User) => void) | undefined;
+      let userUnloadedHandler: (() => void) | undefined;
+      const removeUser = vi.fn().mockImplementation(async () => {
+        userUnloadedHandler?.();
+        throw new Error("cleanup unavailable");
+      });
+      const manager = {
+        storeUser: vi.fn().mockRejectedValue(new Error("storage unavailable")),
+        removeUser,
+        events: {
+          addUserLoaded: (handler: (user: User) => void) => {
+            userLoadedHandler = handler;
+          },
+          addUserUnloaded: (handler: () => void) => {
+            userUnloadedHandler = handler;
+          },
+          addAccessTokenExpiring: vi.fn(),
+          addAccessTokenExpired: vi.fn(),
+          addSilentRenewError: vi.fn(),
+          addUserSignedOut: vi.fn(),
+        },
+      } as unknown as UserManager;
+
+      (authService as unknown as { registerUserManagerEvents: (manager: UserManager) => void }).registerUserManagerEvents(
+        manager,
+      );
+
+      const loadedUser = { refresh_token: "stale-refresh-token" } as User;
+      userLoadedHandler?.(loadedUser);
+      await vi.waitFor(() => expect(removeUser).toHaveBeenCalledOnce());
+
+      expect(loadedUser.refresh_token).toBeUndefined();
+      expect(sessionStorage.getItem("oidc_idp_name")).toBeNull();
+      expect(sessionStorage.getItem("oidc_direct_authority")).toBeNull();
+      expect(sessionStorage.getItem("breakglass_active_oidc_user_storage_key")).toBeNull();
+    });
+
     it("clears reactive and persisted user state when the access token expires", async () => {
       const userRef = useUser();
       const loadedUser = {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -279,6 +279,7 @@ describe("AuthService", () => {
 
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBe(idpName);
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -474,9 +475,21 @@ describe("AuthService", () => {
   describe("logout()", () => {
     it("should call userManager.signoutRedirect", async () => {
       const signoutSpy = vi.spyOn(authService.userManager, "signoutRedirect").mockResolvedValue(undefined);
+      sessionStorage.setItem("oidc_idp_name", "corp");
+      localStorage.setItem("breakglass_current_idp_name", "corp");
 
       await authService.logout();
       expect(signoutSpy).toHaveBeenCalled();
+      expect(sessionStorage.getItem("oidc_idp_name")).toBeNull();
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+    });
+  });
+
+  describe("getIdentityProviderName()", () => {
+    it("falls back to the persisted identity provider name", () => {
+      localStorage.setItem("breakglass_current_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBe("corp");
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -266,7 +266,10 @@ describe("AuthService", () => {
 
       const fakeManager = {
         signinRedirect: vi.fn().mockResolvedValue(undefined),
-        settings: {},
+        settings: {
+          authority: "/api/oidc/authority",
+          client_id: "corp-ui",
+        },
       } as unknown as ReturnType<AuthService["getOrCreateUserManagerForIDP"]>;
       const managerSpy = vi
         .spyOn(
@@ -280,6 +283,9 @@ describe("AuthService", () => {
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
       expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+      expect(sessionStorage.getItem("breakglass_active_oidc_user_storage_key")).toBe(
+        "oidc.user:/api/oidc/authority:corp-ui",
+      );
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -481,6 +487,7 @@ describe("AuthService", () => {
       await authService.logout();
       expect(signoutSpy).toHaveBeenCalled();
       expect(sessionStorage.getItem("oidc_idp_name")).toBeNull();
+      expect(sessionStorage.getItem("breakglass_active_oidc_user_storage_key")).toBeNull();
       expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
     });
   });
@@ -503,6 +510,22 @@ describe("AuthService", () => {
       localStorage.setItem("breakglass_current_idp_name", "corp");
 
       expect(authService.getIdentityProviderName()).toBe("corp");
+    });
+  });
+
+  describe("getActiveOIDCUserStorageKeys()", () => {
+    it("returns the default OIDC user key when no identity provider is active", () => {
+      expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:https://example.com:test-client"]);
+    });
+
+    it("returns the active identity provider key from session state", () => {
+      sessionStorage.setItem("oidc_idp_name", "corp");
+      sessionStorage.setItem(
+        "breakglass_active_oidc_user_storage_key",
+        "oidc.user:/api/oidc/authority:corp-ui",
+      );
+
+      expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:/api/oidc/authority:corp-ui"]);
     });
   });
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -520,10 +520,7 @@ describe("AuthService", () => {
 
     it("returns the active identity provider key from session state", () => {
       sessionStorage.setItem("oidc_idp_name", "corp");
-      sessionStorage.setItem(
-        "breakglass_active_oidc_user_storage_key",
-        "oidc.user:/api/oidc/authority:corp-ui",
-      );
+      sessionStorage.setItem("breakglass_active_oidc_user_storage_key", "oidc.user:/api/oidc/authority:corp-ui");
 
       expect(authService.getActiveOIDCUserStorageKeys()).toEqual(["oidc.user:/api/oidc/authority:corp-ui"]);
     });

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -279,7 +279,7 @@ describe("AuthService", () => {
 
       expect(fakeManager.signinRedirect).toHaveBeenCalledWith({ state: { path: "/secure", idpName } });
       expect(sessionStorage.getItem("oidc_idp_name")).toBe(idpName);
-      expect(localStorage.getItem("breakglass_current_idp_name")).toBe(idpName);
+      expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
       expect(sessionStorage.getItem("oidc_direct_authority")).toBe("https://direct.corp");
       expect(authService.getIdentityProviderName()).toBe(idpName);
 
@@ -486,7 +486,20 @@ describe("AuthService", () => {
   });
 
   describe("getIdentityProviderName()", () => {
-    it("falls back to the persisted identity provider name", () => {
+    it("falls back to the session persisted identity provider name", () => {
+      sessionStorage.setItem("oidc_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBe("corp");
+    });
+
+    it("ignores stale local persisted identity provider names by default", () => {
+      localStorage.setItem("breakglass_current_idp_name", "corp");
+
+      expect(authService.getIdentityProviderName()).toBeUndefined();
+    });
+
+    it("uses local persisted identity provider names only when persistent storage is active", () => {
+      localStorage.setItem(TOKEN_PERSISTENCE_KEY, "persistent");
       localStorage.setItem("breakglass_current_idp_name", "corp");
 
       expect(authService.getIdentityProviderName()).toBe("corp");

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/services/logger", () => ({
   error: vi.fn(),
 }));
 
-import AuthService, { useUser, AuthRedirect, AuthSilentRedirect } from "./auth";
+import AuthService, { useUser, AuthRedirect, AuthSilentRedirect, __authTestHooks } from "./auth";
 import type { User, UserManager } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
@@ -614,6 +614,16 @@ describe("AuthService", () => {
       expect(token?.split(".")[2]).toBe("bW9jay1zaWduYXR1cmU");
       expect(await mockAuthService.getUserEmail()).toBe("mock.user@breakglass.dev");
       expect(mockAuthService.getIdentityProviderName()).toBe("production-keycloak");
+    });
+
+    it("stores empty browser storage values instead of clearing the key", () => {
+      expect(__authTestHooks).toBeDefined();
+
+      __authTestHooks!.setBrowserStorageItem("sessionStorage", "empty-storage-value", "");
+      expect(sessionStorage.getItem("empty-storage-value")).toBe("");
+
+      __authTestHooks!.setBrowserStorageItem("sessionStorage", "empty-storage-value", undefined);
+      expect(sessionStorage.getItem("empty-storage-value")).toBeNull();
     });
 
     it("issues synthetic access tokens and email with default profile", async () => {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -840,10 +840,11 @@ export default class AuthService {
       silent_redirect_uri: this.baseURL + AuthSilentRedirect,
       response_type: "code",
       // offline_access intentionally omitted: breakglass tokens are short-lived emergency credentials; silent refresh would allow sessions to outlive their intended window
+      // automaticSilentRenew is also disabled to prevent iframe-based silent session extension
       scope: "openid profile email",
       post_logout_redirect_uri: this.baseURL,
       filterProtocolClaims: true,
-      automaticSilentRenew: true,
+      automaticSilentRenew: false,
       accessTokenExpiringNotificationTimeInSeconds: 60,
       // Prefer refresh tokens over iframe when available (works around CSP frame-ancestors issues)
       revokeTokensOnSignout: true,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -167,6 +167,12 @@ function getOIDCStorage(): Storage {
   }
   const prefersPersistent = getTokenPersistenceMode() === "persistent";
   if (prefersPersistent && typeof window.localStorage !== "undefined") {
+    if (!isProdBuild) {
+      warn(
+        "AuthService",
+        "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
+      );
+    }
     return window.localStorage;
   }
   return typeof window.sessionStorage !== "undefined" ? window.sessionStorage : fallbackStorage;
@@ -833,8 +839,8 @@ export default class AuthService {
       redirect_uri: this.baseURL + AuthRedirect,
       silent_redirect_uri: this.baseURL + AuthSilentRedirect,
       response_type: "code",
-      // Include offline_access to get refresh tokens for CSP-blocked iframe fallback
-      scope: "openid profile email offline_access",
+      // offline_access intentionally omitted: breakglass tokens are short-lived emergency credentials; silent refresh would allow sessions to outlive their intended window
+      scope: "openid profile email",
       post_logout_redirect_uri: this.baseURL,
       filterProtocolClaims: true,
       automaticSilentRenew: true,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -239,17 +239,22 @@ function getOIDCStorage(): Storage {
   }
   if (getTokenPersistenceMode() === "persistent") {
     if (isProductionBuild()) {
-      warn("AuthService", "Persistent OIDC token storage is disabled in production; using sessionStorage");
       const localStorage = getBrowserStorage("localStorage");
+      const sessionStorage = getBrowserStorage("sessionStorage");
       setTokenPersistencePreference("session");
       purgeLegacyLocalOIDCArtifacts(localStorage);
-    } else {
-      const localStorage = getBrowserStorage("localStorage");
       warn(
         "AuthService",
-        "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
+        `Persistent OIDC token storage is disabled in production; using ${sessionStorage ? "sessionStorage" : "in-memory fallback storage"}`,
       );
+      return sessionStorage ?? fallbackStorage;
+    } else {
+      const localStorage = getBrowserStorage("localStorage");
       if (localStorage) {
+        warn(
+          "AuthService",
+          "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
+        );
         return localStorage;
       }
     }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -186,7 +186,7 @@ function setBrowserStorageItem(name: "localStorage" | "sessionStorage", key: str
     return;
   }
   try {
-    if (value) {
+    if (value !== undefined) {
       storage.setItem(key, value);
     } else {
       storage.removeItem(key);
@@ -195,6 +195,13 @@ function setBrowserStorageItem(name: "localStorage" | "sessionStorage", key: str
     warn("AuthService", `Unable to update browser ${name}`, error);
   }
 }
+
+export const __authTestHooks =
+  import.meta.env.MODE === "test"
+    ? {
+        setBrowserStorageItem,
+      }
+    : undefined;
 
 function getTokenPersistenceMode(): TokenPersistenceMode {
   const stored = getBrowserStorageItem("localStorage", TOKEN_PERSISTENCE_KEY);

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -204,6 +204,23 @@ function setTokenPersistencePreference(mode: TokenPersistenceMode) {
   setBrowserStorageItem("localStorage", TOKEN_PERSISTENCE_KEY, mode);
 }
 
+function purgeLegacyLocalOIDCArtifacts(storage: Storage | undefined): void {
+  if (!storage) {
+    return;
+  }
+  try {
+    for (let i = storage.length - 1; i >= 0; i -= 1) {
+      const key = storage.key(i);
+      if (key?.startsWith("oidc.")) {
+        storage.removeItem(key);
+      }
+    }
+    storage.removeItem(CURRENT_IDP_LOCAL_STORAGE_KEY);
+  } catch (error) {
+    warn("AuthService", "Unable to purge legacy localStorage OIDC artifacts", error);
+  }
+}
+
 function getOIDCStorage(): Storage {
   if (!isBrowser) {
     return fallbackStorage;
@@ -212,6 +229,9 @@ function getOIDCStorage(): Storage {
   if (prefersPersistent) {
     if (isProductionBuild()) {
       warn("AuthService", "Persistent OIDC token storage is disabled in production; using sessionStorage");
+      const localStorage = getBrowserStorage("localStorage");
+      setTokenPersistencePreference("session");
+      purgeLegacyLocalOIDCArtifacts(localStorage);
     } else {
       const localStorage = getBrowserStorage("localStorage");
       warn(

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -171,6 +171,16 @@ function getOIDCStorage(): Storage {
   if (!isBrowser) {
     return fallbackStorage;
   }
+  const prefersPersistent = getTokenPersistenceMode() === "persistent";
+  if (prefersPersistent && typeof window.localStorage !== "undefined") {
+    if (!isProdBuild) {
+      warn(
+        "AuthService",
+        "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
+      );
+    }
+    return window.localStorage;
+  }
   return typeof window.sessionStorage !== "undefined" ? window.sessionStorage : fallbackStorage;
 }
 
@@ -900,7 +910,7 @@ export default class AuthService {
       redirect_uri: this.baseURL + AuthRedirect,
       silent_redirect_uri: this.baseURL + AuthSilentRedirect,
       response_type: "code",
-      // Include offline_access to get refresh tokens for CSP-blocked iframe fallback
+      // offline_access intentionally omitted: breakglass tokens are short-lived emergency credentials; silent refresh would allow sessions to outlive their intended window
       scope: "openid profile email",
       post_logout_redirect_uri: this.baseURL,
       filterProtocolClaims: true,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -8,6 +8,8 @@ import { debug, info as logInfo, warn, error as logError } from "@/services/logg
 // Store the current direct authority for header injection during OIDC requests
 // We use sessionStorage so it persists across page reloads during OAuth redirect flow
 const DIRECT_AUTHORITY_STORAGE_KEY = "oidc_direct_authority";
+const CURRENT_IDP_SESSION_STORAGE_KEY = "oidc_idp_name";
+const CURRENT_IDP_LOCAL_STORAGE_KEY = "breakglass_current_idp_name";
 const TOKEN_PERSISTENCE_KEY = "breakglass_oidc_token_persistence";
 export type TokenPersistenceMode = "session" | "persistent";
 const isBrowser = typeof window !== "undefined";
@@ -248,6 +250,51 @@ function getCurrentDirectAuthority(): string | undefined {
   return window.sessionStorage.getItem(DIRECT_AUTHORITY_STORAGE_KEY) || undefined;
 }
 
+function setStoredIdentityProviderName(idpName: string | undefined) {
+  if (!isBrowser) {
+    return;
+  }
+
+  for (const { storageName, key } of [
+    { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
+    { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
+  ] as const) {
+    try {
+      const storage = window[storageName];
+      if (idpName) {
+        storage.setItem(key, idpName);
+      } else {
+        storage.removeItem(key);
+      }
+    } catch (error) {
+      warn("AuthService", "Unable to update stored identity provider name", error);
+    }
+  }
+}
+
+function getStoredIdentityProviderName(): string | undefined {
+  if (!isBrowser) {
+    return undefined;
+  }
+
+  for (const { storageName, key } of [
+    { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
+    { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
+  ] as const) {
+    try {
+      const storage = window[storageName];
+      const storedValue = storage.getItem(key);
+      if (storedValue) {
+        return storedValue;
+      }
+    } catch (error) {
+      warn("AuthService", "Unable to read stored identity provider name", error);
+    }
+  }
+
+  return undefined;
+}
+
 function safeBtoa(value: string): string {
   if (typeof globalThis !== "undefined") {
     const globalAny = globalThis as {
@@ -448,6 +495,7 @@ export default class AuthService {
     }
     this.currentIDPName = state?.idpName;
     currentIDPName.value = state?.idpName;
+    setStoredIdentityProviderName(state?.idpName);
   }
 
   private clearMockSession() {
@@ -458,6 +506,7 @@ export default class AuthService {
     }
     this.currentIDPName = undefined;
     currentIDPName.value = undefined;
+    setStoredIdentityProviderName(undefined);
   }
 
   public async getUser(): Promise<User | null> {
@@ -520,14 +569,11 @@ export default class AuthService {
         // Store the current IDP name for later retrieval
         this.currentIDPName = state.idpName;
         currentIDPName.value = state.idpName;
+        setStoredIdentityProviderName(state.idpName);
 
-        // Also store IDP name in sessionStorage so it survives the OAuth redirect
-        if (state.idpName) {
-          sessionStorage.setItem("oidc_idp_name", state.idpName);
-          debug("AuthService", "Stored IDP name in sessionStorage:", {
-            idpName: state.idpName,
-          });
-        }
+        debug("AuthService", "Stored IDP name for session continuity:", {
+          idpName: state.idpName,
+        });
 
         // Get or create UserManager for this IDP with the proxy authority
         // Also pass the direct authority so we can tell the backend which IDP to proxy to
@@ -562,9 +608,7 @@ export default class AuthService {
     }
 
     debug("AuthService", "Logging in with default IDP (no specific IDP selected)");
-    if (isBrowser) {
-      sessionStorage.removeItem("oidc_idp_name");
-    }
+    setStoredIdentityProviderName(undefined);
     // Clear any previously set direct authority for default login
     setCurrentDirectAuthority(undefined);
     return this.userManager.signinRedirect({ state: resolveState(state) });
@@ -630,7 +674,7 @@ export default class AuthService {
   }
 
   public getIdentityProviderName(): string | undefined {
-    return this.currentIDPName;
+    return this.currentIDPName ?? getStoredIdentityProviderName();
   }
 
   public logout(): Promise<void> {
@@ -642,6 +686,8 @@ export default class AuthService {
     // Clear the current IDP name on logout
     this.currentIDPName = undefined;
     currentIDPName.value = undefined;
+    setStoredIdentityProviderName(undefined);
+    setCurrentDirectAuthority(undefined);
     return this.userManager.signoutRedirect();
   }
 
@@ -843,13 +889,11 @@ export default class AuthService {
           });
         }
 
-        this.currentIDPName = restoredIdpName;
-        currentIDPName.value = restoredIdpName;
-        if (preferredIdpName && isBrowser) {
-          sessionStorage.removeItem("oidc_idp_name");
-        }
+	        this.currentIDPName = restoredIdpName;
+	        currentIDPName.value = restoredIdpName;
+	        setStoredIdentityProviderName(restoredIdpName);
 
-        return result;
+	        return result;
       } catch (error) {
         // Check if this is an authority mismatch error
         const errorMsg = String(error);
@@ -943,6 +987,10 @@ export default class AuthService {
       events.addUserUnloaded(() => {
         debug("AuthService", "User unloaded event - session cleared");
         user.value = undefined;
+        this.currentIDPName = undefined;
+        currentIDPName.value = undefined;
+        setStoredIdentityProviderName(undefined);
+        setCurrentDirectAuthority(undefined);
       });
     }
 
@@ -959,6 +1007,10 @@ export default class AuthService {
         warn("AuthService", "Access token expired - clearing local session");
         logError("AuthService", "Access token expired, user needs to re-authenticate");
         user.value = undefined;
+        this.currentIDPName = undefined;
+        currentIDPName.value = undefined;
+        setStoredIdentityProviderName(undefined);
+        setCurrentDirectAuthority(undefined);
         manager.removeUser().catch((error: unknown) => {
           logError("AuthService", "Failed to remove expired OIDC user", error);
         });
@@ -983,6 +1035,10 @@ export default class AuthService {
       events.addUserSignedOut(() => {
         debug("AuthService", "User signed out event (possibly from another tab)");
         user.value = undefined;
+        this.currentIDPName = undefined;
+        currentIDPName.value = undefined;
+        setStoredIdentityProviderName(undefined);
+        setCurrentDirectAuthority(undefined);
       });
     }
   }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -911,10 +911,11 @@ export default class AuthService {
       silent_redirect_uri: this.baseURL + AuthSilentRedirect,
       response_type: "code",
       // offline_access intentionally omitted: breakglass tokens are short-lived emergency credentials; silent refresh would allow sessions to outlive their intended window
+      // automaticSilentRenew is also disabled to prevent iframe-based silent session extension
       scope: "openid profile email",
       post_logout_redirect_uri: this.baseURL,
       filterProtocolClaims: true,
-      automaticSilentRenew: true,
+      automaticSilentRenew: false,
       accessTokenExpiringNotificationTimeInSeconds: 60,
       // Prefer refresh tokens over iframe when available (works around CSP frame-ancestors issues)
       revokeTokensOnSignout: true,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -10,6 +10,7 @@ import { debug, info as logInfo, warn, error as logError } from "@/services/logg
 const DIRECT_AUTHORITY_STORAGE_KEY = "oidc_direct_authority";
 const CURRENT_IDP_SESSION_STORAGE_KEY = "oidc_idp_name";
 const CURRENT_IDP_LOCAL_STORAGE_KEY = "breakglass_current_idp_name";
+const ACTIVE_OIDC_USER_STORAGE_KEY = "breakglass_active_oidc_user_storage_key";
 const TOKEN_PERSISTENCE_KEY = "breakglass_oidc_token_persistence";
 export type TokenPersistenceMode = "session" | "persistent";
 const isBrowser = typeof window !== "undefined";
@@ -300,6 +301,21 @@ function getCurrentDirectAuthority(): string | undefined {
   return getBrowserStorageItem("sessionStorage", DIRECT_AUTHORITY_STORAGE_KEY) || undefined;
 }
 
+function buildOIDCUserStorageKey(settings: { authority?: string; client_id?: string }): string | undefined {
+  if (!settings.authority || !settings.client_id) {
+    return undefined;
+  }
+  return `oidc.user:${settings.authority}:${settings.client_id}`;
+}
+
+function setActiveOIDCUserStorageKey(key: string | undefined) {
+  setBrowserStorageItem("sessionStorage", ACTIVE_OIDC_USER_STORAGE_KEY, key);
+}
+
+function getStoredActiveOIDCUserStorageKey(): string | undefined {
+  return getBrowserStorageItem("sessionStorage", ACTIVE_OIDC_USER_STORAGE_KEY) || undefined;
+}
+
 function setStoredIdentityProviderName(idpName: string | undefined) {
   setBrowserStorageItem("sessionStorage", CURRENT_IDP_SESSION_STORAGE_KEY, idpName);
   if (shouldUseLocalOIDCStorage()) {
@@ -523,6 +539,7 @@ export default class AuthService {
     this.currentIDPName = state?.idpName;
     currentIDPName.value = state?.idpName;
     setStoredIdentityProviderName(state?.idpName);
+    setActiveOIDCUserStorageKey(buildOIDCUserStorageKey(this.userManager.settings));
   }
 
   private clearMockSession() {
@@ -534,6 +551,7 @@ export default class AuthService {
     this.currentIDPName = undefined;
     currentIDPName.value = undefined;
     setStoredIdentityProviderName(undefined);
+    setActiveOIDCUserStorageKey(undefined);
   }
 
   public async getUser(): Promise<User | null> {
@@ -605,6 +623,7 @@ export default class AuthService {
         // Get or create UserManager for this IDP with the proxy authority
         // Also pass the direct authority so we can tell the backend which IDP to proxy to
         const manager = this.getOrCreateUserManagerForIDP(state.idpName, proxyAuthority, oidcClientID, directAuthority);
+        setActiveOIDCUserStorageKey(buildOIDCUserStorageKey(manager.settings));
 
         debug("AuthService", "About to initiate signin redirect for IDP:", {
           idpName: state.idpName,
@@ -636,6 +655,7 @@ export default class AuthService {
 
     debug("AuthService", "Logging in with default IDP (no specific IDP selected)");
     setStoredIdentityProviderName(undefined);
+    setActiveOIDCUserStorageKey(buildOIDCUserStorageKey(this.userManager.settings));
     // Clear any previously set direct authority for default login
     setCurrentDirectAuthority(undefined);
     return this.userManager.signinRedirect({ state: resolveState(state) });
@@ -704,6 +724,19 @@ export default class AuthService {
     return this.currentIDPName ?? getStoredIdentityProviderName();
   }
 
+  public getActiveOIDCUserStorageKeys(): string[] {
+    const activeIDPName = this.getIdentityProviderName();
+    if (activeIDPName) {
+      const activeIDPManager = this.idpManagers.get(activeIDPName)?.manager;
+      const activeIDPKey = activeIDPManager ? buildOIDCUserStorageKey(activeIDPManager.settings) : undefined;
+      const storedActiveKey = getStoredActiveOIDCUserStorageKey();
+      return [...new Set([activeIDPKey, storedActiveKey].filter((key): key is string => !!key))];
+    }
+
+    const defaultKey = buildOIDCUserStorageKey(this.userManager.settings);
+    return defaultKey ? [defaultKey] : [];
+  }
+
   public logout(): Promise<void> {
     if (this.mockMode) {
       this.clearMockSession();
@@ -714,6 +747,7 @@ export default class AuthService {
     this.currentIDPName = undefined;
     currentIDPName.value = undefined;
     setStoredIdentityProviderName(undefined);
+    setActiveOIDCUserStorageKey(undefined);
     setCurrentDirectAuthority(undefined);
     return this.userManager.signoutRedirect();
   }
@@ -919,6 +953,7 @@ export default class AuthService {
         this.currentIDPName = restoredIdpName;
         currentIDPName.value = restoredIdpName;
         setStoredIdentityProviderName(restoredIdpName);
+        setActiveOIDCUserStorageKey(buildOIDCUserStorageKey(candidate.manager.settings));
 
         return result;
       } catch (error) {
@@ -1019,6 +1054,7 @@ export default class AuthService {
         this.currentIDPName = undefined;
         currentIDPName.value = undefined;
         setStoredIdentityProviderName(undefined);
+        setActiveOIDCUserStorageKey(undefined);
         setCurrentDirectAuthority(undefined);
       });
     }
@@ -1039,6 +1075,7 @@ export default class AuthService {
         this.currentIDPName = undefined;
         currentIDPName.value = undefined;
         setStoredIdentityProviderName(undefined);
+        setActiveOIDCUserStorageKey(undefined);
         setCurrentDirectAuthority(undefined);
         manager.removeUser().catch((error: unknown) => {
           logError("AuthService", "Failed to remove expired OIDC user", error);
@@ -1067,6 +1104,7 @@ export default class AuthService {
         this.currentIDPName = undefined;
         currentIDPName.value = undefined;
         setStoredIdentityProviderName(undefined);
+        setActiveOIDCUserStorageKey(undefined);
         setCurrentDirectAuthority(undefined);
       });
     }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -154,19 +154,54 @@ class MemoryStorage implements Storage {
 
 const fallbackStorage: Storage = new MemoryStorage();
 
-function getTokenPersistenceMode(): TokenPersistenceMode {
-  if (!isBrowser || typeof window.localStorage === "undefined") {
-    return "session";
+function getBrowserStorage(name: "localStorage" | "sessionStorage"): Storage | undefined {
+  if (!isBrowser) {
+    return undefined;
   }
-  const stored = window.localStorage.getItem(TOKEN_PERSISTENCE_KEY);
+  try {
+    return window[name];
+  } catch (error) {
+    warn("AuthService", `Unable to access browser ${name}`, error);
+    return undefined;
+  }
+}
+
+function getBrowserStorageItem(name: "localStorage" | "sessionStorage", key: string): string | null {
+  const storage = getBrowserStorage(name);
+  if (!storage) {
+    return null;
+  }
+  try {
+    return storage.getItem(key);
+  } catch (error) {
+    warn("AuthService", `Unable to read browser ${name}`, error);
+    return null;
+  }
+}
+
+function setBrowserStorageItem(name: "localStorage" | "sessionStorage", key: string, value: string | undefined): void {
+  const storage = getBrowserStorage(name);
+  if (!storage) {
+    return;
+  }
+  try {
+    if (value) {
+      storage.setItem(key, value);
+    } else {
+      storage.removeItem(key);
+    }
+  } catch (error) {
+    warn("AuthService", `Unable to update browser ${name}`, error);
+  }
+}
+
+function getTokenPersistenceMode(): TokenPersistenceMode {
+  const stored = getBrowserStorageItem("localStorage", TOKEN_PERSISTENCE_KEY);
   return stored === "persistent" ? "persistent" : "session";
 }
 
 function setTokenPersistencePreference(mode: TokenPersistenceMode) {
-  if (!isBrowser || typeof window.localStorage === "undefined") {
-    return;
-  }
-  window.localStorage.setItem(TOKEN_PERSISTENCE_KEY, mode);
+  setBrowserStorageItem("localStorage", TOKEN_PERSISTENCE_KEY, mode);
 }
 
 function getOIDCStorage(): Storage {
@@ -177,15 +212,18 @@ function getOIDCStorage(): Storage {
   if (prefersPersistent) {
     if (isProductionBuild()) {
       warn("AuthService", "Persistent OIDC token storage is disabled in production; using sessionStorage");
-    } else if (typeof window.localStorage !== "undefined") {
+    } else {
+      const localStorage = getBrowserStorage("localStorage");
       warn(
         "AuthService",
         "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
       );
-      return window.localStorage;
+      if (localStorage) {
+        return localStorage;
+      }
     }
   }
-  return typeof window.sessionStorage !== "undefined" ? window.sessionStorage : fallbackStorage;
+  return getBrowserStorage("sessionStorage") ?? fallbackStorage;
 }
 
 export function getOIDCUserStorageKey(authority: string | undefined, clientID: string | undefined): string | undefined {
@@ -224,19 +262,11 @@ export function getStoredOIDCUser(authority: string | undefined, clientID: strin
  * Stored in sessionStorage to survive page reloads during OAuth redirects.
  */
 function setCurrentDirectAuthority(authority: string | undefined) {
-  if (!isBrowser || typeof window.sessionStorage === "undefined") {
-    return;
-  }
   debug("AuthService", "Setting current direct authority for header injection:", {
     newAuthority: authority,
     previousAuthority: getCurrentDirectAuthority(),
   });
-  const storage = window.sessionStorage;
-  if (authority) {
-    storage.setItem(DIRECT_AUTHORITY_STORAGE_KEY, authority);
-  } else {
-    storage.removeItem(DIRECT_AUTHORITY_STORAGE_KEY);
-  }
+  setBrowserStorageItem("sessionStorage", DIRECT_AUTHORITY_STORAGE_KEY, authority);
 }
 
 /**
@@ -244,51 +274,26 @@ function setCurrentDirectAuthority(authority: string | undefined) {
  * This survives page reloads during OAuth redirect flow
  */
 function getCurrentDirectAuthority(): string | undefined {
-  if (!isBrowser || typeof window.sessionStorage === "undefined") {
-    return undefined;
-  }
-  return window.sessionStorage.getItem(DIRECT_AUTHORITY_STORAGE_KEY) || undefined;
+  return getBrowserStorageItem("sessionStorage", DIRECT_AUTHORITY_STORAGE_KEY) || undefined;
 }
 
 function setStoredIdentityProviderName(idpName: string | undefined) {
-  if (!isBrowser) {
-    return;
-  }
-
   for (const { storageName, key } of [
     { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
     { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
   ] as const) {
-    try {
-      const storage = window[storageName];
-      if (idpName) {
-        storage.setItem(key, idpName);
-      } else {
-        storage.removeItem(key);
-      }
-    } catch (error) {
-      warn("AuthService", "Unable to update stored identity provider name", error);
-    }
+    setBrowserStorageItem(storageName, key, idpName);
   }
 }
 
 function getStoredIdentityProviderName(): string | undefined {
-  if (!isBrowser) {
-    return undefined;
-  }
-
   for (const { storageName, key } of [
     { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
     { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
   ] as const) {
-    try {
-      const storage = window[storageName];
-      const storedValue = storage.getItem(key);
-      if (storedValue) {
-        return storedValue;
-      }
-    } catch (error) {
-      warn("AuthService", "Unable to read stored identity provider name", error);
+    const storedValue = getBrowserStorageItem(storageName, key);
+    if (storedValue) {
+      return storedValue;
     }
   }
 
@@ -617,7 +622,7 @@ export default class AuthService {
   public async handleSilentSigninCallback() {
     if (this.mockMode) return;
 
-    const preferredIdpName = isBrowser ? sessionStorage.getItem("oidc_idp_name") || undefined : undefined;
+    const preferredIdpName = getBrowserStorageItem("sessionStorage", CURRENT_IDP_SESSION_STORAGE_KEY) || undefined;
     const directAuthority = getCurrentDirectAuthority();
 
     if (preferredIdpName || directAuthority) {
@@ -792,7 +797,7 @@ export default class AuthService {
       hasIssuer: !!issuerParam,
     });
 
-    const preferredIdpName = isBrowser ? sessionStorage.getItem("oidc_idp_name") || undefined : undefined;
+    const preferredIdpName = getBrowserStorageItem("sessionStorage", CURRENT_IDP_SESSION_STORAGE_KEY) || undefined;
     const candidateManagers: Array<{ manager: UserManager; idpName?: string; directAuthority?: string }> = [];
     const seenManagers = new Set<UserManager>();
 
@@ -889,11 +894,11 @@ export default class AuthService {
           });
         }
 
-	        this.currentIDPName = restoredIdpName;
-	        currentIDPName.value = restoredIdpName;
-	        setStoredIdentityProviderName(restoredIdpName);
+        this.currentIDPName = restoredIdpName;
+        currentIDPName.value = restoredIdpName;
+        setStoredIdentityProviderName(restoredIdpName);
 
-	        return result;
+        return result;
       } catch (error) {
         // Check if this is an authority mismatch error
         const errorMsg = String(error);
@@ -921,8 +926,10 @@ export default class AuthService {
   }
 
   private buildUserManager(authority: string, clientID: string): UserManager {
+    const oidcStorage = getOIDCStorage();
     const settings: UserManagerSettingsWithFetch = {
-      userStore: new WebStorageStateStore({ store: getOIDCStorage() }),
+      stateStore: new WebStorageStateStore({ store: oidcStorage }),
+      userStore: new WebStorageStateStore({ store: oidcStorage }),
       authority,
       client_id: clientID,
       redirect_uri: this.baseURL + AuthRedirect,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -172,14 +172,16 @@ function getOIDCStorage(): Storage {
     return fallbackStorage;
   }
   const prefersPersistent = getTokenPersistenceMode() === "persistent";
-  if (prefersPersistent && typeof window.localStorage !== "undefined") {
-    if (!isProductionBuild()) {
+  if (prefersPersistent) {
+    if (isProductionBuild()) {
+      warn("AuthService", "Persistent OIDC token storage is disabled in production; using sessionStorage");
+    } else if (typeof window.localStorage !== "undefined") {
       warn(
         "AuthService",
         "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
       );
+      return window.localStorage;
     }
-    return window.localStorage;
   }
   return typeof window.sessionStorage !== "undefined" ? window.sessionStorage : fallbackStorage;
 }
@@ -685,12 +687,8 @@ export default class AuthService {
   }
 
   /**
-   * Try to silently renew the token. Returns true if successful.
-   * This can be called manually if the automatic silent renew failed.
-   *
-   * Strategy:
-   * 1. Remove any stale refresh token from previously persisted user state
-   * 2. Try signinSilent(), which falls back to iframe flow when no refresh token is present
+   * Silent renewal is intentionally disabled for breakglass sessions.
+   * Users must explicitly re-authenticate when their short-lived token expires.
    */
   public async trySilentRenew(): Promise<boolean> {
     if (this.mockMode) {
@@ -698,32 +696,8 @@ export default class AuthService {
       return true;
     }
 
-    // First, check if we have a valid user with a refresh token
-    const currentUser = await this.userManager.getUser();
-    if (!currentUser) {
-      warn("AuthService", "No user found for silent renew");
-      return false;
-    }
-    await this.stripAndStoreRefreshToken(this.userManager, currentUser);
-
-    try {
-      debug("AuthService", "Attempting silent renew without refresh-token fallback");
-      const renewedUser = await this.userManager.signinSilent();
-      if (renewedUser) {
-        const sanitizedUser = await this.stripAndStoreRefreshToken(this.userManager, renewedUser);
-        debug("AuthService", "Silent renew successful", {
-          email: renewedUser.profile?.email,
-          expiresAt: renewedUser.expires_at,
-        });
-        user.value = sanitizedUser;
-        return true;
-      }
-      warn("AuthService", "Silent renew returned no user");
-      return false;
-    } catch (iframeError) {
-      warn("AuthService", "Silent renew failed; user must re-authenticate", iframeError);
-      return false;
-    }
+    warn("AuthService", "Silent token renewal is disabled for breakglass sessions");
+    return false;
   }
 
   public async getUserEmail(): Promise<string> {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -204,6 +204,10 @@ function setTokenPersistencePreference(mode: TokenPersistenceMode) {
   setBrowserStorageItem("localStorage", TOKEN_PERSISTENCE_KEY, mode);
 }
 
+function shouldUseLocalOIDCStorage(): boolean {
+  return !isProductionBuild() && getTokenPersistenceMode() === "persistent";
+}
+
 function purgeLegacyLocalOIDCArtifacts(storage: Storage | undefined): void {
   if (!storage) {
     return;
@@ -225,8 +229,7 @@ function getOIDCStorage(): Storage {
   if (!isBrowser) {
     return fallbackStorage;
   }
-  const prefersPersistent = getTokenPersistenceMode() === "persistent";
-  if (prefersPersistent) {
+  if (getTokenPersistenceMode() === "persistent") {
     if (isProductionBuild()) {
       warn("AuthService", "Persistent OIDC token storage is disabled in production; using sessionStorage");
       const localStorage = getBrowserStorage("localStorage");
@@ -298,23 +301,22 @@ function getCurrentDirectAuthority(): string | undefined {
 }
 
 function setStoredIdentityProviderName(idpName: string | undefined) {
-  for (const { storageName, key } of [
-    { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
-    { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
-  ] as const) {
-    setBrowserStorageItem(storageName, key, idpName);
+  setBrowserStorageItem("sessionStorage", CURRENT_IDP_SESSION_STORAGE_KEY, idpName);
+  if (shouldUseLocalOIDCStorage()) {
+    setBrowserStorageItem("localStorage", CURRENT_IDP_LOCAL_STORAGE_KEY, idpName);
+  } else {
+    setBrowserStorageItem("localStorage", CURRENT_IDP_LOCAL_STORAGE_KEY, undefined);
   }
 }
 
 function getStoredIdentityProviderName(): string | undefined {
-  for (const { storageName, key } of [
-    { storageName: "sessionStorage", key: CURRENT_IDP_SESSION_STORAGE_KEY },
-    { storageName: "localStorage", key: CURRENT_IDP_LOCAL_STORAGE_KEY },
-  ] as const) {
-    const storedValue = getBrowserStorageItem(storageName, key);
-    if (storedValue) {
-      return storedValue;
-    }
+  const sessionStorageValue = getBrowserStorageItem("sessionStorage", CURRENT_IDP_SESSION_STORAGE_KEY);
+  if (sessionStorageValue) {
+    return sessionStorageValue;
+  }
+
+  if (shouldUseLocalOIDCStorage()) {
+    return getBrowserStorageItem("localStorage", CURRENT_IDP_LOCAL_STORAGE_KEY) || undefined;
   }
 
   return undefined;

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -173,7 +173,7 @@ function getOIDCStorage(): Storage {
   }
   const prefersPersistent = getTokenPersistenceMode() === "persistent";
   if (prefersPersistent && typeof window.localStorage !== "undefined") {
-    if (!isProdBuild) {
+    if (!isProductionBuild()) {
       warn(
         "AuthService",
         "SECURITY WARNING: Persistent OIDC token storage (localStorage) is used. This is vulnerable to XSS and should be avoided for high-privilege breakglass sessions.",
@@ -917,7 +917,7 @@ export default class AuthService {
       filterProtocolClaims: true,
       automaticSilentRenew: false,
       accessTokenExpiringNotificationTimeInSeconds: 60,
-      // Prefer refresh tokens over iframe when available (works around CSP frame-ancestors issues)
+      // Revoke provider-side tokens during sign-out when supported by the IdP
       revokeTokensOnSignout: true,
     };
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -975,15 +975,19 @@ export default class AuthService {
     // Token about to expire
     if (typeof events.addAccessTokenExpiring === "function") {
       events.addAccessTokenExpiring(() => {
-        debug("AuthService", "Access token expiring soon, silent renew should trigger");
+        debug("AuthService", "Access token expiring soon, user will need to re-authenticate");
       });
     }
 
-    // Token expired (silent renew didn't work)
+    // Token expired. Automatic silent renewal is disabled, so clear local auth state immediately.
     if (typeof events.addAccessTokenExpired === "function") {
       events.addAccessTokenExpired(() => {
-        warn("AuthService", "Access token expired - silent renew failed or not configured");
+        warn("AuthService", "Access token expired - clearing local session");
         logError("AuthService", "Access token expired, user needs to re-authenticate");
+        user.value = undefined;
+        manager.removeUser().catch((error: unknown) => {
+          logError("AuthService", "Failed to remove expired OIDC user", error);
+        });
       });
     }
 

--- a/frontend/src/services/httpClient.spec.ts
+++ b/frontend/src/services/httpClient.spec.ts
@@ -142,13 +142,19 @@ describe("createAuthenticatedApiClient", () => {
 
     const client = createAuthenticatedApiClient(auth, { baseURL: "https://api.example.com" });
     client.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
-      throw new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, {}, {
-        data: {},
-        status: 401,
-        statusText: "Unauthorized",
-        headers: {},
+      throw new AxiosError(
+        "Unauthorized",
+        "ERR_BAD_REQUEST",
         config,
-      });
+        {},
+        {
+          data: {},
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {},
+          config,
+        },
+      );
     };
 
     await expect(client.get("/protected")).rejects.toThrow("Unauthorized");
@@ -166,18 +172,26 @@ describe("createAuthenticatedApiClient", () => {
     client.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
       attempts += 1;
       if (attempts === 1) {
-        throw new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, {}, {
-          data: {},
-          status: 401,
-          statusText: "Unauthorized",
-          headers: {},
+        throw new AxiosError(
+          "Unauthorized",
+          "ERR_BAD_REQUEST",
           config,
-        });
+          {},
+          {
+            data: {},
+            status: 401,
+            statusText: "Unauthorized",
+            headers: {},
+            config,
+          },
+        );
       }
       return {
         data: {
           authorization:
-            typeof config.headers?.get === "function" ? config.headers.get("Authorization") : config.headers?.Authorization,
+            typeof config.headers?.get === "function"
+              ? config.headers.get("Authorization")
+              : config.headers?.Authorization,
         },
         status: 200,
         statusText: "OK",

--- a/frontend/src/services/httpClient.spec.ts
+++ b/frontend/src/services/httpClient.spec.ts
@@ -133,6 +133,65 @@ describe("createAuthenticatedApiClient", () => {
     expect(logged).not.toContain("Bearer sensitive-token");
     expect(logged).not.toContain("sensitive-token");
   });
+
+  it("does not attempt silent renew on 401 by default", async () => {
+    const auth = {
+      getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+      trySilentRenew: vi.fn().mockResolvedValue(true),
+    } as unknown as AuthService;
+
+    const client = createAuthenticatedApiClient(auth, { baseURL: "https://api.example.com" });
+    client.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+      throw new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, {}, {
+        data: {},
+        status: 401,
+        statusText: "Unauthorized",
+        headers: {},
+        config,
+      });
+    };
+
+    await expect(client.get("/protected")).rejects.toThrow("Unauthorized");
+    expect((auth as unknown as { trySilentRenew: ReturnType<typeof vi.fn> }).trySilentRenew).not.toHaveBeenCalled();
+  });
+
+  it("retries a 401 only when retryOn401 is explicitly enabled", async () => {
+    const auth = {
+      getAccessToken: vi.fn().mockResolvedValueOnce("old-token").mockResolvedValue("new-token"),
+      trySilentRenew: vi.fn().mockResolvedValue(true),
+    } as unknown as AuthService;
+
+    let attempts = 0;
+    const client = createAuthenticatedApiClient(auth, { baseURL: "https://api.example.com", retryOn401: true });
+    client.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, {}, {
+          data: {},
+          status: 401,
+          statusText: "Unauthorized",
+          headers: {},
+          config,
+        });
+      }
+      return {
+        data: {
+          authorization:
+            typeof config.headers?.get === "function" ? config.headers.get("Authorization") : config.headers?.Authorization,
+        },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config,
+      };
+    };
+
+    const response = await client.get("/protected");
+
+    expect(attempts).toBe(2);
+    expect((auth as unknown as { trySilentRenew: ReturnType<typeof vi.fn> }).trySilentRenew).toHaveBeenCalledTimes(1);
+    expect(response.data.authorization).toBe("Bearer new-token");
+  });
 });
 
 describe("timeout detection", () => {

--- a/frontend/src/services/httpClient.ts
+++ b/frontend/src/services/httpClient.ts
@@ -5,7 +5,7 @@ import logger from "@/services/logger";
 export interface ApiClientOptions {
   baseURL?: string;
   enableDevTokenLogging?: boolean;
-  /** If true, will attempt silent token renew on 401 and retry the request once */
+  /** If true, attempts silent token renew on 401 and retries the request once. Disabled by default. */
   retryOn401?: boolean;
   /** Request timeout in milliseconds. Defaults to 30000 (30 seconds). */
   timeout?: number;
@@ -119,8 +119,8 @@ export function createAuthenticatedApiClient(auth: AuthService, options?: ApiCli
     async (error) => {
       const config = error.config as InternalAxiosRequestConfig & { [RETRY_FLAG]?: boolean };
 
-      // Handle 401 errors with optional retry after silent renew
-      if (error.response?.status === 401 && options?.retryOn401 !== false && !config?.[RETRY_FLAG]) {
+      // Handle 401 errors with opt-in retry after silent renew.
+      if (error.response?.status === 401 && options?.retryOn401 === true && !config?.[RETRY_FLAG]) {
         logger.debug("HttpClient", "Received 401, attempting silent token renew before retry");
 
         try {

--- a/frontend/src/services/logger.spec.ts
+++ b/frontend/src/services/logger.spec.ts
@@ -279,3 +279,28 @@ describe("Logger Service", () => {
     });
   });
 });
+
+describe("Logger Service storage guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("loads when localStorage getter throws", async () => {
+    const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage blocked");
+      },
+    });
+
+    try {
+      await expect(import("@/services/logger")).resolves.toBeDefined();
+    } finally {
+      if (localStorageDescriptor) {
+        Object.defineProperty(window, "localStorage", localStorageDescriptor);
+      }
+    }
+  });
+});

--- a/frontend/src/services/logger.spec.ts
+++ b/frontend/src/services/logger.spec.ts
@@ -293,3 +293,28 @@ describe("Logger Service", () => {
     });
   });
 });
+
+describe("Logger Service storage guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("loads when localStorage getter throws", async () => {
+    const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage blocked");
+      },
+    });
+
+    try {
+      await expect(import("@/services/logger")).resolves.toBeDefined();
+    } finally {
+      if (localStorageDescriptor) {
+        Object.defineProperty(window, "localStorage", localStorageDescriptor);
+      }
+    }
+  });
+});

--- a/frontend/src/services/logger.ts
+++ b/frontend/src/services/logger.ts
@@ -44,23 +44,35 @@ function parseBooleanFlag(value: string | null | undefined): boolean | null {
   return null;
 }
 
+function getLocalStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    // localStorage unavailable (SSR, sandboxed iframe) — cannot read or persist flag
+    return undefined;
+  }
+}
+
 function readStoredDebugFlag(): boolean | null {
   if (!isDevRuntime()) return null;
-  if (typeof window === "undefined" || !window.localStorage) return null;
+  const storage = getLocalStorage();
+  if (!storage) return null;
   try {
-    const stored = window.localStorage.getItem(DEBUG_STORAGE_KEY);
+    const stored = storage.getItem(DEBUG_STORAGE_KEY);
     return parseBooleanFlag(stored);
   } catch {
-    // localStorage unavailable (SSR, sandboxed iframe) — cannot read flag
+    // localStorage read failed — cannot read flag
     return null;
   }
 }
 
 function persistDebugFlag(enabled: boolean) {
   if (!isDevRuntime()) return;
-  if (typeof window === "undefined" || !window.localStorage) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    window.localStorage.setItem(DEBUG_STORAGE_KEY, String(enabled));
+    storage.setItem(DEBUG_STORAGE_KEY, String(enabled));
   } catch {
     // localStorage write failed (quota, disabled) — non-critical
   }

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -58,7 +58,7 @@ const sessionStorageMock = (() => {
     get length() {
       return Object.keys(store).length;
     },
-    getItem: (key: string) => store[key] || null,
+    getItem: (key: string) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
     key: (index: number) => Object.keys(store)[index] ?? null,
     setItem: (key: string, value: string) => {
       store[key] = value;
@@ -84,7 +84,7 @@ const localStorageMock = (() => {
     get length() {
       return Object.keys(store).length;
     },
-    getItem: (key: string) => store[key] || null,
+    getItem: (key: string) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
     key: (index: number) => Object.keys(store)[index] ?? null,
     setItem: (key: string, value: string) => {
       store[key] = value;

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -55,7 +55,11 @@ globalThis.IntersectionObserver = vi.fn().mockImplementation(() => ({
 const sessionStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
+    get length() {
+      return Object.keys(store).length;
+    },
     getItem: (key: string) => store[key] || null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
     setItem: (key: string, value: string) => {
       store[key] = value;
     },
@@ -76,7 +80,11 @@ Object.defineProperty(window, "sessionStorage", {
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
+    get length() {
+      return Object.keys(store).length;
+    },
     getItem: (key: string) => store[key] || null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
     setItem: (key: string, value: string) => {
       store[key] = value;
     },

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -73,6 +73,7 @@ const sessionStorageMock = (() => {
 })();
 
 Object.defineProperty(window, "sessionStorage", {
+  configurable: true,
   value: sessionStorageMock,
 });
 
@@ -98,6 +99,7 @@ const localStorageMock = (() => {
 })();
 
 Object.defineProperty(window, "localStorage", {
+  configurable: true,
   value: localStorageMock,
 });
 

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -50,6 +50,18 @@ describe("AuthService mock mode guard", () => {
     expect(localStorage.getItem("breakglass_oidc_token_persistence")).toBe("session");
     expect(localStorage.getItem("oidc.user:https://auth.example.com:breakglass-ui")).toBeNull();
     expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+    expect(auth.getIdentityProviderName()).toBeUndefined();
+  });
+
+  it("ignores legacy localStorage IDP hints in production", async () => {
+    vi.stubEnv("PROD", true);
+    vi.resetModules();
+    localStorage.setItem("breakglass_current_idp_name", "corp");
+    const { default: AuthService } = await import("@/services/auth");
+
+    const auth = new AuthService(baseConfig);
+
+    expect(auth.getIdentityProviderName()).toBeUndefined();
   });
 
   it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -33,6 +33,8 @@ describe("AuthService mock mode guard", () => {
     vi.stubEnv("PROD", true);
     vi.resetModules();
     localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
+    localStorage.setItem("oidc.user:https://auth.example.com:breakglass-ui", "legacy-refresh-token");
+    localStorage.setItem("breakglass_current_idp_name", "corp");
     const { default: AuthService } = await import("@/services/auth");
 
     const auth = new AuthService(baseConfig);
@@ -45,6 +47,9 @@ describe("AuthService mock mode guard", () => {
 
     expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
     expect(localStorage.getItem("oidc.probe")).toBeNull();
+    expect(localStorage.getItem("breakglass_oidc_token_persistence")).toBe("session");
+    expect(localStorage.getItem("oidc.user:https://auth.example.com:breakglass-ui")).toBeNull();
+    expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
   });
 
   it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import AuthService from "@/services/auth";
 
 const baseConfig = {
@@ -11,6 +11,10 @@ describe("AuthService mock mode guard", () => {
 
   afterEach(() => {
     process.env.NODE_ENV = originalEnv;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    sessionStorage.clear();
+    localStorage.clear();
   });
 
   it("throws when mock mode is enabled in production builds", () => {
@@ -23,5 +27,23 @@ describe("AuthService mock mode guard", () => {
   it("allows mock mode in non-production builds", () => {
     process.env.NODE_ENV = "test";
     expect(() => new AuthService(baseConfig, { mock: true })).not.toThrow();
+  });
+
+  it("uses sessionStorage for OIDC user data in production even when persistent mode is requested", async () => {
+    vi.stubEnv("PROD", true);
+    vi.resetModules();
+    localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
+    const { default: AuthService } = await import("@/services/auth");
+
+    const auth = new AuthService(baseConfig);
+    const userStore = auth.userManager.settings.userStore;
+    if (!userStore) {
+      throw new Error("AuthService did not configure an OIDC user store");
+    }
+
+    await userStore.set("probe", "session-only");
+
+    expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
+    expect(localStorage.getItem("oidc.probe")).toBeNull();
   });
 });

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -46,4 +46,44 @@ describe("AuthService mock mode guard", () => {
     expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
     expect(localStorage.getItem("oidc.probe")).toBeNull();
   });
+
+  it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {
+    vi.stubEnv("PROD", false);
+    vi.resetModules();
+    const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage blocked");
+      },
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("sessionStorage blocked");
+      },
+    });
+
+    try {
+      const { default: AuthService } = await import("@/services/auth");
+
+      const auth = new AuthService(baseConfig);
+      const userStore = auth.userManager.settings.userStore;
+      if (!userStore) {
+        throw new Error("AuthService did not configure an OIDC user store");
+      }
+
+      await userStore.set("probe", "memory-only");
+
+      await expect(userStore.get("probe")).resolves.toBe("memory-only");
+    } finally {
+      if (localStorageDescriptor) {
+        Object.defineProperty(window, "localStorage", localStorageDescriptor);
+      }
+      if (sessionStorageDescriptor) {
+        Object.defineProperty(window, "sessionStorage", sessionStorageDescriptor);
+      }
+    }
+  });
 });

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -52,6 +52,8 @@ describe("AuthService mock mode guard", () => {
     vi.stubEnv("PROD", true);
     vi.resetModules();
     localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
+    localStorage.setItem("oidc.user:https://auth.example.com:breakglass-ui", "legacy-refresh-token");
+    localStorage.setItem("breakglass_current_idp_name", "corp");
     const { default: AuthService } = await import("@/services/auth");
 
     const auth = new AuthService(baseConfig);
@@ -64,6 +66,9 @@ describe("AuthService mock mode guard", () => {
 
     expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
     expect(localStorage.getItem("oidc.probe")).toBeNull();
+    expect(localStorage.getItem("breakglass_oidc_token_persistence")).toBe("session");
+    expect(localStorage.getItem("oidc.user:https://auth.example.com:breakglass-ui")).toBeNull();
+    expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
   });
 
   it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -65,4 +65,44 @@ describe("AuthService mock mode guard", () => {
     expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
     expect(localStorage.getItem("oidc.probe")).toBeNull();
   });
+
+  it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {
+    vi.stubEnv("PROD", false);
+    vi.resetModules();
+    const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("localStorage blocked");
+      },
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("sessionStorage blocked");
+      },
+    });
+
+    try {
+      const { default: AuthService } = await import("@/services/auth");
+
+      const auth = new AuthService(baseConfig);
+      const userStore = auth.userManager.settings.userStore;
+      if (!userStore) {
+        throw new Error("AuthService did not configure an OIDC user store");
+      }
+
+      await userStore.set("probe", "memory-only");
+
+      await expect(userStore.get("probe")).resolves.toBe("memory-only");
+    } finally {
+      if (localStorageDescriptor) {
+        Object.defineProperty(window, "localStorage", localStorageDescriptor);
+      }
+      if (sessionStorageDescriptor) {
+        Object.defineProperty(window, "sessionStorage", sessionStorageDescriptor);
+      }
+    }
+  });
 });

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -49,6 +49,7 @@ describe("AuthService mock mode guard", () => {
   });
 
   it("uses sessionStorage for OIDC user data in production even when persistent mode is requested", async () => {
+    process.env.NODE_ENV = "production";
     vi.stubEnv("PROD", true);
     vi.resetModules();
     localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
@@ -73,6 +74,7 @@ describe("AuthService mock mode guard", () => {
   });
 
   it("ignores legacy localStorage IDP hints in production", async () => {
+    process.env.NODE_ENV = "production";
     vi.stubEnv("PROD", true);
     vi.resetModules();
     localStorage.setItem("breakglass_current_idp_name", "corp");
@@ -84,6 +86,7 @@ describe("AuthService mock mode guard", () => {
   });
 
   it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {
+    process.env.NODE_ENV = "test";
     vi.stubEnv("PROD", false);
     vi.resetModules();
     const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -69,6 +69,18 @@ describe("AuthService mock mode guard", () => {
     expect(localStorage.getItem("breakglass_oidc_token_persistence")).toBe("session");
     expect(localStorage.getItem("oidc.user:https://auth.example.com:breakglass-ui")).toBeNull();
     expect(localStorage.getItem("breakglass_current_idp_name")).toBeNull();
+    expect(auth.getIdentityProviderName()).toBeUndefined();
+  });
+
+  it("ignores legacy localStorage IDP hints in production", async () => {
+    vi.stubEnv("PROD", true);
+    vi.resetModules();
+    localStorage.setItem("breakglass_current_idp_name", "corp");
+    const { default: AuthService } = await import("@/services/auth");
+
+    const auth = new AuthService(baseConfig);
+
+    expect(auth.getIdentityProviderName()).toBeUndefined();
   });
 
   it("falls back to in-memory OIDC storage when browser storage is blocked", async () => {

--- a/frontend/tests/unit/auth.spec.ts
+++ b/frontend/tests/unit/auth.spec.ts
@@ -11,6 +11,10 @@ describe("AuthService mock mode guard", () => {
 
   afterEach(() => {
     process.env.NODE_ENV = originalEnv;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    sessionStorage.clear();
+    localStorage.clear();
   });
 
   it("throws when mock mode is enabled in production builds", () => {
@@ -42,5 +46,23 @@ describe("AuthService mock mode guard", () => {
 
     expect(sanitized).not.toHaveProperty("refresh_token");
     expect(removeUser).toHaveBeenCalledOnce();
+  });
+
+  it("uses sessionStorage for OIDC user data in production even when persistent mode is requested", async () => {
+    vi.stubEnv("PROD", true);
+    vi.resetModules();
+    localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
+    const { default: AuthService } = await import("@/services/auth");
+
+    const auth = new AuthService(baseConfig);
+    const userStore = auth.userManager.settings.userStore;
+    if (!userStore) {
+      throw new Error("AuthService did not configure an OIDC user store");
+    }
+
+    await userStore.set("probe", "session-only");
+
+    expect(sessionStorage.getItem("oidc.probe")).toBe("session-only");
+    expect(localStorage.getItem("oidc.probe")).toBeNull();
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -101,6 +101,20 @@ describe("AutoLogoutWarning", () => {
     });
   });
 
+  it("uses the persisted identity provider when the in-memory and session hints are absent", async () => {
+    const auth = createMockAuth();
+    localStorage.setItem("breakglass_current_idp_name", "corp");
+    window.history.pushState({}, "", "/sessions?cluster=prod#approval");
+    wrapper = mountWithAuth(auth);
+
+    await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
+
+    expect(auth.login).toHaveBeenCalledWith({
+      path: "/sessions?cluster=prod#approval",
+      idpName: "corp",
+    });
+  });
+
   it("falls back to default reauthentication when session storage is unavailable", async () => {
     const auth = createMockAuth();
     const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -101,8 +101,9 @@ describe("AutoLogoutWarning", () => {
     });
   });
 
-  it("uses the persisted identity provider when the in-memory and session hints are absent", async () => {
+  it("uses the local persisted identity provider when persistent storage is active", async () => {
     const auth = createMockAuth();
+    localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
     localStorage.setItem("breakglass_current_idp_name", "corp");
     window.history.pushState({}, "", "/sessions?cluster=prod#approval");
     wrapper = mountWithAuth(auth);
@@ -112,6 +113,19 @@ describe("AutoLogoutWarning", () => {
     expect(auth.login).toHaveBeenCalledWith({
       path: "/sessions?cluster=prod#approval",
       idpName: "corp",
+    });
+  });
+
+  it("ignores stale local persisted identity provider names by default", async () => {
+    const auth = createMockAuth();
+    localStorage.setItem("breakglass_current_idp_name", "corp");
+    window.history.pushState({}, "", "/sessions?cluster=prod#approval");
+    wrapper = mountWithAuth(auth);
+
+    await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
+
+    expect(auth.login).toHaveBeenCalledWith({
+      path: "/sessions?cluster=prod#approval",
     });
   });
 
@@ -176,5 +190,44 @@ describe("AutoLogoutWarning", () => {
 
     expect((wrapper.vm as unknown as { show: boolean }).show).toBe(false);
     expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
+  });
+
+  it("ignores stale localStorage OIDC users unless persistent storage is active", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    localStorage.setItem(
+      "oidc.user:/api/oidc/authority:corp-ui",
+      JSON.stringify({
+        expires_at: expiresAt,
+      }),
+    );
+
+    wrapper = mountWithAuth(createMockAuth());
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { show: boolean }).show).toBe(false);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
+  });
+
+  it("uses localStorage OIDC users when non-production persistent storage is active", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
+    localStorage.setItem(
+      "oidc.user:/api/oidc/authority:corp-ui",
+      JSON.stringify({
+        expires_at: expiresAt,
+      }),
+    );
+
+    wrapper = mountWithAuth(createMockAuth());
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { show: boolean }).show).toBe(true);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -14,6 +14,7 @@ type MockAuth = {
   login: (state?: { path: string; idpName?: string }) => Promise<void>;
   logout: () => void;
   getIdentityProviderName: () => string | undefined;
+  getActiveOIDCUserStorageKeys: () => string[];
   userManager: {
     settings: {
       authority: string;
@@ -58,6 +59,7 @@ describe("AutoLogoutWarning", () => {
     login: vi.fn().mockResolvedValue(undefined),
     logout: vi.fn(),
     getIdentityProviderName: vi.fn(() => undefined),
+    getActiveOIDCUserStorageKeys: vi.fn(() => ["oidc.user:https://issuer.example.com:breakglass-ui"]),
     userManager: {
       settings: {
         authority: "https://issuer.example.com",
@@ -175,6 +177,9 @@ describe("AutoLogoutWarning", () => {
   it("shows the warning for an expiring IDP-specific OIDC user", async () => {
     vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
     const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    const auth = createMockAuth({
+      getActiveOIDCUserStorageKeys: vi.fn(() => ["oidc.user:/api/oidc/authority:corp-ui"]),
+    });
     sessionStorage.setItem(
       "oidc.user:/api/oidc/authority:corp-ui",
       JSON.stringify({
@@ -182,7 +187,7 @@ describe("AutoLogoutWarning", () => {
       }),
     );
 
-    wrapper = mountWithAuth(createMockAuth());
+    wrapper = mountWithAuth(auth);
 
     await vi.advanceTimersByTimeAsync(5000);
     await wrapper.vm.$nextTick();
@@ -232,6 +237,9 @@ describe("AutoLogoutWarning", () => {
   it("uses localStorage OIDC users when non-production persistent storage is active", async () => {
     vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
     const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    const auth = createMockAuth({
+      getActiveOIDCUserStorageKeys: vi.fn(() => ["oidc.user:/api/oidc/authority:corp-ui"]),
+    });
     localStorage.setItem("breakglass_oidc_token_persistence", "persistent");
     localStorage.setItem(
       "oidc.user:/api/oidc/authority:corp-ui",
@@ -240,12 +248,42 @@ describe("AutoLogoutWarning", () => {
       }),
     );
 
-    wrapper = mountWithAuth(createMockAuth());
+    wrapper = mountWithAuth(auth);
 
     await vi.advanceTimersByTimeAsync(5000);
     await wrapper.vm.$nextTick();
 
     expect((wrapper.vm as unknown as { show: boolean }).show).toBe(true);
     expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
+  });
+
+  it("ignores inactive IDP OIDC users when only they are expiring", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const inactiveExpiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    const activeExpiresAt = Math.floor((Date.now() + 120_000) / 1000);
+    const auth = createMockAuth({
+      getIdentityProviderName: vi.fn(() => "corp"),
+      getActiveOIDCUserStorageKeys: vi.fn(() => ["oidc.user:/api/oidc/authority:corp-ui"]),
+    });
+    sessionStorage.setItem(
+      "oidc.user:/api/oidc/authority:legacy-ui",
+      JSON.stringify({
+        expires_at: inactiveExpiresAt,
+      }),
+    );
+    sessionStorage.setItem(
+      "oidc.user:/api/oidc/authority:corp-ui",
+      JSON.stringify({
+        expires_at: activeExpiresAt,
+      }),
+    );
+
+    wrapper = mountWithAuth(auth);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { show: boolean }).show).toBe(false);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -37,6 +37,8 @@ type MockAuth = {
 
 type AutoLogoutWarningVm = {
   reauthenticate: () => Promise<void>;
+  dismiss: () => void;
+  show: boolean;
 };
 
 describe("AutoLogoutWarning", () => {
@@ -206,6 +208,44 @@ describe("AutoLogoutWarning", () => {
     await wrapper.vm.$nextTick();
 
     expect((wrapper.vm as unknown as { show: boolean }).show).toBe(true);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
+  });
+
+  it("resets dismissal when active OIDC user storage disappears", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const userKey = "oidc.user:/api/oidc/authority:corp-ui";
+    const auth = createMockAuth({
+      getActiveOIDCUserStorageKeys: vi.fn(() => [userKey]),
+    });
+    const setExpiringUser = () => {
+      sessionStorage.setItem(
+        userKey,
+        JSON.stringify({
+          expires_at: Math.floor((Date.now() + 10_000) / 1000),
+        }),
+      );
+    };
+    setExpiringUser();
+    wrapper = mountWithAuth(auth);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as unknown as AutoLogoutWarningVm).show).toBe(true);
+
+    (wrapper.vm as unknown as AutoLogoutWarningVm).dismiss();
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as unknown as AutoLogoutWarningVm).show).toBe(false);
+
+    sessionStorage.removeItem(userKey);
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as unknown as AutoLogoutWarningVm).show).toBe(false);
+
+    setExpiringUser();
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as AutoLogoutWarningVm).show).toBe(true);
     expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
   });
 

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mount, VueWrapper } from "@vue/test-utils";
 import AutoLogoutWarning from "@/components/AutoLogoutWarning.vue";
+import AuthService from "@/services/auth";
 import { AuthKey } from "@/keys";
 
 type MockAuth = {
@@ -125,6 +126,23 @@ describe("AutoLogoutWarning", () => {
     await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
 
     expect(auth.login).toHaveBeenCalledWith({
+      path: "/sessions?cluster=prod#approval",
+    });
+  });
+
+  it("does not recover stale local persisted identity provider names through AuthService", async () => {
+    const auth = new AuthService({
+      oidcAuthority: "https://issuer.example.com",
+      oidcClientID: "breakglass-ui",
+    });
+    const loginSpy = vi.spyOn(auth, "login").mockResolvedValue(undefined);
+    localStorage.setItem("breakglass_current_idp_name", "corp");
+    window.history.pushState({}, "", "/sessions?cluster=prod#approval");
+    wrapper = mountWithAuth(auth);
+
+    await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
+
+    expect(loginSpy).toHaveBeenCalledWith({
       path: "/sessions?cluster=prod#approval",
     });
   });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -101,6 +101,31 @@ describe("AutoLogoutWarning", () => {
     });
   });
 
+  it("falls back to default reauthentication when session storage is unavailable", async () => {
+    const auth = createMockAuth();
+    const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("storage blocked");
+      },
+    });
+
+    try {
+      wrapper = mountWithAuth(auth);
+
+      await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
+
+      expect(auth.login).toHaveBeenCalledWith({
+        path: "/",
+      });
+    } finally {
+      if (sessionStorageDescriptor) {
+        Object.defineProperty(window, "sessionStorage", sessionStorageDescriptor);
+      }
+    }
+  });
+
   it("shows the warning for an expiring IDP-specific OIDC user", async () => {
     vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
     const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
@@ -118,5 +143,24 @@ describe("AutoLogoutWarning", () => {
 
     expect((wrapper.vm as unknown as { show: boolean }).show).toBe(true);
     expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
+  });
+
+  it("ignores expiring OIDC users from unrelated authorities", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    sessionStorage.setItem(
+      "oidc.user:https://other.example.com:other-ui",
+      JSON.stringify({
+        expires_at: expiresAt,
+      }),
+    );
+
+    wrapper = mountWithAuth(createMockAuth());
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { show: boolean }).show).toBe(false);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -5,6 +5,18 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
+
+const loggerMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock("@/services/logger", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: loggerMocks.warn,
+  error: vi.fn(),
+}));
+
 import { mount, VueWrapper } from "@vue/test-utils";
 import AutoLogoutWarning from "@/components/AutoLogoutWarning.vue";
 import AuthService from "@/services/auth";
@@ -35,6 +47,7 @@ describe("AutoLogoutWarning", () => {
     wrapper = null;
     vi.clearAllTimers();
     vi.restoreAllMocks();
+    loggerMocks.warn.mockReset();
     vi.useRealTimers();
     sessionStorage.clear();
     localStorage.clear();
@@ -285,5 +298,57 @@ describe("AutoLogoutWarning", () => {
 
     expect((wrapper.vm as unknown as { show: boolean }).show).toBe(false);
     expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
+  });
+
+  it("warns once per storage item when OIDC user storage reads fail repeatedly", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    const throwingStorage = {
+      get length() {
+        return 0;
+      },
+      clear: vi.fn(),
+      getItem: vi.fn(() => {
+        throw new Error("storage read blocked");
+      }),
+      key: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    } satisfies Storage;
+
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: throwingStorage,
+    });
+
+    try {
+      wrapper = mountWithAuth(createMockAuth());
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      const readWarnings = loggerMocks.warn.mock.calls.filter(
+        ([tag, message]) => tag === "AutoLogoutWarning" && message === "Unable to read browser storage item",
+      );
+      expect(readWarnings).toHaveLength(1);
+    } finally {
+      if (originalSessionStorageDescriptor) {
+        Object.defineProperty(window, "sessionStorage", originalSessionStorageDescriptor);
+      }
+    }
+  });
+
+  it("warns once per malformed OIDC user value when parsing fails repeatedly", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    sessionStorage.setItem("oidc.user:https://issuer.example.com:breakglass-ui", "{not-json");
+
+    wrapper = mountWithAuth(createMockAuth());
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    const parseWarnings = loggerMocks.warn.mock.calls.filter(
+      ([tag, message]) =>
+        tag === "AutoLogoutWarning" && message === "Failed to parse OIDC user data from browser storage",
+    );
+    expect(parseWarnings).toHaveLength(1);
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -33,13 +33,13 @@ describe("AutoLogoutWarning", () => {
     localStorage.clear();
   });
   const createMockAuth = () => ({
+    login: vi.fn().mockResolvedValue(undefined),
     logout: vi.fn(),
     userManager: {
       settings: {
         authority: AUTHORITY,
         client_id: CLIENT_ID,
       },
-      signinSilent: vi.fn().mockResolvedValue(undefined),
     },
   });
 

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -4,50 +4,46 @@
  * @vitest-environment jsdom
  */
 
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { mount, type VueWrapper } from "@vue/test-utils";
-import { nextTick } from "vue";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
 import AutoLogoutWarning from "@/components/AutoLogoutWarning.vue";
 import { AuthKey } from "@/keys";
-import { getOIDCUserStorageKey, getStoredOIDCUser } from "@/services/auth";
 
-const AUTHORITY = "https://issuer.example.com";
-const CLIENT_ID = "breakglass-ui";
-const OIDC_USER_STORAGE_KEY = getOIDCUserStorageKey(AUTHORITY, CLIENT_ID);
+type MockAuth = {
+  login: (state?: { path: string; idpName?: string }) => Promise<void>;
+  logout: () => void;
+  getIdentityProviderName: () => string | undefined;
+  userManager: {
+    settings: {
+      authority: string;
+      client_id: string;
+    };
+  };
+};
+
+type AutoLogoutWarningVm = {
+  reauthenticate: () => Promise<void>;
+};
 
 describe("AutoLogoutWarning", () => {
   let wrapper: VueWrapper | null = null;
-
-  beforeEach(() => {
-    sessionStorage.clear();
-    localStorage.clear();
-  });
 
   afterEach(() => {
     wrapper?.unmount();
     wrapper = null;
     vi.clearAllTimers();
-    vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.useRealTimers();
     sessionStorage.clear();
     localStorage.clear();
-  });
-  const createMockAuth = () => ({
-    login: vi.fn().mockResolvedValue(undefined),
-    logout: vi.fn(),
-    userManager: {
-      settings: {
-        authority: AUTHORITY,
-        client_id: CLIENT_ID,
-      },
-    },
+    window.history.pushState({}, "", "/");
   });
 
-  const mountWithAuth = () =>
+  const mountWithAuth = (auth: MockAuth) =>
     mount(AutoLogoutWarning, {
       global: {
         provide: {
-          [AuthKey as symbol]: createMockAuth(),
+          [AuthKey as symbol]: auth,
         },
         stubs: {
           transition: false,
@@ -57,24 +53,18 @@ describe("AutoLogoutWarning", () => {
       },
     });
 
-  const runExpiryCheck = async () => {
-    await vi.advanceTimersByTimeAsync(5000);
-    await nextTick();
-  };
-
-  const storeOIDCUser = (storage: Storage, expiresAt: number | undefined) => {
-    if (!OIDC_USER_STORAGE_KEY) {
-      throw new Error("Expected OIDC user storage key");
-    }
-    storage.setItem(OIDC_USER_STORAGE_KEY, JSON.stringify({ expires_at: expiresAt }));
-  };
-
-  const storeOIDCUserString = (storage: Storage, value: string) => {
-    if (!OIDC_USER_STORAGE_KEY) {
-      throw new Error("Expected OIDC user storage key");
-    }
-    storage.setItem(OIDC_USER_STORAGE_KEY, value);
-  };
+  const createMockAuth = (overrides: Partial<MockAuth> = {}): MockAuth => ({
+    login: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn(),
+    getIdentityProviderName: vi.fn(() => undefined),
+    userManager: {
+      settings: {
+        authority: "https://issuer.example.com",
+        client_id: "breakglass-ui",
+      },
+    },
+    ...overrides,
+  });
 
   it("throws a clear error when mounted without auth provider", () => {
     expect(() => {
@@ -91,97 +81,42 @@ describe("AutoLogoutWarning", () => {
   });
 
   it("mounts successfully when auth provider is present", () => {
-    wrapper = mountWithAuth();
+    wrapper = mountWithAuth(createMockAuth());
 
     expect(wrapper.exists()).toBe(true);
   });
 
-  it("shows the warning when the sessionStorage OIDC user expires soon", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    storeOIDCUser(sessionStorage, Math.floor(Date.now() / 1000) + 20);
-
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
-  });
-
-  it("falls back to localStorage when no sessionStorage OIDC user exists", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    storeOIDCUser(localStorage, Math.floor(Date.now() / 1000) + 20);
-
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
-  });
-
-  it("keeps the warning hidden when no OIDC user is stored", async () => {
-    vi.useFakeTimers();
-
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
-  });
-
-  it("keeps the warning hidden for expired and non-expiring stored users", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-
-    storeOIDCUser(sessionStorage, Math.floor(Date.now() / 1000) - 1);
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
-
-    wrapper.unmount();
-    sessionStorage.clear();
-    storeOIDCUser(sessionStorage, undefined);
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
-  });
-
-  it("hides a visible warning when the stored OIDC user disappears", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    storeOIDCUser(sessionStorage, Math.floor(Date.now() / 1000) + 20);
-
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
-
-    if (!OIDC_USER_STORAGE_KEY) {
-      throw new Error("Expected OIDC user storage key");
-    }
-    sessionStorage.removeItem(OIDC_USER_STORAGE_KEY);
-    await runExpiryCheck();
-
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
-  });
-
-  it("hides a visible warning when stored OIDC user data becomes invalid", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    storeOIDCUser(sessionStorage, Math.floor(Date.now() / 1000) + 20);
-
-    wrapper = mountWithAuth();
-    await runExpiryCheck();
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
-
-    storeOIDCUserString(sessionStorage, "{not-json");
-    await runExpiryCheck();
-
-    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(false);
-  });
-
-  it("returns null when browser storage access is blocked", () => {
-    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new DOMException("blocked", "SecurityError");
+  it("preserves the active identity provider when reauthenticating", async () => {
+    const auth = createMockAuth({
+      getIdentityProviderName: vi.fn(() => "corp"),
     });
+    window.history.pushState({}, "", "/sessions?cluster=prod#approval");
+    wrapper = mountWithAuth(auth);
 
-    expect(getStoredOIDCUser(AUTHORITY, CLIENT_ID)).toBeNull();
+    await (wrapper.vm as unknown as AutoLogoutWarningVm).reauthenticate();
+
+    expect(auth.login).toHaveBeenCalledWith({
+      path: "/sessions?cluster=prod#approval",
+      idpName: "corp",
+    });
+  });
+
+  it("shows the warning for an expiring IDP-specific OIDC user", async () => {
+    vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+    const expiresAt = Math.floor((Date.now() + 10_000) / 1000);
+    sessionStorage.setItem(
+      "oidc.user:/api/oidc/authority:corp-ui",
+      JSON.stringify({
+        expires_at: expiresAt,
+      }),
+    );
+
+    wrapper = mountWithAuth(createMockAuth());
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { show: boolean }).show).toBe(true);
+    expect(wrapper.find('[data-testid="auto-logout-warning"]').exists()).toBe(true);
   });
 });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -25,8 +25,8 @@ import { AuthKey } from "@/keys";
 type MockAuth = {
   login: (state?: { path: string; idpName?: string }) => Promise<void>;
   logout: () => void;
-  getIdentityProviderName: () => string | undefined;
-  getActiveOIDCUserStorageKeys: () => string[];
+  getIdentityProviderName?: () => string | undefined;
+  getActiveOIDCUserStorageKeys?: () => string[];
   userManager: {
     settings: {
       authority: string;
@@ -100,6 +100,18 @@ describe("AutoLogoutWarning", () => {
 
   it("mounts successfully when auth provider is present", () => {
     wrapper = mountWithAuth(createMockAuth());
+
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it("mounts with a minimal auth provider when optional storage helpers are absent", () => {
+    const auth = {
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn(),
+      userManager: { settings: { authority: "https://issuer.example.com", client_id: "breakglass-ui" } },
+    } as MockAuth;
+
+    wrapper = mountWithAuth(auth);
 
     expect(wrapper.exists()).toBe(true);
   });

--- a/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
+++ b/frontend/tests/unit/components/AutoLogoutWarning.spec.ts
@@ -17,7 +17,7 @@ vi.mock("@/services/logger", () => ({
   error: vi.fn(),
 }));
 
-import { mount, VueWrapper } from "@vue/test-utils";
+import { mount, type VueWrapper } from "@vue/test-utils";
 import AutoLogoutWarning from "@/components/AutoLogoutWarning.vue";
 import AuthService from "@/services/auth";
 import { AuthKey } from "@/keys";


### PR DESCRIPTION
Breakglass is an emergency access tool, and its sessions should not persist via silent refresh. The `offline_access` scope was the vector for refresh token storage in localStorage (via "persistent" mode), which is an XSS vulnerability. 

This PR:
- Removes `offline_access` scope from OIDC settings.
- Adds an explicit comment explaining the rationale for omitting this scope.
- Logs a security warning when `getTokenPersistenceMode` returns "persistent" in development builds.

## Evidence / duplicate check

Refresh before PR body update on 2026-06-27:
- Target verified: `gh repo view telekom/k8s-breakglass --json nameWithOwner,isFork,defaultBranchRef,url` -> `telekom/k8s-breakglass`, `isFork=false`, default branch `main`, URL `https://github.com/telekom/k8s-breakglass`.
- PR target verified: `gh api repos/telekom/k8s-breakglass/pulls/661` -> base `telekom/k8s-breakglass:main`, head `telekom/k8s-breakglass:fix/review-oidc-storage-hardening`.
- Head-branch duplicate search: `gh pr list --repo telekom/k8s-breakglass --state open --search "head:fix/review-oidc-storage-hardening"` -> #661.
- Open duplicate search: `gh search prs --repo telekom/k8s-breakglass "remove offline_access scope to prevent refresh token issuance in breakglass sessions" --state open` -> #661.
- Recently merged duplicate search: `gh search prs --repo telekom/k8s-breakglass "remove offline_access scope to prevent refresh token issuance in breakglass sessions updated:>=2026-06-13" --merged` -> none.

