### PR TITLE
fix(ratelimit): make IPRateLimiter.Stop() idempotent to prevent double-close panic

### DIFF
--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -84,10 +84,11 @@ type entry struct {
 
 // IPRateLimiter implements per-IP rate limiting with automatic cleanup
 type IPRateLimiter struct {
-	mu      sync.RWMutex
-	entries map[string]*entry
-	config  Config
-	done    chan struct{}
+	mu       sync.RWMutex
+	entries  map[string]*entry
+	config   Config
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // New creates a new per-IP rate limiter with the given configuration
@@ -159,9 +160,9 @@ func (rl *IPRateLimiter) MiddlewareWithExclusions(excludedPrefixes []string) gin
 	}
 }
 
-// Stop stops the cleanup goroutine
+// Stop stops the cleanup goroutine. Safe to call multiple times concurrently.
 func (rl *IPRateLimiter) Stop() {
-	close(rl.done)
+	rl.stopOnce.Do(func() { close(rl.done) })
 }
 
 // cleanup periodically removes stale entries

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -214,7 +214,7 @@ func (rl *IPRateLimiter) MiddlewareWithExclusions(excludedPrefixes []string) gin
 	}
 }
 
-// Stop stops the cleanup goroutine. Safe to call multiple times.
+// Stop stops the cleanup goroutine. Safe to call multiple times concurrently.
 func (rl *IPRateLimiter) Stop() {
 	rl.stopOnce.Do(func() { close(rl.done) })
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -433,7 +433,13 @@ func TestConcurrency(t *testing.T) {
 			}()
 		}
 
-		wg.Wait()
+		done1 := make(chan struct{})
+		go func() { wg.Wait(); close(done1) }()
+		select {
+		case <-done1:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines to finish")
+		}
 		// Should not panic or deadlock
 		assert.Equal(t, 1, rl.Len())
 	})
@@ -457,7 +463,13 @@ func TestConcurrency(t *testing.T) {
 			}(i)
 		}
 
-		wg.Wait()
+		done2 := make(chan struct{})
+		go func() { wg.Wait(); close(done2) }()
+		select {
+		case <-done2:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines to finish")
+		}
 		// Should not panic or deadlock
 		assert.LessOrEqual(t, rl.Len(), 10) // At most 10 unique IPs (0-9)
 	})

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1060,5 +1060,18 @@ func TestIPRateLimiterStopIdempotent(t *testing.T) {
 			rl.Stop()
 		}()
 	}
-	wg.Wait()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	timeout := 2 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) / 10; remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for concurrent Stop calls to complete")
+	}
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1048,3 +1048,17 @@ func TestAuthenticatedConcurrency(t *testing.T) {
 		// Should not panic or deadlock
 	})
 }
+
+func TestIPRateLimiterStopIdempotent(t *testing.T) {
+	rl := New(DefaultAPIConfig())
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rl.Stop()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1165,5 +1165,18 @@ func TestIPRateLimiterStopIdempotent(t *testing.T) {
 			rl.Stop()
 		}()
 	}
-	wg.Wait()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	timeout := 2 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) / 10; remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for concurrent Stop calls to complete")
+	}
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1153,3 +1153,17 @@ func TestAuthenticatedConcurrency(t *testing.T) {
 		// Should not panic or deadlock
 	})
 }
+
+func TestIPRateLimiterStopIdempotent(t *testing.T) {
+	rl := New(DefaultAPIConfig())
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rl.Stop()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -538,7 +538,13 @@ func TestConcurrency(t *testing.T) {
 			}()
 		}
 
-		wg.Wait()
+		done1 := make(chan struct{})
+		go func() { wg.Wait(); close(done1) }()
+		select {
+		case <-done1:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines to finish")
+		}
 		// Should not panic or deadlock
 		assert.Equal(t, 1, rl.Len())
 	})
@@ -562,7 +568,13 @@ func TestConcurrency(t *testing.T) {
 			}(i)
 		}
 
-		wg.Wait()
+		done2 := make(chan struct{})
+		go func() { wg.Wait(); close(done2) }()
+		select {
+		case <-done2:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines to finish")
+		}
 		// Should not panic or deadlock
 		assert.LessOrEqual(t, rl.Len(), 10) // At most 10 unique IPs (0-9)
 	})


### PR DESCRIPTION
## Summary

`IPRateLimiter.Stop()` unconditionally called `close(rl.done)`. If two shutdown paths (e.g. HTTP server shutdown handler + OS signal handler) call `Stop()` concurrently or sequentially, the second call panics with _close of closed channel_.

## Change

- Add `stopOnce sync.Once` field to `IPRateLimiter`
- Guard `close(rl.done)` with `rl.stopOnce.Do(...)` so it executes exactly once
- Add `TestIPRateLimiterStopIdempotent` to verify 10 concurrent `Stop()` calls neither panic nor deadlock (run with `-race`)

## Risk

Low — purely additive. The `sync.Once` zero value is safe; existing callers that call `Stop()` once are unaffected.