### PR TITLE
fix(reconciler): set Ready condition and requeue on transient ref errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
           echo "=== Manifest Comparison Summary ==="
           cat manifest-diff.md
       - name: Comment on PR with manifest changes
-        if: github.event_name == 'pull_request' && steps.get_release.outputs.has_previous_release == 'true'
+        if: github.event_name == 'pull_request' && steps.get_release.outputs.has_previous_release == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -673,7 +673,7 @@ jobs:
   single-cluster-e2e:
     name: Single-Cluster E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     needs: [build-image, lint, unit-tests-controller, unit-tests-cli, crd-validation, frontend-tests, helm-lint]
     steps:
       - name: Checkout code
@@ -1392,8 +1392,27 @@ jobs:
           ) &
           echo "API port-forward keepalive started (PID: $!)"
 
-          # Wait for Keycloak to be reachable
-          for i in {1..30}; do
+          # Wait for Keycloak pod to be Ready in-cluster first.
+          # The pod must be Ready before port-forward will succeed reliably.
+          echo "Waiting for Keycloak pod to be Ready in-cluster (up to 180s)..."
+          if ! kubectl wait pod -n breakglass-system -l app=keycloak \
+              --for=condition=Ready --timeout=180s 2>&1; then
+            echo "WARNING: Keycloak pod not Ready after 180s, attempting restart..."
+            kubectl delete pod -n breakglass-system -l app=keycloak --grace-period=10 2>&1 || true
+            echo "Waiting for Keycloak pod to restart and become Ready (up to 120s)..."
+            sleep 5
+            if ! kubectl wait pod -n breakglass-system -l app=keycloak \
+                --for=condition=Ready --timeout=120s 2>&1; then
+              echo "ERROR: Keycloak pod not Ready after restart"
+              kubectl get pods -n breakglass-system -l app=keycloak -o wide 2>&1 || true
+              kubectl describe pod -n breakglass-system -l app=keycloak 2>&1 || true
+              exit 1
+            fi
+          fi
+          echo "✓ Keycloak pod is Ready in-cluster"
+
+          # Wait for Keycloak to be reachable via port-forward
+          for i in {1..60}; do
             if curl -sk https://localhost:8443/realms/breakglass-e2e/.well-known/openid-configuration > /dev/null 2>&1; then
               echo "✓ Keycloak reachable at localhost:8443"
               break
@@ -1402,27 +1421,10 @@ jobs:
           done
 
           if ! curl -sk https://localhost:8443/realms/breakglass-e2e/.well-known/openid-configuration > /dev/null 2>&1; then
-            echo "ERROR: Keycloak not reachable at localhost:8443"
+            echo "ERROR: Keycloak not reachable at localhost:8443 after 60s"
             kubectl get pods -n breakglass-system -l app=keycloak 2>&1 || true
             exit 1
           fi
-
-          # Wait for Keycloak pod to be Ready in-cluster.
-          # The port-forward confirms localhost connectivity, but the Keycloak pod
-          # itself may still be starting or recovering from a restart. The controller
-          # reaches Keycloak via the in-cluster service URL, so we must ensure the pod
-          # is Ready before the tests create ClusterConfig objects that trigger OIDC
-          # discovery requests. Without this, the rotation tests (OT-007, OT-008) fail
-          # with "connection refused" on breakglass-keycloak.breakglass-system.svc.cluster.local:8443.
-          echo "Waiting for Keycloak pod to be Ready in-cluster (up to 120s)..."
-          if ! kubectl wait pod -n breakglass-system -l app=keycloak \
-              --for=condition=Ready --timeout=120s 2>&1; then
-            echo "ERROR: Keycloak pod not Ready after 120s"
-            kubectl get pods -n breakglass-system -l app=keycloak -o wide 2>&1 || true
-            kubectl describe pod -n breakglass-system -l app=keycloak 2>&1 || true
-            exit 1
-          fi
-          echo "✓ Keycloak pod is Ready in-cluster"
 
           # Wait for API to be reachable
           for i in {1..20}; do
@@ -1510,7 +1512,7 @@ jobs:
   ui-e2e:
     name: UI E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: [build-image, lint, unit-tests-controller, unit-tests-cli, crd-validation, frontend-tests, helm-lint]
     steps:
       - name: Checkout code
@@ -2145,7 +2147,7 @@ jobs:
   multi-cluster-e2e:
     name: Multi-Cluster E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     needs: [build-image, lint, unit-tests-controller, unit-tests-cli, crd-validation, frontend-tests, helm-lint]
     steps:
       - name: Checkout code

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -40,5 +40,5 @@ jobs:
           # Fail on moderate or higher severity vulnerabilities
           fail-on-severity: moderate
 
-          # Comment on PR with details
-          comment-summary-in-pr: always
+          # Comment on PR with details (only for non-fork PRs where write access is available)
+          comment-summary-in-pr: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'always' || 'never' }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,7 @@ jobs:
   labeler:
     name: Add Labels to PR
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Add labels based on changed files
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -26,6 +27,7 @@ jobs:
   size-label:
     name: Add Size Label
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Add size label
         uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1.10.4

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -172,7 +172,7 @@ jobs:
           retention-days: 7
 
       - name: Comment PR with screenshots
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -210,6 +210,16 @@ func (r *EscalationReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 				"error", ve.error)
 		}
 
+		// Set aggregate Ready condition to false
+		apimeta.SetStatusCondition(&escalation.Status.Conditions, metav1.Condition{
+			Type:               string(breakglassv1alpha1.BreakglassEscalationConditionReady),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: escalation.Generation,
+			Reason:             "ValidationFailed",
+			Message:            "One or more validations failed, see other conditions for details",
+			LastTransitionTime: now,
+		})
+
 		// Update ObservedGeneration before applying status
 		escalation.Status.ObservedGeneration = escalation.Generation
 		if err := r.applyStatus(ctx, escalation); err != nil {
@@ -217,7 +227,19 @@ func (r *EscalationReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 				"escalation", escalation.Name,
 				"error", err)
 		}
-		// Validation errors are persisted to status; avoid requeue storms for invalid resources.
+
+		// Reference validation errors (cluster, IDP, deny policy, mail provider) may be
+		// transient if the referenced resource hasn't been created yet. Requeue to retry.
+		hasRefError := false
+		for _, ve := range validationErrors {
+			if ve.conditionType != string(breakglassv1alpha1.BreakglassEscalationConditionConfigValidated) {
+				hasRefError = true
+				break
+			}
+		}
+		if hasRefError {
+			return reconcile.Result{RequeueAfter: 3 * time.Second}, nil
+		}
 		return reconcile.Result{}, nil
 	}
 
@@ -228,6 +250,7 @@ func (r *EscalationReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		breakglassv1alpha1.BreakglassEscalationConditionIDPRefsValid,
 		breakglassv1alpha1.BreakglassEscalationConditionDenyPolicyRefsValid,
 		breakglassv1alpha1.BreakglassEscalationConditionMailProviderValid,
+		breakglassv1alpha1.BreakglassEscalationConditionReady,
 	} {
 		condition := metav1.Condition{
 			Type:               string(condType),

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -403,7 +403,7 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 	var missing []string
 	for _, clusterName := range esc.Spec.ClusterConfigRefs {
 		name := strings.TrimSpace(clusterName)
-		if name == "" {
+		if name == "" || name == "*" {
 			continue
 		}
 

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -441,6 +441,21 @@ func TestEscalationReconciler_ValidateClusterRef(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("wildcard cluster ref is valid", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+
+		esc := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				ClusterConfigRefs: []string{"*"},
+			},
+		}
+
+		err := r.validateClusterRef(context.Background(), esc)
+		require.NoError(t, err)
+	})
+
 	t.Run("valid cluster ref passes", func(t *testing.T) {
 		cluster := &breakglassv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "default"},

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -173,9 +173,9 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Validation errors are now persisted to status instead of returning an error
+		// Reference validation errors requeue to handle transient missing resources
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -219,9 +219,9 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Validation errors are now persisted to status instead of returning an error
+		// Reference validation errors requeue to handle transient missing resources
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -276,9 +276,9 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Validation errors are now persisted to status instead of returning an error
+		// Reference validation errors requeue to handle transient missing resources
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -322,9 +322,9 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Validation errors are now persisted to status instead of returning an error
+		// Reference validation errors requeue to handle transient missing resources
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation


### PR DESCRIPTION
## Summary

Fixes common E2E failures across all open PRs and improves CI fork compatibility.

### Reconciler fixes
- **Set aggregate Ready condition**: The escalation reconciler never set `BreakglassEscalationConditionReady`, causing `WaitForEscalationReady` to time out in all E2E tests.
- **Requeue on transient ref errors**: Add `RequeueAfter: 3s` when reference validation fails (cluster, IDP, deny policy, mail provider). Handles startup race where escalations are created before their referenced resources.
- **Skip wildcard cluster ref validation**: `clusterConfigRefs: ["*"]` was treated as a literal cluster name lookup, permanently failing validation for global-scope escalations like `mc-global-readonly`.

### CI infrastructure fixes
- **Increase E2E timeouts**: Single-Cluster/Multi-Cluster 60→75 min, UI E2E 30→45 min. Under load (9 concurrent PRs), tests ran slower and hit the previous limits.
- **Fork PR compatibility**: Skip labeling, manifest comparison comments, dependency review comments, and UI screenshot comments for fork PRs (no write permission to target repo).
- **Keycloak resilience**: Wait for pod Ready before port-forward (180s), auto-restart pod if unhealthy, increase curl retry to 60s. Addresses transient OIDC "connection refused" errors.

## Root Cause

Three reconciler bugs caused cascading E2E failures:
1. `IsReady()` checks for a `Ready` condition, but the reconciler never set it
2. Reference validation errors were terminal (no requeue) — wrong apply order meant permanent failure
3. Wildcard `"*"` in `clusterConfigRefs` was treated as a literal name

CI infrastructure issues (timeouts, fork permissions) compounded the problem by making it hard to distinguish real failures from resource constraints.

## Test plan
- [x] Unit tests pass (`go test ./pkg/config/ -run TestEscalationReconciler`)
- [x] Wildcard cluster ref test added
- [x] Full project builds cleanly
- [ ] E2E suites pass with increased timeouts
- [ ] Fork PRs no longer fail on label/comment steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)