### PR TITLE
ci: skip Codecov without token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: make test-controller
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: always()
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cover-controller.out
@@ -81,7 +81,7 @@ jobs:
         run: make test-cli-e2e
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: always()
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cover-cli.out
@@ -350,7 +350,7 @@ jobs:
           retention-days: 7
       - name: Upload frontend coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: always()
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
   unit-tests-controller:
     name: Controller Unit Tests
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Go
@@ -58,9 +60,9 @@ jobs:
         run: make test-controller
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: cover-controller.out
           flags: controller
           fail_ci_if_error: false
@@ -68,6 +70,8 @@ jobs:
   unit-tests-cli:
     name: CLI Unit Tests
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Go
@@ -81,9 +85,9 @@ jobs:
         run: make test-cli-e2e
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: cover-cli.out
           flags: cli
           fail_ci_if_error: false
@@ -310,6 +314,8 @@ jobs:
   frontend-tests:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     defaults:
       run:
         working-directory: frontend
@@ -350,9 +356,9 @@ jobs:
           retention-days: 7
       - name: Upload frontend coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: ${{ always() && env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           directory: frontend
           files: coverage/coverage-final.json
           flags: frontend

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Run GitHub Action for ORT
         uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
-          # Avoid the moving latest tag breaking all PRs when an upstream ORT
-          # image release is bad.
-          image: 'ghcr.io/oss-review-toolkit/ort@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7'
           ort-config-repository: 'https://github.com/telekom/ort-config.git'
+          image: 'ghcr.io/oss-review-toolkit/ort:89.2.0@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7'
           log-level: info

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Run GitHub Action for ORT
         uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
+          # Avoid the moving latest tag breaking all PRs when an upstream ORT
+          # image release is bad.
+          image: 'ghcr.io/oss-review-toolkit/ort:89.2.0'
           ort-config-repository: 'https://github.com/telekom/ort-config.git'
-          image: 'ghcr.io/oss-review-toolkit/ort:89.2.0@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7'
           log-level: info

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           # Avoid the moving latest tag breaking all PRs when an upstream ORT
           # image release is bad.
-          image: 'ghcr.io/oss-review-toolkit/ort:89.2.0'
+          image: 'ghcr.io/oss-review-toolkit/ort@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7'
           ort-config-repository: 'https://github.com/telekom/ort-config.git'
           log-level: info


### PR DESCRIPTION
## Summary
- skip Codecov uploads whenever `CODECOV_TOKEN` is unavailable
- keep controller, CLI, and frontend coverage uploads from failing in secretless contexts

## Evidence
- Target verified before PR creation: `gh repo view telekom/k8s-breakglass` => `nameWithOwner=telekom/k8s-breakglass`, `isFork=false`, `defaultBranch=main`.
- PR #803 Controller Unit Tests completed tests but failed in Codecov upload: `Token required because branch is protected`.
- The failure source was Dependabot/secretless execution, so `secrets.CODECOV_TOKEN` was unavailable.
- GitHub Actions expressions cannot read `secrets.*` directly in a step `if`; the workflow now maps the secret to a job environment variable and gates the upload on `env.CODECOV_TOKEN != ''`.

## Duplicate check
- The ORT image pin originally carried by this PR has been removed after #830 landed on `main`; #830 is now the dedicated ORT fix.
- Current diff against `main` only changes `.github/workflows/ci.yml` Codecov upload gating.
- Open/recent searches for `Codecov Token required branch protected Dependabot CODECOV_TOKEN` had no matching upstream PR.

## Validation
- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/ort.yml].each { |f| YAML.load_file(f); puts "#{f} ok" }'`
- `git -c core.fsmonitor=false diff --check`
