### PR TITLE
docs: add hierarchical agents.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Breakglass Controller — Agent Instructions
 
 This document provides conventions for AI coding agents working on this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ cd frontend && npm test          # Frontend tests
 Go-based Kubernetes controller (controller-runtime) + Vue 3/TypeScript frontend (Vite).
 Hub-and-spoke topology: central breakglass service manages temporary privilege escalations across multiple K8s clusters.
 
+## Agent Documentation Hierarchy
+
+This project uses hierarchical `AGENTS.md` files to provide context-specific instructions to AI agents based on the directory they are working in:
+- **Root**: `AGENTS.md` (This file) - General project structure and reviewer personas.
+- **Frontend**: [`frontend/AGENTS.md`](frontend/AGENTS.md) - Vue 3, Vite, and Scale UI component conventions.
+- **Backend**: [`pkg/AGENTS.md`](pkg/AGENTS.md) - Go controller-runtime, error wrapping, and Gin API rules.
+- **API Types**: [`api/AGENTS.md`](api/AGENTS.md) - CRD kubebuilder markers, generation, and backwards compatibility.
+
 ## Directory Layout
 
 ```

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,10 @@
+# Breakglass API Types — Agent Instructions
+
+This document provides conventions specifically for AI coding agents working in the `api` directory (Kubernetes CRDs).
+
+## Critical Rules
+1. **Never Remove Scaffold Comments**: Always preserve `// +kubebuilder:scaffold:*` comments. These are essential for code generation.
+2. **Generation Required**: After making any changes to `*_types.go` files, you MUST run `make generate && make manifests` from the project root.
+3. **Validation**: Use kubebuilder validation markers (e.g. `//+kubebuilder:validation:Required`, `//+kubebuilder:validation:Enum=...`) on all new fields to enforce API constraints.
+4. **Fuzz Testing**: Add cases to `fuzz_test.go` when adding new complex types or validations.
+5. **Backwards Compatibility**: Do not make backwards-incompatible changes to `v1alpha1` unless absolutely necessary and documented in the CHANGELOG.

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Breakglass API Types — Agent Instructions
 
 This document provides conventions specifically for AI coding agents working in the `api` directory (Kubernetes CRDs).

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,21 @@
+# Breakglass Frontend — Agent Instructions
+
+This document provides conventions specifically for AI coding agents working in the `frontend` directory.
+
+## Tech Stack
+- Vue 3
+- TypeScript
+- Vite
+- scale-components (Telekom UI library)
+
+## Critical Rules
+1. **Component Design**: Always use `scale-` components when available (e.g., `scale-button`, `scale-tag`, `scale-card`) rather than building custom UI from scratch.
+2. **State Management**: Prefer the native Vue 3 Reactivity API (`ref`, `computed`, `watch`) over Pinia unless complex global state warrants it.
+3. **Typing**: Use strict TypeScript. Avoid `any` types. Provide explicit types for all component props and emits.
+4. **Styling**: Use existing CSS custom properties (tokens) in `frontend/src/assets/base.css` (e.g. `var(--space-md)`) rather than hardcoding px or rem values.
+5. **Testing**: All new services and components must have accompanying unit tests in `frontend/tests/unit`. We use Vitest for testing. Run tests via `npm test`.
+
+## Architecture Notes
+- `src/services/` contains API wrappers (e.g. `breakglass.ts`). Ensure error handling uses the `handleAxiosError` utility.
+- `src/components/` contains reusable UI pieces.
+- `src/views/` contains route-level pages.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Breakglass Frontend — Agent Instructions
 
 This document provides conventions specifically for AI coding agents working in the `frontend` directory.

--- a/pkg/AGENTS.md
+++ b/pkg/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Breakglass Controller Packages — Agent Instructions
 
 This document provides conventions specifically for AI coding agents working in the `pkg` directory.

--- a/pkg/AGENTS.md
+++ b/pkg/AGENTS.md
@@ -1,0 +1,16 @@
+# Breakglass Controller Packages — Agent Instructions
+
+This document provides conventions specifically for AI coding agents working in the `pkg` directory.
+
+## Core Packages
+- `pkg/api`: Contains the Gin REST API endpoints.
+- `pkg/breakglass`: Core domain logic (session lifecycle, group checker, debug controllers).
+- `pkg/cluster`: Multi-cluster management logic.
+- `pkg/reconciler`: The core controller-runtime managers.
+
+## Critical Rules
+1. **Error Handling**: Use `fmt.Errorf("context: %w", err)` for proper error wrapping.
+2. **Logging**: Use structured logging with `go.uber.org/zap` (`SugaredLogger`). Include relevant context (e.g., `escalation`, `group`, `user`).
+3. **Event Recording**: When modifying status or reacting to significant state changes, emit a Kubernetes event using the `events.EventRecorder` (e.g., `pkg/breakglass/eventrecorder`).
+4. **Testing**: Every new package or significant functionality requires unit tests with `>70%` coverage. 
+5. **HTTP Server**: When modifying Gin endpoints in `pkg/api`, ensure you add telemetry/metrics calls where appropriate. Use standard HTTP constants (e.g., `http.MethodGet`).


### PR DESCRIPTION
Adds granular per-folder AGENTS.md instructions and indexes them in the root.