### PR TITLE
fix: harden breakglass approval authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed and scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present.
+- **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed, scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present, and checks approval/rejection authorization before body validation or state-specific errors so unrelated callers cannot infer session details.
 - **BreakglassSession approval body validation**: Classic session approve and reject endpoints now reject malformed optional approver bodies, unknown JSON fields, and trailing JSON values instead of approving or rejecting with silently discarded payloads.
 - **DebugSession API request body validation**: Debug session create, approve, and reject endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional approval bodies instead of silently ignoring client typos or invalid payloads.
 - **DebugSession cluster authorization precedence**: Debug session creation now checks template or binding access before returning ClusterConfig readiness, missing-cluster, or tenant-alias errors, preventing unauthorized callers from probing cluster state through error messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed and scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present.
 - **BreakglassSession approval body validation**: Classic session approve and reject endpoints now reject malformed optional approver bodies, unknown JSON fields, and trailing JSON values instead of approving or rejecting with silently discarded payloads.
 - **DebugSession API request body validation**: Debug session create, approve, and reject endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional approval bodies instead of silently ignoring client typos or invalid payloads.
 - **DebugSession cluster authorization precedence**: Debug session creation now checks template or binding access before returning ClusterConfig readiness, missing-cluster, or tenant-alias errors, preventing unauthorized callers from probing cluster state through error messages.

--- a/config/dev/resources/rbac/tenant-rbac-test.yaml
+++ b/config/dev/resources/rbac/tenant-rbac-test.yaml
@@ -50,6 +50,8 @@ roleRef:
 subjects:
 - kind: Group
   name: breakglass-pods-admin
+- kind: Group
+  name: breakglass-policy-pods-admin
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -75,6 +77,8 @@ roleRef:
 subjects:
 - kind: Group
   name: breakglass-emergency-admin
+- kind: Group
+  name: breakglass-policy-emergency-admin
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -162,6 +166,8 @@ roleRef:
 subjects:
 - kind: Group
   name: breakglass-multi-cluster-ops
+- kind: Group
+  name: breakglass-policy-multi-cluster-ops
 ---
 # Additional test groups for e2e test escalation scenarios
 # These groups are used by various e2e tests that create escalations

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -309,6 +309,10 @@ referenced by the session's `metadata.ownerReferences` controller reference,
 when present. For legacy sessions without that owner reference, approval falls
 back to the existing cluster/group escalation lookup. Sibling escalations for the
 same cluster and group are not considered when an owner reference is present.
+Authorization is checked before request-body validation and state-specific
+responses, so unrelated callers receive only authorization errors instead of
+learning whether the session is terminal, timed out, or has malformed request
+details.
 
 **Request validation:** `reason` is required when the session's stored
 `approvalReasonConfig.mandatory` is `true`.
@@ -374,6 +378,8 @@ Authorization: Bearer <token>
 **Status Code:** `200 OK`
 
 **Authorization:** Approvers can reject any pending request. Session requesters can also reject their own pending requests.
+Approver authorization is checked before request-body validation and
+state-specific responses; unrelated callers receive only authorization errors.
 
 **Request validation:** `reason` is required when the session's stored
 `approvalReasonConfig.mandatory` is `true`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -304,10 +304,14 @@ Authorization: Bearer <token>
 
 **Status Code:** `200 OK`
 
-**Authorization:** Only users who can approve the escalation (approvers or approver groups)
+**Authorization:** Only users who can approve the owning escalation (approvers or approver groups)
 
 **Request validation:** `reason` is required when the session's stored
 `approvalReasonConfig.mandatory` is `true`.
+
+If the pending session's approval timeout has already elapsed, the endpoint returns
+`409 Conflict` and leaves the session pending until cleanup records the
+`ApprovalTimeout` terminal state.
 
 **Response:** Complete updated `BreakglassSession` resource with approved status.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -304,7 +304,11 @@ Authorization: Bearer <token>
 
 **Status Code:** `200 OK`
 
-**Authorization:** Only users who can approve the owning escalation (approvers or approver groups)
+**Authorization:** Only users who can approve the `BreakglassEscalation`
+referenced by the session's `metadata.ownerReferences` controller reference,
+when present. For legacy sessions without that owner reference, approval falls
+back to the existing cluster/group escalation lookup. Sibling escalations for the
+same cluster and group are not considered when an owner reference is present.
 
 **Request validation:** `reason` is required when the session's stored
 `approvalReasonConfig.mandatory` is `true`.

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -24,7 +24,7 @@ The breakglass controller implements a **state-first validation architecture** w
 
 Admission webhooks enforce valid state transitions and reject invalid updates (for example, preventing terminal states from reverting to active states).
 
-Approval and rejection REST requests may omit the optional JSON body. When a body is supplied, it must be a single valid JSON object using supported fields such as `reason`; malformed JSON, trailing JSON values, and unknown fields are rejected before any session state transition is applied.
+Approval and rejection REST requests may omit the optional JSON body. When a body is supplied, it must be a single valid JSON object using supported fields such as `reason`; malformed JSON, trailing JSON values, and unknown fields are rejected before any session state transition is applied. Approver authorization is checked before body validation and state-specific errors, so unrelated callers cannot infer session details from approval or rejection error responses.
 
 ### Session States
 

--- a/e2e/api/deny_policy_test.go
+++ b/e2e/api/deny_policy_test.go
@@ -30,6 +30,12 @@ import (
 	"github.com/telekom/k8s-breakglass/e2e/helpers"
 )
 
+const (
+	denyPolicyPodsAdminGroup       = "breakglass-policy-pods-admin"
+	denyPolicyEmergencyAdminGroup  = "breakglass-policy-emergency-admin"
+	denyPolicyMultiClusterOpsGroup = "breakglass-policy-multi-cluster-ops"
+)
+
 // TestDenyPolicyEnforcement tests that DenyPolicy resources are enforced correctly.
 //
 // Test coverage for issue #48:
@@ -188,7 +194,7 @@ func TestDenyPolicyBlocksSpecificVerbs(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp001-escalation", namespace).
-		WithEscalatedGroup("breakglass-pods-admin"). // Use breakglass-pods-admin which has RBAC for pods
+		WithEscalatedGroup(denyPolicyPodsAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -199,6 +205,7 @@ func TestDenyPolicyBlocksSpecificVerbs(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -281,7 +288,7 @@ func TestDenyPolicyBlocksSpecificResources(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp002-escalation", namespace).
-		WithEscalatedGroup("breakglass-emergency-admin"). // Use breakglass-emergency-admin which has RBAC for all resources
+		WithEscalatedGroup(denyPolicyEmergencyAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -292,6 +299,7 @@ func TestDenyPolicyBlocksSpecificResources(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -373,7 +381,7 @@ func TestDenyPolicyBlocksSpecificNamespaces(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp003-escalation", namespace).
-		WithEscalatedGroup("breakglass-pods-admin"). // Use breakglass-pods-admin which has RBAC for pods
+		WithEscalatedGroup(denyPolicyPodsAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -384,6 +392,7 @@ func TestDenyPolicyBlocksSpecificNamespaces(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -466,7 +475,7 @@ func TestDenyPolicyBlocksSpecificAPIGroups(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp004-escalation", namespace).
-		WithEscalatedGroup("breakglass-multi-cluster-ops"). // Use breakglass-multi-cluster-ops which has RBAC for apps group
+		WithEscalatedGroup(denyPolicyMultiClusterOpsGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -477,6 +486,7 @@ func TestDenyPolicyBlocksSpecificAPIGroups(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -567,7 +577,7 @@ func TestDenyPolicyBlocksSpecificResourceNames(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp005-escalation", namespace).
-		WithEscalatedGroup("breakglass-emergency-admin"). // Use breakglass-emergency-admin which has RBAC for all resources
+		WithEscalatedGroup(denyPolicyEmergencyAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -578,6 +588,7 @@ func TestDenyPolicyBlocksSpecificResourceNames(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -675,7 +686,7 @@ func TestDenyPolicyPrecedenceOrdering(t *testing.T) {
 
 	// Create escalation referencing both policies
 	escalation := helpers.NewEscalationBuilder("e2e-dp007-escalation", namespace).
-		WithEscalatedGroup("breakglass-emergency-admin"). // Use breakglass-emergency-admin which has RBAC for all resources
+		WithEscalatedGroup(denyPolicyEmergencyAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -686,6 +697,7 @@ func TestDenyPolicyPrecedenceOrdering(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{
@@ -829,7 +841,7 @@ func TestDenyPolicyAppliesToClusters(t *testing.T) {
 
 	// Create escalation referencing the DenyPolicy
 	escalation := helpers.NewEscalationBuilder("e2e-dp011-escalation", namespace).
-		WithEscalatedGroup("breakglass-emergency-admin"). // Must have RBAC binding for SAR to succeed
+		WithEscalatedGroup(denyPolicyEmergencyAdminGroup).
 		WithAllowedClusters(clusterName).
 		WithMaxValidFor("1h").
 		WithApprovalTimeout("15m").
@@ -840,6 +852,7 @@ func TestDenyPolicyAppliesToClusters(t *testing.T) {
 	cleanup.Add(escalation)
 	err = cli.Create(ctx, escalation)
 	require.NoError(t, err, "Failed to create escalation")
+	helpers.WaitForEscalationReady(t, ctx, cli, escalation.Name, namespace, helpers.WaitForStateTimeout)
 
 	// Create and approve session
 	session, err := apiClient.CreateSessionAndWaitForPending(ctx, t, helpers.SessionRequest{

--- a/e2e/kind-setup-multi.sh
+++ b/e2e/kind-setup-multi.sh
@@ -1718,6 +1718,9 @@ subjects:
 - kind: Group
   name: breakglass-pods-admin
   apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: breakglass-policy-pods-admin
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1730,6 +1733,9 @@ roleRef:
 subjects:
 - kind: Group
   name: breakglass-emergency-admin
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: breakglass-policy-emergency-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1867,6 +1873,9 @@ roleRef:
 subjects:
 - kind: Group
   name: breakglass-multi-cluster-ops
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: breakglass-policy-multi-cluster-ops
   apiGroup: rbac.authorization.k8s.io
 EOF
 

--- a/pkg/api/api_end_to_end_test.go
+++ b/pkg/api/api_end_to_end_test.go
@@ -116,6 +116,7 @@ func setupAPIEndToEndEnv(t *testing.T) *apiEndToEndEnv {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      e2eEscalation,
 			Namespace: e2eNamespace,
+			UID:       "allow-create-uid",
 		},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{

--- a/pkg/api/api_end_to_end_test.go
+++ b/pkg/api/api_end_to_end_test.go
@@ -962,6 +962,7 @@ func TestEndToEndSARPodSecurityWithEscalationOverride(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "override-escalation",
 			Namespace: e2eNamespace,
+			UID:       "override-escalation-uid",
 		},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -230,7 +230,7 @@ func sessionOwnedByEscalation(session breakglassv1alpha1.BreakglassSession, esc 
 		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() &&
 			ownerRef.Kind == "BreakglassEscalation" &&
 			ownerRef.Name == esc.Name {
-			return ownerRef.UID == "" || esc.UID == "" || ownerRef.UID == esc.UID
+			return ownerRef.UID != "" && esc.UID != "" && ownerRef.UID == esc.UID
 		}
 	}
 	return false

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -218,7 +218,10 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 
 func sessionHasEscalationOwner(session breakglassv1alpha1.BreakglassSession) bool {
 	for _, ownerRef := range session.OwnerReferences {
-		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() && ownerRef.Kind == "BreakglassEscalation" {
+		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() &&
+			ownerRef.Kind == "BreakglassEscalation" &&
+			ownerRef.Controller != nil &&
+			*ownerRef.Controller {
 			return true
 		}
 	}
@@ -229,7 +232,9 @@ func sessionOwnedByEscalation(session breakglassv1alpha1.BreakglassSession, esc 
 	for _, ownerRef := range session.OwnerReferences {
 		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() &&
 			ownerRef.Kind == "BreakglassEscalation" &&
-			ownerRef.Name == esc.Name {
+			ownerRef.Name == esc.Name &&
+			ownerRef.Controller != nil &&
+			*ownerRef.Controller {
 			return ownerRef.UID != "" && esc.UID != "" && ownerRef.UID == esc.UID
 		}
 	}

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -90,6 +90,10 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 		if esc.Spec.EscalatedGroup != session.Spec.GrantedGroup {
 			continue
 		}
+		if sessionHasEscalationOwner(session) && !sessionOwnedByEscalation(session, esc) {
+			reqLog.Debugw("Skipping escalation that does not own the session", "session", session.Name, "escalation", esc.Name)
+			continue
+		}
 		foundMatchingEscalation = true
 		reqLog.Debugw("Evaluating matching escalation", "escalation", esc.Name, "users", len(esc.Spec.Approvers.Users), "groups", len(esc.Spec.Approvers.Groups))
 
@@ -210,6 +214,26 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 	}
 
 	return mostSpecificDenial
+}
+
+func sessionHasEscalationOwner(session breakglassv1alpha1.BreakglassSession) bool {
+	for _, ownerRef := range session.OwnerReferences {
+		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() && ownerRef.Kind == "BreakglassEscalation" {
+			return true
+		}
+	}
+	return false
+}
+
+func sessionOwnedByEscalation(session breakglassv1alpha1.BreakglassSession, esc breakglassv1alpha1.BreakglassEscalation) bool {
+	for _, ownerRef := range session.OwnerReferences {
+		if ownerRef.APIVersion == breakglassv1alpha1.GroupVersion.String() &&
+			ownerRef.Kind == "BreakglassEscalation" &&
+			ownerRef.Name == esc.Name {
+			return ownerRef.UID == "" || esc.UID == "" || ownerRef.UID == esc.UID
+		}
+	}
+	return false
 }
 
 // isSessionApprover returns true if the current user is authorized to approve/reject the session.

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -97,6 +97,20 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 			})
 			return
 		}
+		if sesCondition == breakglassv1alpha1.SessionConditionTypeApproved &&
+			!bs.Status.TimeoutAt.IsZero() &&
+			time.Now().After(bs.Status.TimeoutAt.Time) {
+			c.JSON(http.StatusConflict, struct {
+				Error   string                               `json:"error"`
+				Code    string                               `json:"code"`
+				Session breakglassv1alpha1.BreakglassSession `json:"session"`
+			}{
+				Error:   "session approval timeout has elapsed",
+				Code:    "CONFLICT",
+				Session: bs,
+			})
+			return
+		}
 	} else {
 		if currState == breakglassv1alpha1.SessionStateRejected || currState == breakglassv1alpha1.SessionStateWithdrawn || currState == breakglassv1alpha1.SessionStateExpired || currState == breakglassv1alpha1.SessionStateTimeout || currState == breakglassv1alpha1.SessionStateIdleExpired {
 			c.JSON(http.StatusBadRequest, struct {

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -97,20 +97,6 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 			})
 			return
 		}
-		if sesCondition == breakglassv1alpha1.SessionConditionTypeApproved &&
-			!bs.Status.TimeoutAt.IsZero() &&
-			time.Now().After(bs.Status.TimeoutAt.Time) {
-			c.JSON(http.StatusConflict, struct {
-				Error   string                               `json:"error"`
-				Code    string                               `json:"code"`
-				Session breakglassv1alpha1.BreakglassSession `json:"session"`
-			}{
-				Error:   "session approval timeout has elapsed",
-				Code:    "CONFLICT",
-				Session: bs,
-			})
-			return
-		}
 	} else {
 		if currState == breakglassv1alpha1.SessionStateRejected || currState == breakglassv1alpha1.SessionStateWithdrawn || currState == breakglassv1alpha1.SessionStateExpired || currState == breakglassv1alpha1.SessionStateTimeout || currState == breakglassv1alpha1.SessionStateIdleExpired {
 			c.JSON(http.StatusBadRequest, struct {
@@ -161,6 +147,21 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 			}
 			return
 		}
+	}
+
+	if sesCondition == breakglassv1alpha1.SessionConditionTypeApproved &&
+		!bs.Status.TimeoutAt.IsZero() &&
+		!time.Now().Before(bs.Status.TimeoutAt.Time) {
+		c.JSON(http.StatusConflict, struct {
+			Error   string                               `json:"error"`
+			Code    string                               `json:"code"`
+			Session breakglassv1alpha1.BreakglassSession `json:"session"`
+		}{
+			Error:   "session approval timeout has elapsed",
+			Code:    "CONFLICT",
+			Session: bs,
+		})
+		return
 	}
 
 	approverReasonAction := "approval"

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -40,6 +40,43 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		return
 	}
 
+	// Authorization must happen before body validation and state-specific
+	// responses so unauthorized callers cannot learn session details from
+	// terminal-state or malformed-body errors.
+	allowOwnerReject := false
+	if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
+		if requesterEmail, err := wc.identityProvider.GetEmail(c); err == nil {
+			if requesterEmail == bs.Spec.User && IsSessionPendingApproval(bs) {
+				allowOwnerReject = true
+			}
+		}
+	}
+
+	if !allowOwnerReject {
+		authResult := wc.checkApprovalAuthorization(c, bs)
+		if !authResult.Allowed {
+			// Use appropriate HTTP status code based on denial reason:
+			// - 401 for authentication failures (can't identify user)
+			// - 403 for authorization failures (user identified but not allowed)
+			switch authResult.Reason {
+			case ApprovalDenialUnauthenticated:
+				apiresponses.RespondUnauthorizedWithMessage(c, authResult.Message)
+			case ApprovalDenialSelfApprovalBlocked:
+				apiresponses.RespondForbidden(c, authResult.Message)
+			case ApprovalDenialDomainNotAllowed:
+				apiresponses.RespondForbidden(c, authResult.Message)
+			case ApprovalDenialNotAnApprover:
+				apiresponses.RespondForbidden(c, authResult.Message)
+			case ApprovalDenialNoMatchingEscalation:
+				apiresponses.RespondForbidden(c, authResult.Message)
+			default:
+				// Fallback for unknown reasons
+				apiresponses.RespondForbidden(c, "Access denied")
+			}
+			return
+		}
+	}
+
 	// Attempt to decode optional approver reason from the request body (for approve/reject)
 	var approverPayload struct {
 		Reason string `json:"reason,omitempty"`
@@ -108,43 +145,6 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 				Code:    "BAD_REQUEST",
 				Session: bs,
 			})
-			return
-		}
-	}
-
-	// Authorization: determine whether the caller is allowed to perform the action.
-	// Allow the session requester to reject their own pending session. For reject actions only,
-	// if the caller is the original requester and the session is still pending, bypass the approver check.
-	allowOwnerReject := false
-	if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
-		if requesterEmail, err := wc.identityProvider.GetEmail(c); err == nil {
-			if requesterEmail == bs.Spec.User && IsSessionPendingApproval(bs) {
-				allowOwnerReject = true
-			}
-		}
-	}
-
-	if !allowOwnerReject {
-		authResult := wc.checkApprovalAuthorization(c, bs)
-		if !authResult.Allowed {
-			// Use appropriate HTTP status code based on denial reason:
-			// - 401 for authentication failures (can't identify user)
-			// - 403 for authorization failures (user identified but not allowed)
-			switch authResult.Reason {
-			case ApprovalDenialUnauthenticated:
-				apiresponses.RespondUnauthorizedWithMessage(c, authResult.Message)
-			case ApprovalDenialSelfApprovalBlocked:
-				apiresponses.RespondForbidden(c, authResult.Message)
-			case ApprovalDenialDomainNotAllowed:
-				apiresponses.RespondForbidden(c, authResult.Message)
-			case ApprovalDenialNotAnApprover:
-				apiresponses.RespondForbidden(c, authResult.Message)
-			case ApprovalDenialNoMatchingEscalation:
-				apiresponses.RespondForbidden(c, authResult.Message)
-			default:
-				// Fallback for unknown reasons
-				apiresponses.RespondForbidden(c, "Access denied")
-			}
 			return
 		}
 	}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1584,6 +1584,70 @@ func TestApproveExpiredPendingSessionReturnsConflict(t *testing.T) {
 	require.Empty(t, fetched.Status.Approver)
 }
 
+func TestApproveExpiredPendingSessionChecksAuthorizationBeforeTimeout(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "expired-secret-session", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "test-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStatePending,
+			TimeoutAt:     metav1.NewTime(time.Now().Add(-time.Minute)),
+			RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+		},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-escalation", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+		},
+	}
+
+	cli := builder.
+		WithObjects(session, escalation).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "intruder@example.com")
+			c.Set("username", "intruder@example.com")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/expired-secret-session/approve", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.NotContains(t, w.Body.String(), "expired-secret-session")
+	require.NotContains(t, w.Body.String(), "approval timeout has elapsed")
+
+	var fetched breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "expired-secret-session"}, &fetched))
+	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+	require.Empty(t, fetched.Status.Approver)
+}
+
 func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
@@ -1662,6 +1726,77 @@ func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 
 	var fetched breakglassv1alpha1.BreakglassSession
 	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "owned-session"}, &fetched))
+	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+	require.Empty(t, fetched.Status.Approver)
+}
+
+func TestApprovalAuthorizationRequiresOwnerReferenceUIDMatch(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	owningEscalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "owning-escalation", Namespace: "default", UID: types.UID("owner-escalation-uid")},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"owner-approver@example.com"}},
+		},
+	}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "malformed-owner-session",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: breakglassv1alpha1.GroupVersion.String(),
+				Kind:       "BreakglassEscalation",
+				Name:       owningEscalation.Name,
+			}},
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "test-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStatePending,
+			TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
+			RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+		},
+	}
+
+	cli := builder.
+		WithObjects(owningEscalation, session).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "owner-approver@example.com")
+			c.Set("username", "owner-approver@example.com")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/malformed-owner-session/approve", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "No matching escalation found")
+
+	var fetched breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "malformed-owner-session"}, &fetched))
 	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
 	require.Empty(t, fetched.Status.Approver)
 }

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1708,6 +1708,112 @@ func TestApproveExpiredPendingSessionChecksAuthorizationBeforeTimeout(t *testing
 	require.Empty(t, fetched.Status.Approver)
 }
 
+func TestApproveRejectChecksAuthorizationBeforeBodyAndStateResponses(t *testing.T) {
+	tests := []struct {
+		name             string
+		action           string
+		body             string
+		state            breakglassv1alpha1.BreakglassSessionState
+		conditions       []metav1.Condition
+		forbiddenDetails []string
+	}{
+		{
+			name:   "approve hides already approved session",
+			action: "approve",
+			state:  breakglassv1alpha1.SessionStateApproved,
+			conditions: []metav1.Condition{{
+				Type:   string(breakglassv1alpha1.SessionConditionTypeApproved),
+				Status: metav1.ConditionTrue,
+				Reason: "AlreadyApproved",
+			}},
+			forbiddenDetails: []string{"secret-terminal-session", "session already in requested state", "sensitive maintenance reason"},
+		},
+		{
+			name:             "reject hides malformed body details",
+			action:           "reject",
+			body:             `{"reasn":"typo"}`,
+			state:            breakglassv1alpha1.SessionStatePending,
+			forbiddenDetails: []string{"secret-terminal-session", "unknown field", "invalid request body", "sensitive maintenance reason"},
+		},
+		{
+			name:             "reject hides terminal state details",
+			action:           "reject",
+			state:            breakglassv1alpha1.SessionStateExpired,
+			forbiddenDetails: []string{"secret-terminal-session", "session must be pending", "current state", "sensitive maintenance reason"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(Scheme)
+			for index, fn := range sessionIndexFunctions {
+				builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+			}
+
+			session := &breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret-terminal-session", Namespace: "default"},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster:       "secret-cluster",
+					User:          "requester@example.com",
+					GrantedGroup:  "secret-admins",
+					RequestReason: "sensitive maintenance reason",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:         tt.state,
+					Conditions:    tt.conditions,
+					TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
+					RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+				},
+			}
+			escalation := &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret-escalation", Namespace: "default"},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"secret-cluster"}, Groups: []string{"system:authenticated"}},
+					EscalatedGroup: "secret-admins",
+					Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+				},
+			}
+
+			cli := builder.
+				WithObjects(session, escalation).
+				WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+				Build()
+			sesmanager := SessionManager{Client: cli}
+			escmanager := testEscalationLookup{Client: cli}
+
+			logger, _ := zap.NewDevelopment()
+			ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+				func(c *gin.Context) {
+					c.Set("email", "intruder@example.com")
+					c.Set("username", "intruder@example.com")
+					c.Next()
+				}, "/config/config.yaml", nil, cli)
+			ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+				return []string{"system:authenticated"}, nil
+			}
+
+			engine := gin.New()
+			require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+			req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/secret-terminal-session/"+tt.action, bytes.NewBufferString(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusForbidden, w.Code)
+			for _, forbidden := range tt.forbiddenDetails {
+				require.NotContains(t, w.Body.String(), forbidden)
+			}
+
+			var fetched breakglassv1alpha1.BreakglassSession
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "secret-terminal-session"}, &fetched))
+			require.Equal(t, tt.state, fetched.Status.State)
+			require.Empty(t, fetched.Status.Approver)
+		})
+	}
+}
+
 func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
@@ -1716,6 +1822,7 @@ func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 
 	ownerUID := types.UID("owner-escalation-uid")
 	otherUID := types.UID("other-escalation-uid")
+	controllerOwner := true
 	owningEscalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{Name: "owning-escalation", Namespace: "default", UID: ownerUID},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
@@ -1741,6 +1848,7 @@ func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 				Kind:       "BreakglassEscalation",
 				Name:       owningEscalation.Name,
 				UID:        ownerUID,
+				Controller: &controllerOwner,
 			}},
 		},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -1790,12 +1898,103 @@ func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
 	require.Empty(t, fetched.Status.Approver)
 }
 
+func TestApprovalAuthorizationIgnoresNonControllerEscalationOwnerRefs(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	controllerOwner := true
+	owningEscalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "owning-escalation", Namespace: "default", UID: types.UID("owner-escalation-uid")},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"owner-approver@example.com"}},
+		},
+	}
+	nonControllerEscalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "non-controller-escalation", Namespace: "default", UID: types.UID("non-controller-escalation-uid")},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"non-controller-approver@example.com"}},
+		},
+	}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mixed-owner-session",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: breakglassv1alpha1.GroupVersion.String(),
+					Kind:       "BreakglassEscalation",
+					Name:       owningEscalation.Name,
+					UID:        owningEscalation.UID,
+					Controller: &controllerOwner,
+				},
+				{
+					APIVersion: breakglassv1alpha1.GroupVersion.String(),
+					Kind:       "BreakglassEscalation",
+					Name:       nonControllerEscalation.Name,
+					UID:        nonControllerEscalation.UID,
+				},
+			},
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "test-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStatePending,
+			TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
+			RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+		},
+	}
+
+	cli := builder.
+		WithObjects(owningEscalation, nonControllerEscalation, session).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "non-controller-approver@example.com")
+			c.Set("username", "non-controller-approver@example.com")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/mixed-owner-session/approve", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "not in an approver group")
+
+	var fetched breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "mixed-owner-session"}, &fetched))
+	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+	require.Empty(t, fetched.Status.Approver)
+}
+
 func TestApprovalAuthorizationRequiresOwnerReferenceUIDMatch(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
 	}
 
+	controllerOwner := true
 	owningEscalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{Name: "owning-escalation", Namespace: "default", UID: types.UID("owner-escalation-uid")},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
@@ -1812,6 +2011,7 @@ func TestApprovalAuthorizationRequiresOwnerReferenceUIDMatch(t *testing.T) {
 				APIVersion: breakglassv1alpha1.GroupVersion.String(),
 				Kind:       "BreakglassEscalation",
 				Name:       owningEscalation.Name,
+				Controller: &controllerOwner,
 			}},
 		},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -2119,7 +2319,7 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 //   - Create a new session.
 //   - Approve it once (expect 200 OK).
 //   - Approve it again (expect 409 Conflict).
-//   - Attempt to reject it after approval (expect 400 Bad Request).
+	//   - Attempt to reject it as an authorized approver after approval (expect 400 Bad Request).
 func TestTerminalStateImmutability(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
@@ -2142,12 +2342,12 @@ func TestTerminalStateImmutability(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
-		if c.Request.Method == http.MethodPost {
-			if strings.Contains(c.Request.URL.String(), "/approve") {
-				c.Set("email", "a@e.com")
-			} else if strings.Contains(c.Request.URL.String(), "/reject") {
-				c.Set("email", "r@e.com")
-			} else {
+			if c.Request.Method == http.MethodPost {
+				if strings.Contains(c.Request.URL.String(), "/approve") {
+					c.Set("email", "a@e.com")
+				} else if strings.Contains(c.Request.URL.String(), "/reject") {
+					c.Set("email", "a@e.com")
+				} else {
 				// plain POST (e.g. session creation) -> set requester email to avoid IDP call
 				c.Set("email", "a@e.com")
 			}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -2319,7 +2319,7 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 //   - Create a new session.
 //   - Approve it once (expect 200 OK).
 //   - Approve it again (expect 409 Conflict).
-	//   - Attempt to reject it as an authorized approver after approval (expect 400 Bad Request).
+//   - Attempt to reject it as an authorized approver after approval (expect 400 Bad Request).
 func TestTerminalStateImmutability(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
@@ -2342,12 +2342,12 @@ func TestTerminalStateImmutability(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
-			if c.Request.Method == http.MethodPost {
-				if strings.Contains(c.Request.URL.String(), "/approve") {
-					c.Set("email", "a@e.com")
-				} else if strings.Contains(c.Request.URL.String(), "/reject") {
-					c.Set("email", "a@e.com")
-				} else {
+		if c.Request.Method == http.MethodPost {
+			if strings.Contains(c.Request.URL.String(), "/approve") {
+				c.Set("email", "a@e.com")
+			} else if strings.Contains(c.Request.URL.String(), "/reject") {
+				c.Set("email", "a@e.com")
+			} else {
 				// plain POST (e.g. session creation) -> set requester email to avoid IDP call
 				c.Set("email", "a@e.com")
 			}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -542,7 +542,7 @@ func TestCreateSessionAttachesOwnerReference(t *testing.T) {
 	}
 }
 
-func TestCreateSessionSkipsOwnerReferenceWhenEscalationUIDMissing(t *testing.T) {
+func TestCreateSessionRejectsEscalationWithoutUID(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
@@ -564,10 +564,9 @@ func TestCreateSessionSkipsOwnerReferenceWhenEscalationUIDMissing(t *testing.T) 
 			},
 		},
 	}
-	builder.WithObjects(esc)
 	cli := builder.WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).Build()
 	sesmanager := SessionManager{Client: cli}
-	escmanager := testEscalationLookup{Client: cli}
+	escmanager := uidlessEscalationLookup{escalation: *esc}
 
 	logger, _ := zap.NewDevelopment()
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
@@ -595,13 +594,12 @@ func TestCreateSessionSkipsOwnerReferenceWhenEscalationUIDMissing(t *testing.T) 
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "resolve matched escalation identity")
 
 	allSessions, err := sesmanager.GetAllBreakglassSessions(context.Background())
 	require.NoError(t, err)
-	require.Len(t, allSessions, 1)
-	require.Equal(t, "default", allSessions[0].Namespace)
-	require.Empty(t, allSessions[0].OwnerReferences)
+	require.Empty(t, allSessions)
 }
 
 func TestCreateSessionRejectsUnreadyClusterConfig(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -542,6 +542,68 @@ func TestCreateSessionAttachesOwnerReference(t *testing.T) {
 	}
 }
 
+func TestCreateSessionSkipsOwnerReferenceWhenEscalationUIDMissing(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	esc := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "esc-without-uid",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"test"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup: "esc-group",
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Users: []string{"approver@example.com"},
+			},
+		},
+	}
+	builder.WithObjects(esc)
+	cli := builder.WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "requester@example.com")
+			c.Set("username", "requester")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	reqData := BreakglassSessionRequest{
+		Clustername: "test",
+		Username:    "requester@example.com",
+		GroupName:   "esc-group",
+	}
+	b, err := json.Marshal(reqData)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions", bytes.NewReader(b))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	allSessions, err := sesmanager.GetAllBreakglassSessions(context.Background())
+	require.NoError(t, err)
+	require.Len(t, allSessions, 1)
+	require.Equal(t, "default", allSessions[0].Namespace)
+	require.Empty(t, allSessions[0].OwnerReferences)
+}
+
 func TestCreateSessionRejectsUnreadyClusterConfig(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1382,7 +1382,6 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
 	}
 
-	now := metav1.Now()
 	pending := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "pending-1"},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -1390,7 +1389,7 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 			User:         "requester@example.com",
 			GrantedGroup: "g1",
 		},
-		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending, TimeoutAt: now, RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration))},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending, TimeoutAt: metav1.NewTime(time.Now().Add(time.Hour)), RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration))},
 	}
 
 	// Escalation exists but approver user is different
@@ -1470,7 +1469,7 @@ func TestSessionApproveRejectInvalidOptionalBody(t *testing.T) {
 				},
 				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:         breakglassv1alpha1.SessionStatePending,
-					TimeoutAt:     metav1.Now(),
+					TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
 					RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
 				},
 			}
@@ -1522,6 +1521,151 @@ func TestSessionApproveRejectInvalidOptionalBody(t *testing.T) {
 	}
 }
 
+func TestApproveExpiredPendingSessionReturnsConflict(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approval-timeout", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "test-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStatePending,
+			TimeoutAt:     metav1.NewTime(time.Now().Add(-time.Minute)),
+			RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+		},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-escalation", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+		},
+	}
+
+	cli := builder.
+		WithObjects(session, escalation).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "approver@example.com")
+			c.Set("username", "approver@example.com")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/approval-timeout/approve", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "approval timeout has elapsed")
+
+	var fetched breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "approval-timeout"}, &fetched))
+	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+	require.Empty(t, fetched.Status.Approver)
+}
+
+func TestApprovalAuthorizationUsesOwningEscalation(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	ownerUID := types.UID("owner-escalation-uid")
+	otherUID := types.UID("other-escalation-uid")
+	owningEscalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "owning-escalation", Namespace: "default", UID: ownerUID},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"owner-approver@example.com"}},
+		},
+	}
+	otherEscalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-escalation", Namespace: "default", UID: otherUID},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed:        breakglassv1alpha1.BreakglassEscalationAllowed{Clusters: []string{"test-cluster"}, Groups: []string{"system:authenticated"}},
+			EscalatedGroup: "test-group",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"other-approver@example.com"}},
+		},
+	}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned-session",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: breakglassv1alpha1.GroupVersion.String(),
+				Kind:       "BreakglassEscalation",
+				Name:       owningEscalation.Name,
+				UID:        ownerUID,
+			}},
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "test-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStatePending,
+			TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
+			RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
+		},
+	}
+
+	cli := builder.
+		WithObjects(owningEscalation, otherEscalation, session).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", "other-approver@example.com")
+			c.Set("username", "other-approver@example.com")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, err := http.NewRequest(http.MethodPost, "/breakglassSessions/owned-session/approve", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "not in an approver group")
+
+	var fetched breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "owned-session"}, &fetched))
+	require.Equal(t, breakglassv1alpha1.SessionStatePending, fetched.Status.State)
+	require.Empty(t, fetched.Status.Approver)
+}
+
 func TestApprovalReasonMandatoryEnforced(t *testing.T) {
 	setup := func(t *testing.T, sessionName string) *gin.Engine {
 		t.Helper()
@@ -1530,7 +1674,6 @@ func TestApprovalReasonMandatoryEnforced(t *testing.T) {
 			builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
 		}
 
-		now := metav1.Now()
 		pending := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: sessionName},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -1544,7 +1687,7 @@ func TestApprovalReasonMandatoryEnforced(t *testing.T) {
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:         breakglassv1alpha1.SessionStatePending,
-				TimeoutAt:     now,
+				TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
 				RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
 			},
 		}
@@ -1714,7 +1857,6 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 			}
 
 			// Create a pending session
-			now := metav1.Now()
 			session := &breakglassv1alpha1.BreakglassSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-session", Namespace: esc.Namespace},
 				Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -1724,7 +1866,7 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 				},
 				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:         breakglassv1alpha1.SessionStatePending,
-					TimeoutAt:     now,
+					TimeoutAt:     metav1.NewTime(time.Now().Add(time.Hour)),
 					RetainedUntil: metav1.NewTime(time.Now().Add(MonthDuration)),
 				},
 			}

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -652,21 +652,26 @@ func (wc *BreakglassSessionController) createAndPersistSession(
 	bs.Labels["breakglass.t-caas.telekom.com/group"] = naming.ToRFC1123Label(params.request.GroupName)
 	// Ensure session is created in the same namespace as the matched escalation
 	if params.matchedEsc != nil {
-		reqLog.Debugw("Matched escalation found during session creation; attaching ownerRef",
+		reqLog.Debugw("Matched escalation found during session creation",
 			"escalationName", params.matchedEsc.Name, "escalationUID", params.matchedEsc.UID, "escalationNamespace", params.matchedEsc.Namespace)
 		bs.Namespace = params.matchedEsc.Namespace
-		// Attach owner reference so the session can be linked back to its escalation
-		// This allows other components (webhook/controller) to resolve the escalation
-		// via the session's OwnerReferences.
-		bs.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: breakglassv1alpha1.GroupVersion.String(),
-			Kind:       "BreakglassEscalation",
-			Name:       params.matchedEsc.Name,
-			UID:        params.matchedEsc.UID,
-			// Controller and BlockOwnerDeletion are optional; set Controller=true for clarity.
-			Controller: func() *bool { b := true; return &b }(),
-		}}
-		reqLog.Debugw("OwnerReference prepared for session create", "ownerRefs", bs.OwnerReferences)
+		if params.matchedEsc.UID == "" {
+			reqLog.Debugw("Matched escalation has no UID; session ownerRef will not be attached",
+				"escalationName", params.matchedEsc.Name, "escalationNamespace", params.matchedEsc.Namespace)
+		} else {
+			// Attach owner reference so the session can be linked back to its escalation.
+			// This allows other components (webhook/controller) to resolve the escalation
+			// via the session's OwnerReferences.
+			bs.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: breakglassv1alpha1.GroupVersion.String(),
+				Kind:       "BreakglassEscalation",
+				Name:       params.matchedEsc.Name,
+				UID:        params.matchedEsc.UID,
+				// Controller and BlockOwnerDeletion are optional; set Controller=true for clarity.
+				Controller: func() *bool { b := true; return &b }(),
+			}}
+			reqLog.Debugw("OwnerReference prepared for session create", "ownerRefs", bs.OwnerReferences)
+		}
 	} else {
 		reqLog.Debugw("No matching escalation found during session creation; no ownerRef will be attached", "requestedGroup", system.RedactGroupName(params.request.GroupName), "cluster", params.request.Clustername)
 	}

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -656,22 +656,24 @@ func (wc *BreakglassSessionController) createAndPersistSession(
 			"escalationName", params.matchedEsc.Name, "escalationUID", params.matchedEsc.UID, "escalationNamespace", params.matchedEsc.Namespace)
 		bs.Namespace = params.matchedEsc.Namespace
 		if params.matchedEsc.UID == "" {
-			reqLog.Debugw("Matched escalation has no UID; session ownerRef will not be attached",
-				"escalationName", params.matchedEsc.Name, "escalationNamespace", params.matchedEsc.Namespace)
-		} else {
-			// Attach owner reference so the session can be linked back to its escalation.
-			// This allows other components (webhook/controller) to resolve the escalation
-			// via the session's OwnerReferences.
-			bs.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion: breakglassv1alpha1.GroupVersion.String(),
-				Kind:       "BreakglassEscalation",
-				Name:       params.matchedEsc.Name,
-				UID:        params.matchedEsc.UID,
-				// Controller and BlockOwnerDeletion are optional; set Controller=true for clarity.
-				Controller: func() *bool { b := true; return &b }(),
-			}}
-			reqLog.Debugw("OwnerReference prepared for session create", "ownerRefs", bs.OwnerReferences)
+			err := fmt.Errorf("matched escalation %s/%s has no UID", params.matchedEsc.Namespace, params.matchedEsc.Name)
+			reqLog.Errorw("Refusing to create session for matched escalation without UID",
+				"error", err, "escalationName", params.matchedEsc.Name, "escalationNamespace", params.matchedEsc.Namespace)
+			apiresponses.RespondInternalError(c, "resolve matched escalation identity", err, reqLog)
+			return nil, false
 		}
+		// Attach owner reference so the session can be linked back to its escalation.
+		// This allows other components (webhook/controller) to resolve the escalation
+		// via the session's OwnerReferences.
+		bs.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: breakglassv1alpha1.GroupVersion.String(),
+			Kind:       "BreakglassEscalation",
+			Name:       params.matchedEsc.Name,
+			UID:        params.matchedEsc.UID,
+			// Controller and BlockOwnerDeletion are optional; set Controller=true for clarity.
+			Controller: func() *bool { b := true; return &b }(),
+		}}
+		reqLog.Debugw("OwnerReference prepared for session create", "ownerRefs", bs.OwnerReferences)
 	} else {
 		reqLog.Debugw("No matching escalation found during session creation; no ownerRef will be attached", "requestedGroup", system.RedactGroupName(params.request.GroupName), "cluster", params.request.Clustername)
 	}

--- a/pkg/breakglass/test_helpers_test.go
+++ b/pkg/breakglass/test_helpers_test.go
@@ -22,6 +22,7 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -91,12 +92,24 @@ func (t *testEscalationLookup) GetClusterBreakglassEscalations(ctx context.Conte
 	for _, e := range list.Items {
 		for _, c := range e.Spec.Allowed.Clusters {
 			if c == cluster || c == "*" {
-				out = append(out, e)
+				out = append(out, testEscalationWithUID(e))
 				break
 			}
 		}
 	}
 	return out, nil
+}
+
+func testEscalationWithUID(escalation breakglassv1alpha1.BreakglassEscalation) breakglassv1alpha1.BreakglassEscalation {
+	if escalation.UID != "" {
+		return escalation
+	}
+	namespace := escalation.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	escalation.UID = types.UID("test-" + namespace + "-" + escalation.Name)
+	return escalation
 }
 
 func (t *testEscalationLookup) GetClusterGroupBreakglassEscalations(ctx context.Context, cluster string, groups []string) ([]breakglassv1alpha1.BreakglassEscalation, error) {
@@ -126,4 +139,44 @@ func (t *testEscalationLookup) GetResolver() GroupMemberResolver {
 
 func (t *testEscalationLookup) SetResolver(resolver GroupMemberResolver) {
 	t.resolver = resolver
+}
+
+type uidlessEscalationLookup struct {
+	escalation breakglassv1alpha1.BreakglassEscalation
+	resolver   GroupMemberResolver
+}
+
+func (u *uidlessEscalationLookup) GetClusterBreakglassEscalations(ctx context.Context, cluster string) ([]breakglassv1alpha1.BreakglassEscalation, error) {
+	_ = ctx
+	for _, allowedCluster := range u.escalation.Spec.Allowed.Clusters {
+		if allowedCluster == cluster || allowedCluster == "*" {
+			return []breakglassv1alpha1.BreakglassEscalation{u.escalation}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (u *uidlessEscalationLookup) GetClusterGroupBreakglassEscalations(ctx context.Context, cluster string, groups []string) ([]breakglassv1alpha1.BreakglassEscalation, error) {
+	clusterEscalations, err := u.GetClusterBreakglassEscalations(ctx, cluster)
+	if err != nil || len(clusterEscalations) == 0 {
+		return clusterEscalations, err
+	}
+	groupSet := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		groupSet[group] = struct{}{}
+	}
+	for _, allowedGroup := range u.escalation.Spec.Allowed.Groups {
+		if _, ok := groupSet[allowedGroup]; ok {
+			return clusterEscalations, nil
+		}
+	}
+	return nil, nil
+}
+
+func (u *uidlessEscalationLookup) GetResolver() GroupMemberResolver {
+	return u.resolver
+}
+
+func (u *uidlessEscalationLookup) SetResolver(resolver GroupMemberResolver) {
+	u.resolver = resolver
 }


### PR DESCRIPTION
## Summary
- reject approval attempts for pending BreakglassSessions whose approval timeout has already elapsed
- scope approver authorization to the owning BreakglassEscalation when the session carries an escalation owner reference
- fail closed during session creation if the matched escalation has no UID, so sessions are never created without provenance needed for owner-scoped approval
- isolate deny-policy E2E escalations from broad fixture escalations that share the same production-style escalated groups
- add regression coverage plus API docs and changelog notes

## Evidence
The audit found two approval paths that could diverge from controller intent: an approval request could beat cleanup after `status.timeoutAt`, and a session created by one escalation could be approved by a user who only matches a sibling escalation with the same cluster/group.

Review follow-up also noted that creating a session from a UID-less escalation would omit the ownerRef and weaken that scoping. This PR now fails closed if the matched escalation has no UID; tests normalize fake-client escalations to mirror Kubernetes persisted objects with UIDs.

CI follow-up: Multi-Cluster E2E run `28291205551`, job `83823779928`, failed because deny-policy tests created sessions for shared groups such as `breakglass-pods-admin`; the manager logs showed those sessions were owned by broad fixture escalations like `mc-spoke-a-pods`, then the new owner-scoped approval correctly rejected `policy-approver@example.com`. The tests now use dedicated RBAC-bound deny-policy groups and wait for each test escalation to become Ready before requesting a session.

Duplicate check before opening: open PRs #839, #838, #832, and draft #661 do not cover this behavior. Searches for `approval timeout BreakglassSession` and `owning escalation approval` only found already-merged reason/lifecycle work, not this fix.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -run 'TestApproveExpiredPendingSessionReturnsConflict|TestApproveExpiredPendingSessionChecksAuthorizationBeforeTimeout|TestApprovalAuthorizationUsesOwningEscalation|TestApprovalAuthorizationRequiresOwnerReferenceUIDMatch|TestCreateSessionAttachesOwnerReference|TestCreateSessionRejectsEscalationWithoutUID' -count=1 -timeout=120s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test -race -count=1 ./pkg/api ./pkg/breakglass -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./e2e/api -run '^$' -count=0`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -run 'TestApprovalAuthorizationUsesOwningEscalation|TestCreateSessionAttachesOwnerReference|TestCreateSessionRejectsEscalationWithoutUID|TestApprovalAuthorizationDetailedResponses' -count=1 -timeout=120s`
- `bash -n e2e/kind-setup-multi.sh`
- `git diff --check`
