### PR TITLE
fix: reject invalid debug session JSON bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **DebugSession API request body validation**: Debug session create, approve, and reject endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional approval bodies instead of silently ignoring client typos or invalid payloads.
 - **DebugSession scheduling option ACL enforcement**: `DebugSessionTemplate` and `DebugSessionClusterBinding` scheduling option `allowedUsers` and `allowedGroups` are now enforced at session creation for selected options and required defaults. Unauthorized requests receive `403 Forbidden` instead of creating a debug session with restricted scheduling constraints.
 - **OIDC group path matching hardening**: JWT group claims now preserve hierarchical group paths such as `/tenant/admin` instead of collapsing them to the leaf name `admin`, keeping `BreakglassEscalation` group matching exact and preventing same-leaf group collisions across OIDC hierarchies.
 - **DenyPolicy webhook evaluation now fails closed**: Authorization requests are denied when DenyPolicy listing/evaluation fails or when namespace labels required for selector-based DenyPolicy rules cannot be loaded, preventing policy bypass during cache or spoke-cluster lookup errors.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -912,10 +912,12 @@ POST /api/debugSessions
 | `selectedSchedulingOption` | string | No | Name of a scheduling option from template's `schedulingOptions`; restricted options must allow the requester's username, email, or group |
 | `invitedParticipants` | array | No | List of users to invite to the session |
 
+JSON bodies for debug-session create requests must contain only known field names and exactly one JSON object. Unknown fields, malformed JSON, and trailing JSON values are rejected with `400 Bad Request`.
+
 **Response:** Created `DebugSession` object (201 Created).
 
 **Error Responses:**
-- `400 Bad Request`: Invalid template, malformed or missing binding, invalid cluster, invalid duration, or invalid scheduling option
+- `400 Bad Request`: Unknown JSON fields, malformed request body, invalid template, malformed or missing binding, invalid cluster, invalid duration, or invalid scheduling option
 - `403 Forbidden`: Requester, namespace, scheduling option, cluster readiness, or binding is not allowed by the effective template/binding constraints
 
 ### Join Debug Session
@@ -984,6 +986,8 @@ POST /api/debugSessions/:name/approve
 }
 ```
 
+When present, the optional approval body must contain only the known `reason` field and exactly one JSON object.
+
 Approves a session in `PendingApproval` state.
 
 **Response:** Updated `DebugSession` object with `state: Approved`.
@@ -1003,6 +1007,8 @@ POST /api/debugSessions/:name/reject
 ```
 
 Rejects a session in `PendingApproval` state.
+
+When present, the rejection body must contain only the known `reason` field and exactly one JSON object.
 
 **Response:** Updated `DebugSession` object with `state: Rejected`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -998,7 +998,7 @@ Approves a session in `PendingApproval` state.
 POST /api/debugSessions/:name/reject
 ```
 
-**Request Body:**
+**Request Body (optional):**
 
 ```json
 {

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -18,7 +18,6 @@ package debug
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass/jsonutil"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/naming"
@@ -206,26 +206,7 @@ type ApprovalRequest struct {
 }
 
 func decodeDebugJSONStrict(r io.Reader, dest interface{}) error {
-	if r == nil {
-		return io.EOF
-	}
-
-	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
-
-	if err := dec.Decode(dest); err != nil {
-		return err
-	}
-
-	var extra struct{}
-	if err := dec.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("unexpected extra JSON input")
-		}
-		return err
-	}
-
-	return nil
+	return jsonutil.DecodeStrict(r, dest)
 }
 
 func validateCreateDebugSessionRequest(req CreateDebugSessionRequest) error {

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -18,8 +18,10 @@ package debug
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -201,6 +203,39 @@ type RenewDebugSessionRequest struct {
 // ApprovalRequest represents the request body for approve/reject actions
 type ApprovalRequest struct {
 	Reason string `json:"reason,omitempty"`
+}
+
+func decodeDebugJSONStrict(r io.Reader, dest interface{}) error {
+	if r == nil {
+		return io.EOF
+	}
+
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(dest); err != nil {
+		return err
+	}
+
+	var extra struct{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected extra JSON input")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func validateCreateDebugSessionRequest(req CreateDebugSessionRequest) error {
+	if req.TemplateRef == "" {
+		return fmt.Errorf("templateRef is required")
+	}
+	if req.Cluster == "" {
+		return fmt.Errorf("cluster is required")
+	}
+	return nil
 }
 
 // InjectEphemeralContainerRequest represents the request to inject an ephemeral container
@@ -406,8 +441,12 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	reqLog := system.GetReqLogger(ctx, c.log)
 
 	var req CreateDebugSessionRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
 		reqLog.Warnw("Failed to parse CreateDebugSession request", "error", err)
+		apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+		return
+	}
+	if err := validateCreateDebugSessionRequest(req); err != nil {
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1168,6 +1168,61 @@ func TestHandleApproveDebugSession_Success(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "approver@example.com")
 }
 
+func TestHandleApproveDebugSession_RejectsUnknownJSONFields(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-session",
+			Namespace: "default",
+			Labels: map[string]string{
+				DebugSessionLabelKey: "pending-session",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "requester@example.com",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		},
+	}
+
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", "approver@example.com")
+		c.Set("groups", []string{})
+		c.Next()
+	})
+	api := router.Group("/api")
+	rg := api.Group("/debugSessions")
+	_ = ctrl.Register(rg)
+
+	body := bytes.NewBuffer([]byte(`{"reason":"valid","ignored":true}`))
+	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/approve?namespace=default", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unknown field")
+}
+
 // ============================================================================
 // Tests for handleRejectDebugSession
 // ============================================================================
@@ -1381,6 +1436,61 @@ func TestHandleRejectDebugSession_Success(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "pending-session")
 	assert.Contains(t, rr.Body.String(), "Terminated")
 	assert.Contains(t, rr.Body.String(), "Rejected by approver@example.com")
+}
+
+func TestHandleRejectDebugSession_RejectsTrailingJSON(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-session",
+			Namespace: "default",
+			Labels: map[string]string{
+				DebugSessionLabelKey: "pending-session",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "requester@example.com",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		},
+	}
+
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", "approver@example.com")
+		c.Set("groups", []string{})
+		c.Next()
+	})
+	api := router.Group("/api")
+	rg := api.Group("/debugSessions")
+	_ = ctrl.Register(rg)
+
+	body := bytes.NewBuffer([]byte(`{"reason":"valid"} {"reason":"extra"}`))
+	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/reject?namespace=default", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid request body")
 }
 
 // ============================================================================

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1210,10 +1210,11 @@ func TestHandleApproveDebugSession_RejectsUnknownJSONFields(t *testing.T) {
 	})
 	api := router.Group("/api")
 	rg := api.Group("/debugSessions")
-	_ = ctrl.Register(rg)
+	require.NoError(t, ctrl.Register(rg))
 
 	body := bytes.NewBuffer([]byte(`{"reason":"valid","ignored":true}`))
-	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/approve?namespace=default", body)
+	req, err := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/approve?namespace=default", body)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -1480,10 +1481,11 @@ func TestHandleRejectDebugSession_RejectsTrailingJSON(t *testing.T) {
 	})
 	api := router.Group("/api")
 	rg := api.Group("/debugSessions")
-	_ = ctrl.Register(rg)
+	require.NoError(t, ctrl.Register(rg))
 
 	body := bytes.NewBuffer([]byte(`{"reason":"valid"} {"reason":"extra"}`))
-	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/reject?namespace=default", body)
+	req, err := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/reject?namespace=default", body)
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -392,14 +392,20 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	var req ApprovalRequest
-	_ = ctx.ShouldBindJSON(&req) // Optional body
-
 	// Get current user
 	currentUser, exists := ctx.Get("username")
 	if !exists || currentUser == nil {
 		apiresponses.RespondUnauthorized(ctx)
 		return
+	}
+
+	var req ApprovalRequest
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		if !errors.Is(err, io.EOF) {
+			reqLog.Warnw("Failed to parse ApproveDebugSession request", "error", err)
+			apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+			return
+		}
 	}
 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
@@ -468,14 +474,20 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	var req ApprovalRequest
-	_ = ctx.ShouldBindJSON(&req) // Optional body with reason
-
 	// Get current user
 	currentUser, exists := ctx.Get("username")
 	if !exists || currentUser == nil {
 		apiresponses.RespondUnauthorized(ctx)
 		return
+	}
+
+	var req ApprovalRequest
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		if !errors.Is(err, io.EOF) {
+			reqLog.Warnw("Failed to parse RejectDebugSession request", "error", err)
+			apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+			return
+		}
 	}
 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -14,6 +14,7 @@ import (
 	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass/jsonutil"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -401,7 +402,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 
 	var req ApprovalRequest
 	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
-		if !errors.Is(err, io.EOF) {
+		if !errors.Is(err, jsonutil.ErrEmptyBody) {
 			reqLog.Warnw("Failed to parse ApproveDebugSession request", "error", err)
 			apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
 			return
@@ -483,7 +484,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	var req ApprovalRequest
 	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
-		if !errors.Is(err, io.EOF) {
+		if !errors.Is(err, jsonutil.ErrEmptyBody) {
 			reqLog.Warnw("Failed to parse RejectDebugSession request", "error", err)
 			apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
 			return

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2888,6 +2888,58 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "unknown field")
 	})
 
+	t.Run("create session rejects empty request body clearly", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(""))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "empty JSON body")
+		assert.NotContains(t, w.Body.String(), "EOF")
+	})
+
+	t.Run("create session rejects trailing JSON values", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"standard-debug","cluster":"production"} {"templateRef":"standard-debug","cluster":"production"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "unexpected extra JSON input")
+	})
+
 	t.Run("create session with non-existent template", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2861,6 +2861,33 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.Equal(t, 400, w.Code)
 	})
 
+	t.Run("create session rejects unknown JSON fields", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&template).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"standard-debug","cluster":"production","unknownField":"ignored"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "unknown field")
+	})
+
 	t.Run("create session with non-existent template", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/breakglass/jsonutil/strict.go
+++ b/pkg/breakglass/jsonutil/strict.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// DecodeStrict decodes exactly one JSON value and rejects unknown fields and
+// trailing non-whitespace content.
+func DecodeStrict(r io.Reader, dest interface{}) error {
+	if r == nil {
+		return io.EOF
+	}
+
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(dest); err != nil {
+		return err
+	}
+
+	var extra struct{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected extra JSON input")
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/breakglass/jsonutil/strict.go
+++ b/pkg/breakglass/jsonutil/strict.go
@@ -6,25 +6,32 @@ package jsonutil
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
+
+// ErrEmptyBody indicates that a required JSON request body was empty.
+var ErrEmptyBody = errors.New("empty JSON body")
 
 // DecodeStrict decodes exactly one JSON value and rejects unknown fields and
 // trailing non-whitespace content.
 func DecodeStrict(r io.Reader, dest interface{}) error {
 	if r == nil {
-		return io.EOF
+		return ErrEmptyBody
 	}
 
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 
 	if err := dec.Decode(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return ErrEmptyBody
+		}
 		return err
 	}
 
-	var extra struct{}
+	var extra json.RawMessage
 	if err := dec.Decode(&extra); err != io.EOF {
 		if err == nil {
 			return fmt.Errorf("unexpected extra JSON input")

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -2,7 +2,6 @@ package breakglass
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +16,7 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass/jsonutil"
 	"github.com/telekom/k8s-breakglass/pkg/config"
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/ratelimit"
@@ -173,23 +173,7 @@ func (wc *BreakglassSessionController) Register(rg *gin.RouterGroup) error {
 // It also ensures that the body contains exactly one JSON value and no trailing
 // non-whitespace content.
 func decodeJSONStrict(r io.Reader, dest interface{}) error {
-	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
-
-	if err := dec.Decode(dest); err != nil {
-		return err
-	}
-
-	// Ensure there is no extra non-whitespace data after the first JSON value.
-	var extra struct{}
-	if err := dec.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("unexpected extra JSON input")
-		}
-		return err
-	}
-
-	return nil
+	return jsonutil.DecodeStrict(r, dest)
 }
 
 // validateSessionRequest validates the session request input

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/apiresponses"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass/jsonutil"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	"github.com/telekom/k8s-breakglass/pkg/utils"
@@ -47,7 +47,7 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	// Ignore errors; payload is optional. Guard against nil Request.Body which can occur in tests/clients.
 	if c.Request != nil && c.Request.Body != nil {
 		if err := decodeJSONStrict(c.Request.Body, &approverPayload); err != nil {
-			if !errors.Is(err, io.EOF) {
+			if !errors.Is(err, jsonutil.ErrEmptyBody) {
 				reqLog.Debugw("Failed to decode optional approver payload (using empty values)", "error", err)
 			}
 		}


### PR DESCRIPTION
## Summary

- reject unknown fields, trailing JSON values, and malformed JSON on debug-session create requests
- reject malformed or unknown-field optional bodies on debug-session approve/reject while still allowing an empty body
- keep explicit `templateRef` and `cluster` required-field validation after replacing Gin binding with strict decoding
- document the stricter API behavior and add changelog coverage

## Target verification

- Verified with `gh repo view telekom/k8s-breakglass --json nameWithOwner,isFork,parent,defaultBranchRef,viewerPermission`.
- Result: `nameWithOwner=telekom/k8s-breakglass`, `isFork=false`, `parent=null`, `defaultBranchRef=main`, `viewerPermission=ADMIN`.

## Duplicate check

- Open upstream PR search: `debug session unknown fields DisallowUnknownFields ShouldBindJSON approve reject invalid JSON strict` in `telekom/k8s-breakglass` returned `[]`.
- Recently merged upstream PR search since 2026-04-01 with the same query returned `[]`.

## Tests

- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -run 'TestDebugSessionAPIController_HandleCreateDebugSession|TestHandleApproveDebugSession|TestHandleRejectDebugSession' -count=1 -timeout=120s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -count=1 -timeout=180s`
- `git -c core.fsmonitor=false diff --check -- CHANGELOG.md docs/api-reference.md pkg/breakglass/debug/debug_session_api.go pkg/breakglass/debug/debug_session_api_session_ops.go pkg/breakglass/debug/debug_session_api_test.go pkg/breakglass/debug/debug_session_api_handlers_test.go`
