### PR TITLE
fix: pin ORT scan image

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -24,4 +24,5 @@ jobs:
         uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           ort-config-repository: 'https://github.com/telekom/ort-config.git'
+          image: 'ghcr.io/oss-review-toolkit/ort:89.2.0@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7'
           log-level: info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI: pin ORT scan image**: The ORT workflow now uses a digest-pinned `ghcr.io/oss-review-toolkit/ort:89.2.0` image instead of the moving `latest` tag, avoiding transient ORT CLI startup failures from mutable container image updates.
 - **Session drop preserves terminal audit history**: Owner `POST /api/breakglassSessions/{name}/drop` now rejects sessions that are already in a terminal state instead of rewriting Rejected, Expired, IdleExpired, Withdrawn, or ApprovalTimeout sessions to `Withdrawn`.
 - **Session retention is terminal-state only**: `RetainedUntil` is no longer set while sessions are pending, active, or waiting for a scheduled start. Cleanup and webhook session filtering now ignore stale retained-until timestamps on live sessions, and automatic time/idle expiry stamps retention only after the session enters a terminal state.
 - **Debug session renewal max duration enforcement**: Renewing a debug session now rejects extensions that would move `status.expiresAt` past `status.startsAt + maxDuration`, closing a gap where near-limit sessions could be extended beyond the configured maximum total duration.


### PR DESCRIPTION
## Summary
- pins the ORT CI action runtime image to `ghcr.io/oss-review-toolkit/ort:89.2.0@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7`
- stops the workflow from consuming the mutable `latest` image tag from the upstream action default
- records the CI stability fix in the changelog

## Root cause
The upstream `oss-review-toolkit/ort-ci-github-action@v1.2.0` defaults to `ghcr.io/oss-review-toolkit/ort:latest` and runs ORT with this mount pattern:

```bash
docker run --mount type=bind,source=$HOME,target=/home/ort -u $(id -u):$(id -g) ... ghcr.io/oss-review-toolkit/ort:<tag> ... analyze ...
```

The current `latest` image resolves to ORT `89.3.0`. That image starts for shallow commands, but fails with the action's bind mount / UID invocation before analyzer output is produced:

- `java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics`
- `/home/runner/.ort/ort-results/analyzer-result.json not found`

`89.2.0` was verified with the same bind mount / UID / ORT argument pattern and reaches the analyzer help path successfully. The workflow pins by digest so the runtime cannot drift under the tag.

## Validation
- `docker run --rm ghcr.io/oss-review-toolkit/ort:89.3.0 --version` -> `89.3.0`
- `docker run --rm --mount type=bind,source=/private/tmp/ort-home-repro,target=/home/ort -u $(id -u):$(id -g) -e JDK_JAVA_OPTIONS='-Xmx5120m' -e ORT_DATA_DIR='/home/ort/.ort' ghcr.io/oss-review-toolkit/ort:89.3.0 --info -P ort.forceOverwrite=true --stacktrace analyze --help` -> reproduces `NoClassDefFoundError`
- `docker run --rm ghcr.io/oss-review-toolkit/ort:89.2.0 --version` -> `89.2.0`
- `docker run --rm --mount type=bind,source=/private/tmp/ort-home-repro,target=/home/ort -u $(id -u):$(id -g) -e JDK_JAVA_OPTIONS='-Xmx5120m' -e ORT_DATA_DIR='/home/ort/.ort' ghcr.io/oss-review-toolkit/ort:89.2.0@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7 --info -P ort.forceOverwrite=true --stacktrace analyze --help` -> succeeds
- `docker image inspect ghcr.io/oss-review-toolkit/ort:89.2.0 --format '{{index .RepoDigests 0}}'` -> `ghcr.io/oss-review-toolkit/ort@sha256:e5ac80500e8f8e996f7e2163a1f7dcce133141bef581d24dc1f610254705d6e7`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ort.yml"); puts "ort.yml OK"'`
- `git diff --check`
