### PR TITLE
fix: honor deny policy precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DenyPolicy precedence is now honored during evaluation**: Multiple matching `DenyPolicy` resources are now evaluated in stable ascending `spec.precedence` order, with unset precedence defaulting to `100`, matching the documented policy semantics.
 - **Frontend: restored persisted theme selection in the app header**: The accessibility remediation now keeps both theme and high-contrast controls available, persists manual light/dark selection, preserves the forced dark canvas while high-contrast mode is enabled, and avoids duplicate modal form-control IDs in debug session cards.
 - **Orphaned session cleanup now restricted to terminal states**: `markCleanupExpiredSession` previously deleted orphaned `BreakglassSession` objects in any non-Pending state, including active `Approved` and `WaitingForScheduledTime` sessions that had no `RetainedUntil` set. The predicate is now an explicit allowlist of terminal states (`Expired`, `IdleExpired`, `Rejected`, `Withdrawn`, `ApprovalTimeout`) — active sessions are never deleted by the orphan cleanup path.
 

--- a/pkg/policy/deny.go
+++ b/pkg/policy/deny.go
@@ -126,8 +126,8 @@ func (e *Evaluator) Match(ctx context.Context, act Action) (bool, string, error)
 }
 
 // MatchWithDetails is like Match but also returns pod security evaluation details.
-// It evaluates all policies and returns denial if any policy denies.
-// Warning results are collected but do not short-circuit policy evaluation.
+// It evaluates policies by precedence and returns on the first denial.
+// Warning results are collected until a denial short-circuits policy evaluation.
 func (e *Evaluator) MatchWithDetails(ctx context.Context, act Action) (denied bool, policyName string, podSecResult *PodSecurityResult, err error) {
 	policies, err := e.listPolicies(ctx)
 	if err != nil {

--- a/pkg/policy/deny.go
+++ b/pkg/policy/deny.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -83,6 +84,7 @@ func (e *Evaluator) Match(ctx context.Context, act Action) (bool, string, error)
 	if err != nil {
 		return false, "", err
 	}
+	sortPoliciesByPrecedence(policies)
 	for _, pol := range policies {
 		if !scopeMatches(pol.Spec.AppliesTo, act) {
 			continue
@@ -131,6 +133,7 @@ func (e *Evaluator) MatchWithDetails(ctx context.Context, act Action) (denied bo
 	if err != nil {
 		return false, "", nil, err
 	}
+	sortPoliciesByPrecedence(policies)
 
 	// Track the first warning result to return if no denial occurs
 	var warnResult *PodSecurityResult
@@ -177,6 +180,19 @@ func (e *Evaluator) MatchWithDetails(ctx context.Context, act Action) (denied bo
 	}
 	// Return warning result (if any) after confirming no policy denied
 	return false, "", warnResult, nil
+}
+
+func sortPoliciesByPrecedence(policies []breakglassv1alpha1.DenyPolicy) {
+	sort.SliceStable(policies, func(i, j int) bool {
+		return denyPolicyPrecedence(policies[i]) < denyPolicyPrecedence(policies[j])
+	})
+}
+
+func denyPolicyPrecedence(policy breakglassv1alpha1.DenyPolicy) int32 {
+	if policy.Spec.Precedence == nil {
+		return 100
+	}
+	return *policy.Spec.Precedence
 }
 
 // evaluatePodSecurity checks if the action should be denied based on pod security rules.

--- a/pkg/policy/deny_test.go
+++ b/pkg/policy/deny_test.go
@@ -92,6 +92,79 @@ func TestEvaluatorWildcards(t *testing.T) {
 	}
 }
 
+func TestEvaluatorMatch_UsesDenyPolicyPrecedence(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	lowPriority := int32(200)
+	highPriority := int32(10)
+	defaultPriorityPolicy := &breakglassv1alpha1.DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-priority"},
+		Spec: breakglassv1alpha1.DenyPolicySpec{
+			Rules: []breakglassv1alpha1.DenyRule{{
+				Verbs:      []string{"get"},
+				APIGroups:  []string{""},
+				Resources:  []string{"secrets"},
+				Namespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"*"}},
+			}},
+		},
+	}
+	lowPriorityPolicy := &breakglassv1alpha1.DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "low-priority"},
+		Spec: breakglassv1alpha1.DenyPolicySpec{
+			Precedence: &lowPriority,
+			Rules: []breakglassv1alpha1.DenyRule{{
+				Verbs:      []string{"get"},
+				APIGroups:  []string{""},
+				Resources:  []string{"secrets"},
+				Namespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"*"}},
+			}},
+		},
+	}
+	highPriorityPolicy := &breakglassv1alpha1.DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "high-priority"},
+		Spec: breakglassv1alpha1.DenyPolicySpec{
+			Precedence: &highPriority,
+			Rules: []breakglassv1alpha1.DenyRule{{
+				Verbs:      []string{"get"},
+				APIGroups:  []string{""},
+				Resources:  []string{"secrets"},
+				Namespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"*"}},
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(lowPriorityPolicy, defaultPriorityPolicy, highPriorityPolicy).
+		Build()
+	eval := NewEvaluator(c, zap.NewNop().Sugar())
+
+	act := Action{Verb: "get", APIGroup: "", Resource: "secrets", Namespace: "default"}
+	denied, policyName, err := eval.Match(context.Background(), act)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied")
+	}
+	if policyName != "high-priority" {
+		t.Fatalf("expected high-priority policy to win, got %s", policyName)
+	}
+
+	denied, policyName, _, err = eval.MatchWithDetails(context.Background(), act)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !denied {
+		t.Fatal("expected denied")
+	}
+	if policyName != "high-priority" {
+		t.Fatalf("expected high-priority policy to win in detailed match, got %s", policyName)
+	}
+}
+
 func TestEvaluatorCalculateRiskScore(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)


### PR DESCRIPTION
## Summary
- sort DenyPolicy resources by ascending `spec.precedence` before evaluation
- keep ordering stable for policies with equal precedence
- treat unset precedence as the documented default of `100`

## Finding
The audit found that DenyPolicy documentation promises precedence-based evaluation, but the evaluator used controller-runtime list order. When multiple policies matched the same request, a lower-priority policy could win over a higher-priority one depending on cache order.

## Validation
- `go test ./pkg/policy -run 'TestEvaluatorMatch|TestEvaluatorMatch_UsesDenyPolicyPrecedence|TestEvaluatorWildcards' -count=1`
- `go test ./pkg/policy -count=1`
- `git diff --check`
