### PR TITLE
fix: enforce debug approval timeout in handlers

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1068,6 +1068,12 @@ When present, the optional approval body must contain only the known `reason` fi
 
 Approves a session in `PendingApproval` state.
 
+If the `DEBUG_SESSION_APPROVAL_TIMEOUT` deadline has elapsed, the handler
+returns `409 Conflict`. Before returning the conflict, it reloads the latest
+session state and may mark the session `Failed` with an approval-timeout
+message; already decided approvals and already recorded timeout failures also
+return `409 Conflict`.
+
 `reason` is required when the session's stored `approvalReasonConfig.mandatory`
 is `true`, and must satisfy the configured `minLength` after sanitization.
 
@@ -1088,6 +1094,12 @@ POST /api/debugSessions/:name/reject
 ```
 
 Rejects a session in `PendingApproval` state.
+
+If the `DEBUG_SESSION_APPROVAL_TIMEOUT` deadline has elapsed, the handler
+returns `409 Conflict`. Before returning the conflict, it reloads the latest
+session state and may mark the session `Failed` with an approval-timeout
+message; already decided approvals and already recorded timeout failures also
+return `409 Conflict`.
 
 When present, the rejection body must contain only the known `reason` field and exactly one JSON object.
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1902,7 +1902,7 @@ spec:
 - Verify approver groups/users are configured
 - Check if user is in autoApproveFor groups
 - Contact an approver to approve/reject
-- Sessions automatically fail after `DEBUG_SESSION_APPROVAL_TIMEOUT` (default: 24h) — the reconciler checks this on every requeue cycle
+- Sessions automatically fail after `DEBUG_SESSION_APPROVAL_TIMEOUT` (default: 24h) — approve/reject API calls enforce the deadline immediately, and the reconciler also checks this on every requeue cycle
 
 ### Debug pods not starting
 

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -1443,6 +1443,24 @@ func TestShouldSendNotification(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "enabled config - termination event with notify on termination",
+			cfg: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:             true,
+				NotifyOnTermination: true,
+			},
+			event:    notificationEventTermination,
+			expected: true,
+		},
+		{
+			name: "enabled config - termination event without notify on termination",
+			cfg: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:             true,
+				NotifyOnTermination: false,
+			},
+			event:    notificationEventTermination,
+			expected: false,
+		},
+		{
 			name: "enabled config - unknown event returns true",
 			cfg: &breakglassv1alpha1.DebugSessionNotificationConfig{
 				Enabled: true,

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -234,6 +234,53 @@ func (c *DebugSessionAPIController) sendDebugSessionRejectionEmail(ctx context.C
 	}
 }
 
+// sendDebugSessionFailedEmail sends email notification to requester when a debug session fails.
+func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Context, session *breakglassv1alpha1.DebugSession, reason string) {
+	if c.disableEmail || c.mailService == nil || !c.mailService.IsEnabled() {
+		return
+	}
+
+	recipientEmail := session.Spec.RequestedByEmail
+	if recipientEmail == "" {
+		recipientEmail = session.Spec.RequestedBy
+	}
+	if !strings.Contains(recipientEmail, "@") {
+		c.log.Warnw("Skipping failure email - no valid email address", "session", session.Name, "recipient", recipientEmail)
+		return
+	}
+
+	requesterName := session.Spec.RequestedByDisplayName
+	if requesterName == "" {
+		requesterName = session.Spec.RequestedBy
+	}
+
+	params := mail.DebugSessionFailedMailParams{
+		RequesterName:  requesterName,
+		RequesterEmail: recipientEmail,
+		SessionID:      session.Name,
+		Cluster:        session.Spec.Cluster,
+		TemplateName:   session.Spec.TemplateRef,
+		Namespace:      session.Namespace,
+		FailedAt:       time.Now().Format(time.RFC3339),
+		FailureReason:  reason,
+		URL:            fmt.Sprintf("%s/debug-sessions", c.baseURL),
+		BrandingName:   c.brandingName,
+	}
+
+	body, err := mail.RenderDebugSessionFailed(params)
+	if err != nil {
+		c.log.Errorw("Failed to render debug session failed email", "session", session.Name, "error", err)
+		return
+	}
+
+	subject := fmt.Sprintf("[%s] Debug Session Failed: %s", c.brandingName, session.Name)
+	if err := c.mailService.Enqueue(session.Name, []string{recipientEmail}, subject, body); err != nil {
+		c.log.Errorw("Failed to enqueue debug session failed email", "session", session.Name, "error", err)
+	} else {
+		c.log.Infow("Debug session failed email queued", "session", session.Name, "requester", session.Spec.RequestedBy)
+	}
+}
+
 // sendDebugSessionCreatedEmail sends email confirmation to requester when a debug session is created
 func (c *DebugSessionAPIController) sendDebugSessionCreatedEmail(ctx context.Context, session *breakglassv1alpha1.DebugSession, template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) {
 	if c.disableEmail || c.mailService == nil || !c.mailService.IsEnabled() {

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -247,7 +247,7 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 	recipients := []string{requesterEmail}
 
 	params := mail.DebugSessionFailedMailParams{
-		RequesterName:  session.Spec.RequestedBy,
+		RequesterName:  debugSessionRequesterDisplayName(session),
 		RequesterEmail: requesterEmail,
 		SessionID:      session.Name,
 		Cluster:        session.Spec.Cluster,
@@ -271,6 +271,13 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 	} else {
 		c.log.Infow("Debug session failed email queued", "session", session.Name, "requester", requesterEmail)
 	}
+}
+
+func debugSessionRequesterDisplayName(session *breakglassv1alpha1.DebugSession) string {
+	if session.Spec.RequestedByDisplayName != "" {
+		return session.Spec.RequestedByDisplayName
+	}
+	return session.Spec.RequestedBy
 }
 
 // sendDebugSessionCreatedEmail sends email confirmation to requester when a debug session is created

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -240,23 +240,11 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 		return
 	}
 
-	recipientEmail := session.Spec.RequestedByEmail
-	if recipientEmail == "" {
-		recipientEmail = session.Spec.RequestedBy
-	}
-	if !strings.Contains(recipientEmail, "@") {
-		c.log.Warnw("Skipping failure email - no valid email address", "session", session.Name, "recipient", recipientEmail)
-		return
-	}
-
-	requesterName := session.Spec.RequestedByDisplayName
-	if requesterName == "" {
-		requesterName = session.Spec.RequestedBy
-	}
+	recipients := []string{session.Spec.RequestedBy}
 
 	params := mail.DebugSessionFailedMailParams{
-		RequesterName:  requesterName,
-		RequesterEmail: recipientEmail,
+		RequesterName:  session.Spec.RequestedBy,
+		RequesterEmail: session.Spec.RequestedBy,
 		SessionID:      session.Name,
 		Cluster:        session.Spec.Cluster,
 		TemplateName:   session.Spec.TemplateRef,
@@ -274,7 +262,7 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 	}
 
 	subject := fmt.Sprintf("[%s] Debug Session Failed: %s", c.brandingName, session.Name)
-	if err := c.mailService.Enqueue(session.Name, []string{recipientEmail}, subject, body); err != nil {
+	if err := c.mailService.Enqueue(session.Name, recipients, subject, body); err != nil {
 		c.log.Errorw("Failed to enqueue debug session failed email", "session", session.Name, "error", err)
 	} else {
 		c.log.Infow("Debug session failed email queued", "session", session.Name, "requester", session.Spec.RequestedBy)
@@ -372,6 +360,16 @@ func (c *DebugSessionAPIController) emitDebugSessionAuditEvent(ctx context.Conte
 	}
 
 	c.auditService.Emit(ctx, event)
+}
+
+func (c *DebugSessionAPIController) shouldEmitAudit(session *breakglassv1alpha1.DebugSession) bool {
+	if session.Status.ResolvedTemplate == nil {
+		return true
+	}
+	if session.Status.ResolvedTemplate.Audit == nil {
+		return true
+	}
+	return session.Status.ResolvedTemplate.Audit.Enabled
 }
 
 // handleInjectEphemeralContainer injects a debug container into an existing pod

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -240,11 +240,15 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 		return
 	}
 
-	recipients := []string{session.Spec.RequestedBy}
+	requesterEmail := session.Spec.RequestedByEmail
+	if requesterEmail == "" {
+		requesterEmail = session.Spec.RequestedBy
+	}
+	recipients := []string{requesterEmail}
 
 	params := mail.DebugSessionFailedMailParams{
 		RequesterName:  session.Spec.RequestedBy,
-		RequesterEmail: session.Spec.RequestedBy,
+		RequesterEmail: requesterEmail,
 		SessionID:      session.Name,
 		Cluster:        session.Spec.Cluster,
 		TemplateName:   session.Spec.TemplateRef,
@@ -265,7 +269,7 @@ func (c *DebugSessionAPIController) sendDebugSessionFailedEmail(ctx context.Cont
 	if err := c.mailService.Enqueue(session.Name, recipients, subject, body); err != nil {
 		c.log.Errorw("Failed to enqueue debug session failed email", "session", session.Name, "error", err)
 	} else {
-		c.log.Infow("Debug session failed email queued", "session", session.Name, "requester", session.Spec.RequestedBy)
+		c.log.Infow("Debug session failed email queued", "session", session.Name, "requester", requesterEmail)
 	}
 }
 

--- a/pkg/breakglass/debug/debug_session_api_email_test.go
+++ b/pkg/breakglass/debug/debug_session_api_email_test.go
@@ -397,9 +397,111 @@ func TestSendDebugSessionFailedEmail_HappyPath(t *testing.T) {
 	messages := mockMail.GetMessages()
 	require.Len(t, messages, 1)
 	assert.Equal(t, "failed-debug-session", messages[0].SessionID)
-	assert.Equal(t, []string{"developer@example.com"}, messages[0].Recipients)
+	assert.Equal(t, []string{"developer"}, messages[0].Recipients)
 	assert.Contains(t, messages[0].Subject, "Debug Session Failed")
 	assert.Contains(t, messages[0].Body, "Approval timed out after 24h")
+}
+
+func TestSendDebugSessionFailedEmail_IgnoresNotificationRecipients(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "standard-debug"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Notification: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:              true,
+				NotifyOnTermination:  true,
+				AdditionalRecipients: []string{"ops@example.com"},
+				ExcludedRecipients: &breakglassv1alpha1.NotificationExclusions{
+					Users: []string{"developer@example.com"},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(template).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:            "standard-debug",
+			RequestedBy:            "developer",
+			RequestedByEmail:       "developer@example.com",
+			RequestedByDisplayName: "Developer User",
+		},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "Approval timed out after 24h")
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"developer"}, messages[0].Recipients)
+}
+
+func TestSendDebugSessionFailedEmail_SendsWhenNotificationApprovalDisabled(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "standard-debug"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Notification: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:             true,
+				NotifyOnApproval:    false,
+				NotifyOnTermination: true,
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(template).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:      "standard-debug",
+			RequestedBy:      "developer@example.com",
+			RequestedByEmail: "developer@example.com",
+		},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "Approval timed out after 24h")
+
+	require.Len(t, mockMail.GetMessages(), 1)
+}
+
+func TestSendDebugSessionFailedEmail_SendsWhenNotificationTerminationDisabled(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "standard-debug"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Notification: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:             true,
+				NotifyOnApproval:    true,
+				NotifyOnTermination: false,
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(template).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:      "standard-debug",
+			RequestedBy:      "developer@example.com",
+			RequestedByEmail: "developer@example.com",
+		},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "Approval timed out after 24h")
+
+	require.Len(t, mockMail.GetMessages(), 1)
 }
 
 func TestSendDebugSessionFailedEmail_SkipsWhenDisabled(t *testing.T) {
@@ -421,7 +523,7 @@ func TestSendDebugSessionFailedEmail_SkipsWhenDisabled(t *testing.T) {
 	assert.Empty(t, mockMail.GetMessages())
 }
 
-func TestSendDebugSessionFailedEmail_SkipsInvalidRecipient(t *testing.T) {
+func TestSendDebugSessionFailedEmail_SendsRequesterEvenWhenNotEmail(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	mockMail := NewMockMailEnqueuer(true)
 
@@ -436,7 +538,9 @@ func TestSendDebugSessionFailedEmail_SkipsInvalidRecipient(t *testing.T) {
 
 	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "failed")
 
-	assert.Empty(t, mockMail.GetMessages())
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"developer"}, messages[0].Recipients)
 }
 
 func TestSendDebugSessionFailedEmail_EnqueueError(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_email_test.go
+++ b/pkg/breakglass/debug/debug_session_api_email_test.go
@@ -367,6 +367,98 @@ func TestSendDebugSessionRejectionEmail_EnqueueError(t *testing.T) {
 }
 
 // ============================================================================
+// Tests for sendDebugSessionFailedEmail
+// ============================================================================
+
+func TestSendDebugSessionFailedEmail_HappyPath(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed-debug-session",
+			Namespace: "breakglass",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:                "production",
+			TemplateRef:            "standard-debug",
+			RequestedBy:            "developer",
+			RequestedByEmail:       "developer@example.com",
+			RequestedByDisplayName: "Developer User",
+		},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "Approval timed out after 24h")
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, "failed-debug-session", messages[0].SessionID)
+	assert.Equal(t, []string{"developer@example.com"}, messages[0].Recipients)
+	assert.Contains(t, messages[0].Subject, "Debug Session Failed")
+	assert.Contains(t, messages[0].Body, "Approval timed out after 24h")
+}
+
+func TestSendDebugSessionFailedEmail_SkipsWhenDisabled(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithDisableEmail(true)
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{RequestedBy: "developer@example.com"},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "failed")
+
+	assert.Empty(t, mockMail.GetMessages())
+}
+
+func TestSendDebugSessionFailedEmail_SkipsInvalidRecipient(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{RequestedBy: "developer"},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "failed")
+
+	assert.Empty(t, mockMail.GetMessages())
+}
+
+func TestSendDebugSessionFailedEmail_EnqueueError(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+	mockMail.SetError(assert.AnError)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-debug-session"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{RequestedBy: "developer@example.com"},
+	}
+
+	ctrl.sendDebugSessionFailedEmail(context.Background(), session, "failed")
+
+	assert.Empty(t, mockMail.GetMessages())
+}
+
+// ============================================================================
 // Tests for sendDebugSessionRequestEmail
 // ============================================================================
 

--- a/pkg/breakglass/debug/debug_session_api_email_test.go
+++ b/pkg/breakglass/debug/debug_session_api_email_test.go
@@ -397,7 +397,7 @@ func TestSendDebugSessionFailedEmail_HappyPath(t *testing.T) {
 	messages := mockMail.GetMessages()
 	require.Len(t, messages, 1)
 	assert.Equal(t, "failed-debug-session", messages[0].SessionID)
-	assert.Equal(t, []string{"developer"}, messages[0].Recipients)
+	assert.Equal(t, []string{"developer@example.com"}, messages[0].Recipients)
 	assert.Contains(t, messages[0].Subject, "Debug Session Failed")
 	assert.Contains(t, messages[0].Body, "Approval timed out after 24h")
 }
@@ -437,7 +437,7 @@ func TestSendDebugSessionFailedEmail_IgnoresNotificationRecipients(t *testing.T)
 
 	messages := mockMail.GetMessages()
 	require.Len(t, messages, 1)
-	assert.Equal(t, []string{"developer"}, messages[0].Recipients)
+	assert.Equal(t, []string{"developer@example.com"}, messages[0].Recipients)
 }
 
 func TestSendDebugSessionFailedEmail_SendsWhenNotificationApprovalDisabled(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1627,6 +1627,10 @@ func TestHandleApproveDebugSession_PendingApprovalWithRecordedDecisionConflicts(
 	runDebugApprovalDecisionConflictTest(t, "approve")
 }
 
+func TestHandleApproveDebugSession_UnauthorizedRecordedDecisionForbidden(t *testing.T) {
+	runDebugApprovalDecisionUnauthorizedTest(t, "approve")
+}
+
 func TestHandleApproveDebugSession_NotAuthorized(t *testing.T) {
 	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2132,6 +2136,10 @@ func TestHandleRejectDebugSession_PendingApprovalWithRecordedDecisionConflicts(t
 	runDebugApprovalDecisionConflictTest(t, "reject")
 }
 
+func TestHandleRejectDebugSession_UnauthorizedRecordedDecisionForbidden(t *testing.T) {
+	runDebugApprovalDecisionUnauthorizedTest(t, "reject")
+}
+
 func runDebugApprovalDecisionConflictTest(t *testing.T, action string) {
 	t.Helper()
 
@@ -2204,6 +2212,57 @@ func runDebugApprovalDecisionConflictTest(t *testing.T, action string) {
 			assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, updated.Status.State)
 		})
 	}
+}
+
+func runDebugApprovalDecisionUnauthorizedTest(t *testing.T, action string) {
+	t.Helper()
+
+	now := metav1.Now()
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-session-decided",
+			Namespace: "default",
+			Labels: map[string]string{
+				DebugSessionLabelKey: "pending-session-decided",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "requester@example.com",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+			Approval: &breakglassv1alpha1.DebugSessionApproval{
+				Required:   true,
+				ApprovedBy: "first-approver@example.com",
+				ApprovedAt: &now,
+			},
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"admin@example.com"},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil)
+	router := setupAuthenticatedDebugSessionRouter(t, ctrl, "unauthorized@example.com", "unauthorized@example.com", []string{})
+
+	req, err := http.NewRequest(http.MethodPost, "/api/debugSessions/"+session.Name+"/"+action+"?namespace=default", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "already been decided")
 }
 
 func TestHandleRejectDebugSession_NotAuthorized(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1623,6 +1623,10 @@ func TestHandleApproveDebugSession_NotPendingApproval(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "not pending approval")
 }
 
+func TestHandleApproveDebugSession_PendingApprovalWithRecordedDecisionConflicts(t *testing.T) {
+	runDebugApprovalDecisionConflictTest(t, "approve")
+}
+
 func TestHandleApproveDebugSession_NotAuthorized(t *testing.T) {
 	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2122,6 +2126,84 @@ func TestHandleRejectDebugSession_NotPendingApproval(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "not pending approval")
+}
+
+func TestHandleRejectDebugSession_PendingApprovalWithRecordedDecisionConflicts(t *testing.T) {
+	runDebugApprovalDecisionConflictTest(t, "reject")
+}
+
+func runDebugApprovalDecisionConflictTest(t *testing.T, action string) {
+	t.Helper()
+
+	for _, decision := range []string{"approved", "rejected"} {
+		t.Run(action+"_"+decision, func(t *testing.T) {
+			now := metav1.Now()
+			approval := &breakglassv1alpha1.DebugSessionApproval{
+				Required: true,
+			}
+			if decision == "approved" {
+				approval.ApprovedBy = "first-approver@example.com"
+				approval.ApprovedAt = &now
+			} else {
+				approval.RejectedBy = "first-approver@example.com"
+				approval.RejectedAt = &now
+				approval.Reason = "Already rejected"
+			}
+
+			session := &breakglassv1alpha1.DebugSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pending-session-" + decision,
+					Namespace: "default",
+					Labels: map[string]string{
+						DebugSessionLabelKey: "pending-session-" + decision,
+					},
+				},
+				Spec: breakglassv1alpha1.DebugSessionSpec{
+					Cluster:     "test-cluster",
+					RequestedBy: "requester@example.com",
+					TemplateRef: "test-template",
+				},
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					State:    breakglassv1alpha1.DebugSessionStatePendingApproval,
+					Approval: approval,
+					ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+						Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+							Users: []string{"approver@example.com"},
+						},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(Scheme).
+				WithObjects(session).
+				WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+				Build()
+			ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil)
+			router := setupAuthenticatedDebugSessionRouter(t, ctrl, "approver@example.com", "approver@example.com", []string{})
+
+			req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/"+session.Name+"/"+action+"?namespace=default", nil)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusConflict, rr.Code)
+			assert.Contains(t, rr.Body.String(), "already been decided")
+
+			var updated breakglassv1alpha1.DebugSession
+			require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: session.Name}, &updated))
+			require.NotNil(t, updated.Status.Approval)
+			if decision == "approved" {
+				assert.NotNil(t, updated.Status.Approval.ApprovedAt)
+				assert.Nil(t, updated.Status.Approval.RejectedAt)
+			} else {
+				assert.NotNil(t, updated.Status.Approval.RejectedAt)
+				assert.Nil(t, updated.Status.Approval.ApprovedAt)
+			}
+			assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, updated.Status.State)
+		})
+	}
 }
 
 func TestHandleRejectDebugSession_NotAuthorized(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -1480,18 +1480,38 @@ func TestDebugSessionApprovalTimedOut(t *testing.T) {
 	tests := []struct {
 		name      string
 		createdAt metav1.Time
+		approval  *breakglassv1alpha1.DebugSessionApproval
 		want      bool
 	}{
 		{name: "zero timestamp is not treated as timed out", createdAt: metav1.Time{}, want: false},
 		{name: "before timeout", createdAt: metav1.NewTime(now.Add(-timeout + time.Second)), want: false},
-		{name: "at timeout", createdAt: metav1.NewTime(now.Add(-timeout)), want: true},
+		{name: "at timeout", createdAt: metav1.NewTime(now.Add(-timeout)), want: false},
 		{name: "after timeout", createdAt: metav1.NewTime(now.Add(-timeout - time.Second)), want: true},
+		{
+			name:      "approved pending status is not timed out",
+			createdAt: metav1.NewTime(now.Add(-timeout - time.Second)),
+			approval: &breakglassv1alpha1.DebugSessionApproval{
+				ApprovedAt: &metav1.Time{Time: now},
+			},
+			want: false,
+		},
+		{
+			name:      "rejected pending status is not timed out",
+			createdAt: metav1.NewTime(now.Add(-timeout - time.Second)),
+			approval: &breakglassv1alpha1.DebugSessionApproval{
+				RejectedAt: &metav1.Time{Time: now},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			session := &breakglassv1alpha1.DebugSession{
 				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: tt.createdAt},
+				Status: breakglassv1alpha1.DebugSessionStatus{
+					Approval: tt.approval,
+				},
 			}
 			got, reason := debugSessionApprovalTimedOut(session, now)
 			assert.Equal(t, tt.want, got)
@@ -1738,7 +1758,9 @@ func TestHandleApproveDebugSession_ApprovalTimedOut(t *testing.T) {
 		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		Build()
 
-	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	mockMail := NewMockMailEnqueuer(true)
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -1765,6 +1787,11 @@ func TestHandleApproveDebugSession_ApprovalTimedOut(t *testing.T) {
 	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updated.Status.State)
 	assert.Contains(t, updated.Status.Message, "Approval timed out")
 	assert.Nil(t, updated.Status.Approval)
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
+	assert.Contains(t, messages[0].Subject, "Debug Session Failed")
 }
 
 func TestHandleApproveDebugSession_Success(t *testing.T) {
@@ -2232,7 +2259,9 @@ func TestHandleRejectDebugSession_ApprovalTimedOut(t *testing.T) {
 		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		Build()
 
-	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	mockMail := NewMockMailEnqueuer(true)
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com")
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -2260,6 +2289,11 @@ func TestHandleRejectDebugSession_ApprovalTimedOut(t *testing.T) {
 	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updated.Status.State)
 	assert.Contains(t, updated.Status.Message, "Approval timed out")
 	assert.Nil(t, updated.Status.Approval)
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
+	assert.Contains(t, messages[0].Subject, "Debug Session Failed")
 }
 
 func TestHandleRejectDebugSession_Success(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1472,6 +1473,37 @@ func TestHandleGetDebugSession_NotFound(t *testing.T) {
 // Tests for handleApproveDebugSession
 // ============================================================================
 
+func TestDebugSessionApprovalTimedOut(t *testing.T) {
+	now := time.Now()
+	timeout := breakglass.DebugSessionApprovalTimeout
+
+	tests := []struct {
+		name      string
+		createdAt metav1.Time
+		want      bool
+	}{
+		{name: "zero timestamp is not treated as timed out", createdAt: metav1.Time{}, want: false},
+		{name: "before timeout", createdAt: metav1.NewTime(now.Add(-timeout + time.Second)), want: false},
+		{name: "at timeout", createdAt: metav1.NewTime(now.Add(-timeout)), want: true},
+		{name: "after timeout", createdAt: metav1.NewTime(now.Add(-timeout - time.Second)), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &breakglassv1alpha1.DebugSession{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: tt.createdAt},
+			}
+			got, reason := debugSessionApprovalTimedOut(session, now)
+			assert.Equal(t, tt.want, got)
+			if tt.want {
+				assert.Contains(t, reason, "Approval timed out")
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
+}
+
 func TestHandleApproveDebugSession_Unauthorized(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
@@ -1672,6 +1704,67 @@ func TestHandleApproveDebugSession_BlocksRequesterEmailSelfApproval(t *testing.T
 	var fetched breakglassv1alpha1.DebugSession
 	require.NoError(t, fakeClient.Get(req.Context(), client.ObjectKey{Namespace: "default", Name: "pending-session"}, &fetched))
 	require.Nil(t, fetched.Status.Approval)
+}
+
+func TestHandleApproveDebugSession_ApprovalTimedOut(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pending-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+			Labels: map[string]string{
+				DebugSessionLabelKey: "pending-session",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "requester@example.com",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		},
+	}
+
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", "approver@example.com")
+		c.Set("groups", []string{})
+		c.Next()
+	})
+	api := router.Group("/api")
+	rg := api.Group("/debugSessions")
+	_ = ctrl.Register(rg)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/approve?namespace=default", nil)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Approval timed out")
+
+	var updated breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "pending-session"}, &updated))
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updated.Status.State)
+	assert.Contains(t, updated.Status.Message, "Approval timed out")
+	assert.Nil(t, updated.Status.Approval)
 }
 
 func TestHandleApproveDebugSession_Success(t *testing.T) {
@@ -2105,6 +2198,68 @@ func TestHandleRejectDebugSession_BlocksRequesterEmailSelfApproval(t *testing.T)
 	var fetched breakglassv1alpha1.DebugSession
 	require.NoError(t, fakeClient.Get(req.Context(), client.ObjectKey{Namespace: "default", Name: "pending-session"}, &fetched))
 	require.Nil(t, fetched.Status.Approval)
+}
+
+func TestHandleRejectDebugSession_ApprovalTimedOut(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pending-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+			Labels: map[string]string{
+				DebugSessionLabelKey: "pending-session",
+			},
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "requester@example.com",
+			TemplateRef: "test-template",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		},
+	}
+
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("username", "approver@example.com")
+		c.Set("groups", []string{})
+		c.Next()
+	})
+	api := router.Group("/api")
+	rg := api.Group("/debugSessions")
+	_ = ctrl.Register(rg)
+
+	body := bytes.NewBuffer([]byte(`{"reason": "Too late"}`))
+	req, _ := http.NewRequest(http.MethodPost, "/api/debugSessions/pending-session/reject?namespace=default", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Approval timed out")
+
+	var updated breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "pending-session"}, &updated))
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updated.Status.State)
+	assert.Contains(t, updated.Status.Message, "Approval timed out")
+	assert.Nil(t, updated.Status.Approval)
 }
 
 func TestHandleRejectDebugSession_Success(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -360,9 +360,10 @@ func (c *DebugSessionAPIController) resolveNotification(template *breakglassv1al
 type notificationEvent string
 
 const (
-	notificationEventRequest  notificationEvent = "request"
-	notificationEventApproval notificationEvent = "approval"
-	notificationEventExpiry   notificationEvent = "expiry"
+	notificationEventRequest     notificationEvent = "request"
+	notificationEventApproval    notificationEvent = "approval"
+	notificationEventExpiry      notificationEvent = "expiry"
+	notificationEventTermination notificationEvent = "termination"
 )
 
 func resolveNotificationConfig(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) *breakglassv1alpha1.DebugSessionNotificationConfig {
@@ -386,6 +387,8 @@ func shouldSendNotification(cfg *breakglassv1alpha1.DebugSessionNotificationConf
 		return cfg.NotifyOnApproval
 	case notificationEventExpiry:
 		return cfg.NotifyOnExpiry
+	case notificationEventTermination:
+		return cfg.NotifyOnTermination
 	default:
 		return true
 	}

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -423,11 +423,6 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		apiresponses.RespondBadRequest(ctx, fmt.Sprintf("session is not pending approval (state: %s)", session.Status.State))
 		return
 	}
-	if debugSessionApprovalDecisionRecorded(session) {
-		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
-		return
-	}
-
 	// Check if user is authorized to approve (in allowed approver groups)
 	userGroups, _ := ctx.Get("groups")
 	currentUserEmail := ""
@@ -436,6 +431,10 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	}
 	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to approve this session")
+		return
+	}
+	if debugSessionApprovalDecisionRecorded(session) {
+		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 		return
 	}
 
@@ -529,11 +528,6 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		apiresponses.RespondBadRequest(ctx, fmt.Sprintf("session is not pending approval (state: %s)", session.Status.State))
 		return
 	}
-	if debugSessionApprovalDecisionRecorded(session) {
-		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
-		return
-	}
-
 	// Check if user is authorized to reject (in allowed approver groups)
 	userGroups, _ := ctx.Get("groups")
 	currentUserEmail := ""
@@ -542,6 +536,10 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	}
 	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to reject this session")
+		return
+	}
+	if debugSessionApprovalDecisionRecorded(session) {
+		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 		return
 	}
 
@@ -632,10 +630,14 @@ func debugSessionApprovalDecisionConflict(session *breakglassv1alpha1.DebugSessi
 
 func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string) error {
 	latest := &breakglassv1alpha1.DebugSession{}
-	if err := c.client.Get(ctx, ctrlclient.ObjectKeyFromObject(session), latest); err != nil {
+	if err := c.reader().Get(ctx, ctrlclient.ObjectKeyFromObject(session), latest); err != nil {
 		return fmt.Errorf("load latest debug session before approval timeout: %w", err)
 	}
 
+	if debugSessionApprovalTimeoutAlreadyRecorded(latest) {
+		session.Status = latest.Status
+		return nil
+	}
 	if debugSessionApprovalDecisionRecorded(latest) {
 		return debugSessionApprovalDecisionConflict(latest)
 	}
@@ -648,7 +650,7 @@ func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context
 	latest.Status.State = breakglassv1alpha1.DebugSessionStateFailed
 	latest.Status.Message = reason
 
-	if err := c.client.Status().Update(ctx, latest); err != nil {
+	if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, latest); err != nil {
 		if apierrors.IsConflict(err) {
 			return err
 		}
@@ -662,6 +664,11 @@ func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context
 	}
 	metrics.DebugSessionsFailed.WithLabelValues(latest.Spec.Cluster, latest.Spec.TemplateRef).Inc()
 	return nil
+}
+
+func debugSessionApprovalTimeoutAlreadyRecorded(session *breakglassv1alpha1.DebugSession) bool {
+	return session.Status.State == breakglassv1alpha1.DebugSessionStateFailed &&
+		strings.Contains(strings.ToLower(session.Status.Message), "approval timed out")
 }
 
 // handleLeaveDebugSession allows a participant to leave a session

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -18,6 +18,8 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *DebugSessionAPIController) handleJoinDebugSession(ctx *gin.Context) {
@@ -421,6 +423,10 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		apiresponses.RespondBadRequest(ctx, fmt.Sprintf("session is not pending approval (state: %s)", session.Status.State))
 		return
 	}
+	if debugSessionApprovalDecisionRecorded(session) {
+		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
+		return
+	}
 
 	// Check if user is authorized to approve (in allowed approver groups)
 	userGroups, _ := ctx.Get("groups")
@@ -435,6 +441,10 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 
 	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
 		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+			if apierrors.IsConflict(err) {
+				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
+				return
+			}
 			reqLog.Errorw("Failed to mark timed-out debug session approval", "session", name, "error", err)
 			apiresponses.RespondInternalErrorSimple(ctx, "failed to update timed-out debug session")
 			return
@@ -519,6 +529,10 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		apiresponses.RespondBadRequest(ctx, fmt.Sprintf("session is not pending approval (state: %s)", session.Status.State))
 		return
 	}
+	if debugSessionApprovalDecisionRecorded(session) {
+		apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
+		return
+	}
 
 	// Check if user is authorized to reject (in allowed approver groups)
 	userGroups, _ := ctx.Get("groups")
@@ -533,6 +547,10 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
 		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+			if apierrors.IsConflict(err) {
+				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
+				return
+			}
 			reqLog.Errorw("Failed to mark timed-out debug session rejection", "session", name, "error", err)
 			apiresponses.RespondInternalErrorSimple(ctx, "failed to update timed-out debug session")
 			return
@@ -588,8 +606,7 @@ func debugSessionApprovalTimedOut(session *breakglassv1alpha1.DebugSession, now 
 	if session.CreationTimestamp.IsZero() {
 		return false, ""
 	}
-	if session.Status.Approval != nil &&
-		(session.Status.Approval.ApprovedAt != nil || session.Status.Approval.RejectedAt != nil) {
+	if debugSessionApprovalDecisionRecorded(session) {
 		return false, ""
 	}
 
@@ -601,19 +618,49 @@ func debugSessionApprovalTimedOut(session *breakglassv1alpha1.DebugSession, now 
 	return true, fmt.Sprintf("Approval timed out after %s", timeout)
 }
 
-func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string) error {
-	session.Status.State = breakglassv1alpha1.DebugSessionStateFailed
-	session.Status.Message = reason
+func debugSessionApprovalDecisionRecorded(session *breakglassv1alpha1.DebugSession) bool {
+	return session.Status.Approval != nil &&
+		(session.Status.Approval.ApprovedAt != nil || session.Status.Approval.RejectedAt != nil)
+}
 
-	if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, session); err != nil {
+func debugSessionApprovalDecisionConflict(session *breakglassv1alpha1.DebugSession) error {
+	return apierrors.NewConflict(schema.GroupResource{
+		Group:    breakglassv1alpha1.GroupVersion.Group,
+		Resource: "debugsessions",
+	}, session.Name, errors.New("debug session approval has already been decided"))
+}
+
+func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string) error {
+	latest := &breakglassv1alpha1.DebugSession{}
+	if err := c.client.Get(ctx, ctrlclient.ObjectKeyFromObject(session), latest); err != nil {
+		return fmt.Errorf("load latest debug session before approval timeout: %w", err)
+	}
+
+	if debugSessionApprovalDecisionRecorded(latest) {
+		return debugSessionApprovalDecisionConflict(latest)
+	}
+	if timedOut, latestReason := debugSessionApprovalTimedOut(latest, time.Now()); !timedOut {
+		return debugSessionApprovalDecisionConflict(latest)
+	} else if reason == "" {
+		reason = latestReason
+	}
+
+	latest.Status.State = breakglassv1alpha1.DebugSessionStateFailed
+	latest.Status.Message = reason
+
+	if err := c.client.Status().Update(ctx, latest); err != nil {
+		if apierrors.IsConflict(err) {
+			return err
+		}
 		return fmt.Errorf("mark debug session approval timed out: %w", err)
 	}
 
-	c.sendDebugSessionFailedEmail(ctx, session, reason)
-	if c.shouldEmitAudit(session) {
-		c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, session, actor, reason)
+	session.Status = latest.Status
+	c.sendDebugSessionFailedEmail(ctx, latest, reason)
+	if c.shouldEmitAudit(latest) {
+		c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, latest, actor, reason)
 	}
-	metrics.DebugSessionsFailed.WithLabelValues(session.Spec.Cluster, session.Spec.TemplateRef).Inc()
+	metrics.DebugSessionsFailed.WithLabelValues(latest.Spec.Cluster, latest.Spec.TemplateRef).Inc()
 	return nil
 }
 

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -433,6 +433,16 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		return
 	}
 
+	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+			reqLog.Errorw("Failed to mark timed-out debug session approval", "session", name, "error", err)
+			apiresponses.RespondInternalErrorSimple(ctx, "failed to update timed-out debug session")
+			return
+		}
+		apiresponses.RespondConflict(ctx, reason)
+		return
+	}
+
 	if req.Reason != "" {
 		req.Reason = breakglass.SanitizeReasonText(req.Reason)
 	}
@@ -521,6 +531,16 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		return
 	}
 
+	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+			reqLog.Errorw("Failed to mark timed-out debug session rejection", "session", name, "error", err)
+			apiresponses.RespondInternalErrorSimple(ctx, "failed to update timed-out debug session")
+			return
+		}
+		apiresponses.RespondConflict(ctx, reason)
+		return
+	}
+
 	sanitizedReason := req.Reason
 	if req.Reason != "" {
 		sanitizedReason = breakglass.SanitizeReasonText(req.Reason)
@@ -562,6 +582,32 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	// Return updated session - client expects the session object, not just a message
 	ctx.JSON(http.StatusOK, session)
+}
+
+func debugSessionApprovalTimedOut(session *breakglassv1alpha1.DebugSession, now time.Time) (bool, string) {
+	if session.CreationTimestamp.IsZero() {
+		return false, ""
+	}
+
+	timeout := breakglass.DebugSessionApprovalTimeout
+	if now.Before(session.CreationTimestamp.Add(timeout)) {
+		return false, ""
+	}
+
+	return true, fmt.Sprintf("Approval timed out after %s", timeout)
+}
+
+func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string) error {
+	session.Status.State = breakglassv1alpha1.DebugSessionStateFailed
+	session.Status.Message = reason
+
+	if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, session); err != nil {
+		return fmt.Errorf("mark debug session approval timed out: %w", err)
+	}
+
+	c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, session, actor, reason)
+	metrics.DebugSessionsFailed.WithLabelValues(session.Spec.Cluster, session.Spec.TemplateRef).Inc()
+	return nil
 }
 
 // handleLeaveDebugSession allows a participant to leave a session

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -588,9 +588,13 @@ func debugSessionApprovalTimedOut(session *breakglassv1alpha1.DebugSession, now 
 	if session.CreationTimestamp.IsZero() {
 		return false, ""
 	}
+	if session.Status.Approval != nil &&
+		(session.Status.Approval.ApprovedAt != nil || session.Status.Approval.RejectedAt != nil) {
+		return false, ""
+	}
 
 	timeout := breakglass.DebugSessionApprovalTimeout
-	if now.Before(session.CreationTimestamp.Add(timeout)) {
+	if !session.CreationTimestamp.Add(timeout).Before(now) {
 		return false, ""
 	}
 
@@ -605,6 +609,7 @@ func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context
 		return fmt.Errorf("mark debug session approval timed out: %w", err)
 	}
 
+	c.sendDebugSessionFailedEmail(ctx, session, reason)
 	c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, session, actor, reason)
 	metrics.DebugSessionsFailed.WithLabelValues(session.Spec.Cluster, session.Spec.TemplateRef).Inc()
 	return nil

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -440,7 +440,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 
 	timeoutNow := time.Now()
 	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason, timeoutNow); err != nil {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, username, reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return
@@ -546,7 +546,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	timeoutNow := time.Now()
 	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason, timeoutNow); err != nil {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, username, reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -438,8 +438,9 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		return
 	}
 
-	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+	timeoutNow := time.Now()
+	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return
@@ -543,8 +544,9 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		return
 	}
 
-	if timedOut, reason := debugSessionApprovalTimedOut(session, time.Now()); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason); err != nil {
+	timeoutNow := time.Now()
+	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser.(string), reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return
@@ -628,7 +630,7 @@ func debugSessionApprovalDecisionConflict(session *breakglassv1alpha1.DebugSessi
 	}, session.Name, errors.New("debug session approval has already been decided"))
 }
 
-func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string) error {
+func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context.Context, session *breakglassv1alpha1.DebugSession, actor, reason string, now time.Time) error {
 	latest := &breakglassv1alpha1.DebugSession{}
 	if err := c.reader().Get(ctx, ctrlclient.ObjectKeyFromObject(session), latest); err != nil {
 		return fmt.Errorf("load latest debug session before approval timeout: %w", err)
@@ -641,7 +643,7 @@ func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context
 	if debugSessionApprovalDecisionRecorded(latest) {
 		return debugSessionApprovalDecisionConflict(latest)
 	}
-	if timedOut, latestReason := debugSessionApprovalTimedOut(latest, time.Now()); !timedOut {
+	if timedOut, latestReason := debugSessionApprovalTimedOut(latest, now); !timedOut {
 		return debugSessionApprovalDecisionConflict(latest)
 	} else if reason == "" {
 		reason = latestReason

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -610,7 +610,9 @@ func (c *DebugSessionAPIController) failTimedOutDebugSessionApproval(ctx context
 	}
 
 	c.sendDebugSessionFailedEmail(ctx, session, reason)
-	c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, session, actor, reason)
+	if c.shouldEmitAudit(session) {
+		c.emitDebugSessionAuditEvent(ctx, audit.EventDebugSessionApprovalTimeout, session, actor, reason)
+	}
 	metrics.DebugSessionsFailed.WithLabelValues(session.Spec.Cluster, session.Spec.TemplateRef).Inc()
 	return nil
 }

--- a/pkg/breakglass/debug/debug_session_api_timeout_test.go
+++ b/pkg/breakglass/debug/debug_session_api_timeout_test.go
@@ -57,7 +57,7 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 		WithObjects(session).
 		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourceUpdate: func(_ context.Context, _ client.Client, subResource string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+			SubResourcePatch: func(_ context.Context, _ client.Client, subResource string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 				if subResource == "status" {
 					return expectedErr
 				}
@@ -77,6 +77,61 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 	assert.ErrorIs(t, err, expectedErr)
 	assert.Empty(t, mockMail.GetMessages())
 	assert.Empty(t, mockAudit.GetEvents())
+}
+
+func TestFailTimedOutDebugSessionApproval_UsesAPIReaderForLatestDecision(t *testing.T) {
+	stale := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+		},
+	}
+
+	now := metav1.Now()
+	latest := stale.DeepCopy()
+	latest.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{
+		Required:   true,
+		ApprovedBy: "first-approver@example.com",
+		ApprovedAt: &now,
+	}
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(stale).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	apiReader := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(latest).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), cachedClient, nil, nil).
+		WithAPIReader(apiReader).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h")
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Empty(t, mockMail.GetMessages())
+	assert.Empty(t, mockAudit.GetEvents())
+
+	var stored breakglassv1alpha1.DebugSession
+	require.NoError(t, cachedClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: stale.Name}, &stored))
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, stored.Status.State)
+	assert.Nil(t, stored.Status.Approval)
 }
 
 func TestFailTimedOutDebugSessionApproval_LatestDecisionReturnsConflict(t *testing.T) {
@@ -127,11 +182,49 @@ func TestFailTimedOutDebugSessionApproval_LatestDecisionReturnsConflict(t *testi
 	assert.NotNil(t, stored.Status.Approval.ApprovedAt)
 }
 
+func TestFailTimedOutDebugSessionApproval_AlreadyFailedTimeoutIsIdempotent(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State:   breakglassv1alpha1.DebugSessionStateFailed,
+			Message: "Approval timed out after 24h0m0s",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+
+	require.NoError(t, err)
+	assert.Empty(t, mockMail.GetMessages())
+	assert.Empty(t, mockAudit.GetEvents())
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, session.Status.State)
+}
+
 func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testing.T) {
 	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "timed-out-debug-session",
 			Namespace:         "default",
+			Generation:        7,
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
 		},
 		Spec: breakglassv1alpha1.DebugSessionSpec{
@@ -165,4 +258,8 @@ func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testi
 	require.NoError(t, err)
 	require.Len(t, mockMail.GetMessages(), 1)
 	assert.Empty(t, mockAudit.GetEvents())
+
+	var stored breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: session.Name}, &stored))
+	assert.Equal(t, int64(7), stored.Status.ObservedGeneration)
 }

--- a/pkg/breakglass/debug/debug_session_api_timeout_test.go
+++ b/pkg/breakglass/debug/debug_session_api_timeout_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"go.uber.org/zap/zaptest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -35,13 +38,17 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 	expectedErr := errors.New("status apply failed")
 	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "timed-out-debug-session",
-			Namespace: "default",
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
 		},
 		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "production",
 			TemplateRef: "standard-debug",
 			RequestedBy: "developer@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
 		},
 	}
 
@@ -50,7 +57,7 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 		WithObjects(session).
 		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourcePatch: func(_ context.Context, _ client.Client, subResource string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+			SubResourceUpdate: func(_ context.Context, _ client.Client, subResource string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
 				if subResource == "status" {
 					return expectedErr
 				}
@@ -72,11 +79,60 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 	assert.Empty(t, mockAudit.GetEvents())
 }
 
+func TestFailTimedOutDebugSessionApproval_LatestDecisionReturnsConflict(t *testing.T) {
+	stale := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+	}
+
+	now := metav1.Now()
+	latest := stale.DeepCopy()
+	latest.Status.State = breakglassv1alpha1.DebugSessionStatePendingApproval
+	latest.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{
+		Required:   true,
+		ApprovedBy: "first-approver@example.com",
+		ApprovedAt: &now,
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(latest).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h")
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Empty(t, mockMail.GetMessages())
+	assert.Empty(t, mockAudit.GetEvents())
+
+	var stored breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: stale.Name}, &stored))
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, stored.Status.State)
+	require.NotNil(t, stored.Status.Approval)
+	assert.NotNil(t, stored.Status.Approval.ApprovedAt)
+}
+
 func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testing.T) {
 	session := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "timed-out-debug-session",
-			Namespace: "default",
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
 		},
 		Spec: breakglassv1alpha1.DebugSessionSpec{
 			Cluster:     "production",
@@ -84,6 +140,7 @@ func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testi
 			RequestedBy: "developer@example.com",
 		},
 		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
 			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
 				Audit: &breakglassv1alpha1.DebugSessionAuditConfig{
 					Enabled: false,

--- a/pkg/breakglass/debug/debug_session_api_timeout_test.go
+++ b/pkg/breakglass/debug/debug_session_api_timeout_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
+	expectedErr := errors.New("status apply failed")
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "timed-out-debug-session",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ client.Client, subResource string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+				if subResource == "status" {
+					return expectedErr
+				}
+				return nil
+			},
+		}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, mockMail.GetMessages())
+	assert.Empty(t, mockAudit.GetEvents())
+}

--- a/pkg/breakglass/debug/debug_session_api_timeout_test.go
+++ b/pkg/breakglass/debug/debug_session_api_timeout_test.go
@@ -71,3 +71,41 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 	assert.Empty(t, mockMail.GetMessages())
 	assert.Empty(t, mockAudit.GetEvents())
 }
+
+func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "timed-out-debug-session",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Audit: &breakglassv1alpha1.DebugSessionAuditConfig{
+					Enabled: false,
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+
+	require.NoError(t, err)
+	require.Len(t, mockMail.GetMessages(), 1)
+	assert.Empty(t, mockAudit.GetEvents())
+}

--- a/pkg/breakglass/debug/debug_session_api_timeout_test.go
+++ b/pkg/breakglass/debug/debug_session_api_timeout_test.go
@@ -71,7 +71,7 @@ func TestFailTimedOutDebugSessionApproval_StatusApplyError(t *testing.T) {
 		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
 		WithAuditService(mockAudit)
 
-	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h", time.Now())
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, expectedErr)
@@ -121,7 +121,7 @@ func TestFailTimedOutDebugSessionApproval_UsesAPIReaderForLatestDecision(t *test
 		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
 		WithAuditService(mockAudit)
 
-	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h")
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h", time.Now())
 
 	require.Error(t, err)
 	assert.True(t, apierrors.IsConflict(err))
@@ -132,6 +132,43 @@ func TestFailTimedOutDebugSessionApproval_UsesAPIReaderForLatestDecision(t *test
 	require.NoError(t, cachedClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: stale.Name}, &stored))
 	assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, stored.Status.State)
 	assert.Nil(t, stored.Status.Approval)
+}
+
+func TestFailTimedOutDebugSessionApproval_UsesHandlerTimestampForLatestTimeout(t *testing.T) {
+	now := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "timed-out-debug-session",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-breakglass.DebugSessionApprovalTimeout - time.Minute)),
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "developer@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	mockMail := NewMockMailEnqueuer(true)
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewDebugSessionAPIController(zaptest.NewLogger(t).Sugar(), fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
+		WithAuditService(mockAudit)
+
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h", now)
+
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, session.Status.State)
+	assert.Len(t, mockMail.GetMessages(), 1)
+	assert.Len(t, mockAudit.GetEvents(), 1)
 }
 
 func TestFailTimedOutDebugSessionApproval_LatestDecisionReturnsConflict(t *testing.T) {
@@ -168,7 +205,7 @@ func TestFailTimedOutDebugSessionApproval_LatestDecisionReturnsConflict(t *testi
 		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
 		WithAuditService(mockAudit)
 
-	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h")
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), stale, "approver@example.com", "Approval timed out after 24h", time.Now())
 
 	require.Error(t, err)
 	assert.True(t, apierrors.IsConflict(err))
@@ -211,7 +248,7 @@ func TestFailTimedOutDebugSessionApproval_AlreadyFailedTimeoutIsIdempotent(t *te
 		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
 		WithAuditService(mockAudit)
 
-	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h", time.Now())
 
 	require.NoError(t, err)
 	assert.Empty(t, mockMail.GetMessages())
@@ -253,7 +290,7 @@ func TestFailTimedOutDebugSessionApproval_RespectsTemplateAuditDisabled(t *testi
 		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com").
 		WithAuditService(mockAudit)
 
-	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h")
+	err := ctrl.failTimedOutDebugSessionApproval(context.Background(), session, "approver@example.com", "Approval timed out after 24h", time.Now())
 
 	require.NoError(t, err)
 	require.Len(t, mockMail.GetMessages(), 1)


### PR DESCRIPTION
## Summary
- reject approve/reject requests for timed-out `PendingApproval` DebugSessions with `409 Conflict`
- mark timed-out sessions `Failed` immediately in the API handler before returning
- align the API timeout boundary with the reconciler, avoid timing out already-approved/rejected pending status, and send the same failure email notification from the handler path
- document that approve/reject APIs enforce `DEBUG_SESSION_APPROVAL_TIMEOUT`, with reconciler enforcement as a backstop

## Evidence
- `handlePendingApproval()` already fails timed-out sessions during reconciliation, but the approve/reject handlers only checked `PendingApproval` state before accepting authorized approver actions.
- A request that arrives after `creationTimestamp + DEBUG_SESSION_APPROVAL_TIMEOUT` but before the next reconcile could approve or reject the stale session.
- The new handler tests cover both approve and reject after the timeout, assert no approval/rejection is recorded, and assert the requester receives a failed-session email.

## Duplicate check
- `gh search prs --repo telekom/k8s-breakglass "DebugSession approval timeout approve reject PendingApproval" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "DebugSessionApprovalTimeout approve reject handler" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "debug session approval timeout expired pending approval" --state closed` -> `[]`

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -run 'TestDebugSessionApprovalTimedOut|TestHandle(Approve|Reject)DebugSession_(ApprovalTimedOut|Success|NotAuthorized|NotPendingApproval)' -count=1 -timeout=120s`\n- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -count=1 -timeout=180s`\n- `git -c core.fsmonitor=false diff --check`