### PR TITLE
fix: emit breakglass lifecycle audit events

### DIFF
--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -120,8 +120,10 @@ func (cr CleanupRoutine) clean(ctx context.Context) {
 	// Activate scheduled sessions first (before expiry checks)
 	if cr.Manager != nil {
 		activator := NewScheduledSessionActivator(cr.Log, cr.Manager).
-			WithMailService(cr.MailService, cr.BrandingName, cr.DisableEmail).
-			WithAuditService(cr.AuditService)
+			WithMailService(cr.MailService, cr.BrandingName, cr.DisableEmail)
+		if cr.AuditService != nil {
+			activator = activator.WithAuditService(cr.AuditService)
+		}
 		activator.ActivateScheduledSessions()
 	}
 

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -120,7 +120,8 @@ func (cr CleanupRoutine) clean(ctx context.Context) {
 	// Activate scheduled sessions first (before expiry checks)
 	if cr.Manager != nil {
 		activator := NewScheduledSessionActivator(cr.Log, cr.Manager).
-			WithMailService(cr.MailService, cr.BrandingName, cr.DisableEmail)
+			WithMailService(cr.MailService, cr.BrandingName, cr.DisableEmail).
+			WithAuditService(cr.AuditService)
 		activator.ActivateScheduledSessions()
 	}
 

--- a/pkg/breakglass/cleanup_task_test.go
+++ b/pkg/breakglass/cleanup_task_test.go
@@ -869,6 +869,56 @@ func TestCleanupRoutine_clean(t *testing.T) {
 	routine.clean(context.Background())
 }
 
+func TestCleanupRoutine_cleanActivatesScheduledSessionWithoutAuditService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := breakglassv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	logger := zaptest.NewLogger(t).Sugar()
+	now := time.Now()
+	scheduledSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scheduled-session",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:            "test-cluster",
+			User:               "alice@example.com",
+			GrantedGroup:       "admin",
+			ScheduledStartTime: &metav1.Time{Time: now.Add(-time.Minute)},
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+			ApprovedAt: metav1.NewTime(now.Add(-2 * time.Minute)),
+			ExpiresAt:  metav1.NewTime(now.Add(time.Hour)),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(scheduledSession).
+		WithStatusSubresource(
+			&breakglassv1alpha1.BreakglassSession{},
+			&breakglassv1alpha1.DebugSession{},
+		).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerSched).
+		Build()
+
+	manager := NewSessionManagerWithClient(fakeClient)
+	routine := CleanupRoutine{Log: logger, Manager: manager}
+
+	require.NotPanics(t, func() {
+		routine.clean(context.Background())
+	})
+
+	var updated breakglassv1alpha1.BreakglassSession
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{
+		Name:      scheduledSession.Name,
+		Namespace: scheduledSession.Namespace,
+	}, &updated))
+	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, updated.Status.State)
+}
+
 func TestCleanupRoutine_DebugSessionRetentionPeriod(t *testing.T) {
 	// Verify the default retention period is set correctly
 	assert.Equal(t, 168*time.Hour, DebugSessionRetentionPeriod, "Default retention period should be 7 days")

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/audit"
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
@@ -35,6 +36,7 @@ type ScheduledSessionActivator struct {
 	log            *zap.SugaredLogger
 	sessionManager *SessionManager
 	mailService    MailEnqueuer
+	auditService   AuditEmitter
 	brandingName   string
 	disableEmail   bool
 }
@@ -52,6 +54,12 @@ func (ssa *ScheduledSessionActivator) WithMailService(mailService MailEnqueuer, 
 	ssa.mailService = mailService
 	ssa.brandingName = brandingName
 	ssa.disableEmail = disableEmail
+	return ssa
+}
+
+// WithAuditService sets the audit service for scheduled activation events.
+func (ssa *ScheduledSessionActivator) WithAuditService(auditService AuditEmitter) *ScheduledSessionActivator {
+	ssa.auditService = auditService
 	return ssa
 }
 
@@ -137,12 +145,47 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 		// Record metric for successful activation
 		metrics.SessionActivated.WithLabelValues(ses.Spec.Cluster).Inc()
 
+		ssa.emitSessionActivatedAuditEvent(ses)
+
 		// Send activation notification email
 		ssa.sendSessionActivatedEmail(ses)
 
 		// RBAC group will now be applied by the authorization controller
 		// (same mechanism as immediate sessions)
 	}
+}
+
+func (ssa *ScheduledSessionActivator) emitSessionActivatedAuditEvent(session breakglassv1alpha1.BreakglassSession) {
+	if ssa.auditService == nil || !ssa.auditService.IsEnabled() {
+		return
+	}
+
+	ssa.auditService.Emit(context.Background(), &audit.Event{
+		Type:      audit.EventSessionActivated,
+		Severity:  audit.SeverityInfo,
+		Timestamp: time.Now().UTC(),
+		Actor: audit.Actor{
+			User: "system",
+		},
+		Target: audit.Target{
+			Kind:      "BreakglassSession",
+			Name:      session.Name,
+			Namespace: session.Namespace,
+			Cluster:   session.Spec.Cluster,
+		},
+		RequestContext: &audit.RequestContext{
+			SessionName:    session.Name,
+			EscalationName: session.Spec.GrantedGroup,
+		},
+		Details: map[string]interface{}{
+			"message":            "Scheduled session activated",
+			"cluster":            session.Spec.Cluster,
+			"grantedGroup":       session.Spec.GrantedGroup,
+			"state":              string(session.Status.State),
+			"scheduledStartTime": session.Spec.ScheduledStartTime,
+			"actualStartTime":    session.Status.ActualStartTime,
+		},
+	})
 }
 
 // sendSessionActivatedEmail sends a notification when a scheduled session becomes active

--- a/pkg/breakglass/scheduled_session_test.go
+++ b/pkg/breakglass/scheduled_session_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/audit"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -519,10 +520,12 @@ func TestScheduledSessionActivator_FullActivationFlow(t *testing.T) {
 
 	// Create mock mail enqueuer
 	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
 
 	// Create the activator
 	activator := NewScheduledSessionActivator(log, sesManager).
-		WithMailService(mockMail, "TestBrand", false)
+		WithMailService(mockMail, "TestBrand", false).
+		WithAuditService(mockAudit)
 
 	// Run activation
 	activator.ActivateScheduledSessions()
@@ -552,6 +555,16 @@ func TestScheduledSessionActivator_FullActivationFlow(t *testing.T) {
 	}
 	if !hasCondition {
 		t.Error("session-to-activate should have ScheduledStartTimeReached condition")
+	}
+	events := mockAudit.GetEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 audit event for scheduled activation, got %d", len(events))
+	}
+	if events[0].Type != audit.EventSessionActivated {
+		t.Fatalf("expected session activated audit event, got %s", events[0].Type)
+	}
+	if events[0].Target.Name != "session-to-activate" {
+		t.Fatalf("audit event should target session-to-activate, got %s", events[0].Target.Name)
 	}
 
 	// Verify sessionNotReady was NOT activated

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -272,6 +272,9 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 
 		// Emit audit event for session approval
 		wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionApproved, &bs, approver, "Session approved")
+		if bs.Status.State == breakglassv1alpha1.SessionStateApproved {
+			wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionActivated, &bs, approver, "Session activated")
+		}
 
 		// Send approval notification email to requester
 		emailSent := false
@@ -285,8 +288,8 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		return
 	case breakglassv1alpha1.SessionConditionTypeRejected:
 		metrics.SessionRejected.WithLabelValues(bs.Spec.Cluster).Inc()
-		// Emit audit event for session rejection
-		wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionRejected, &bs, approver, "Session rejected")
+		// Emit audit event for manual denial. EventSessionRejected is reserved for automated/policy rejection.
+		wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionDenied, &bs, approver, "Session denied")
 
 		// Send rejection notification email to requester
 		if !wc.disableEmail && bs.Spec.User != "" && (wc.mailService != nil && wc.mailService.IsEnabled() || wc.mailQueue != nil) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/audit"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/naming"
 	"github.com/telekom/k8s-breakglass/pkg/ratelimit"
@@ -154,6 +155,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 	}
 
 	logger, _ := zap.NewDevelopment()
+	mockAudit := NewMockAuditEmitter(true)
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{},
 		&sesmanager, &escmanager,
 		func(c *gin.Context) {
@@ -178,7 +180,7 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 			}
 
 			c.Next()
-		}, "/config/config.yaml", nil, cli)
+		}, "/config/config.yaml", nil, cli).WithAuditService(mockAudit)
 
 	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
 		return []string{"system:authenticated", "breakglass-standard-user"}, nil
@@ -237,6 +239,9 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status OK (200) got '%d' instead", response.StatusCode)
 	}
+	events := mockAudit.GetEvents()
+	assert.Contains(t, eventTypes(events), audit.EventSessionApproved)
+	assert.Contains(t, eventTypes(events), audit.EventSessionActivated)
 
 	// check if session status is approved
 	ses = getSession()
@@ -2479,6 +2484,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	sesmanager := SessionManager{Client: cli}
 	escmanager := testEscalationLookup{Client: cli}
 	logger, _ := zap.NewDevelopment()
+	mockAudit := NewMockAuditEmitter(true)
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
 		func(c *gin.Context) {
 			if c.Request.Method == http.MethodPost {
@@ -2496,7 +2502,7 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 				c.Set("username", "Owner")
 			}
 			c.Next()
-		}, "/config/config.yaml", nil, cli)
+		}, "/config/config.yaml", nil, cli).WithAuditService(mockAudit)
 	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
 		return []string{"system:authenticated"}, nil
 	}
@@ -2541,6 +2547,9 @@ func TestOwnerCanRejectPendingSession(t *testing.T) {
 	if sessions[0].Status.State != breakglassv1alpha1.SessionStateRejected {
 		t.Fatalf("expected state rejected, got %s", sessions[0].Status.State)
 	}
+	types := eventTypes(mockAudit.GetEvents())
+	assert.Contains(t, types, audit.EventSessionDenied)
+	assert.NotContains(t, types, audit.EventSessionRejected)
 }
 
 func TestFilterBreakglassSessionsByClusterAndGroupQueryParams(t *testing.T) {

--- a/pkg/breakglass/test_helpers_test.go
+++ b/pkg/breakglass/test_helpers_test.go
@@ -66,6 +66,14 @@ func (m *MockAuditEmitter) Clear() {
 	m.events = make([]*audit.Event, 0)
 }
 
+func eventTypes(events []*audit.Event) []audit.EventType {
+	types := make([]audit.EventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
 // testEscalationLookup implements EscalationLookup for root tests by wrapping a
 // controller-runtime client. It performs the same List+filter that EscalationManager
 // does, so tests using pre-seeded fake clients work identically.


### PR DESCRIPTION
## Summary
- emit `session.activated` when immediate approvals become active
- emit `session.activated` when scheduled sessions transition to active
- classify manual session rejection as `session.denied` so `session.rejected` remains available for automated/policy rejection

## Audit Evidence
The audit contract documents separate session lifecycle events for approval, denial, rejection, and activation. Current runtime emitted `session.approved` for approvals, emitted `session.rejected` for manual denial, and did not emit `session.activated` when sessions became usable.

## Tests
- `go test ./pkg/breakglass -run 'Test(RequestApproveRejectGetSession|OwnerCanRejectPendingSession|ScheduledSessionActivator_FullActivationFlow)$'`\n- `make test`\n