### PR TITLE
fix: reconcile breakglass escalation spec updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BreakglassEscalation generation reconciliation**: Escalation updates now reconcile on metadata generation changes and deletion-timestamp transitions, keeping `status.observedGeneration` current for Helm/Flux-driven spec updates while still ignoring status-only updates.
+- **BreakglassEscalation reconciliation and events**: Escalation reconciliation now reacts to all spec generation changes and deletion timestamp updates, and Kubernetes Events emitted through the breakglass recorder retain a valid involved-object namespace when the scheme reference omits one.
 - **CI: pin ORT scan image**: The ORT workflow now uses a digest-pinned `ghcr.io/oss-review-toolkit/ort:89.2.0` image instead of the moving `latest` tag, avoiding transient ORT CLI startup failures from mutable container image updates.
 - **Debug session namespace semantics**: `POST /api/debugSessions` now treats legacy body `namespace` as a deprecated alias for `targetNamespace` and rejects conflicting values. DebugSession objects are always created in the matching `ClusterConfig` namespace, and named debug-session routes honor an explicit `?namespace=` hint strictly instead of falling back to another namespace.
 - **Session drop preserves terminal audit history**: Owner `POST /api/breakglassSessions/{name}/drop` now rejects sessions that are already in a terminal state instead of rewriting Rejected, Expired, IdleExpired, Withdrawn, or ApprovalTimeout sessions to `Withdrawn`.

--- a/pkg/breakglass/eventrecorder/event_recorder.go
+++ b/pkg/breakglass/eventrecorder/event_recorder.go
@@ -67,6 +67,9 @@ func (r *K8sEventRecorder) Eventf(regarding runtime.Object, related runtime.Obje
 	if r.Scheme != nil {
 		if ref, err := reference.GetReference(r.Scheme, regarding); err == nil {
 			regardingRef = ref
+			if regardingRef.Namespace == "" {
+				regardingRef.Namespace = involvedNS
+			}
 		}
 	}
 

--- a/pkg/breakglass/eventrecorder/event_recorder_test.go
+++ b/pkg/breakglass/eventrecorder/event_recorder_test.go
@@ -106,7 +106,6 @@ func TestEventRecorder_FallbackToPodNamespaceWithSchemeReference(t *testing.T) {
 	}
 
 	rec.Eventf(obj, nil, "Warning", "ReasonWithScheme", "ReasonWithScheme", "scheme message")
-	time.Sleep(10 * time.Millisecond)
 
 	evs, err := cs.EventsV1().Events("podns").List(context.Background(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/breakglass/eventrecorder/event_recorder_test.go
+++ b/pkg/breakglass/eventrecorder/event_recorder_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -80,4 +81,45 @@ func TestEventRecorder_FallbackToPodNamespace(t *testing.T) {
 	if !found {
 		t.Fatalf("expected event involvedObject.namespace to be 'podns' when object has no namespace")
 	}
+}
+
+func TestEventRecorder_FallbackToPodNamespaceWithSchemeReference(t *testing.T) {
+	cs := fake.NewClientset()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	logger, _ := zap.NewDevelopment()
+	rec := &K8sEventRecorder{
+		Clientset: cs,
+		Source:    corev1.EventSource{Component: "test"},
+		Scheme:    scheme,
+		Namespace: "podns",
+		Logger:    logger.Sugar(),
+	}
+
+	obj := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-without-namespace",
+			UID:  "3333",
+		},
+	}
+
+	rec.Eventf(obj, nil, "Warning", "ReasonWithScheme", "ReasonWithScheme", "scheme message")
+	time.Sleep(10 * time.Millisecond)
+
+	evs, err := cs.EventsV1().Events("podns").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list events: %v", err)
+	}
+	if len(evs.Items) == 0 {
+		t.Fatalf("expected at least one event in namespace 'podns', got 0")
+	}
+
+	for _, e := range evs.Items {
+		if e.Regarding.Name == "pod-without-namespace" && e.Regarding.Namespace == "podns" {
+			return
+		}
+	}
+	t.Fatalf("expected scheme reference fallback to set event involvedObject.namespace to 'podns'")
 }

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -343,15 +343,7 @@ func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// changes from apply tools and deletion timestamp transitions.
 	specChangePredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldEsc, ok := e.ObjectOld.(*breakglassv1alpha1.BreakglassEscalation)
-			if !ok {
-				return true
-			}
-			newEsc, ok := e.ObjectNew.(*breakglassv1alpha1.BreakglassEscalation)
-			if !ok {
-				return true
-			}
-			return shouldReconcileEscalationUpdate(oldEsc, newEsc)
+			return shouldReconcileEscalationUpdate(e.ObjectOld, e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool { return true },
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
@@ -366,11 +358,30 @@ func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func shouldReconcileEscalationUpdate(oldEsc, newEsc *breakglassv1alpha1.BreakglassEscalation) bool {
-	oldDeleting := oldEsc.GetDeletionTimestamp() != nil
-	newDeleting := newEsc.GetDeletionTimestamp() != nil
+func shouldReconcileEscalationUpdate(oldObj, newObj client.Object) bool {
+	oldEsc, ok := oldObj.(*breakglassv1alpha1.BreakglassEscalation)
+	if !ok {
+		return true
+	}
+	newEsc, ok := newObj.(*breakglassv1alpha1.BreakglassEscalation)
+	if !ok {
+		return true
+	}
 
-	return oldEsc.GetGeneration() != newEsc.GetGeneration() || oldDeleting != newDeleting
+	if oldEsc.GetGeneration() != newEsc.GetGeneration() {
+		return true
+	}
+
+	oldDeletionTimestamp := oldEsc.GetDeletionTimestamp()
+	newDeletionTimestamp := newEsc.GetDeletionTimestamp()
+	switch {
+	case oldDeletionTimestamp == nil && newDeletionTimestamp == nil:
+		return false
+	case oldDeletionTimestamp == nil || newDeletionTimestamp == nil:
+		return true
+	default:
+		return !oldDeletionTimestamp.Equal(newDeletionTimestamp)
+	}
 }
 
 // validateEscalationConfig validates the escalation's configuration structure.

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -85,6 +85,69 @@ func (f *escalationFakeEventRecorder) Eventf(_ runtime.Object, _ runtime.Object,
 	}
 }
 
+func TestShouldReconcileEscalationUpdate(t *testing.T) {
+	baseEscalation := func() *breakglassv1alpha1.BreakglassEscalation {
+		return &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-escalation",
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				EscalatedGroup: "test-group",
+				MaxValidFor:    "1h",
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+					Groups: []string{"allowed-group"},
+				},
+				Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		}
+	}
+
+	t.Run("ignores status only update", func(t *testing.T) {
+		oldEsc := baseEscalation()
+		newEsc := oldEsc.DeepCopy()
+		newEsc.ResourceVersion = "2"
+		newEsc.Status.ObservedGeneration = 1
+		newEsc.SetCondition(metav1.Condition{
+			Type:               string(breakglassv1alpha1.BreakglassEscalationConditionReady),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 1,
+			Reason:             "ValidationSucceeded",
+			Message:            "Validation passed",
+		})
+
+		assert.False(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
+	})
+
+	t.Run("reconciles any spec generation update", func(t *testing.T) {
+		oldEsc := baseEscalation()
+		newEsc := oldEsc.DeepCopy()
+		newEsc.Generation = 2
+		newEsc.Spec.EscalatedGroup = "updated-group"
+
+		assert.True(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
+	})
+
+	t.Run("reconciles deletion timestamp changes", func(t *testing.T) {
+		oldEsc := baseEscalation()
+		newEsc := oldEsc.DeepCopy()
+		now := metav1.Now()
+		newEsc.DeletionTimestamp = &now
+
+		assert.True(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
+	})
+
+	t.Run("allows unexpected object types", func(t *testing.T) {
+		assert.True(t, shouldReconcileEscalationUpdate(
+			&breakglassv1alpha1.ClusterConfig{},
+			&breakglassv1alpha1.ClusterConfig{},
+		))
+	})
+}
+
 func TestEscalationReconciler_Reconcile(t *testing.T) {
 	scheme := newTestEscalationReconcilerScheme()
 	logger := zap.NewNop().Sugar()

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -140,9 +140,36 @@ func TestShouldReconcileEscalationUpdate(t *testing.T) {
 		assert.True(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
 	})
 
-	t.Run("allows unexpected object types", func(t *testing.T) {
+	t.Run("ignores unchanged deletion timestamp", func(t *testing.T) {
+		oldEsc := baseEscalation()
+		now := metav1.NewTime(time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC))
+		oldEsc.DeletionTimestamp = &now
+		newEsc := oldEsc.DeepCopy()
+
+		assert.False(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
+	})
+
+	t.Run("reconciles changed deletion timestamp", func(t *testing.T) {
+		oldEsc := baseEscalation()
+		oldTime := metav1.NewTime(time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC))
+		oldEsc.DeletionTimestamp = &oldTime
+		newEsc := oldEsc.DeepCopy()
+		newTime := metav1.NewTime(oldTime.Add(time.Minute))
+		newEsc.DeletionTimestamp = &newTime
+
+		assert.True(t, shouldReconcileEscalationUpdate(oldEsc, newEsc))
+	})
+
+	t.Run("allows unexpected old object type", func(t *testing.T) {
 		assert.True(t, shouldReconcileEscalationUpdate(
 			&breakglassv1alpha1.ClusterConfig{},
+			baseEscalation(),
+		))
+	})
+
+	t.Run("allows unexpected new object type", func(t *testing.T) {
+		assert.True(t, shouldReconcileEscalationUpdate(
+			baseEscalation(),
 			&breakglassv1alpha1.ClusterConfig{},
 		))
 	})


### PR DESCRIPTION
## Summary
- reconcile BreakglassEscalation updates whenever metadata.generation changes, not only when allowedIdentityProviders changes
- preserve the fallback event namespace after reference.GetReference returns a namespaced object reference with an empty namespace
- add regression tests for status-only updates, spec generation updates, deletion timestamps, and fallback event references with a scheme

## Validation
- git diff --check
- go test ./pkg/...

This fixes stale observedGeneration on BreakglassEscalation updates and the invalid events.v1 object namespace seen when group sync token acquisition fails.