### PR TITLE
fix: enforce debug scheduling option access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **DebugSession scheduling option ACL enforcement**: `DebugSessionTemplate` and `DebugSessionClusterBinding` scheduling option `allowedUsers` and `allowedGroups` are now enforced at session creation for selected options and required defaults. Unauthorized requests receive `403 Forbidden` instead of creating a debug session with restricted scheduling constraints.
 - **OIDC group path matching hardening**: JWT group claims now preserve hierarchical group paths such as `/tenant/admin` instead of collapsing them to the leaf name `admin`, keeping `BreakglassEscalation` group matching exact and preventing same-leaf group collisions across OIDC hierarchies.
 - **Debug session authorization hardening**: Debug session creation now enforces `DebugSessionTemplate`/`DebugSessionClusterBinding` requester allowlists, validates explicit `bindingRef` values against the selected template and cluster, requires invited users plus enabled terminal sharing for join requests, prevents join callers from self-selecting the privileged `participant` role, and ignores stale `Active` debug sessions after `status.expiresAt` for renewals and pod-operation authorization.
 - **Frontend dependency audit fixes**: Updated vulnerable Babel and brace-expansion transitive dependencies in the frontend lockfile, deduplicated Babel parser/types resolutions, and raised the frontend Node.js minimum plus CI runtime baseline to 24.11.0.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -899,14 +899,14 @@ POST /api/debugSessions
 | `nodeSelector` | object | No | Additional node selector labels |
 | `reason` | string | No | Explanation for the debug session request |
 | `targetNamespace` | string | No | Target namespace for debug pods (if allowed by template's `namespaceConstraints`) |
-| `selectedSchedulingOption` | string | No | Name of a scheduling option from template's `schedulingOptions` |
+| `selectedSchedulingOption` | string | No | Name of a scheduling option from template's `schedulingOptions`; restricted options must allow the requester's username, email, or group |
 | `invitedParticipants` | array | No | List of users to invite to the session |
 
 **Response:** Created `DebugSession` object (201 Created).
 
 **Error Responses:**
 - `400 Bad Request`: Invalid template, malformed or missing binding, invalid cluster, invalid duration, or invalid scheduling option
-- `403 Forbidden`: Requester, namespace, cluster readiness, or binding is not allowed by the effective template/binding constraints
+- `403 Forbidden`: Requester, namespace, scheduling option, cluster readiness, or binding is not allowed by the effective template/binding constraints
 
 ### Join Debug Session
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -828,6 +828,8 @@ schedulingOptions:
       schedulingConstraints: {}  # No additional constraints
 ```
 
+`allowedGroups` and `allowedUsers` are enforced when a `DebugSession` request is created. The API checks the selected option, including a required option that is selected by default, against the authenticated user's username, email, and groups. Requests for restricted options return `403 Forbidden` when the requester does not match. Leave both fields empty only for options that are safe for every requester who can use the template.
+
 **Merge Logic**: When a user selects an option, the constraints are merged in this order:
 1. Base constraints from `DebugPodTemplate`
 2. Overrides from `DebugSessionTemplate`

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -18,6 +18,7 @@ package debug
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -665,13 +666,22 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	}
 
 	// Validate and resolve scheduling option
-	resolvedScheduling, selectedOption, err := c.resolveSchedulingConstraints(template, req.SelectedSchedulingOption, resolvedBinding)
+	resolvedScheduling, selectedOption, err := c.resolveSchedulingConstraints(template, req.SelectedSchedulingOption, resolvedBinding, schedulingOptionRequester{
+		Username: currentUserStr,
+		Email:    userEmail,
+		Groups:   userGroups,
+	})
 	if err != nil {
 		reqLog.Warnw("Scheduling option validation failed",
 			"templateRef", req.TemplateRef,
 			"selectedSchedulingOption", req.SelectedSchedulingOption,
 			"error", err,
 		)
+		var accessErr *schedulingOptionAccessError
+		if errors.As(err, &accessErr) {
+			apiresponses.RespondForbidden(ctx, err.Error())
+			return
+		}
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}

--- a/pkg/breakglass/debug/debug_session_api_constraints.go
+++ b/pkg/breakglass/debug/debug_session_api_constraints.go
@@ -7,6 +7,20 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
+type schedulingOptionRequester struct {
+	Username string
+	Email    string
+	Groups   []string
+}
+
+type schedulingOptionAccessError struct {
+	optionName string
+}
+
+func (e *schedulingOptionAccessError) Error() string {
+	return fmt.Sprintf("user is not allowed to select scheduling option '%s'", e.optionName)
+}
+
 func (c *DebugSessionAPIController) resolveTargetNamespace(template *breakglassv1alpha1.DebugSessionTemplate, requestedNamespace string, binding *breakglassv1alpha1.DebugSessionClusterBinding) (string, error) {
 	// Start with template's namespace constraints
 	nc := template.Spec.NamespaceConstraints
@@ -214,6 +228,7 @@ func (c *DebugSessionAPIController) resolveSchedulingConstraints(
 	template *breakglassv1alpha1.DebugSessionTemplate,
 	selectedOption string,
 	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+	requester schedulingOptionRequester,
 ) (*breakglassv1alpha1.SchedulingConstraints, string, error) {
 	// Start with the template's base scheduling constraints and merge in binding-level
 	// base constraints (which are documented as mandatory additions on top of the template).
@@ -278,10 +293,39 @@ func (c *DebugSessionAPIController) resolveSchedulingConstraints(
 		return nil, "", fmt.Errorf("scheduling option '%s' not found in template or binding", selectedOption)
 	}
 
+	if !isSchedulingOptionAllowedForRequester(selectedOpt, requester) {
+		return nil, "", &schedulingOptionAccessError{optionName: selectedOption}
+	}
+
 	// Merge base constraints with option's constraints
 	merged := mergeSchedulingConstraints(baseConstraints, selectedOpt.SchedulingConstraints)
 
 	return merged, selectedOption, nil
+}
+
+func isSchedulingOptionAllowedForRequester(opt *breakglassv1alpha1.SchedulingOption, requester schedulingOptionRequester) bool {
+	if opt == nil || (len(opt.AllowedUsers) == 0 && len(opt.AllowedGroups) == 0) {
+		return true
+	}
+
+	for _, allowedUser := range opt.AllowedUsers {
+		if matchPattern(allowedUser, requester.Username) {
+			return true
+		}
+		if requester.Email != "" && matchPattern(allowedUser, requester.Email) {
+			return true
+		}
+	}
+
+	for _, allowedGroup := range opt.AllowedGroups {
+		for _, userGroup := range requester.Groups {
+			if matchPattern(allowedGroup, userGroup) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // mergeSchedulingConstraints merges base constraints with option constraints.

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1833,6 +1833,11 @@ func TestResolveTargetNamespace(t *testing.T) {
 func TestResolveSchedulingConstraints(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+	requester := schedulingOptionRequester{
+		Username: "alice@example.com",
+		Email:    "alice@example.com",
+		Groups:   []string{"tenant-admins"},
+	}
 
 	t.Run("no scheduling options returns base constraints", func(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
@@ -1842,7 +1847,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", nil)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", nil, requester)
 		require.NoError(t, err)
 		assert.Empty(t, selectedOpt)
 		require.NotNil(t, resolved)
@@ -1860,7 +1865,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				// No SchedulingOptions defined
 			},
 		}
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "any-worker", nil)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "any-worker", nil, requester)
 		require.NoError(t, err, "should not error when stale option is sent")
 		assert.Empty(t, selectedOpt, "selected option should be empty")
 		require.NotNil(t, resolved)
@@ -1877,7 +1882,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := ctrl.resolveSchedulingConstraints(template, "nonexistent", nil)
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "nonexistent", nil, requester)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in template")
 	})
@@ -1893,7 +1898,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := ctrl.resolveSchedulingConstraints(template, "", nil)
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "", nil, requester)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "required but none selected")
 	})
@@ -1910,9 +1915,106 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		_, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", nil)
+		_, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", nil, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "standard", selectedOpt)
+	})
+
+	t.Run("allows restricted scheduling option by username email or group", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "by-username", AllowedUsers: []string{"alice@example.com"}},
+						{Name: "by-email", AllowedUsers: []string{"alice.alias@example.com"}},
+						{Name: "by-group", AllowedGroups: []string{"tenant-*"}},
+					},
+				},
+			},
+		}
+		emailRequester := schedulingOptionRequester{
+			Username: "alice",
+			Email:    "alice.alias@example.com",
+			Groups:   []string{"dev-team"},
+		}
+
+		_, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "by-username", nil, requester)
+		require.NoError(t, err)
+		assert.Equal(t, "by-username", selectedOpt)
+
+		_, selectedOpt, err = ctrl.resolveSchedulingConstraints(template, "by-email", nil, emailRequester)
+		require.NoError(t, err)
+		assert.Equal(t, "by-email", selectedOpt)
+
+		_, selectedOpt, err = ctrl.resolveSchedulingConstraints(template, "by-group", nil, requester)
+		require.NoError(t, err)
+		assert.Equal(t, "by-group", selectedOpt)
+	})
+
+	t.Run("denies restricted scheduling option for unauthorized requester", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "platform-only", AllowedGroups: []string{"platform-admins"}},
+					},
+				},
+			},
+		}
+
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "platform-only", nil, requester)
+		require.Error(t, err)
+		var accessErr *schedulingOptionAccessError
+		require.ErrorAs(t, err, &accessErr)
+		assert.Contains(t, err.Error(), "platform-only")
+	})
+
+	t.Run("denies restricted default scheduling option for unauthorized requester", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Required: true,
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "restricted-default", Default: true, AllowedGroups: []string{"platform-admins"}},
+					},
+				},
+			},
+		}
+
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "", nil, requester)
+		require.Error(t, err)
+		var accessErr *schedulingOptionAccessError
+		require.ErrorAs(t, err, &accessErr)
+		assert.Contains(t, err.Error(), "restricted-default")
+	})
+
+	t.Run("enforces binding scheduling option restrictions", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "binding-platform", AllowedGroups: []string{"platform-admins"}},
+					},
+				},
+			},
+		}
+
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "binding-platform", binding, requester)
+		require.Error(t, err)
+		var accessErr *schedulingOptionAccessError
+		require.ErrorAs(t, err, &accessErr)
+
+		allowedRequester := schedulingOptionRequester{
+			Username: "bob@example.com",
+			Email:    "bob@example.com",
+			Groups:   []string{"platform-admins"},
+		}
+		_, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "binding-platform", binding, allowedRequester)
+		require.NoError(t, err)
+		assert.Equal(t, "binding-platform", selectedOpt)
 	})
 
 	t.Run("merges base and option constraints", func(t *testing.T) {
@@ -1936,7 +2038,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "sriov", nil)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "sriov", nil, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "sriov", selectedOpt)
 		require.NotNil(t, resolved)
@@ -1980,7 +2082,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 			},
 		}
 
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "binding-opt", binding)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "binding-opt", binding, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "binding-opt", selectedOpt)
 		require.NotNil(t, resolved)
@@ -2015,7 +2117,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 			},
 		}
 
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "dedicated-debug", binding)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "dedicated-debug", binding, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "dedicated-debug", selectedOpt)
 		require.NotNil(t, resolved)
@@ -2035,7 +2137,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 			},
 		}
 
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "template-opt", nil)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "template-opt", nil, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "template-opt", selectedOpt)
 		assert.Nil(t, resolved)
@@ -2060,7 +2162,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 		}
 
 		// No scheduling options - just base constraints
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", binding)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "", binding, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "", selectedOpt)
 		require.NotNil(t, resolved)
@@ -2099,7 +2201,7 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 			},
 		}
 
-		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "gpu", binding)
+		resolved, selectedOpt, err := ctrl.resolveSchedulingConstraints(template, "gpu", binding, requester)
 		require.NoError(t, err)
 		assert.Equal(t, "gpu", selectedOpt)
 		require.NotNil(t, resolved)

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -3372,6 +3372,61 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.True(t, foundSchedulingWarning, "expected warning about scheduling option defaulting to 'default-option'")
 	})
 
+	t.Run("create session rejects restricted scheduling option for unauthorized requester", func(t *testing.T) {
+		templateWithRestrictedScheduling := breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "template-with-restricted-scheduling",
+			},
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeWorkload,
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace: "test-ns",
+				},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Clusters: []string{"production"},
+				},
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "tenant-safe", DisplayName: "Tenant Safe"},
+						{
+							Name:          "platform-node",
+							DisplayName:   "Platform Node",
+							AllowedGroups: []string{"platform-admins"},
+						},
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&templateWithRestrictedScheduling).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Set("email", "alice@example.com")
+			c.Set("groups", []string{"tenant-admins"})
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"template-with-restricted-scheduling","cluster":"production","reason":"testing","targetNamespace":"test-ns","selectedSchedulingOption":"platform-node"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), "not allowed to select scheduling option")
+		assert.Contains(t, w.Body.String(), "platform-node")
+	})
+
 	t.Run("create session returns warning when scheduling option is ignored", func(t *testing.T) {
 		// Template without scheduling options
 		templateNoScheduling := breakglassv1alpha1.DebugSessionTemplate{


### PR DESCRIPTION
## Summary
- enforce `DebugSessionTemplate` and `DebugSessionClusterBinding` scheduling option `allowedUsers` / `allowedGroups` at DebugSession creation
- return `403 Forbidden` for unauthorized selected options, including required default options
- add resolver and API handler regressions plus docs and changelog updates

## Audit evidence
`SchedulingOption.allowedUsers` and `allowedGroups` were rendered into templates and exposed by the API, but `resolveSchedulingConstraints` previously merged the selected option without checking whether the requester was allowed to use it. That allowed a user who could create a DebugSession from a template to select platform-only scheduling constraints.

## Validation
- `go test ./pkg/breakglass/debug -run 'TestResolveSchedulingConstraints|TestDebugSessionAPIController_HandleCreateDebugSession/create_session_(returns_warnings_when_scheduling_option_is_defaulted|rejects_restricted_scheduling_option_for_unauthorized_requester|returns_warning_when_scheduling_option_is_ignored)'`\n- `go test ./pkg/breakglass/debug`\n- `git diff --check`\n- `make test`\n\n## Notes\nThis does not add new privileged debug capability. It closes an existing authorization gap for restricted scheduling choices.