### PR TITLE
ci: avoid Docker Hub pulls in OIDC e2e setup

### DIFF
--- a/config/dev/resources/audit-webhook-receiver.yaml
+++ b/config/dev/resources/audit-webhook-receiver.yaml
@@ -244,6 +244,7 @@ spec:
       containers:
         - name: receiver
           image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
           command: ["python3", "/app/server.py"]
           ports:
             - containerPort: 8080

--- a/e2e/kind-setup-single.sh
+++ b/e2e/kind-setup-single.sh
@@ -1023,6 +1023,7 @@ load_image_into_kind "$TMUX_DEBUG_IMAGE"
 # Preload busybox for debug session tests (used by test-basic-debug template)
 load_image_into_kind "busybox:latest"
 # Preload the audit webhook receiver image so E2E setup does not depend on Docker Hub pulls.
+ensure_image_exists "python:3.11-slim"
 load_image_into_kind "python:3.11-slim"
 # Load Kafka image for audit sink testing
 load_image_into_kind "apache/kafka:3.7.0"

--- a/e2e/kind-setup-single.sh
+++ b/e2e/kind-setup-single.sh
@@ -1022,6 +1022,8 @@ load_image_into_kind "nicolaka/netshoot"
 load_image_into_kind "$TMUX_DEBUG_IMAGE"
 # Preload busybox for debug session tests (used by test-basic-debug template)
 load_image_into_kind "busybox:latest"
+# Preload the audit webhook receiver image so E2E setup does not depend on Docker Hub pulls.
+load_image_into_kind "python:3.11-slim"
 # Load Kafka image for audit sink testing
 load_image_into_kind "apache/kafka:3.7.0"
 
@@ -1940,7 +1942,7 @@ for i in {1..40}; do
     KUBECONFIG="$HUB_KUBECONFIG" $KUBECTL get svc -l app=keycloak -n "$DEV_NS" -o wide 2>&1 || true
     log "--- Testing Keycloak connectivity via netshoot pod ---"
     # Use a temporary netshoot pod to test connectivity (controller image is distroless)
-    KUBECONFIG="$HUB_KUBECONFIG" $KUBECTL run keycloak-test-$i --rm -i --restart=Never --image=nicolaka/netshoot:latest \
+    KUBECONFIG="$HUB_KUBECONFIG" $KUBECTL run keycloak-test-$i --rm -i --restart=Never --image=nicolaka/netshoot --image-pull-policy=IfNotPresent \
       --namespace="$DEV_NS" -- curl -sk --max-time 5 \
       "https://breakglass-keycloak.breakglass-system.svc.cluster.local:8443/realms/breakglass-e2e/.well-known/openid-configuration" 2>&1 | head -10 || \
       log "Keycloak connectivity test via netshoot failed"
@@ -2309,4 +2311,3 @@ log "  - MailHog:             http://localhost:${MAILHOG_UI_PORT}"
 log "  - Audit Webhook Recv:  http://localhost:${AUDIT_WEBHOOK_RECEIVER_PORT}"
 log ""
 log "To stop port-forwards: kill \$(cat $PF_FILE)"
-

--- a/e2e/kind-setup-single.sh
+++ b/e2e/kind-setup-single.sh
@@ -1022,7 +1022,7 @@ load_image_into_kind "nicolaka/netshoot"
 load_image_into_kind "$TMUX_DEBUG_IMAGE"
 # Preload busybox for debug session tests (used by test-basic-debug template)
 load_image_into_kind "busybox:latest"
-# Preload the audit webhook receiver image so E2E setup does not depend on Docker Hub pulls.
+# Preload the audit webhook receiver image so the in-cluster deployment does not pull it.
 ensure_image_exists "python:3.11-slim"
 load_image_into_kind "python:3.11-slim"
 # Load Kafka image for audit sink testing


### PR DESCRIPTION
## Summary
- preload `python:3.11-slim` into the single-cluster kind node for the dev audit webhook receiver
- make the temporary Keycloak diagnostic netshoot pod use the preloaded image with `IfNotPresent`
- keep OIDC E2E setup from depending on Docker Hub pulls that can fail with 429 rate limits

## Evidence
- #727 OIDC rerun failed in setup after Docker Hub returned 429 for `python:3.11-slim` and `nicolaka/netshoot:latest`
- the setup already preloads `nicolaka/netshoot`, but `:latest` defaulted to `Always` for the temporary probe pod

## Validation
- `git diff --check`
- `bash -n e2e/kind-setup-single.sh`
- `kustomize build config/dev` could not run in a clean worktree because generated TLS cert inputs under `config/dev/certs/` are absent before E2E setup creates them
