### PR TITLE
fix: reject drop for terminal sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Session drop preserves terminal audit history**: Owner `POST /api/breakglassSessions/{name}/drop` now rejects sessions that are already in a terminal state instead of rewriting Rejected, Expired, IdleExpired, Withdrawn, or ApprovalTimeout sessions to `Withdrawn`.
 - **DenyPolicy precedence is now honored during evaluation**: Multiple matching `DenyPolicy` resources are now evaluated in stable ascending `spec.precedence` order, with unset precedence defaulting to `100`, matching the documented policy semantics.
 - **Debug session duration constraints are enforced at creation**: Debug session requests now reject non-positive requested durations and reject requested durations that exceed the effective template or cluster-binding `maxDuration`, instead of accepting them for later clamping. Direct `DebugSession` CR admission now also rejects non-positive `requestedDuration` values.
 - **Frontend: persistent API error states**: Request access, session search, pending approvals, and debug-session pages now show persistent error states with retry actions when primary API loads fail instead of rendering misleading empty-state messages.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -504,7 +504,7 @@ Authorization: Bearer <token>
 
 ### Drop Session
 
-Drop your own session (either pending or active).
+Drop your own non-terminal session (pending, waiting for scheduled start, or active).
 
 ```http
 POST /api/breakglassSessions/{session-name}/drop
@@ -517,6 +517,9 @@ Authorization: Bearer <token>
 
 - **Requester**: Can drop pending requests
 - **Owner**: Can drop active sessions
+
+Terminal sessions (`Rejected`, `Withdrawn`, `Expired`, `IdleExpired`, `ApprovalTimeout`)
+return `400 Bad Request` and are not modified.
 
 **Response:** Complete updated `BreakglassSession` resource with dropped/terminated status
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -511,7 +511,10 @@ POST /api/breakglassSessions/{session-name}/drop
 Authorization: Bearer <token>
 ```
 
-**Status Code:** `200 OK`
+**Status Codes:**
+
+- `200 OK` - Session was dropped and updated
+- `400 Bad Request` - Session is already terminal and was not modified
 
 **Authorization:**
 

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -126,7 +126,7 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 		return
 	}
 
-	if isDropTerminalState(bs.Status.State) {
+	if IsSessionTerminalState(bs.Status.State) {
 		apiresponses.RespondBadRequest(c, fmt.Sprintf("session is in terminal state %s and cannot be dropped", bs.Status.State))
 		return
 	}
@@ -187,19 +187,6 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionDropped, &bs, requesterEmail, "Session dropped by owner")
 
 	c.JSON(http.StatusOK, bs)
-}
-
-func isDropTerminalState(state breakglassv1alpha1.BreakglassSessionState) bool {
-	switch state {
-	case breakglassv1alpha1.SessionStateRejected,
-		breakglassv1alpha1.SessionStateExpired,
-		breakglassv1alpha1.SessionStateIdleExpired,
-		breakglassv1alpha1.SessionStateWithdrawn,
-		breakglassv1alpha1.SessionStateTimeout:
-		return true
-	default:
-		return false
-	}
 }
 
 // handleApproverCancel allows an approver to cancel/terminate a running (approved) session.

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -126,6 +126,11 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 		return
 	}
 
+	if isDropTerminalState(bs.Status.State) {
+		apiresponses.RespondBadRequest(c, fmt.Sprintf("session is in terminal state %s and cannot be dropped", bs.Status.State))
+		return
+	}
+
 	// If approved -> mark as Expired and set RetainedUntil appropriately (owner requested termination)
 	if bs.Status.State == breakglassv1alpha1.SessionStateApproved && !bs.Status.ApprovedAt.IsZero() {
 		// Approved session dropped - transition to Expired
@@ -182,6 +187,19 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionDropped, &bs, requesterEmail, "Session dropped by owner")
 
 	c.JSON(http.StatusOK, bs)
+}
+
+func isDropTerminalState(state breakglassv1alpha1.BreakglassSessionState) bool {
+	switch state {
+	case breakglassv1alpha1.SessionStateRejected,
+		breakglassv1alpha1.SessionStateExpired,
+		breakglassv1alpha1.SessionStateIdleExpired,
+		breakglassv1alpha1.SessionStateWithdrawn,
+		breakglassv1alpha1.SessionStateTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 // handleApproverCancel allows an approver to cancel/terminate a running (approved) session.

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -295,14 +295,25 @@ func IsSessionExpired(session breakglassv1alpha1.BreakglassSession) bool {
 	return false
 }
 
+// IsSessionTerminalState returns true when a session state is terminal and must
+// not be transitioned by user actions.
+func IsSessionTerminalState(state breakglassv1alpha1.BreakglassSessionState) bool {
+	switch state {
+	case breakglassv1alpha1.SessionStateRejected,
+		breakglassv1alpha1.SessionStateWithdrawn,
+		breakglassv1alpha1.SessionStateExpired,
+		breakglassv1alpha1.SessionStateIdleExpired,
+		breakglassv1alpha1.SessionStateTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 func IsSessionValid(session breakglassv1alpha1.BreakglassSession) bool {
 	// CRITICAL: Check terminal states FIRST. State is the ultimate truth.
 	// Even if timestamps suggest validity, terminal states are never valid.
-	if session.Status.State == breakglassv1alpha1.SessionStateRejected ||
-		session.Status.State == breakglassv1alpha1.SessionStateWithdrawn ||
-		session.Status.State == breakglassv1alpha1.SessionStateExpired ||
-		session.Status.State == breakglassv1alpha1.SessionStateIdleExpired ||
-		session.Status.State == breakglassv1alpha1.SessionStateTimeout {
+	if IsSessionTerminalState(session.Status.State) {
 		return false
 	}
 
@@ -333,11 +344,7 @@ func IsSessionValid(session breakglassv1alpha1.BreakglassSession) bool {
 // State is the primary determinant; timestamps are secondary validators.
 func IsSessionActive(session breakglassv1alpha1.BreakglassSession) bool {
 	// CRITICAL: Check terminal states FIRST. State is the ultimate truth.
-	if session.Status.State == breakglassv1alpha1.SessionStateRejected ||
-		session.Status.State == breakglassv1alpha1.SessionStateWithdrawn ||
-		session.Status.State == breakglassv1alpha1.SessionStateExpired ||
-		session.Status.State == breakglassv1alpha1.SessionStateIdleExpired ||
-		session.Status.State == breakglassv1alpha1.SessionStateTimeout {
+	if IsSessionTerminalState(session.Status.State) {
 		return false
 	}
 

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1674,6 +1674,77 @@ func TestDropApprovedSessionExpires(t *testing.T) {
 	}
 }
 
+func TestDropTerminalSessionRejected(t *testing.T) {
+	terminalStates := []breakglassv1alpha1.BreakglassSessionState{
+		breakglassv1alpha1.SessionStateRejected,
+		breakglassv1alpha1.SessionStateExpired,
+		breakglassv1alpha1.SessionStateIdleExpired,
+		breakglassv1alpha1.SessionStateWithdrawn,
+		breakglassv1alpha1.SessionStateTimeout,
+	}
+
+	for _, terminalState := range terminalStates {
+		t.Run(string(terminalState), func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(Scheme)
+			for index, fn := range sessionIndexFunctions {
+				builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+			}
+
+			baseTime := time.Date(2026, time.June, 24, 16, 0, 0, 0, time.UTC)
+			originalWithdrawnAt := metav1.NewTime(baseTime.Add(-2 * time.Hour))
+			originalRejectedAt := metav1.NewTime(baseTime.Add(-90 * time.Minute))
+			originalExpiresAt := metav1.NewTime(baseTime.Add(-1 * time.Hour))
+			originalRetainedUntil := metav1.NewTime(baseTime.Add(24 * time.Hour))
+			session := &breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{Name: "terminal-drop"},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster:      "c",
+					User:         "user@e.com",
+					GrantedGroup: "g",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         terminalState,
+					RejectedAt:    originalRejectedAt,
+					WithdrawnAt:   originalWithdrawnAt,
+					ExpiresAt:     originalExpiresAt,
+					RetainedUntil: originalRetainedUntil,
+					ReasonEnded:   "original-reason",
+					Approver:      "approver@e.com",
+					Approvers:     []string{"approver@e.com"},
+				},
+			}
+
+			cli := builder.WithObjects(session).WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).Build()
+			sesmanager := SessionManager{Client: cli}
+			escmanager := testEscalationLookup{Client: cli}
+
+			logger, _ := zap.NewDevelopment()
+			ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
+				c.Set("email", "user@e.com")
+				c.Next()
+			}, "/config/config.yaml", nil, cli)
+			engine := gin.New()
+			_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+			req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/terminal-drop/drop", nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+
+			var got breakglassv1alpha1.BreakglassSession
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Name: "terminal-drop"}, &got))
+			require.Equal(t, terminalState, got.Status.State)
+			assert.True(t, got.Status.RejectedAt.Time.Equal(originalRejectedAt.Time), "rejectedAt changed")
+			assert.True(t, got.Status.WithdrawnAt.Time.Equal(originalWithdrawnAt.Time), "withdrawnAt changed")
+			assert.True(t, got.Status.ExpiresAt.Time.Equal(originalExpiresAt.Time), "expiresAt changed")
+			assert.True(t, got.Status.RetainedUntil.Time.Equal(originalRetainedUntil.Time), "retainedUntil changed")
+			assert.Equal(t, "original-reason", got.Status.ReasonEnded)
+			assert.Equal(t, "approver@e.com", got.Status.Approver)
+			assert.Equal(t, []string{"approver@e.com"}, got.Status.Approvers)
+		})
+	}
+}
+
 // TestApproverCancelRunningSession verifies that an approver can cancel a running session
 // and that a non-approver is forbidden to do so.
 // TestApproverCancelRunningSession


### PR DESCRIPTION
## Summary
- reject owner `/drop` requests when the session is already terminal
- preserve existing terminal audit timestamps, reason, and approver metadata instead of rewriting the session to `Withdrawn`
- document the `400 Bad Request` behavior for terminal sessions

## Evidence
The session lifecycle audit found that `POST /api/breakglassSessions/{name}/drop` accepted terminal sessions and rewrote every non-approved state to `Withdrawn`, corrupting Rejected, Expired, IdleExpired, Withdrawn, and ApprovalTimeout audit history.

## Validation
- `go test ./pkg/breakglass -run 'TestDropApprovedSessionExpires|TestDropTerminalSessionRejected' -count=1`\n- `go test ./pkg/breakglass -count=1`\n- `git diff --check`\n\n## Open PR duplicate check\nChecked live open PRs before creating this branch: #807 is audit circuit breaker hardening, #808 is terminal-only session retention, #661 covers frontend OIDC/offline_access storage hardening, and #803 is Dockerfile-only. None covers `/drop` terminal-state immutability.