### PR TITLE
fix: enforce debug session duration constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **DenyPolicy precedence is now honored during evaluation**: Multiple matching `DenyPolicy` resources are now evaluated in stable ascending `spec.precedence` order, with unset precedence defaulting to `100`, matching the documented policy semantics.
+- **Debug session duration constraints are enforced at creation**: Debug session requests now reject non-positive requested durations and reject requested durations that exceed the effective template or cluster-binding `maxDuration`, instead of accepting them for later clamping. Direct `DebugSession` CR admission now also rejects non-positive `requestedDuration` values.
 - **Frontend: restored persisted theme selection in the app header**: The accessibility remediation now keeps both theme and high-contrast controls available, persists manual light/dark selection, preserves the forced dark canvas while high-contrast mode is enabled, and avoids duplicate modal form-control IDs in debug session cards.
 - **Orphaned session cleanup now restricted to terminal states**: `markCleanupExpiredSession` previously deleted orphaned `BreakglassSession` objects in any non-Pending state, including active `Approved` and `WaitingForScheduledTime` sessions that had no `RetainedUntil` set. The predicate is now an explicit allowlist of terminal states (`Expired`, `IdleExpired`, `Rejected`, `Withdrawn`, `ApprovalTimeout`) — active sessions are never deleted by the orphan cleanup path.
 

--- a/api/v1alpha1/debug_session_types.go
+++ b/api/v1alpha1/debug_session_types.go
@@ -634,7 +634,7 @@ func validateDebugSessionSpec(session *DebugSession) field.ErrorList {
 
 	// Validate duration format if specified
 	if session.Spec.RequestedDuration != "" {
-		allErrs = append(allErrs, validateDurationFormat(session.Spec.RequestedDuration, specPath.Child("requestedDuration"))...)
+		allErrs = append(allErrs, validatePositiveDurationFormat(session.Spec.RequestedDuration, specPath.Child("requestedDuration"))...)
 	}
 
 	// Validate extraDeployValues keys are valid Go identifiers

--- a/api/v1alpha1/debug_session_types_test.go
+++ b/api/v1alpha1/debug_session_types_test.go
@@ -1388,6 +1388,31 @@ func TestDebugSession_ValidateCreate_InvalidDuration(t *testing.T) {
 	}
 }
 
+func TestDebugSession_ValidateCreate_NonPositiveDuration(t *testing.T) {
+	ctx := context.Background()
+	for _, duration := range []string{"0", "-1h"} {
+		t.Run(duration, func(t *testing.T) {
+			session := &DebugSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-session",
+					Namespace: "breakglass",
+				},
+				Spec: DebugSessionSpec{
+					Cluster:           "cluster",
+					TemplateRef:       "template",
+					RequestedBy:       "user@example.com",
+					RequestedDuration: duration,
+				},
+			}
+
+			_, err := session.ValidateCreate(ctx, session)
+			if err == nil {
+				t.Errorf("ValidateCreate() expected error for non-positive duration %q", duration)
+			}
+		})
+	}
+}
+
 func TestDebugSession_ValidateCreate_ValidDurations(t *testing.T) {
 	ctx := context.Background()
 	validDurations := []string{"1h", "30m", "2h30m", "24h", "1h30m45s", ""}
@@ -1743,6 +1768,28 @@ func TestValidateDebugSessionSpec_InvalidDuration(t *testing.T) {
 	errs := validateDebugSessionSpec(session)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid duration, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateDebugSessionSpec_NonPositiveDuration(t *testing.T) {
+	for _, duration := range []string{"0", "-1h"} {
+		t.Run(duration, func(t *testing.T) {
+			session := &DebugSession{
+				Spec: DebugSessionSpec{
+					Cluster:           "cluster",
+					TemplateRef:       "template",
+					RequestedBy:       "user@example.com",
+					RequestedDuration: duration,
+				},
+			}
+			errs := validateDebugSessionSpec(session)
+			if len(errs) != 1 {
+				t.Fatalf("expected 1 error for non-positive duration, got %d: %v", len(errs), errs)
+			}
+			if errs[0].Field != "spec.requestedDuration" {
+				t.Errorf("expected error field spec.requestedDuration, got %s", errs[0].Field)
+			}
+		})
 	}
 }
 

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -707,7 +707,7 @@ func ValidateDebugSession(ds *DebugSession) *ValidationResult {
 
 	// Validate duration format if specified
 	if ds.Spec.RequestedDuration != "" {
-		result.Errors = append(result.Errors, validateDurationFormat(ds.Spec.RequestedDuration, specPath.Child("requestedDuration"))...)
+		result.Errors = append(result.Errors, validatePositiveDurationFormat(ds.Spec.RequestedDuration, specPath.Child("requestedDuration"))...)
 	}
 
 	return result

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -832,6 +832,23 @@ func validateDurationFormat(duration string, fieldPath *field.Path) field.ErrorL
 	return nil
 }
 
+// validatePositiveDurationFormat validates that a string is a valid positive duration.
+func validatePositiveDurationFormat(duration string, fieldPath *field.Path) field.ErrorList {
+	if duration == "" || fieldPath == nil {
+		return nil
+	}
+
+	parsed, err := ParseDuration(duration)
+	if err != nil {
+		return field.ErrorList{field.Invalid(fieldPath, duration, fmt.Sprintf("invalid duration format: %v", err))}
+	}
+	if parsed <= 0 {
+		return field.ErrorList{field.Invalid(fieldPath, duration, "duration must be positive")}
+	}
+
+	return nil
+}
+
 // validateClusterAuthConfig validates that exactly one authentication method is configured
 // for a ClusterConfig. Either kubeconfigSecretRef OR oidcAuth/oidcFromIdentityProvider must be specified, but not both.
 func validateClusterAuthConfig(spec ClusterConfigSpec, specPath *field.Path) field.ErrorList {

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1389,6 +1389,10 @@ constraints:
   requireApprovalForRenewal: false
 ```
 
+Requested durations must be positive and cannot exceed the effective
+`maxDuration`. When a `DebugSessionClusterBinding` matches the target cluster,
+its duration constraints override the template constraints for that session.
+
 ## Terminal Sharing
 
 Enable collaborative debugging with terminal sharing:

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1390,8 +1390,10 @@ constraints:
 ```
 
 Requested durations must be positive and cannot exceed the effective
-`maxDuration`. When a `DebugSessionClusterBinding` matches the target cluster,
-its duration constraints override the template constraints for that session.
+`maxDuration`. When a request selects a `DebugSessionClusterBinding` through
+`bindingRef`, or the API/reconciler defaults to an applicable binding for the
+target cluster, that binding's duration constraints override the template
+constraints for that session.
 
 ## Terminal Sharing
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1939,5 +1939,3 @@ The following test categories are implemented:
 - **Bad case tests**: Invalid inputs, unauthorized access, invalid state transitions
 - **E2E tests**: Template creation, session lifecycle, multi-participant sessions, kubectl-debug operations
 - **Frontend tests**: 478 tests passing (Vitest)
-
-```

--- a/e2e/debug_session_e2e_test.go
+++ b/e2e/debug_session_e2e_test.go
@@ -960,11 +960,11 @@ func TestDebugSession_E2E_ConstraintsEnforcement(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = cli.Delete(ctx, template) }()
 
-	// Create session requesting duration longer than max via API
+	// Create a session within the configured maximum duration.
 	session := api.MustCreateDebugSession(t, ctx, helpers.DebugSessionRequest{
 		Cluster:           "tenant-a",
 		TemplateRef:       template.Name,
-		RequestedDuration: "4h", // Requesting 4h, max is 1h
+		RequestedDuration: "30m",
 		Namespace:         testNamespace,
 		Reason:            "Testing constraints enforcement",
 	})
@@ -973,9 +973,21 @@ func TestDebugSession_E2E_ConstraintsEnforcement(t *testing.T) {
 	// Wait for session to be processed using helper
 	session = helpers.WaitForDebugSessionStateAny(t, ctx, cli, session.Name, session.Namespace, defaultTimeout)
 
-	// The session should still exist, potentially with capped duration
+	// The session should exist because the requested duration is within maxDuration.
 	t.Logf("Session state: %s, requestedDuration: %s", session.Status.State, session.Spec.RequestedDuration)
 	assert.NotEmpty(t, session.Status.State)
+
+	// Requests longer than maxDuration are rejected at the API boundary.
+	_, err = api.CreateDebugSession(ctx, t, helpers.DebugSessionRequest{
+		Cluster:           "tenant-a",
+		TemplateRef:       template.Name,
+		RequestedDuration: "4h",
+		Namespace:         testNamespace,
+		Reason:            "Testing constraints enforcement rejection",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status=400")
+	assert.Contains(t, err.Error(), "exceeds maximum duration 1h")
 }
 
 // D-014: DebugSession access control - allowed groups

--- a/e2e/e2e-todo.md
+++ b/e2e/e2e-todo.md
@@ -357,7 +357,7 @@ The following tests in `e2e/api/use_cases_test.go` cover real-world scenarios do
 
 [D-013] DebugSession constraints enforcement
 - Steps: Create a DebugSessionTemplate with maxDuration=1h. Try to create a DebugSession requesting 4h.
-- Expected: Session is created with duration capped at maxDuration (1h).
+- Expected: Session creation is rejected because requestedDuration exceeds maxDuration.
 - Priority: Medium
 
 [D-014] DebugSession access control - allowed groups

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -492,18 +492,40 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		"allowedBySource", allowedResult.AllowedBySource,
 	)
 
+	resolvedBinding, err := selectEffectiveDebugSessionBinding(req.BindingRef, allowedResult)
+	if err != nil {
+		reqLog.Warnw("Requested binding is not valid for debug session",
+			"bindingRef", req.BindingRef,
+			"cluster", req.Cluster,
+			"templateRef", req.TemplateRef,
+			"error", err)
+		apiresponses.RespondBadRequest(ctx, err.Error())
+		return
+	}
+
+	effectiveConstraints := effectiveDebugSessionConstraints(template, resolvedBinding)
+	if err := validateRequestedDebugSessionDuration(req.RequestedDuration, effectiveConstraints); err != nil {
+		reqLog.Warnw("Requested debug session duration is invalid",
+			"templateRef", req.TemplateRef,
+			"bindingRef", req.BindingRef,
+			"requestedDuration", req.RequestedDuration,
+			"error", err)
+		apiresponses.RespondBadRequest(ctx, err.Error())
+		return
+	}
+
 	// Track warnings for defaults that were applied
 	var warnings []string
 
 	// Validate and resolve target namespace (pass binding for constraint override)
-	targetNamespace, err := c.resolveTargetNamespace(template, req.TargetNamespace, allowedResult.MatchingBinding)
+	targetNamespace, err := c.resolveTargetNamespace(template, req.TargetNamespace, resolvedBinding)
 	if err != nil {
 		// Provide more context about namespace constraints when validation fails
 		var effectiveAllowUserNs bool
 		var effectiveDefault string
-		if allowedResult.MatchingBinding != nil && allowedResult.MatchingBinding.Spec.NamespaceConstraints != nil {
-			effectiveAllowUserNs = allowedResult.MatchingBinding.Spec.NamespaceConstraints.AllowUserNamespace
-			effectiveDefault = allowedResult.MatchingBinding.Spec.NamespaceConstraints.DefaultNamespace
+		if resolvedBinding != nil && resolvedBinding.Spec.NamespaceConstraints != nil {
+			effectiveAllowUserNs = resolvedBinding.Spec.NamespaceConstraints.AllowUserNamespace
+			effectiveDefault = resolvedBinding.Spec.NamespaceConstraints.DefaultNamespace
 		} else if template.Spec.NamespaceConstraints != nil {
 			effectiveAllowUserNs = template.Spec.NamespaceConstraints.AllowUserNamespace
 			effectiveDefault = template.Spec.NamespaceConstraints.DefaultNamespace
@@ -513,7 +535,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 			"requestedNamespace", req.TargetNamespace,
 			"allowUserNamespace", effectiveAllowUserNs,
 			"defaultNamespace", effectiveDefault,
-			"bindingUsed", allowedResult.MatchingBinding != nil,
+			"bindingUsed", resolvedBinding != nil,
 			"error", err,
 		)
 		apiresponses.RespondBadRequest(ctx, err.Error())
@@ -526,7 +548,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	}
 
 	// Validate and resolve scheduling option
-	resolvedScheduling, selectedOption, err := c.resolveSchedulingConstraints(template, req.SelectedSchedulingOption, allowedResult.MatchingBinding)
+	resolvedScheduling, selectedOption, err := c.resolveSchedulingConstraints(template, req.SelectedSchedulingOption, resolvedBinding)
 	if err != nil {
 		reqLog.Warnw("Scheduling option validation failed",
 			"templateRef", req.TemplateRef,
@@ -545,7 +567,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	if req.SelectedSchedulingOption != "" && selectedOption == "" {
 		// Determine if any scheduling options exist (template or binding)
 		hasOptions := (template.Spec.SchedulingOptions != nil && len(template.Spec.SchedulingOptions.Options) > 0) ||
-			(allowedResult.MatchingBinding != nil && allowedResult.MatchingBinding.Spec.SchedulingOptions != nil && len(allowedResult.MatchingBinding.Spec.SchedulingOptions.Options) > 0)
+			(resolvedBinding != nil && resolvedBinding.Spec.SchedulingOptions != nil && len(resolvedBinding.Spec.SchedulingOptions.Options) > 0)
 		if !hasOptions {
 			warnings = append(warnings, fmt.Sprintf("Scheduling option '%s' was ignored (template has no scheduling options)", req.SelectedSchedulingOption))
 			reqLog.Debugw("Scheduling option ignored", "ignoredOption", req.SelectedSchedulingOption)
@@ -674,6 +696,12 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 			ExtraDeployValues:             req.ExtraDeployValues,
 		},
 	}
+	if resolvedBinding != nil {
+		session.Spec.BindingRef = &breakglassv1alpha1.BindingReference{
+			Name:      resolvedBinding.Name,
+			Namespace: resolvedBinding.Namespace,
+		}
+	}
 
 	// Copy reason configurations as snapshots so session is self-contained
 	// This avoids needing to look up the template later
@@ -682,44 +710,6 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	}
 	if template.Spec.ApprovalReason != nil {
 		session.Spec.ApprovalReasonConfig = template.Spec.ApprovalReason.DeepCopy()
-	}
-
-	// Set explicit binding reference if provided (format: "namespace/name")
-	var resolvedBinding *breakglassv1alpha1.DebugSessionClusterBinding
-	if req.BindingRef != "" {
-		parts := strings.SplitN(req.BindingRef, "/", 2)
-		if len(parts) == 2 {
-			session.Spec.BindingRef = &breakglassv1alpha1.BindingReference{
-				Name:      parts[1],
-				Namespace: parts[0],
-			}
-			// Fetch the binding for limit checking
-			resolvedBinding = &breakglassv1alpha1.DebugSessionClusterBinding{}
-			if err := c.client.Get(apiCtx, ctrlclient.ObjectKey{Name: parts[1], Namespace: parts[0]}, resolvedBinding); err != nil {
-				if apierrors.IsNotFound(err) {
-					reqLog.Warnw("Binding not found", "bindingRef", req.BindingRef)
-					apiresponses.RespondBadRequest(ctx, fmt.Sprintf("binding '%s' not found", req.BindingRef))
-					return
-				}
-				reqLog.Errorw("Failed to get binding", "binding", req.BindingRef, "error", err)
-				apiresponses.RespondInternalErrorSimple(ctx, "failed to validate binding")
-				return
-			}
-
-			// Check if binding is active
-			if !breakglass.IsBindingActive(resolvedBinding) {
-				reqLog.Warnw("Binding is not active",
-					"bindingRef", req.BindingRef,
-					"disabled", resolvedBinding.Spec.Disabled,
-					"effectiveFrom", resolvedBinding.Spec.EffectiveFrom,
-					"expiresAt", resolvedBinding.Spec.ExpiresAt,
-				)
-				apiresponses.RespondForbidden(ctx, "binding is not active (disabled, expired, or not yet effective)")
-				return
-			}
-		} else {
-			reqLog.Warnw("Invalid bindingRef format, expected namespace/name", "bindingRef", req.BindingRef)
-		}
 	}
 
 	// Check binding session limits if a binding is resolved

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -733,13 +733,15 @@ func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrBinding(
 				)
 				result.Allowed = true
 				result.AllowedBySource = "template"
-				return result
+				break
 			}
 		}
-		c.log.Debugw("Cluster not allowed by template patterns",
-			"cluster", clusterName,
-			"templatePatterns", template.Spec.Allowed.Clusters,
-		)
+		if !result.Allowed {
+			c.log.Debugw("Cluster not allowed by template patterns",
+				"cluster", clusterName,
+				"templatePatterns", template.Spec.Allowed.Clusters,
+			)
+		}
 	}
 
 	// 2. Check if allowed by any binding that references this template

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -854,18 +854,18 @@ func (c *DebugSessionAPIController) mergeConstraints(templateConstraints *breakg
 	if binding == nil || binding.Spec.Constraints == nil {
 		return templateConstraints
 	}
-	if templateConstraints == nil {
-		return binding.Spec.Constraints
-	}
 
 	// Binding constraints override template constraints
-	merged := templateConstraints.DeepCopy()
+	merged := &breakglassv1alpha1.DebugSessionConstraints{}
+	if templateConstraints != nil {
+		merged = templateConstraints.DeepCopy()
+	}
 	bc := binding.Spec.Constraints
 
-	if bc.MaxDuration != "" {
+	if isPositiveDebugSessionDuration(bc.MaxDuration) {
 		merged.MaxDuration = bc.MaxDuration
 	}
-	if bc.DefaultDuration != "" {
+	if isPositiveDebugSessionDuration(bc.DefaultDuration) {
 		merged.DefaultDuration = bc.DefaultDuration
 	}
 	if bc.MaxConcurrentSessions > 0 {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -2826,6 +2827,102 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, 401, w.Code)
+	})
+
+	t.Run("create session rejects non-positive requested duration", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&template).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		for _, duration := range []string{"0", "-1h"} {
+			body := fmt.Sprintf(`{"templateRef":"standard-debug","cluster":"production","requestedDuration":%q}`, duration)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "requestedDuration must be positive")
+		}
+	})
+
+	t.Run("create session enforces binding max duration", func(t *testing.T) {
+		bindingOnlyTemplate := breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "binding-debug",
+			},
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode:         breakglassv1alpha1.DebugSessionModeWorkload,
+				WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
+				Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+					MaxDuration:     "4h",
+					DefaultDuration: "1h",
+				},
+			},
+		}
+		binding := breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tight-binding",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "binding-debug"},
+				Clusters:    []string{"production"},
+				Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+					MaxDuration:     "2h",
+					DefaultDuration: "30m",
+				},
+			},
+		}
+		cluster := breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "production",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.ClusterConfigSpec{
+				KubeconfigSecretRef: &breakglassv1alpha1.SecretKeyReference{
+					Name:      "production-kubeconfig",
+					Namespace: "breakglass",
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&bindingOnlyTemplate, &binding, &cluster).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Set("email", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"binding-debug","cluster":"production","bindingRef":"breakglass/tight-binding","requestedDuration":"3h"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "exceeds maximum duration 2h")
 	})
 
 	t.Run("create session returns warnings when namespace is defaulted", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2925,6 +2925,76 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "exceeds maximum duration 2h")
 	})
 
+	t.Run("create session applies implicit binding max duration when template also allows cluster", func(t *testing.T) {
+		templateWithBinding := breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "template-and-binding-debug",
+			},
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode:         breakglassv1alpha1.DebugSessionModeWorkload,
+				WorkloadType: breakglassv1alpha1.DebugWorkloadDaemonSet,
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Clusters: []string{"production"},
+				},
+				Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+					MaxDuration:     "4h",
+					DefaultDuration: "1h",
+				},
+			},
+		}
+		binding := breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tight-binding",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "template-and-binding-debug"},
+				Clusters:    []string{"production"},
+				Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+					MaxDuration:     "2h",
+					DefaultDuration: "30m",
+				},
+			},
+		}
+		cluster := breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "production",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.ClusterConfigSpec{
+				KubeconfigSecretRef: &breakglassv1alpha1.SecretKeyReference{
+					Name:      "production-kubeconfig",
+					Namespace: "breakglass",
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&templateWithBinding, &binding, &cluster).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Set("email", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"template-and-binding-debug","cluster":"production","requestedDuration":"3h"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "exceeds maximum duration 2h")
+	})
+
 	t.Run("create session returns warnings when namespace is defaulted", func(t *testing.T) {
 		templateWithNsDefaults := breakglassv1alpha1.DebugSessionTemplate{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/breakglass/debug/debug_session_duration.go
+++ b/pkg/breakglass/debug/debug_session_duration.go
@@ -111,7 +111,13 @@ func selectEffectiveDebugSessionBinding(
 	allowedResult ClusterAllowedResult,
 ) (*breakglassv1alpha1.DebugSessionClusterBinding, error) {
 	if strings.TrimSpace(bindingRef) == "" {
-		return allowedResult.MatchingBinding, nil
+		if allowedResult.MatchingBinding != nil {
+			return allowedResult.MatchingBinding, nil
+		}
+		if len(allowedResult.AllBindings) > 0 {
+			return &allowedResult.AllBindings[0], nil
+		}
+		return nil, nil
 	}
 
 	namespace, name, ok := strings.Cut(bindingRef, "/")

--- a/pkg/breakglass/debug/debug_session_duration.go
+++ b/pkg/breakglass/debug/debug_session_duration.go
@@ -24,10 +24,10 @@ func effectiveDebugSessionConstraints(
 		constraints = &breakglassv1alpha1.DebugSessionConstraints{}
 	}
 	bindingConstraints := binding.Spec.Constraints
-	if bindingConstraints.MaxDuration != "" {
+	if isPositiveDebugSessionDuration(bindingConstraints.MaxDuration) {
 		constraints.MaxDuration = bindingConstraints.MaxDuration
 	}
-	if bindingConstraints.DefaultDuration != "" {
+	if isPositiveDebugSessionDuration(bindingConstraints.DefaultDuration) {
 		constraints.DefaultDuration = bindingConstraints.DefaultDuration
 	}
 	if bindingConstraints.AllowRenewal != nil {
@@ -43,6 +43,14 @@ func effectiveDebugSessionConstraints(
 	}
 
 	return constraints
+}
+
+func isPositiveDebugSessionDuration(value string) bool {
+	if value == "" {
+		return false
+	}
+	duration, err := breakglassv1alpha1.ParseDuration(value)
+	return err == nil && duration > 0
 }
 
 func validateRequestedDebugSessionDuration(requested string, constraints *breakglassv1alpha1.DebugSessionConstraints) error {

--- a/pkg/breakglass/debug/debug_session_duration.go
+++ b/pkg/breakglass/debug/debug_session_duration.go
@@ -1,0 +1,109 @@
+package debug
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+func effectiveDebugSessionConstraints(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+) *breakglassv1alpha1.DebugSessionConstraints {
+	var constraints *breakglassv1alpha1.DebugSessionConstraints
+	if template != nil && template.Spec.Constraints != nil {
+		constraints = template.Spec.Constraints.DeepCopy()
+	}
+	if binding == nil || binding.Spec.Constraints == nil {
+		return constraints
+	}
+
+	if constraints == nil {
+		constraints = &breakglassv1alpha1.DebugSessionConstraints{}
+	}
+	bindingConstraints := binding.Spec.Constraints
+	if bindingConstraints.MaxDuration != "" {
+		constraints.MaxDuration = bindingConstraints.MaxDuration
+	}
+	if bindingConstraints.DefaultDuration != "" {
+		constraints.DefaultDuration = bindingConstraints.DefaultDuration
+	}
+	if bindingConstraints.AllowRenewal != nil {
+		allowRenewal := *bindingConstraints.AllowRenewal
+		constraints.AllowRenewal = &allowRenewal
+	}
+	if bindingConstraints.MaxRenewals != nil {
+		maxRenewals := *bindingConstraints.MaxRenewals
+		constraints.MaxRenewals = &maxRenewals
+	}
+	if bindingConstraints.RenewalLimit != 0 {
+		constraints.RenewalLimit = bindingConstraints.RenewalLimit
+	}
+
+	return constraints
+}
+
+func validateRequestedDebugSessionDuration(requested string, constraints *breakglassv1alpha1.DebugSessionConstraints) error {
+	if requested == "" {
+		return nil
+	}
+
+	requestedDuration, err := breakglassv1alpha1.ParseDuration(requested)
+	if err != nil {
+		return fmt.Errorf("invalid requestedDuration: %w", err)
+	}
+	if requestedDuration <= 0 {
+		return fmt.Errorf("requestedDuration must be positive")
+	}
+
+	maxDuration, maxLabel, err := maxDebugSessionDuration(constraints)
+	if err != nil {
+		return err
+	}
+	if maxDuration > 0 && requestedDuration > maxDuration {
+		return fmt.Errorf("requestedDuration %s exceeds maximum duration %s", requested, maxLabel)
+	}
+
+	return nil
+}
+
+func maxDebugSessionDuration(constraints *breakglassv1alpha1.DebugSessionConstraints) (time.Duration, string, error) {
+	if constraints == nil || constraints.MaxDuration == "" {
+		return 0, "", nil
+	}
+
+	maxDuration, err := breakglassv1alpha1.ParseDuration(constraints.MaxDuration)
+	if err != nil {
+		return 0, "", fmt.Errorf("configured maxDuration %q is invalid: %w", constraints.MaxDuration, err)
+	}
+	if maxDuration <= 0 {
+		return 0, "", fmt.Errorf("configured maxDuration must be positive")
+	}
+
+	return maxDuration, constraints.MaxDuration, nil
+}
+
+func selectEffectiveDebugSessionBinding(
+	bindingRef string,
+	allowedResult ClusterAllowedResult,
+) (*breakglassv1alpha1.DebugSessionClusterBinding, error) {
+	if strings.TrimSpace(bindingRef) == "" {
+		return allowedResult.MatchingBinding, nil
+	}
+
+	namespace, name, ok := strings.Cut(bindingRef, "/")
+	if !ok || strings.TrimSpace(namespace) == "" || strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("invalid bindingRef format, expected namespace/name")
+	}
+
+	for i := range allowedResult.AllBindings {
+		binding := &allowedResult.AllBindings[i]
+		if binding.Namespace == namespace && binding.Name == name {
+			return binding, nil
+		}
+	}
+
+	return nil, fmt.Errorf("binding %q does not allow the requested template and cluster", bindingRef)
+}

--- a/pkg/breakglass/debug/debug_session_duration.go
+++ b/pkg/breakglass/debug/debug_session_duration.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package debug
 
 import (
@@ -83,11 +99,8 @@ func maxDebugSessionDuration(constraints *breakglassv1alpha1.DebugSessionConstra
 	}
 
 	maxDuration, err := breakglassv1alpha1.ParseDuration(constraints.MaxDuration)
-	if err != nil {
-		return 0, "", fmt.Errorf("configured maxDuration %q is invalid: %w", constraints.MaxDuration, err)
-	}
-	if maxDuration <= 0 {
-		return 0, "", fmt.Errorf("configured maxDuration must be positive")
+	if err != nil || maxDuration <= 0 {
+		return 0, "", nil
 	}
 
 	return maxDuration, constraints.MaxDuration, nil

--- a/pkg/breakglass/debug/debug_session_duration_test.go
+++ b/pkg/breakglass/debug/debug_session_duration_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package debug
 
 import (
@@ -120,4 +136,16 @@ func TestValidateRequestedDebugSessionDuration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2*time.Hour, maxDuration)
 	assert.Equal(t, "2h", maxLabel)
+}
+
+func TestValidateRequestedDebugSessionDuration_IgnoresInvalidConfiguredMaxDuration(t *testing.T) {
+	for _, maxDuration := range []string{"0", "-1h", "not-a-duration"} {
+		t.Run(maxDuration, func(t *testing.T) {
+			constraints := &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: maxDuration}
+
+			err := validateRequestedDebugSessionDuration("30m", constraints)
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/pkg/breakglass/debug/debug_session_duration_test.go
+++ b/pkg/breakglass/debug/debug_session_duration_test.go
@@ -42,6 +42,51 @@ func TestEffectiveDebugSessionConstraints(t *testing.T) {
 	assert.Equal(t, int32(4), *constraints.MaxRenewals)
 }
 
+func TestEffectiveDebugSessionConstraints_IgnoresInvalidBindingDurationOverrides(t *testing.T) {
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+				MaxDuration:     "4h",
+				DefaultDuration: "1h",
+			},
+		},
+	}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+				MaxDuration:     "-1h",
+				DefaultDuration: "not-a-duration",
+			},
+		},
+	}
+
+	constraints := effectiveDebugSessionConstraints(template, binding)
+
+	require.NotNil(t, constraints)
+	assert.Equal(t, "4h", constraints.MaxDuration)
+	assert.Equal(t, "1h", constraints.DefaultDuration)
+}
+
+func TestMergeConstraints_IgnoresInvalidBindingDurationOverridesWithoutTemplateConstraints(t *testing.T) {
+	controller := &DebugSessionAPIController{}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+				MaxDuration:           "-1h",
+				DefaultDuration:       "not-a-duration",
+				MaxConcurrentSessions: 3,
+			},
+		},
+	}
+
+	constraints := controller.mergeConstraints(nil, binding)
+
+	require.NotNil(t, constraints)
+	assert.Empty(t, constraints.MaxDuration)
+	assert.Empty(t, constraints.DefaultDuration)
+	assert.Equal(t, int32(3), constraints.MaxConcurrentSessions)
+}
+
 func TestValidateRequestedDebugSessionDuration(t *testing.T) {
 	constraints := &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: "2h"}
 

--- a/pkg/breakglass/debug/debug_session_duration_test.go
+++ b/pkg/breakglass/debug/debug_session_duration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEffectiveDebugSessionConstraints(t *testing.T) {
@@ -148,4 +149,23 @@ func TestValidateRequestedDebugSessionDuration_IgnoresInvalidConfiguredMaxDurati
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestSelectEffectiveDebugSessionBinding_DefaultsToFirstApplicableBinding(t *testing.T) {
+	first := breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "first", Namespace: "default"},
+	}
+	second := breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "second", Namespace: "default"},
+	}
+	result := ClusterAllowedResult{
+		Allowed:     true,
+		AllBindings: []breakglassv1alpha1.DebugSessionClusterBinding{first, second},
+	}
+
+	binding, err := selectEffectiveDebugSessionBinding("", result)
+
+	require.NoError(t, err)
+	require.NotNil(t, binding)
+	assert.Equal(t, "first", binding.Name)
 }

--- a/pkg/breakglass/debug/debug_session_duration_test.go
+++ b/pkg/breakglass/debug/debug_session_duration_test.go
@@ -1,0 +1,78 @@
+package debug
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+func TestEffectiveDebugSessionConstraints(t *testing.T) {
+	allowRenewal := true
+	maxRenewals := int32(4)
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+				MaxDuration:     "4h",
+				DefaultDuration: "1h",
+				AllowRenewal:    &allowRenewal,
+				MaxRenewals:     &maxRenewals,
+			},
+		},
+	}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+				MaxDuration: "2h",
+			},
+		},
+	}
+
+	constraints := effectiveDebugSessionConstraints(template, binding)
+
+	require.NotNil(t, constraints)
+	assert.Equal(t, "2h", constraints.MaxDuration)
+	assert.Equal(t, "1h", constraints.DefaultDuration)
+	require.NotNil(t, constraints.AllowRenewal)
+	assert.True(t, *constraints.AllowRenewal)
+	require.NotNil(t, constraints.MaxRenewals)
+	assert.Equal(t, int32(4), *constraints.MaxRenewals)
+}
+
+func TestValidateRequestedDebugSessionDuration(t *testing.T) {
+	constraints := &breakglassv1alpha1.DebugSessionConstraints{MaxDuration: "2h"}
+
+	tests := []struct {
+		name        string
+		requested   string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "empty is allowed", requested: ""},
+		{name: "within max", requested: "90m"},
+		{name: "zero rejected", requested: "0", wantErr: true, errContains: "positive"},
+		{name: "negative rejected", requested: "-1h", wantErr: true, errContains: "positive"},
+		{name: "above max rejected", requested: "3h", wantErr: true, errContains: "exceeds maximum duration 2h"},
+		{name: "invalid rejected", requested: "not-a-duration", wantErr: true, errContains: "invalid requestedDuration"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRequestedDebugSessionDuration(tt.requested, constraints)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+
+	maxDuration, maxLabel, err := maxDebugSessionDuration(constraints)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Hour, maxDuration)
+	assert.Equal(t, "2h", maxLabel)
+}

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -176,9 +176,6 @@ func (c *DebugSessionController) handlePending(ctx context.Context, ds *breakgla
 		return c.failSession(ctx, ds, fmt.Sprintf("template not found: %s", ds.Spec.TemplateRef))
 	}
 
-	// Cache the resolved template in status
-	ds.Status.ResolvedTemplate = &template.Spec
-
 	// Find binding early so we can check its approvers for the approval decision
 	// This ensures bindings with approvers properly trigger approval workflow
 	var binding *breakglassv1alpha1.DebugSessionClusterBinding
@@ -199,6 +196,11 @@ func (c *DebugSessionController) handlePending(ctx context.Context, ds *breakgla
 				"namespace", binding.Namespace)
 		}
 	}
+
+	// Cache the resolved template in status after applying binding-level duration overrides.
+	resolvedTemplate := template.Spec.DeepCopy()
+	resolvedTemplate.Constraints = effectiveDebugSessionConstraints(template, binding)
+	ds.Status.ResolvedTemplate = resolvedTemplate
 
 	// Check if approval is required (checks both template and binding approvers)
 	requiresApproval := c.requiresApproval(template, binding, ds)
@@ -373,7 +375,7 @@ func (c *DebugSessionController) activateSession(ctx context.Context, ds *breakg
 	}
 
 	// Calculate expiration
-	duration := c.parseDuration(ds.Spec.RequestedDuration, template.Spec.Constraints)
+	duration := c.parseDuration(ds.Spec.RequestedDuration, effectiveDebugSessionConstraints(template, binding))
 	now := metav1.Now()
 	expiresAt := metav1.NewTime(now.Add(duration))
 

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -485,10 +485,10 @@ func (c *DebugSessionController) parseDuration(requested string, constraints *br
 	maxDur := 4 * time.Hour
 
 	if constraints != nil {
-		if d, err := breakglassv1alpha1.ParseDuration(constraints.DefaultDuration); err == nil {
+		if d, err := breakglassv1alpha1.ParseDuration(constraints.DefaultDuration); err == nil && d > 0 {
 			defaultDur = d
 		}
-		if d, err := breakglassv1alpha1.ParseDuration(constraints.MaxDuration); err == nil {
+		if d, err := breakglassv1alpha1.ParseDuration(constraints.MaxDuration); err == nil && d > 0 {
 			maxDur = d
 		}
 	}

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -492,6 +492,9 @@ func (c *DebugSessionController) parseDuration(requested string, constraints *br
 			maxDur = d
 		}
 	}
+	if defaultDur > maxDur {
+		defaultDur = maxDur
+	}
 
 	if requested == "" {
 		return defaultDur

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -3684,6 +3684,16 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, 30*time.Minute, result)
 	})
 
+	t.Run("caps default duration at max duration", func(t *testing.T) {
+		constraints := &breakglassv1alpha1.DebugSessionConstraints{
+			DefaultDuration: "3h",
+			MaxDuration:     "1h",
+		}
+
+		assert.Equal(t, time.Hour, ctrl.parseDuration("", constraints))
+		assert.Equal(t, time.Hour, ctrl.parseDuration("invalid", constraints))
+	})
+
 	t.Run("non-positive configured durations are ignored", func(t *testing.T) {
 		constraints := &breakglassv1alpha1.DebugSessionConstraints{
 			DefaultDuration: "-30m",

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -3684,6 +3684,16 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, 30*time.Minute, result)
 	})
 
+	t.Run("non-positive configured durations are ignored", func(t *testing.T) {
+		constraints := &breakglassv1alpha1.DebugSessionConstraints{
+			DefaultDuration: "-30m",
+			MaxDuration:     "0",
+		}
+
+		assert.Equal(t, time.Hour, ctrl.parseDuration("", constraints))
+		assert.Equal(t, 4*time.Hour, ctrl.parseDuration("8h", constraints))
+	})
+
 	t.Run("supports day units", func(t *testing.T) {
 		constraints := &breakglassv1alpha1.DebugSessionConstraints{
 			DefaultDuration: "1h",


### PR DESCRIPTION
## Summary
- reject non-positive `DebugSession.spec.requestedDuration` values in admission validation
- reject debug-session create requests with non-positive or over-limit requested durations before creating the CR
- apply cluster-binding duration overrides to the resolved template snapshot and activation duration calculation
- require explicit `bindingRef` values to match an active binding that grants the selected template and cluster

## Finding
The audit found two related duration enforcement gaps:

1. Direct `DebugSession` CR creation accepted `requestedDuration: "0"` and negative values because validation only checked parseability.
2. API-created debug sessions accepted a duration above a selected binding's `maxDuration`; the reconciler calculated activation duration from the raw template constraints and ignored binding duration overrides.

## Validation
- `go test ./api/v1alpha1 -run 'TestDebugSession_ValidateCreate_(InvalidDuration|NonPositiveDuration|ValidDurations)|TestValidateDebugSessionSpec_(InvalidDuration|NonPositiveDuration)' -count=1`
- `go test ./pkg/breakglass/debug -run 'Test(DebugSessionAPIController_HandleCreateDebugSession|EffectiveDebugSessionConstraints|ValidateRequestedDebugSessionDuration|ParseDuration)' -count=1`
- `go test ./api/v1alpha1 ./pkg/breakglass/debug -count=1`
- `git diff --check`
