### PR TITLE
fix: block debug viewers from pod mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 ### Fixed
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1502,6 +1502,7 @@ Debug sessions support multiple participant roles:
 | `viewer` | Read-only access, can observe terminal sharing |
 
 Joining an existing session requires an entry in `spec.invitedParticipants`, an active unexpired session, and terminal sharing enabled by the resolved template/status. Leaving or terminating through the API also requires the session to still be active and unexpired. Self-service join requests always create `viewer` entries; users cannot request the `participant` role for themselves.
+Kubectl-debug mutation endpoints require the requester, an active `owner`, or an active `participant`; active `viewer` entries remain read-only and receive `403 Forbidden` for pod mutation requests.
 
 Leaving a session sets `status.participants[].leftAt`. Participants with
 `leftAt` set are no longer treated as active participants for kubectl-debug
@@ -1571,6 +1572,9 @@ rejected after `status.expiresAt` even if cleanup has not yet marked the session
 `Expired`. Policy denials such as disallowed namespaces or node selector
 mismatches return `403 Forbidden`; unsupported or malformed operation requests
 return `400 Bad Request`.
+They require the requester, an active `owner`, or an active `participant` role
+on the session. `viewer` participants can observe shared terminals but cannot
+inject ephemeral containers, create pod copies, or create node debug pods.
 
 Kubectl-debug operations merge their operation-specific status fields into the
 latest `DebugSession` status before returning. Concurrent renewals, participant

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -345,12 +345,8 @@ type debugSessionReadIdentity struct {
 }
 
 func debugSessionRequestIdentity(ctx *gin.Context) (debugSessionReadIdentity, bool) {
-	usernameValue, exists := ctx.Get("username")
-	if !exists || usernameValue == nil {
-		return debugSessionReadIdentity{}, false
-	}
-	username, ok := usernameValue.(string)
-	if !ok || username == "" {
+	username, ok := debugSessionUsernameFromContext(ctx)
+	if !ok {
 		return debugSessionReadIdentity{}, false
 	}
 
@@ -364,6 +360,38 @@ func debugSessionRequestIdentity(ctx *gin.Context) (debugSessionReadIdentity, bo
 		identity.groups = debugSessionGroupsFromContext(groupsValue)
 	}
 	return identity, true
+}
+
+func debugSessionUsernameFromContext(ctx *gin.Context) (string, bool) {
+	usernameValue, exists := ctx.Get("username")
+	if !exists || usernameValue == nil {
+		return "", false
+	}
+	username, ok := usernameValue.(string)
+	username = strings.TrimSpace(username)
+	if !ok || username == "" {
+		return "", false
+	}
+	return username, true
+}
+
+func requireDebugSessionUsername(ctx *gin.Context) (string, bool) {
+	usernameValue, exists := ctx.Get("username")
+	if !exists || usernameValue == nil {
+		apiresponses.RespondUnauthorized(ctx)
+		return "", false
+	}
+	username, ok := usernameValue.(string)
+	if !ok {
+		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
+		return "", false
+	}
+	username = strings.TrimSpace(username)
+	if username == "" {
+		apiresponses.RespondUnauthorized(ctx)
+		return "", false
+	}
+	return username, true
 }
 
 func debugSessionGroupsFromContext(groupsValue interface{}) []string {
@@ -621,19 +649,8 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		req.Reason = breakglass.SanitizeReasonText(req.Reason)
 	}
 
-	// Get current user from context before authorization checks.
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
-		return
-	}
-	currentUserStr, ok := currentUser.(string)
+	currentUserStr, ok := requireDebugSessionUsername(ctx)
 	if !ok {
-		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
-		return
-	}
-	if strings.TrimSpace(currentUserStr) == "" {
-		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
 
@@ -1155,13 +1172,13 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	c.sendDebugSessionCreatedEmail(apiCtx, session, template, resolvedBinding)
 
 	// Emit audit event for session creation
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionCreated, session, currentUser.(string), "Debug session created")
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionCreated, session, currentUserStr, "Debug session created")
 
 	reqLog.Infow("Debug session created",
 		"name", sessionName,
 		"cluster", req.Cluster,
 		"template", req.TemplateRef,
-		"user", currentUser)
+		"user", currentUserStr)
 
 	metrics.DebugSessionsCreated.WithLabelValues(req.Cluster, req.TemplateRef).Inc()
 

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -1073,6 +1073,8 @@ func TestCanUserOperateDebugResources(t *testing.T) {
 				{User: "left-participant@example.com", Role: breakglassv1alpha1.ParticipantRoleParticipant, JoinedAt: now, LeftAt: &leftAt},
 				{User: "unknown-role@example.com", Role: breakglassv1alpha1.ParticipantRole("operator"), JoinedAt: now},
 				{User: "empty-role@example.com", JoinedAt: now},
+				{User: "upgraded@example.com", Role: breakglassv1alpha1.ParticipantRoleViewer, JoinedAt: now},
+				{User: "upgraded@example.com", Role: breakglassv1alpha1.ParticipantRoleParticipant, JoinedAt: now},
 			},
 		},
 	}
@@ -1089,6 +1091,7 @@ func TestCanUserOperateDebugResources(t *testing.T) {
 		{name: "left participant cannot mutate", user: "left-participant@example.com", want: false},
 		{name: "unknown role cannot mutate", user: "unknown-role@example.com", want: false},
 		{name: "empty role cannot mutate", user: "empty-role@example.com", want: false},
+		{name: "later participant role can mutate after viewer entry", user: "upgraded@example.com", want: true},
 		{name: "unrelated user", user: "other@example.com", want: false},
 	}
 

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -1054,6 +1054,51 @@ func TestIsUserParticipant_LeftParticipant(t *testing.T) {
 	assert.False(t, ctrl.isUserParticipant(session, "left-participant@example.com"))
 }
 
+func TestCanUserOperateDebugResources(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	now := metav1.Now()
+	leftAt := metav1.Now()
+	session := &breakglassv1alpha1.DebugSession{
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			RequestedBy: "owner@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
+				{User: "participant@example.com", Role: breakglassv1alpha1.ParticipantRoleParticipant, JoinedAt: now},
+				{User: "status-owner@example.com", Role: breakglassv1alpha1.ParticipantRoleOwner, JoinedAt: now},
+				{User: "viewer@example.com", Role: breakglassv1alpha1.ParticipantRoleViewer, JoinedAt: now},
+				{User: "left-participant@example.com", Role: breakglassv1alpha1.ParticipantRoleParticipant, JoinedAt: now, LeftAt: &leftAt},
+				{User: "unknown-role@example.com", Role: breakglassv1alpha1.ParticipantRole("operator"), JoinedAt: now},
+				{User: "empty-role@example.com", JoinedAt: now},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		user string
+		want bool
+	}{
+		{name: "session requester", user: "owner@example.com", want: true},
+		{name: "active participant", user: "participant@example.com", want: true},
+		{name: "status owner", user: "status-owner@example.com", want: true},
+		{name: "viewer cannot mutate", user: "viewer@example.com", want: false},
+		{name: "left participant cannot mutate", user: "left-participant@example.com", want: false},
+		{name: "unknown role cannot mutate", user: "unknown-role@example.com", want: false},
+		{name: "empty role cannot mutate", user: "empty-role@example.com", want: false},
+		{name: "unrelated user", user: "other@example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ctrl.canUserOperateDebugResources(session, tt.user))
+		})
+	}
+}
+
 // ============================================================================
 // Tests for extractCapabilities and extractRunAsNonRoot
 // ============================================================================

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -344,15 +344,8 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 		return
 	}
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
-		return
-	}
-	username, ok := currentUser.(string)
+	username, ok := requireDebugSessionUsername(ctx)
 	if !ok {
-		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
 		return
 	}
 
@@ -428,7 +421,7 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 		"pod", req.PodName,
 		"namespace", req.Namespace,
 		"container", req.ContainerName,
-		"user", currentUser)
+		"user", username)
 
 	ctx.JSON(http.StatusOK, gin.H{
 		"message":   "ephemeral container injected successfully",
@@ -455,15 +448,8 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 		return
 	}
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
-		return
-	}
-	username, ok := currentUser.(string)
+	username, ok := requireDebugSessionUsername(ctx)
 	if !ok {
-		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
 		return
 	}
 
@@ -527,7 +513,7 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 		"originalNamespace", req.Namespace,
 		"copyName", pod.Name,
 		"copyNamespace", pod.Namespace,
-		"user", currentUser)
+		"user", username)
 
 	ctx.JSON(http.StatusOK, gin.H{
 		"message":           "pod copy created successfully",
@@ -555,15 +541,8 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 		return
 	}
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
-		return
-	}
-	username, ok := currentUser.(string)
+	username, ok := requireDebugSessionUsername(ctx)
 	if !ok {
-		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
 		return
 	}
 
@@ -626,7 +605,7 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 		"node", req.NodeName,
 		"podName", pod.Name,
 		"namespace", pod.Namespace,
-		"user", currentUser)
+		"user", username)
 
 	ctx.JSON(http.StatusOK, gin.H{
 		"message":   "node debug pod created successfully",
@@ -713,7 +692,7 @@ func (c *DebugSessionAPIController) canUserOperateDebugResources(session *breakg
 		case breakglassv1alpha1.ParticipantRoleOwner, breakglassv1alpha1.ParticipantRoleParticipant:
 			return true
 		default:
-			return false
+			continue
 		}
 	}
 

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -350,6 +350,11 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
+	username, ok := currentUser.(string)
+	if !ok {
+		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
+		return
+	}
 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
@@ -376,9 +381,9 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 		return
 	}
 
-	// Verify user is a participant
-	if !c.isUserParticipant(session, currentUser.(string)) {
-		apiresponses.RespondForbidden(ctx, "user is not a participant of this session")
+	// Verify user can perform mutating debug operations
+	if !c.canUserOperateDebugResources(session, username) {
+		apiresponses.RespondForbidden(ctx, "user is not allowed to modify debug resources for this session")
 		return
 	}
 
@@ -408,7 +413,7 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 	}
 
 	// Inject the ephemeral container
-	if err := handler.InjectEphemeralContainer(apiCtx, session, req.Namespace, req.PodName, req.ContainerName, req.Image, req.Command, req.SecurityContext, currentUser.(string)); err != nil {
+	if err := handler.InjectEphemeralContainer(apiCtx, session, req.Namespace, req.PodName, req.ContainerName, req.Image, req.Command, req.SecurityContext, username); err != nil {
 		if kubectlDebugOperationHTTPStatus(err) >= http.StatusInternalServerError {
 			reqLog.Errorw("Failed to inject ephemeral container", "error", err)
 		} else {
@@ -456,6 +461,11 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
+	username, ok := currentUser.(string)
+	if !ok {
+		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
+		return
+	}
 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
@@ -482,9 +492,9 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 		return
 	}
 
-	// Verify user is a participant
-	if !c.isUserParticipant(session, currentUser.(string)) {
-		apiresponses.RespondForbidden(ctx, "user is not a participant of this session")
+	// Verify user can perform mutating debug operations
+	if !c.canUserOperateDebugResources(session, username) {
+		apiresponses.RespondForbidden(ctx, "user is not allowed to modify debug resources for this session")
 		return
 	}
 
@@ -500,7 +510,7 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 	handler := NewKubectlDebugHandler(c.client, &clusterClientAdapter{ccProvider: c.ccProvider})
 
 	// Create the pod copy
-	pod, err := handler.CreatePodCopy(apiCtx, session, req.Namespace, req.PodName, req.DebugImage, currentUser.(string))
+	pod, err := handler.CreatePodCopy(apiCtx, session, req.Namespace, req.PodName, req.DebugImage, username)
 	if err != nil {
 		if kubectlDebugOperationHTTPStatus(err) >= http.StatusInternalServerError {
 			reqLog.Errorw("Failed to create pod copy", "error", err)
@@ -551,6 +561,11 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
+	username, ok := currentUser.(string)
+	if !ok {
+		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
+		return
+	}
 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
@@ -577,9 +592,9 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 		return
 	}
 
-	// Verify user is a participant
-	if !c.isUserParticipant(session, currentUser.(string)) {
-		apiresponses.RespondForbidden(ctx, "user is not a participant of this session")
+	// Verify user can perform mutating debug operations
+	if !c.canUserOperateDebugResources(session, username) {
+		apiresponses.RespondForbidden(ctx, "user is not allowed to modify debug resources for this session")
 		return
 	}
 
@@ -595,7 +610,7 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 	handler := NewKubectlDebugHandler(c.client, &clusterClientAdapter{ccProvider: c.ccProvider})
 
 	// Create the node debug pod
-	pod, err := handler.CreateNodeDebugPod(apiCtx, session, req.NodeName, currentUser.(string))
+	pod, err := handler.CreateNodeDebugPod(apiCtx, session, req.NodeName, username)
 	if err != nil {
 		if kubectlDebugOperationHTTPStatus(err) >= http.StatusInternalServerError {
 			reqLog.Errorw("Failed to create node debug pod", "error", err)
@@ -677,6 +692,28 @@ func (c *DebugSessionAPIController) isUserParticipant(session *breakglassv1alpha
 	for _, p := range session.Status.Participants {
 		if p.User == user && p.LeftAt == nil {
 			return true
+		}
+	}
+
+	return false
+}
+
+// canUserOperateDebugResources checks if the user can run mutating kubectl-debug operations.
+func (c *DebugSessionAPIController) canUserOperateDebugResources(session *breakglassv1alpha1.DebugSession, user string) bool {
+	if session.Spec.RequestedBy == user {
+		return true
+	}
+
+	for _, p := range session.Status.Participants {
+		if p.User != user || p.LeftAt != nil {
+			continue
+		}
+
+		switch p.Role {
+		case breakglassv1alpha1.ParticipantRoleOwner, breakglassv1alpha1.ParticipantRoleParticipant:
+			return true
+		default:
+			return false
 		}
 	}
 

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -304,6 +304,70 @@ func TestDebugKubectlOperationsStrictJSON(t *testing.T) {
 	}
 }
 
+func TestDebugKubectlOperationsRejectNonStringUsername(t *testing.T) {
+	_, ctrl := setupTestRouter(t)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", 12345)
+		c.Next()
+	})
+	api := router.Group("/api")
+	rg := api.Group("/debugSessions")
+	require.NoError(t, ctrl.Register(rg))
+
+	tests := []struct {
+		name string
+		path string
+		body interface{}
+	}{
+		{
+			name: "inject ephemeral container",
+			path: "/api/debugSessions/test-session/injectEphemeralContainer",
+			body: InjectEphemeralContainerRequest{
+				Namespace:     "default",
+				PodName:       "test-pod",
+				ContainerName: "debug",
+				Image:         "busybox",
+			},
+		},
+		{
+			name: "create pod copy",
+			path: "/api/debugSessions/test-session/createPodCopy",
+			body: CreatePodCopyRequest{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+		{
+			name: "create node debug pod",
+			path: "/api/debugSessions/test-session/createNodeDebugPod",
+			body: CreateNodeDebugPodRequest{
+				NodeName: "node-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, tt.path, bytes.NewBuffer(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusInternalServerError, rr.Code)
+			assertErrorResponse(t, rr, "INTERNAL_ERROR")
+			assert.Contains(t, rr.Body.String(), "invalid user context type")
+		})
+	}
+}
+
 func TestHandleInjectEphemeralContainer_Unauthorized(t *testing.T) {
 	router, _ := setupTestRouter(t)
 
@@ -494,7 +558,7 @@ func TestHandleInjectEphemeralContainer_UserNotParticipant(t *testing.T) {
 	router.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
-	assert.Contains(t, rr.Body.String(), "not a participant")
+	assert.Contains(t, rr.Body.String(), "not allowed to modify debug resources")
 }
 
 func TestHandleInjectEphemeralContainer_TemplateNotKubectlDebug(t *testing.T) {
@@ -624,9 +688,11 @@ func TestHandleInjectEphemeralContainer_ValidationErrorClassification(t *testing
 				ContainerName: "debug",
 				Image:         "busybox",
 			}
-			body, _ := json.Marshal(reqBody)
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
 
-			req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/active-session/injectEphemeralContainer", bytes.NewBuffer(body))
+			req, err := http.NewRequest(http.MethodPost, "/api/debugSessions/active-session/injectEphemeralContainer", bytes.NewBuffer(body))
+			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			rr := httptest.NewRecorder()
 
@@ -635,6 +701,95 @@ func TestHandleInjectEphemeralContainer_ValidationErrorClassification(t *testing
 			assert.Equal(t, tt.wantHTTP, rr.Code)
 			assertErrorResponse(t, rr, tt.wantCode)
 			assert.Contains(t, rr.Body.String(), tt.wantMessage)
+		})
+	}
+}
+
+func TestKubectlDebugMutationHandlers_ViewerParticipantForbidden(t *testing.T) {
+	now := metav1.Now()
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-session",
+			Namespace: "default",
+			Labels: map[string]string{
+				DebugSessionLabelKey: "active-session",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "owner-user",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeKubectlDebug,
+			},
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
+				{
+					User:     "viewer-user",
+					Role:     breakglassv1alpha1.ParticipantRoleViewer,
+					JoinedAt: now,
+				},
+			},
+		},
+	}
+
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	router := setupAuthenticatedDebugSessionRouter(t, ctrl, "viewer-user", "", nil)
+
+	tests := []struct {
+		name string
+		path string
+		body interface{}
+	}{
+		{
+			name: "inject ephemeral container",
+			path: "/api/debugSessions/active-session/injectEphemeralContainer",
+			body: InjectEphemeralContainerRequest{
+				Namespace:     "default",
+				PodName:       "test-pod",
+				ContainerName: "debug",
+				Image:         "busybox",
+			},
+		},
+		{
+			name: "create pod copy",
+			path: "/api/debugSessions/active-session/createPodCopy",
+			body: CreatePodCopyRequest{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+		{
+			name: "create node debug pod",
+			path: "/api/debugSessions/active-session/createNodeDebugPod",
+			body: CreateNodeDebugPodRequest{
+				NodeName: "node-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, tt.path, bytes.NewBuffer(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Contains(t, rr.Body.String(), "not allowed to modify debug resources")
 		})
 	}
 }

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -25,10 +25,8 @@ func (c *DebugSessionAPIController) handleJoinDebugSession(ctx *gin.Context) {
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
+	username, ok := requireDebugSessionUsername(ctx)
+	if !ok {
 		return
 	}
 	if rejectUnexpectedDebugActionBody(ctx) {
@@ -56,13 +54,6 @@ func (c *DebugSessionAPIController) handleJoinDebugSession(ctx *gin.Context) {
 	}
 	if isDebugSessionExpired(session, time.Now()) {
 		apiresponses.RespondBadRequest(ctx, "cannot join expired session")
-		return
-	}
-
-	// Check if user already joined
-	username, ok := currentUser.(string)
-	if !ok {
-		apiresponses.RespondInternalErrorSimple(ctx, "invalid user context type")
 		return
 	}
 
@@ -326,10 +317,8 @@ func (c *DebugSessionAPIController) handleTerminateDebugSession(ctx *gin.Context
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
+	username, ok := requireDebugSessionUsername(ctx)
+	if !ok {
 		return
 	}
 
@@ -349,7 +338,7 @@ func (c *DebugSessionAPIController) handleTerminateDebugSession(ctx *gin.Context
 
 	// Check if user is allowed to terminate (owner or admin)
 	// For now, only the owner can terminate
-	if session.Spec.RequestedBy != currentUser.(string) {
+	if session.Spec.RequestedBy != username {
 		apiresponses.RespondForbidden(ctx, "only the session owner can terminate")
 		return
 	}
@@ -375,7 +364,7 @@ func (c *DebugSessionAPIController) handleTerminateDebugSession(ctx *gin.Context
 
 	// Mark as terminated
 	session.Status.State = breakglassv1alpha1.DebugSessionStateTerminated
-	session.Status.Message = fmt.Sprintf("Terminated by %s", currentUser)
+	session.Status.Message = fmt.Sprintf("Terminated by %s", username)
 
 	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
 		reqLog.Errorw("Failed to terminate session", "session", name, "error", err)
@@ -384,9 +373,9 @@ func (c *DebugSessionAPIController) handleTerminateDebugSession(ctx *gin.Context
 	}
 
 	// Emit audit event for session termination
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, currentUser.(string), "Debug session terminated by user")
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, username, "Debug session terminated by user")
 
-	reqLog.Infow("Debug session terminated", "session", name, "user", currentUser)
+	reqLog.Infow("Debug session terminated", "session", name, "user", username)
 	metrics.DebugSessionsTerminated.WithLabelValues(session.Spec.Cluster, "user_terminated").Inc()
 
 	// Return updated session - client expects the session object, not just a message
@@ -399,10 +388,8 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
+	username, ok := requireDebugSessionUsername(ctx)
+	if !ok {
 		return
 	}
 
@@ -441,7 +428,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	if email, exists := ctx.Get("email"); exists && email != nil {
 		currentUserEmail, _ = email.(string)
 	}
-	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, currentUser.(string), currentUserEmail, userGroups) {
+	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to approve this session")
 		return
 	}
@@ -460,7 +447,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	if session.Status.Approval == nil {
 		session.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{}
 	}
-	session.Status.Approval.ApprovedBy = currentUser.(string)
+	session.Status.Approval.ApprovedBy = username
 	session.Status.Approval.ApprovedAt = &now
 	session.Status.Approval.Reason = req.Reason
 
@@ -474,9 +461,9 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	c.sendDebugSessionApprovalEmail(apiCtx, session)
 
 	// Emit audit event for session approval
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionStarted, session, currentUser.(string), "Debug session approved")
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionStarted, session, username, "Debug session approved")
 
-	reqLog.Infow("Debug session approved", "session", name, "approver", currentUser)
+	reqLog.Infow("Debug session approved", "session", name, "approver", username)
 	metrics.DebugSessionApproved.WithLabelValues(session.Spec.Cluster, "user").Inc()
 
 	// Return updated session - client expects the session object, not just a message
@@ -489,10 +476,8 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
+	username, ok := requireDebugSessionUsername(ctx)
+	if !ok {
 		return
 	}
 
@@ -531,7 +516,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	if email, exists := ctx.Get("email"); exists && email != nil {
 		currentUserEmail, _ = email.(string)
 	}
-	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, currentUser.(string), currentUserEmail, userGroups) {
+	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to reject this session")
 		return
 	}
@@ -552,13 +537,13 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	if session.Status.Approval == nil {
 		session.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{}
 	}
-	session.Status.Approval.RejectedBy = currentUser.(string)
+	session.Status.Approval.RejectedBy = username
 	session.Status.Approval.RejectedAt = &now
 	session.Status.Approval.Reason = sanitizedReason
 
 	// Move to terminated state
 	session.Status.State = breakglassv1alpha1.DebugSessionStateTerminated
-	session.Status.Message = fmt.Sprintf("Rejected by %s: %s", currentUser, sanitizedReason)
+	session.Status.Message = fmt.Sprintf("Rejected by %s: %s", username, sanitizedReason)
 
 	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
 		reqLog.Errorw("Failed to reject session", "session", name, "error", err)
@@ -570,9 +555,9 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	c.sendDebugSessionRejectionEmail(apiCtx, session)
 
 	// Emit audit event for session rejection
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, currentUser.(string), fmt.Sprintf("Debug session rejected: %s", req.Reason))
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, username, fmt.Sprintf("Debug session rejected: %s", req.Reason))
 
-	reqLog.Infow("Debug session rejected", "session", name, "rejector", currentUser, "reason", req.Reason)
+	reqLog.Infow("Debug session rejected", "session", name, "rejector", username, "reason", req.Reason)
 	metrics.DebugSessionRejected.WithLabelValues(session.Spec.Cluster, "user_rejected").Inc()
 
 	// Return updated session - client expects the session object, not just a message
@@ -585,10 +570,8 @@ func (c *DebugSessionAPIController) handleLeaveDebugSession(ctx *gin.Context) {
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	// Get current user
-	currentUser, exists := ctx.Get("username")
-	if !exists || currentUser == nil {
-		apiresponses.RespondUnauthorized(ctx)
+	username, ok := requireDebugSessionUsername(ctx)
+	if !ok {
 		return
 	}
 
@@ -611,7 +594,6 @@ func (c *DebugSessionAPIController) handleLeaveDebugSession(ctx *gin.Context) {
 	}
 
 	// Find the participant
-	username := currentUser.(string)
 	participantIndex := -1
 	for i := range session.Status.Participants {
 		if session.Status.Participants[i].User == username {


### PR DESCRIPTION
## Summary
- require the requester or an active owner/participant role for kubectl-debug mutation endpoints
- keep active viewer participants read-only for ephemeral container, pod copy, and node debug pod operations
- document the role boundary and add changelog coverage

## Evidence
- `api/v1alpha1/debug_session_types.go` defines `viewer` as observe-only.
- Before this change, `injectEphemeralContainer`, `createPodCopy`, and `createNodeDebugPod` only checked `isUserParticipant`, which accepted active viewers.
- Added handler-level regression coverage for all three mutation endpoints with an active viewer participant.

## Duplicate check
- `gh search prs --repo telekom/k8s-breakglass "viewer participant debug pod mutation createNodeDebugPod injectEphemeralContainer" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "isUserParticipant participant role viewer debug session" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "viewer participant debug pod mutation createNodeDebugPod injectEphemeralContainer" --state closed` -> `[]`

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -run 'Test(IsUserParticipant|CanUserOperateDebugResources|KubectlDebugMutationHandlers_ViewerParticipantForbidden|HandleInjectEphemeralContainer|HandleCreatePodCopy|HandleCreateNodeDebugPod)' -count=1 -timeout=120s`\n- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -count=1 -timeout=180s`\n- `git -c core.fsmonitor=false diff --check`