### PR TITLE
fix(ci): use pull_request_target for labeler to support fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -16,7 +16,6 @@ jobs:
   labeler:
     name: Add Labels to PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Add labels based on changed files
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -27,7 +26,6 @@ jobs:
   size-label:
     name: Add Size Label
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Add size label
         uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1.10.4


### PR DESCRIPTION
## Summary
- Switch labeler workflow from `pull_request` to `pull_request_target` for fork PR support
- Remove redundant `if:` guards that skipped jobs for fork PRs

## Context
The labeler workflow was already guarded to skip fork PRs, but the correct fix is to use `pull_request_target` which runs in the context of the base repo and gets write permissions. This is safe because the labeler only reads `.github/labeler.yml` from the base branch — no untrusted code from the fork is executed.

## Test plan
- [ ] Verify labeler applies labels on fork PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)