### PR TITLE
fix: restrict orphan BreakglassSession cleanup to terminal states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Orphaned session cleanup now restricted to terminal states**: `markCleanupExpiredSession` previously deleted orphaned `BreakglassSession` objects in any non-Pending state, including active `Approved` and `WaitingForScheduledTime` sessions that had no `RetainedUntil` set. The predicate is now an explicit allowlist of terminal states (`Expired`, `IdleExpired`, `Rejected`, `Withdrawn`, `ApprovalTimeout`) — active sessions are never deleted by the orphan cleanup path.
+
 ### Changed
 
 - **Frontend: upgrade Vite 7 → 8 and @vitejs/plugin-legacy 7 → 8** (PR #562): Major version bumps — Vite 8 replaces Rollup with Rolldown and removes esbuild in favor of Oxc. `@vitejs/plugin-vue` patch bumped to 6.0.5. No breaking changes to the frontend build configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`--disable-session-rate-limit` flag**: New CLI flag (`BREAKGLASS_DISABLE_SESSION_RATE_LIMIT` env var) replaces the strict session-creation rate limiter with a permissive one (1000 req/s, burst 10000). Intended for E2E testing and development environments only. Do not use in production.
 
+### Fixed
+
+- **Orphaned session cleanup now restricted to terminal states**: `markCleanupExpiredSession` previously deleted orphaned `BreakglassSession` objects in any non-Pending state, including active `Approved` and `WaitingForScheduledTime` sessions that had no `RetainedUntil` set. The predicate is now an explicit allowlist of terminal states (`Expired`, `IdleExpired`, `Rejected`, `Withdrawn`, `ApprovalTimeout`) — active sessions are never deleted by the orphan cleanup path.
+
 ### Changed
 
 - **Strict Readiness Enforcement for Escalations**: Enforced strict cluster readiness constraints across the API and session management workflows. Escalations API now defaults `activeOnly=true`, hiding unready escalations by default. Session creation logic now skips escalations that are not in a `Ready` state. Added `Ready` condition to `BreakglassEscalation` status, populated by the escalation reconciler based on validation results. `IsReady()` helper added to `BreakglassEscalation` CRD for centralized readiness checks.

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -244,10 +244,19 @@ func (routine CleanupRoutine) markCleanupExpiredSession(ctx context.Context) {
 
 		// Additionally, clean up sessions that do not have an OwnerReference (orphaned/legacy).
 		// To avoid removing valid active sessions, only delete orphaned sessions when
-		// they have no RetainedUntil set (zero value) and are not pending. Expired
-		// sessions are handled above based on RetainedUntil.
+		// they have no RetainedUntil set (zero value) AND are in a terminal state.
+		// Terminal states are those from which no further transitions are possible:
+		// Expired, IdleExpired, Rejected, Withdrawn, ApprovalTimeout.
+		// Active states (Pending, Approved, WaitingForScheduledTime) are never deleted here.
 		if len(ses.OwnerReferences) == 0 {
-			if ses.Status.RetainedUntil.IsZero() && ses.Status.State != breakglassv1alpha1.SessionStatePending {
+			terminalStates := map[breakglassv1alpha1.BreakglassSessionState]bool{
+				breakglassv1alpha1.SessionStateExpired:     true,
+				breakglassv1alpha1.SessionStateIdleExpired: true,
+				breakglassv1alpha1.SessionStateRejected:    true,
+				breakglassv1alpha1.SessionStateWithdrawn:   true,
+				breakglassv1alpha1.SessionStateTimeout:     true,
+			}
+			if ses.Status.RetainedUntil.IsZero() && terminalStates[ses.Status.State] {
 				routine.Log.Infow("Deleting session without OwnerReferences (orphaned/legacy - no RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
 				if err := routine.Manager.DeleteBreakglassSession(ctx, &ses); err != nil {
 					routine.Log.Errorw("error deleting orphaned breakglass session", append(system.NamespacedFields(ses.Name, ses.Namespace), "error", err)...)
@@ -258,7 +267,7 @@ func (routine CleanupRoutine) markCleanupExpiredSession(ctx context.Context) {
 				routine.Log.Debugw("Deleted orphaned breakglass session", system.NamespacedFields(ses.Name, ses.Namespace)...)
 				continue
 			}
-			routine.Log.Debugw("Skipping deletion of session without OwnerReferences (either pending or has RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
+			routine.Log.Debugw("Skipping deletion of session without OwnerReferences (active state or has RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
 		}
 	}
 	routine.Log.Infow("Expired breakglass sessions deletion completed", "deleted", deletedCount)

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -217,6 +217,13 @@ func (routine CleanupRoutine) markCleanupExpiredSession(ctx context.Context) {
 	sessions := bsl.Items
 
 	now := time.Now()
+	terminalStates := map[breakglassv1alpha1.BreakglassSessionState]bool{
+		breakglassv1alpha1.SessionStateExpired:     true,
+		breakglassv1alpha1.SessionStateIdleExpired: true,
+		breakglassv1alpha1.SessionStateRejected:    true,
+		breakglassv1alpha1.SessionStateWithdrawn:   true,
+		breakglassv1alpha1.SessionStateTimeout:     true,
+	}
 	for _, ses := range sessions {
 		// Check for context cancellation to allow graceful shutdown
 		select {
@@ -249,13 +256,6 @@ func (routine CleanupRoutine) markCleanupExpiredSession(ctx context.Context) {
 		// Expired, IdleExpired, Rejected, Withdrawn, ApprovalTimeout.
 		// Active states (Pending, Approved, WaitingForScheduledTime) are never deleted here.
 		if len(ses.OwnerReferences) == 0 {
-			terminalStates := map[breakglassv1alpha1.BreakglassSessionState]bool{
-				breakglassv1alpha1.SessionStateExpired:     true,
-				breakglassv1alpha1.SessionStateIdleExpired: true,
-				breakglassv1alpha1.SessionStateRejected:    true,
-				breakglassv1alpha1.SessionStateWithdrawn:   true,
-				breakglassv1alpha1.SessionStateTimeout:     true,
-			}
 			if ses.Status.RetainedUntil.IsZero() && terminalStates[ses.Status.State] {
 				routine.Log.Infow("Deleting session without OwnerReferences (orphaned/legacy - no RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
 				if err := routine.Manager.DeleteBreakglassSession(ctx, &ses); err != nil {
@@ -267,7 +267,7 @@ func (routine CleanupRoutine) markCleanupExpiredSession(ctx context.Context) {
 				routine.Log.Debugw("Deleted orphaned breakglass session", system.NamespacedFields(ses.Name, ses.Namespace)...)
 				continue
 			}
-			routine.Log.Debugw("Skipping deletion of session without OwnerReferences (active state or has RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
+			routine.Log.Debugw("Skipping deletion of session without OwnerReferences (non-terminal state or has RetainedUntil)", system.NamespacedFields(ses.Name, ses.Namespace)...)
 		}
 	}
 	routine.Log.Infow("Expired breakglass sessions deletion completed", "deleted", deletedCount)

--- a/pkg/breakglass/cleanup_task_test.go
+++ b/pkg/breakglass/cleanup_task_test.go
@@ -1137,6 +1137,78 @@ func TestBuildDebugSessionNotificationRecipients(t *testing.T) {
 	}
 }
 
+func TestCleanupRoutine_OrphanDeletion_TerminalStatesOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+	logger := zaptest.NewLogger(t).Sugar()
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: "breakglass.telekom.com/v1alpha1",
+		Kind:       "BreakglassEscalation",
+		Name:       "parent",
+		UID:        "uid-1",
+	}
+
+	tests := []struct {
+		name          string
+		state         breakglassv1alpha1.BreakglassSessionState
+		hasOwnerRef   bool
+		expectDeleted bool
+	}{
+		{name: "orphan Approved is preserved", state: breakglassv1alpha1.SessionStateApproved, hasOwnerRef: false, expectDeleted: false},
+		{name: "orphan WaitingForScheduledTime is preserved", state: breakglassv1alpha1.SessionStateWaitingForScheduledTime, hasOwnerRef: false, expectDeleted: false},
+		{name: "orphan Pending is preserved", state: breakglassv1alpha1.SessionStatePending, hasOwnerRef: false, expectDeleted: false},
+		{name: "orphan Expired is deleted", state: breakglassv1alpha1.SessionStateExpired, hasOwnerRef: false, expectDeleted: true},
+		{name: "orphan IdleExpired is deleted", state: breakglassv1alpha1.SessionStateIdleExpired, hasOwnerRef: false, expectDeleted: true},
+		{name: "orphan Rejected is deleted", state: breakglassv1alpha1.SessionStateRejected, hasOwnerRef: false, expectDeleted: true},
+		{name: "orphan Withdrawn is deleted", state: breakglassv1alpha1.SessionStateWithdrawn, hasOwnerRef: false, expectDeleted: true},
+		{name: "orphan ApprovalTimeout is deleted", state: breakglassv1alpha1.SessionStateTimeout, hasOwnerRef: false, expectDeleted: true},
+		{name: "owned Expired is NOT deleted by orphan path", state: breakglassv1alpha1.SessionStateExpired, hasOwnerRef: true, expectDeleted: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ses := breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-session",
+					Namespace: "default",
+				},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster: "test-cluster", User: "user@example.com", GrantedGroup: "cluster-admin",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State: tt.state,
+				},
+			}
+			if tt.hasOwnerRef {
+				ses.OwnerReferences = []metav1.OwnerReference{ownerRef}
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&ses).
+				WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+				Build()
+
+			routine := CleanupRoutine{
+				Log:     logger,
+				Manager: &SessionManager{Client: fakeClient},
+			}
+
+			routine.markCleanupExpiredSession(context.Background())
+
+			var list breakglassv1alpha1.BreakglassSessionList
+			require.NoError(t, fakeClient.List(context.Background(), &list))
+			if tt.expectDeleted {
+				assert.Empty(t, list.Items, "session should have been deleted")
+			} else {
+				require.Len(t, list.Items, 1, "session should still exist")
+				assert.Equal(t, tt.state, list.Items[0].Status.State)
+			}
+		})
+	}
+}
+
 // mockActivityCleaner records Cleanup calls for testing.
 type mockActivityCleaner struct {
 	cleanupCalls []map[types.NamespacedName]bool


### PR DESCRIPTION
## Summary

Orphaned `BreakglassSession` objects (no `OwnerReference`, zero `RetainedUntil`) were deleted if their state was anything other than `Pending`. This meant `Approved` and `WaitingForScheduledTime` sessions — which may still be actively in use — could be prematurely deleted by the cleanup routine.

## Root Cause

`markCleanupExpiredSession` used a negative predicate:
```go
ses.Status.State != breakglassv1alpha1.SessionStatePending
```
This deleted sessions in `Approved`, `WaitingForScheduledTime`, `Expired`, `IdleExpired`, `Rejected`, `Withdrawn`, and `ApprovalTimeout` states — far more than intended.

## Fix

Replace with an explicit allowlist of terminal states from which no further transitions are possible:

```go
terminalStates := map[breakglassv1alpha1.BreakglassSessionState]bool{
    breakglassv1alpha1.SessionStateExpired:     true,
    breakglassv1alpha1.SessionStateIdleExpired: true,
    breakglassv1alpha1.SessionStateRejected:    true,
    breakglassv1alpha1.SessionStateWithdrawn:   true,
    breakglassv1alpha1.SessionStateTimeout:     true,
}
if ses.Status.RetainedUntil.IsZero() && terminalStates[ses.Status.State] {
```

Active sessions (`Pending`, `Approved`, `WaitingForScheduledTime`) are never deleted by this path.

## Testing

Added `TestCleanupRoutine_OrphanDeletion_TerminalStatesOnly` covering all 9 state/owner combinations:
- Orphaned `Approved` → preserved ✓
- Orphaned `WaitingForScheduledTime` → preserved ✓
- Orphaned `Pending` → preserved ✓
- Orphaned `Expired` → deleted ✓
- Orphaned `IdleExpired` → deleted ✓
- Orphaned `Rejected` → deleted ✓
- Orphaned `Withdrawn` → deleted ✓
- Orphaned `ApprovalTimeout` → deleted ✓
- Owned `Expired` (has OwnerReference) → preserved ✓ (not touched by orphan path)