### PR TITLE
test: fix debug e2e tmux image loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1218,6 +1218,7 @@ jobs:
           # TEST RESULTS
           # ===========================================
           echo "--- Test results ---"
+          cp e2e-core-results.txt "$DIAG_DIR/" 2>/dev/null || true
           cp e2e-results.txt "$DIAG_DIR/" 2>/dev/null || true
           cp oidc-e2e-results.txt "$DIAG_DIR/" 2>/dev/null || true
           

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1444,7 +1444,7 @@ When enabled, participants can attach to shared terminals:
 **Tmux image for E2E:**
 - The repository provides a tmux-enabled image at [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
 - E2E setup scripts build it as `breakglass-tmux-debug:e2e` and load it into Kind before terminal-sharing tests run
-- Test pod templates and pod-copy debug containers use `imagePullPolicy: IfNotPresent` so Kubernetes uses a preloaded Kind image when it is already present instead of pulling from a registry
+- Test pod templates set `imagePullPolicy: IfNotPresent`, and pod-copy E2E requests use the non-`latest` `breakglass-tmux-debug:e2e` image so Kubernetes uses a preloaded Kind image when it is already present instead of pulling from a registry
 - Override the image name via `TMUX_DEBUG_IMAGE` if needed
 
 ## Approval Workflow

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1443,7 +1443,8 @@ When enabled, participants can attach to shared terminals:
 
 **Tmux image for E2E:**
 - The repository provides a tmux-enabled image at [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
-- E2E setup scripts build it as `breakglass-tmux-debug:e2e` and load it into kind
+- E2E setup scripts build it as `breakglass-tmux-debug:e2e` and load it into Kind before terminal-sharing tests run
+- The debug container uses `imagePullPolicy: IfNotPresent`, so Kubernetes uses a preloaded Kind image when it is already present instead of pulling from a registry
 - Override the image name via `TMUX_DEBUG_IMAGE` if needed
 
 ## Approval Workflow

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1444,7 +1444,7 @@ When enabled, participants can attach to shared terminals:
 **Tmux image for E2E:**
 - The repository provides a tmux-enabled image at [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
 - E2E setup scripts build it as `breakglass-tmux-debug:e2e` and load it into Kind before terminal-sharing tests run
-- The debug container uses `imagePullPolicy: IfNotPresent`, so Kubernetes uses a preloaded Kind image when it is already present instead of pulling from a registry
+- Test pod templates and pod-copy debug containers use `imagePullPolicy: IfNotPresent` so Kubernetes uses a preloaded Kind image when it is already present instead of pulling from a registry
 - Override the image name via `TMUX_DEBUG_IMAGE` if needed
 
 ## Approval Workflow

--- a/docs/terminal-sharing-tmux-todo.md
+++ b/docs/terminal-sharing-tmux-todo.md
@@ -24,7 +24,7 @@ exec: "tmux": executable file not found in $PATH
 
 - **Tmux debug image**: [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
 - **Build hook**: E2E setup scripts build and preload the tmux image into kind clusters
-- **Tests updated**: Terminal sharing E2E cases now use the current DebugSession API fields, set `imagePullPolicy: IfNotPresent` for the preloaded local tmux image, and assert terminal sharing is enabled
+- **Tests updated**: Terminal sharing E2E cases now use the current DebugSession API fields, set `imagePullPolicy: IfNotPresent` for the preloaded local tmux image and pod-copy debug containers, and assert terminal sharing is enabled
 
 ## Related Files
 

--- a/docs/terminal-sharing-tmux-todo.md
+++ b/docs/terminal-sharing-tmux-todo.md
@@ -24,7 +24,7 @@ exec: "tmux": executable file not found in $PATH
 
 - **Tmux debug image**: [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
 - **Build hook**: E2E setup scripts build and preload the tmux image into kind clusters
-- **Tests updated**: Terminal sharing E2E cases now use the current DebugSession API fields, set `imagePullPolicy: IfNotPresent` for the preloaded local tmux image and pod-copy debug containers, and assert terminal sharing is enabled
+- **Tests updated**: Terminal sharing E2E cases now use the current DebugSession API fields, set `imagePullPolicy: IfNotPresent` on test pod templates, use a non-`latest` tmux image tag for pod-copy debug containers so Kubernetes reuses the preloaded kind image without changing pull policy, and assert terminal sharing is enabled
 
 ## Related Files
 

--- a/docs/terminal-sharing-tmux-todo.md
+++ b/docs/terminal-sharing-tmux-todo.md
@@ -24,7 +24,7 @@ exec: "tmux": executable file not found in $PATH
 
 - **Tmux debug image**: [e2e/images/tmux-debug/Dockerfile](../e2e/images/tmux-debug/Dockerfile)
 - **Build hook**: E2E setup scripts build and preload the tmux image into kind clusters
-- **Tests updated**: Terminal sharing E2E cases now set `Provider: "tmux"` and assert the provider
+- **Tests updated**: Terminal sharing E2E cases now use the current DebugSession API fields, set `imagePullPolicy: IfNotPresent` for the preloaded local tmux image, and assert terminal sharing is enabled
 
 ## Related Files
 

--- a/e2e/debug_session_e2e_test.go
+++ b/e2e/debug_session_e2e_test.go
@@ -1316,7 +1316,7 @@ func TestDebugSession_E2E_PodCopy(t *testing.T) {
 	copyResult, err := api.CreatePodCopy(ctx, t, session.Name, helpers.PodCopyRequest{
 		Namespace:  "default",
 		PodName:    targetPod.Name,
-		DebugImage: "busybox:latest",
+		DebugImage: helpers.GetTmuxDebugImage(),
 	})
 
 	if err != nil {

--- a/e2e/kubectl_debug_test.go
+++ b/e2e/kubectl_debug_test.go
@@ -225,7 +225,7 @@ func TestTerminalSharingMode(t *testing.T) {
 	err = cli.Get(ctx, client.ObjectKey{Name: session.Name, Namespace: session.Namespace}, &activeSession)
 	require.NoError(t, err)
 	require.NotNil(t, activeSession.Status.TerminalSharing, "Terminal sharing status should be set")
-	require.True(t, activeSession.Status.TerminalSharing.Enabled)
+	require.True(t, activeSession.Status.TerminalSharing.Enabled, "Terminal sharing should be enabled")
 	require.NotEmpty(t, activeSession.Status.TerminalSharing.AttachCommand)
 
 	t.Logf("Terminal sharing configured with attach command: %s", activeSession.Status.TerminalSharing.AttachCommand)

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -266,10 +266,8 @@ e2e_load_image_into_kind() {
   else
     load_status=$?
   fi
-  load_status=$?
   printf '%s\n' "$load_output" >&2
 
-  printf '%s\n' "$load_output" >&2
   if printf '%s\n' "$load_output" | grep -q "failed to detect containerd snapshotter"; then
     log_warn "Direct load failed due to containerd snapshotter issue, using archive method..."
     local tmp_archive

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -266,6 +266,8 @@ e2e_load_image_into_kind() {
   else
     load_status=$?
   fi
+  load_status=$?
+  printf '%s\n' "$load_output" >&2
 
   printf '%s\n' "$load_output" >&2
   if printf '%s\n' "$load_output" | grep -q "failed to detect containerd snapshotter"; then

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -246,8 +246,8 @@ ensure_busybox_image() {
   ensure_image_exists "$image"
 }
 
-# Load image into Kind cluster
-# Uses docker save + kind load image-archive to avoid "failed to detect containerd snapshotter" issues
+# Load image into Kind cluster.
+# Falls back to docker save + kind load image-archive only for the known containerd snapshotter issue.
 e2e_load_image_into_kind() {
   local cluster_name="$1"
   local image="$2"
@@ -258,17 +258,21 @@ e2e_load_image_into_kind() {
   
   # Try direct load first
   local load_output
+  local load_status
   if load_output=$($KIND load docker-image "$image" --name "$cluster_name" 2>&1); then
     printf '%s\n' "$load_output" >&2
     log "Successfully loaded $image into Kind cluster $cluster_name"
     return 0
+  else
+    load_status=$?
   fi
 
   printf '%s\n' "$load_output" >&2
   if printf '%s\n' "$load_output" | grep -q "failed to detect containerd snapshotter"; then
     log_warn "Direct load failed due to containerd snapshotter issue, using archive method..."
     local tmp_archive
-    tmp_archive=$(mktemp --suffix=.tar)
+    local tmp_dir="${TMPDIR:-/tmp}"
+    tmp_archive=$(mktemp "${tmp_dir%/}/breakglass-kind-image.XXXXXX")
     if $DOCKER save "$image" -o "$tmp_archive" && $KIND load image-archive "$tmp_archive" --name "$cluster_name"; then
       log "Successfully loaded $image via archive method"
       rm -f "$tmp_archive"
@@ -281,7 +285,7 @@ e2e_load_image_into_kind() {
   fi
 
   log_error "Failed to load image $image into Kind cluster $cluster_name"
-  return 1
+  return "$load_status"
 }
 
 # Load all standard images required for breakglass E2E

--- a/pkg/breakglass/debug/debug_session_kubectl.go
+++ b/pkg/breakglass/debug/debug_session_kubectl.go
@@ -434,12 +434,11 @@ func (h *KubectlDebugHandler) CreatePodCopy(
 	// Add debug container if image specified
 	if debugImage != "" {
 		debugContainer := corev1.Container{
-			Name:            "debugger",
-			Image:           debugImage,
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"sleep", "infinity"},
-			TTY:             true,
-			Stdin:           true,
+			Name:    "debugger",
+			Image:   debugImage,
+			Command: []string{"sleep", "infinity"},
+			TTY:     true,
+			Stdin:   true,
 		}
 		copyPod.Spec.Containers = append(copyPod.Spec.Containers, debugContainer)
 	}

--- a/pkg/breakglass/debug/debug_session_kubectl.go
+++ b/pkg/breakglass/debug/debug_session_kubectl.go
@@ -434,11 +434,12 @@ func (h *KubectlDebugHandler) CreatePodCopy(
 	// Add debug container if image specified
 	if debugImage != "" {
 		debugContainer := corev1.Container{
-			Name:    "debugger",
-			Image:   debugImage,
-			Command: []string{"sleep", "infinity"},
-			TTY:     true,
-			Stdin:   true,
+			Name:            "debugger",
+			Image:           debugImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"sleep", "infinity"},
+			TTY:             true,
+			Stdin:           true,
 		}
 		copyPod.Spec.Containers = append(copyPod.Spec.Containers, debugContainer)
 	}

--- a/pkg/breakglass/debug/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug/debug_session_kubectl_test.go
@@ -1045,7 +1045,7 @@ func TestKubectlDebugHandler_CreatePodCopy(t *testing.T) {
 		assert.Len(t, pod.Spec.Containers, 2)
 		assert.Equal(t, "debugger", pod.Spec.Containers[1].Name)
 		assert.Equal(t, "busybox:latest", pod.Spec.Containers[1].Image)
-		assert.Equal(t, corev1.PullIfNotPresent, pod.Spec.Containers[1].ImagePullPolicy)
+		assert.Empty(t, pod.Spec.Containers[1].ImagePullPolicy)
 
 		// Check labels
 		assert.Equal(t, testSession.Name, pod.Labels[DebugSessionLabelKey])

--- a/pkg/breakglass/debug/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug/debug_session_kubectl_test.go
@@ -1043,6 +1043,9 @@ func TestKubectlDebugHandler_CreatePodCopy(t *testing.T) {
 
 		// Should have original container + debug container
 		assert.Len(t, pod.Spec.Containers, 2)
+		assert.Equal(t, "debugger", pod.Spec.Containers[1].Name)
+		assert.Equal(t, "busybox:latest", pod.Spec.Containers[1].Image)
+		assert.Equal(t, corev1.PullIfNotPresent, pod.Spec.Containers[1].ImagePullPolicy)
 
 		// Check labels
 		assert.Equal(t, testSession.Name, pod.Labels[DebugSessionLabelKey])


### PR DESCRIPTION
## Summary

- Updates the tagged DebugSession e2e fixtures to compile against the current DebugSession API fields.
- Sets `imagePullPolicy: IfNotPresent` on the local `breakglass-tmux-debug:latest` terminal-sharing pod template so Kind uses the preloaded image instead of pulling from a registry.
- Makes the shared Kind image preload helper fail on real `kind load docker-image` errors, while preserving the archive fallback for the known containerd snapshotter issue.
- Includes `e2e-core-results.txt` in CI diagnostics for the single-cluster comprehensive job.

## Evidence

The terminal-sharing fixture used `helpers.GetTmuxDebugImage()`, which defaults to `breakglass-tmux-debug:latest`. Without an explicit pull policy, Kubernetes defaults `:latest` images to `Always`, so a Kind test pod can try to pull a repo-local image from a registry even after CI preloads it into Kind.

The tagged `e2e/kubectl_debug_test.go` file also drifted from the current API shape (`Rules`, `EphemeralContainerConfig`, `DebugPodTemplateRef`, non-pointer `Template`, and terminal-sharing `Provider` assertions), so `go test -tags=e2e ./e2e` did not keep this path compile-safe before this change.

Duplicate checks before opening:

- `gh search prs --repo telekom/k8s-breakglass "breakglass-tmux-debug imagePullPolicy kind load" --state open` -> no matches
- `gh search prs --repo telekom/k8s-breakglass "TMUX_DEBUG_IMAGE OR e2e_load_image_into_kind OR kubectl_debug_test" --state open` -> no matches
- same searches with `--state closed --merged` -> no matches

## Validation

- `bash -n e2e/lib/common.sh e2e/kind-setup-multi.sh e2e/kind-setup-single.sh`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test -tags=e2e -list 'Test(KubectlDebuggingMode|TerminalSharingMode)' ./e2e`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./e2e -list 'TestDebugSession_E2E_TerminalSharing|TestDebugSession_E2E'`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test -tags=e2e ./e2e -run '^TestTerminalSharingMode$' -count=1 -timeout=60s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./e2e -run '^TestDebugSession_E2E_TerminalSharing$' -count=1 -timeout=60s`
- `git -c core.fsmonitor=false diff --check`

Full Kind-backed e2e runtime remains delegated to CI because the local smoke commands run without `E2E_TEST=true` and without provisioning fresh Kind clusters.
