### PR TITLE
ci: fix frontend dependabot override conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
         patterns:
           - "vue*"
           - "@vue/*"
-          - "vite*"
+          - "vite"
           - "@vitejs/*"
       npm-major:
         patterns:
@@ -47,7 +47,7 @@ updates:
         exclude-patterns:
           - "vue*"
           - "@vue/*"
-          - "vite*"
+          - "vite"
           - "@vitejs/*"
         update-types:
           - "major"
@@ -57,7 +57,7 @@ updates:
         exclude-patterns:
           - "vue*"
           - "@vue/*"
-          - "vite*"
+          - "vite"
           - "@vitejs/*"
         update-types:
           - "minor"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,8 @@
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
-    "vitest": "^4.1.2",
-    "@vitest/coverage-v8": "^4.1.2"
+    "vitest": "$vitest",
+    "@vitest/coverage-v8": "$@vitest/coverage-v8"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- make `vitest` and `@vitest/coverage-v8` npm overrides reference the direct dependency specs
- narrow the Dependabot `vue-ecosystem` `vite*` pattern to `vite` so it no longer accidentally captures `vitest`

## CI failure addressed
- Addresses repeated `Dependabot Updates` failures where npm returned `EOVERRIDE` for `vitest@4.1.9` because the direct dependency update conflicted with a pinned direct-dependency override.

## Validation
- Parsed `.github/dependabot.yml` with Ruby `YAML.load_file`.
- `(cd frontend && npm install --package-lock-only --ignore-scripts)`
- `(cd frontend && npm install vitest@4.1.9 --package-lock-only --dry-run=true --ignore-scripts)`

## Notes
- `frontend/package-lock.json` did not change.