### PR TITLE
fix(debug): enforce cluster readiness for sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **DenyPolicy precedence is now honored during evaluation**: Multiple matching `DenyPolicy` resources are now evaluated in stable ascending `spec.precedence` order, with unset precedence defaulting to `100`, matching the documented policy semantics.
-- **Debug session cluster readiness enforcement**: Debug session template and cluster-selection APIs now hide clusters whose `ClusterConfig` is explicitly `Ready=False`, and debug session creation rejects requests targeting those unready clusters.
+- **Debug session cluster readiness enforcement**: Debug session template and cluster-selection APIs now require matching `ClusterConfig` resources to report `Ready=True`, and debug session creation rejects requests targeting clusters that are not ready.
 - **Debug session duration constraints are enforced at creation**: Debug session requests now reject non-positive requested durations and reject requested durations that exceed the effective template or cluster-binding `maxDuration`, instead of accepting them for later clamping. Direct `DebugSession` CR admission now also rejects non-positive `requestedDuration` values.
 - **Frontend: persistent API error states**: Request access, session search, pending approvals, and debug-session pages now show persistent error states with retry actions when primary API loads fail instead of rendering misleading empty-state messages.
 - **Release: checksum all payload artifacts**: GitHub Releases now attach a release-wide SHA-256 checksum file covering manifests, the Helm chart package, `bgctl` archives, and the SPDX SBOM instead of checksumming only `bgctl` archives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **DenyPolicy precedence is now honored during evaluation**: Multiple matching `DenyPolicy` resources are now evaluated in stable ascending `spec.precedence` order, with unset precedence defaulting to `100`, matching the documented policy semantics.
+- **Debug session cluster readiness enforcement**: Debug session template and cluster-selection APIs now hide clusters whose `ClusterConfig` is explicitly `Ready=False`, and debug session creation rejects requests targeting those unready clusters.
 - **Debug session duration constraints are enforced at creation**: Debug session requests now reject non-positive requested durations and reject requested durations that exceed the effective template or cluster-binding `maxDuration`, instead of accepting them for later clamping. Direct `DebugSession` CR admission now also rejects non-positive `requestedDuration` values.
 - **Frontend: persistent API error states**: Request access, session search, pending approvals, and debug-session pages now show persistent error states with retry actions when primary API loads fail instead of rendering misleading empty-state messages.
 - **Release: checksum all payload artifacts**: GitHub Releases now attach a release-wide SHA-256 checksum file covering manifests, the Helm chart package, `bgctl` archives, and the SPDX SBOM instead of checksumming only `bgctl` archives.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1096,7 +1096,7 @@ Returns full `DebugSessionTemplate` CRD object.
 GET /api/debugSessions/templates/:name/clusters
 ```
 
-Returns available clusters for a template with resolved constraints from cluster bindings. Used by the two-step session creation wizard to show users cluster-specific options. Clusters with an explicit `ClusterConfig Ready=False` condition are hidden and cannot be selected for new debug sessions.
+Returns available clusters for a template with resolved constraints from cluster bindings. Used by the two-step session creation wizard to show users cluster-specific options. A matching `ClusterConfig` must have `Ready=True`; clusters with `Ready=False`, `Ready=Unknown`, or no ready condition are hidden and cannot be selected for new debug sessions.
 
 **Response (200 OK):**
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -887,7 +887,7 @@ POST /api/debugSessions
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `templateRef` | string | Yes | Name of the DebugSessionTemplate to use |
-| `cluster` | string | Yes | Name of the target cluster |
+| `cluster` | string | Yes | Name of the target cluster. When a matching `ClusterConfig` exists, it must have `Ready=True`. |
 | `bindingRef` | string | No | Binding reference as "namespace/name" (when multiple bindings match cluster). The referenced binding must be active, match the selected template, grant the selected cluster, and allow the authenticated requester. |
 | `requestedDuration` | string | No | Desired session duration (e.g., "2h") |
 | `nodeSelector` | object | No | Additional node selector labels |
@@ -900,7 +900,7 @@ POST /api/debugSessions
 
 **Error Responses:**
 - `400 Bad Request`: Invalid template, malformed or missing binding, invalid cluster, invalid duration, or invalid scheduling option
-- `403 Forbidden`: Requester, namespace, cluster, or binding is not allowed by the effective template/binding constraints
+- `403 Forbidden`: Requester, namespace, cluster readiness, or binding is not allowed by the effective template/binding constraints
 
 ### Join Debug Session
 
@@ -1096,7 +1096,7 @@ Returns full `DebugSessionTemplate` CRD object.
 GET /api/debugSessions/templates/:name/clusters
 ```
 
-Returns available clusters for a template with resolved constraints from cluster bindings. Used by the two-step session creation wizard to show users cluster-specific options.
+Returns available clusters for a template with resolved constraints from cluster bindings. Used by the two-step session creation wizard to show users cluster-specific options. Clusters with an explicit `ClusterConfig Ready=False` condition are hidden and cannot be selected for new debug sessions.
 
 **Response (200 OK):**
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1248,6 +1248,8 @@ The two-step session creation flow uses the template clusters API to show users 
 GET /api/debugSessions/templates/:name/clusters
 ```
 
+Only ready cluster configurations are offered as debug targets. If a `ClusterConfig` has an explicit `Ready=False` condition, it is hidden from this response and `POST /api/debugSessions` rejects new debug sessions that target it.
+
 Response includes per-cluster details:
 
 ```json

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1248,7 +1248,7 @@ The two-step session creation flow uses the template clusters API to show users 
 GET /api/debugSessions/templates/:name/clusters
 ```
 
-Only ready cluster configurations are offered as debug targets. If a `ClusterConfig` has an explicit `Ready=False` condition, it is hidden from this response and `POST /api/debugSessions` rejects new debug sessions that target it.
+Only ready cluster configurations are offered as debug targets. A matching `ClusterConfig` must have `Ready=True`; clusters with `Ready=False`, `Ready=Unknown`, or no ready condition are hidden from this response and `POST /api/debugSessions` rejects new debug sessions that target them.
 
 Response includes per-cluster details:
 

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -462,6 +462,15 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		cc := &clusterConfigList.Items[i]
 		clusterMap[cc.Name] = cc
 	}
+	if cc, exists := clusterMap[req.Cluster]; exists && !isDebugClusterConfigReady(cc) {
+		reqLog.Warnw("ClusterConfig is not ready for debug session creation",
+			"cluster", req.Cluster,
+			"namespace", cc.Namespace,
+		)
+		apiresponses.RespondForbidden(ctx, fmt.Sprintf("cluster '%s' is not ready for debug sessions", req.Cluster))
+		return
+	}
+	readyClusterMap, _ := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Get current user from context before authorization checks.
 	currentUser, exists := ctx.Get("username")
@@ -542,7 +551,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 			return
 		}
 
-		bindingClusters := c.resolveClustersFromBinding(resolvedBinding, clusterMap)
+		bindingClusters := c.resolveClustersFromBinding(resolvedBinding, readyClusterMap)
 		if !stringInSlice(req.Cluster, bindingClusters) {
 			reqLog.Warnw("Binding does not grant requested cluster",
 				"bindingRef", req.BindingRef,
@@ -560,7 +569,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 			AllBindings:     []breakglassv1alpha1.DebugSessionClusterBinding{*resolvedBinding},
 		}
 	} else {
-		allowedResult = c.isClusterAllowedByTemplateOrBinding(template, req.Cluster, bindingList.Items, clusterMap)
+		allowedResult = c.isClusterAllowedByTemplateOrBinding(template, req.Cluster, bindingList.Items, readyClusterMap)
 	}
 	if !allowedResult.Allowed {
 		var errDetails string

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -2260,6 +2260,33 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 		assert.Contains(t, clusterNames, "cluster-b")
 	})
 
+	t.Run("hides unready clusters", func(t *testing.T) {
+		unreadyCluster := clusterB.DeepCopy()
+		unreadyCluster.Status.Conditions = []metav1.Condition{
+			{
+				Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "ConnectionFailed",
+			},
+		}
+		router, _ := setupTestRouter(t, template, clusterA, unreadyCluster)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
+		req.Header.Set("Accept", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp TemplateClustersResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Clusters, 1)
+		assert.Equal(t, "cluster-a", resp.Clusters[0].Name)
+	})
+
 	t.Run("returns clusters with binding constraints", func(t *testing.T) {
 		// Create a binding that overrides constraints
 		binding := &breakglassv1alpha1.DebugSessionClusterBinding{

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -206,13 +206,7 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 		reqLog.Warnw("Failed to list cluster configs for pattern resolution", "error", err)
 		// Continue without pattern resolution - clusters will be empty
 	}
-	allClusterNames := make([]string, 0, len(clusterConfigList.Items))
-	clusterMap := make(map[string]*breakglassv1alpha1.ClusterConfig, len(clusterConfigList.Items))
-	for i := range clusterConfigList.Items {
-		cc := &clusterConfigList.Items[i]
-		allClusterNames = append(allClusterNames, cc.Name)
-		clusterMap[cc.Name] = cc
-	}
+	clusterMap, allClusterNames := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Fetch all bindings to determine which templates have available clusters
 	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
@@ -529,12 +523,8 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 		return
 	}
 
-	// Build cluster name -> ClusterConfig map
-	clusterMap := make(map[string]*breakglassv1alpha1.ClusterConfig, len(clusterConfigList.Items))
-	for i := range clusterConfigList.Items {
-		cc := &clusterConfigList.Items[i]
-		clusterMap[cc.Name] = cc
-	}
+	// Build cluster name -> ready ClusterConfig map. Unready clusters are not offered as debug targets.
+	clusterMap, _ := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Find all bindings that apply to this template
 	applicableBindings := c.findBindingsForTemplate(template, bindingList.Items)

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2269,6 +2269,73 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 		}
 	})
 
+	t.Run("list templates hides unready clusters from availability", func(t *testing.T) {
+		readyCluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-ready"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionTrue,
+						Reason: "Verified",
+					},
+				},
+			},
+		}
+		unreadyCluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-unready"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionFalse,
+						Reason: "ConnectionFailed",
+					},
+				},
+			},
+		}
+		templateWithPattern := breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-template"},
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeWorkload,
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Clusters: []string{"prod-*"},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(readyCluster, unreadyCluster, &templateWithPattern).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Templates []DebugSessionTemplateResponse `json:"templates"`
+			Total     int                            `json:"total"`
+		}
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, response.Total)
+		require.Len(t, response.Templates, 1)
+		assert.Equal(t, []string{"prod-ready"}, response.Templates[0].AllowedClusters)
+		assert.True(t, response.Templates[0].HasAvailableClusters)
+		assert.Equal(t, 1, response.Templates[0].AvailableClusterCount)
+	})
+
 	t.Run("list templates with no cluster configs returns empty clusters", func(t *testing.T) {
 		// Template with pattern but no ClusterConfigs exist
 		templateWithPattern := breakglassv1alpha1.DebugSessionTemplate{
@@ -2726,6 +2793,45 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.Contains(t, response.Name, "debug-")
 		assert.Equal(t, "production", response.Spec.Cluster)
 		assert.Equal(t, "alice@example.com", response.Spec.RequestedBy)
+	})
+
+	t.Run("rejects session for unready ClusterConfig", func(t *testing.T) {
+		unreadyCluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "breakglass"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionFalse,
+						Reason: "ConnectionFailed",
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&template, unreadyCluster).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"standard-debug","cluster":"production","reason":"debugging issue"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), "not ready")
 	})
 
 	t.Run("create session with invalid body", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_cluster_readiness.go
+++ b/pkg/breakglass/debug/debug_session_cluster_readiness.go
@@ -1,0 +1,31 @@
+package debug
+
+import (
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+)
+
+func isDebugClusterConfigReady(cc *breakglassv1alpha1.ClusterConfig) bool {
+	if cc == nil {
+		return false
+	}
+	if len(cc.Status.Conditions) == 0 {
+		// Preserve compatibility with generation-less fake objects in existing unit tests.
+		return cc.Generation == 0
+	}
+	return apimeta.IsStatusConditionTrue(cc.Status.Conditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
+}
+
+func readyDebugClusterConfigMap(items []breakglassv1alpha1.ClusterConfig) (map[string]*breakglassv1alpha1.ClusterConfig, []string) {
+	clusterMap := make(map[string]*breakglassv1alpha1.ClusterConfig, len(items))
+	clusterNames := make([]string, 0, len(items))
+	for i := range items {
+		cc := &items[i]
+		if !isDebugClusterConfigReady(cc) {
+			continue
+		}
+		clusterMap[cc.Name] = cc
+		clusterNames = append(clusterNames, cc.Name)
+	}
+	return clusterMap, clusterNames
+}


### PR DESCRIPTION
## Summary
- hide explicit ClusterConfig Ready=False entries from debug template availability and template cluster detail APIs
- reject new debug sessions targeting a registered unready cluster before template or binding authorization grants access
- document the readiness rule and add focused regression coverage for create, template list, and template cluster endpoints

## Evidence
Audit finding: the debug session creation flow and its two-step UI backing APIs built availability from all ClusterConfig objects. A cluster with Ready=False could still be displayed as a selectable debug target and accepted for new DebugSession creation when the template or binding matched it.

This is adjacent to PR #814, but not covered by it: #814 handles normal BreakglassSession and escalation APIs, while this PR covers DebugSession APIs.

## Validation
- go test ./pkg/breakglass/debug -run "TestDebugSessionAPIController_HandleCreateDebugSession|TestDebugSessionAPIController_HandleListTemplates|TestHandleGetTemplateClusters" -count=1
- go test ./pkg/breakglass/debug -count=1
- make test
- git -c core.fsmonitor=false diff --check