### PR TITLE
fix: reject invalid session approval bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **BreakglassSession approval body validation**: Classic session approve and reject endpoints now reject malformed optional approver bodies, unknown JSON fields, and trailing JSON values instead of approving or rejecting with silently discarded payloads.
 - **DebugSession API request body validation**: Debug session create, approve, and reject endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional approval bodies instead of silently ignoring client typos or invalid payloads.
 - **DebugSession scheduling option ACL enforcement**: `DebugSessionTemplate` and `DebugSessionClusterBinding` scheduling option `allowedUsers` and `allowedGroups` are now enforced at session creation for selected options and required defaults. Unauthorized requests receive `403 Forbidden` instead of creating a debug session with restricted scheduling constraints.
 - **OIDC group path matching hardening**: JWT group claims now preserve hierarchical group paths such as `/tenant/admin` instead of collapsing them to the leaf name `admin`, keeping `BreakglassEscalation` group matching exact and preventing same-leaf group collisions across OIDC hierarchies.

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -24,6 +24,8 @@ The breakglass controller implements a **state-first validation architecture** w
 
 Admission webhooks enforce valid state transitions and reject invalid updates (for example, preventing terminal states from reverting to active states).
 
+Approval and rejection REST requests may omit the optional JSON body. When a body is supplied, it must be a single valid JSON object using supported fields such as `reason`; malformed JSON, trailing JSON values, and unknown fields are rejected before any session state transition is applied.
+
 ### Session States
 
 | State | Meaning | Valid for Access? | When It Happens | Timestamp |

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -44,11 +44,13 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	var approverPayload struct {
 		Reason string `json:"reason,omitempty"`
 	}
-	// Ignore errors; payload is optional. Guard against nil Request.Body which can occur in tests/clients.
+	// Empty bodies are valid, but malformed non-empty bodies must fail closed
+	// so client typos cannot silently approve or reject a session.
 	if c.Request != nil && c.Request.Body != nil {
 		if err := decodeJSONStrict(c.Request.Body, &approverPayload); err != nil {
 			if !errors.Is(err, jsonutil.ErrEmptyBody) {
-				reqLog.Debugw("Failed to decode optional approver payload (using empty values)", "error", err)
+				apiresponses.RespondBadRequest(c, "invalid request body: "+err.Error())
+				return
 			}
 		}
 	}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1433,6 +1433,95 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 	}
 }
 
+func TestSessionApproveRejectInvalidOptionalBody(t *testing.T) {
+	tests := []struct {
+		name         string
+		action       string
+		body         string
+		wantResponse string
+	}{
+		{
+			name:         "approve rejects unknown fields",
+			action:       "approve",
+			body:         `{"reasn":"typo"}`,
+			wantResponse: "unknown field",
+		},
+		{
+			name:         "reject rejects trailing JSON",
+			action:       "reject",
+			body:         `{"reason":"valid"} {"reason":"extra"}`,
+			wantResponse: "invalid request body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(Scheme)
+			for index, fn := range sessionIndexFunctions {
+				builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+			}
+
+			session := &breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending-session", Namespace: "default"},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster:      "test-cluster",
+					User:         "requester@example.com",
+					GrantedGroup: "test-group",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         breakglassv1alpha1.SessionStatePending,
+					TimeoutAt:     metav1.Now(),
+					RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+				},
+			}
+			escalation := &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-escalation", Namespace: "default"},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+					EscalatedGroup: "test-group",
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+				},
+			}
+
+			cli := builder.
+				WithObjects(session, escalation).
+				WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+				Build()
+			sesmanager := SessionManager{Client: cli}
+			escmanager := testEscalationLookup{Client: cli}
+
+			logger, _ := zap.NewDevelopment()
+			ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+				func(c *gin.Context) {
+					c.Set("email", "approver@example.com")
+					c.Set("username", "approver@example.com")
+					c.Next()
+				}, "/config/config.yaml", nil, cli)
+			ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+				return []string{"system:authenticated"}, nil
+			}
+
+			engine := gin.New()
+			require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+			req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/pending-session/"+tt.action, bytes.NewBufferString(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), tt.wantResponse)
+
+			var fetched breakglassv1alpha1.BreakglassSession
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "pending-session"}, &fetched))
+			require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+			require.Empty(t, fetched.Status.Approver)
+			require.Empty(t, fetched.Status.ApprovalReason)
+		})
+	}
+}
+
 // TestApprovalAuthorizationDetailedResponses verifies that approval denials return appropriate
 // HTTP status codes and specific error messages based on the denial reason.
 // - 401 Unauthorized: authentication failures (can't identify user)


### PR DESCRIPTION
## Summary

- reject malformed, trailing, or unknown-field JSON bodies on classic BreakglassSession approve/reject requests
- keep the existing empty-body approve/reject flow valid
- cover the failed cases with controller tests and document the request-body behavior

## Finding fixed

Classic BreakglassSession approve/reject endpoints called the strict approver-body decoder but then ignored every non-empty-body decode error. A malformed request could therefore transition a session without the API returning a 400.

## Target verification

- `gh repo view telekom/k8s-breakglass --json nameWithOwner,url,defaultBranchRef,isFork,parent` returned `telekom/k8s-breakglass`, `https://github.com/telekom/k8s-breakglass`, default branch `main`, `isFork=false`, `parent=null`.
- Local `origin` fetch/push URL is `https://github.com/telekom/k8s-breakglass.git`.

## Duplicate-check evidence

- Open PR search: `gh search prs "BreakglassSession approve reject invalid JSON" --repo telekom/k8s-breakglass --state open ...` returned `[]`.
- Recently merged search: `gh search prs "BreakglassSession approve reject invalid JSON" --repo telekom/k8s-breakglass --state closed --merged --merged-at ">=2026-06-01" ...` returned `[]`.
- Adjacent open PR #828 touches session approval code for reason-policy enforcement, but does not reject malformed classic-session JSON bodies.
- Recently merged PR #833 rejects invalid debug-session JSON bodies; it does not fix classic BreakglassSession approve/reject request handling.

## Tests

- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test -timeout=4m ./pkg/breakglass`
- `git diff --check`
