### PR TITLE
ci: raise OIDC comprehensive E2E timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1223,7 +1223,11 @@ jobs:
   oidc-comprehensive-e2e:
     name: OIDC Comprehensive E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Setup currently takes about 25 minutes and the suite includes two
+    # intentional 6.5-minute access-token expiry checks. Keep the job timeout
+    # above the Go test timeout so the test process, not the runner, owns
+    # suite-level timeout failures.
+    timeout-minutes: 75
     needs: [build-image, lint, unit-tests-controller, unit-tests-cli, crd-validation, frontend-tests, helm-lint]
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- raise the OIDC comprehensive E2E job timeout from 45 minutes to 75 minutes
- leave the `go test -timeout 45m` guard unchanged so the test process still owns suite-level timeouts
- document why the job budget must include setup plus two deliberate 6.5-minute expiry checks

## Evidence
- PR #775 job 81429839422 spent about 26 minutes in setup, then was cancelled by the 45-minute job timeout while `TestOIDC_OfflineToken_AccessTokenExpiry_WithRotation` was still progressing
- the log showed `Ready=true` checks through 6 minutes elapsed in that test immediately before `The operation was canceled`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml OK"'`\n- `git diff --check`\n\n`actionlint` was not available locally.