### PR TITLE
fix: preserve debug cleanup retry state

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -30,7 +30,7 @@ jobs:
   e2e-smoke:
     name: E2E Bootstrap Smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1914,6 +1914,7 @@ spec:
 1. **Monitor expired sessions**: Sessions clean up automatically
 2. **Review long-running sessions**: Set alerts for sessions approaching max duration
 3. **Use termination**: Actively terminate sessions when done
+4. **Investigate cleanup retries**: Failed debug-resource deletes keep their status tracking entries so the controller can retry cleanup on the next reconciliation
 
 ## Troubleshooting
 

--- a/pkg/breakglass/debug/debug_session_kubectl.go
+++ b/pkg/breakglass/debug/debug_session_kubectl.go
@@ -667,6 +667,14 @@ func (h *KubectlDebugHandler) CleanupKubectlDebugResources(ctx context.Context, 
 		return nil
 	}
 
+	if len(ds.Status.KubectlDebugStatus.CopiedPods) == 0 {
+		// Ephemeral containers cannot be removed; without copied pods there is
+		// no spoke-cluster cleanup to perform.
+		return h.patchDebugSessionStatusWithRetry(ctx, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+			status.KubectlDebugStatus = nil
+		})
+	}
+
 	targetClient, err := h.ccProvider.GetClient(ctx, ds.Spec.Cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get client for cluster %s: %w", ds.Spec.Cluster, err)

--- a/pkg/breakglass/debug/debug_session_kubectl.go
+++ b/pkg/breakglass/debug/debug_session_kubectl.go
@@ -18,6 +18,7 @@ package debug
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -671,6 +672,9 @@ func (h *KubectlDebugHandler) CleanupKubectlDebugResources(ctx context.Context, 
 		return fmt.Errorf("failed to get client for cluster %s: %w", ds.Spec.Cluster, err)
 	}
 
+	var cleanupErrors []error
+	remainingCopiedPods := make([]breakglassv1alpha1.CopiedPodRef, 0, len(ds.Status.KubectlDebugStatus.CopiedPods))
+
 	// Cleanup copied pods
 	for _, cp := range ds.Status.KubectlDebugStatus.CopiedPods {
 		pod := &corev1.Pod{
@@ -680,13 +684,25 @@ func (h *KubectlDebugHandler) CleanupKubectlDebugResources(ctx context.Context, 
 			},
 		}
 		if err := targetClient.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
-			// Log but continue cleanup
+			remainingCopiedPods = append(remainingCopiedPods, cp)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete copied pod %s/%s: %w", cp.CopyNamespace, cp.CopyName, err))
 			continue
 		}
 	}
 
 	// Note: Ephemeral containers cannot be removed, they remain until pod deletion
-	// Clear the status
+	if len(remainingCopiedPods) > 0 {
+		if err := h.patchDebugSessionStatusWithRetry(ctx, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+			if status.KubectlDebugStatus == nil {
+				status.KubectlDebugStatus = &breakglassv1alpha1.KubectlDebugStatus{}
+			}
+			status.KubectlDebugStatus.CopiedPods = remainingCopiedPods
+		}); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("preserve kubectl-debug cleanup status: %w", err))
+		}
+		return errors.Join(cleanupErrors...)
+	}
+
 	return h.patchDebugSessionStatusWithRetry(ctx, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
 		status.KubectlDebugStatus = nil
 	})

--- a/pkg/breakglass/debug/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug/debug_session_kubectl_test.go
@@ -1587,6 +1587,43 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("clears empty status without spoke client", func(t *testing.T) {
+		session := &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ephemeral-only-session",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster: "test-cluster",
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State: breakglassv1alpha1.DebugSessionStateTerminated,
+				KubectlDebugStatus: &breakglassv1alpha1.KubectlDebugStatus{
+					EphemeralContainersInjected: []breakglassv1alpha1.EphemeralContainerRef{
+						{
+							PodName:       "app-pod",
+							Namespace:     "default",
+							ContainerName: "debugger",
+						},
+					},
+				},
+			},
+		}
+		hubClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(session).
+			Build()
+		handler := NewKubectlDebugHandler(hubClient, &mockClientProvider{err: assert.AnError})
+
+		err := handler.CleanupKubectlDebugResources(context.Background(), session)
+		require.NoError(t, err)
+
+		var stored breakglassv1alpha1.DebugSession
+		require.NoError(t, hubClient.Get(context.Background(), ctrlclient.ObjectKey{Namespace: "breakglass", Name: "ephemeral-only-session"}, &stored))
+		assert.Nil(t, stored.Status.KubectlDebugStatus)
+	})
+
 	t.Run("returns error when GetClient fails", func(t *testing.T) {
 		hubClient := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/breakglass/debug/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug/debug_session_kubectl_test.go
@@ -1740,6 +1740,64 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 		assert.Nil(t, stored.Status.KubectlDebugStatus)
 	})
 
+	t.Run("preserves copied pods when deletion fails", func(t *testing.T) {
+		targetClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-copy",
+					Namespace: "default",
+				},
+			}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(_ context.Context, _ ctrlclient.WithWatch, _ ctrlclient.Object, _ ...ctrlclient.DeleteOption) error {
+					return errors.New("delete denied")
+				},
+			}).
+			Build()
+
+		session := &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-session",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster: "test-cluster",
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State: breakglassv1alpha1.DebugSessionStateTerminated,
+				KubectlDebugStatus: &breakglassv1alpha1.KubectlDebugStatus{
+					CopiedPods: []breakglassv1alpha1.CopiedPodRef{
+						{CopyName: "pod-copy", CopyNamespace: "default"},
+					},
+				},
+			},
+		}
+
+		hubClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(session).
+			Build()
+
+		mockProvider := &mockClientProvider{
+			clients: map[string]ctrlclient.Client{
+				"test-cluster": targetClient,
+			},
+		}
+		handler := NewKubectlDebugHandler(hubClient, mockProvider)
+
+		err := handler.CleanupKubectlDebugResources(context.Background(), session)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete copied pod")
+
+		var updated breakglassv1alpha1.DebugSession
+		require.NoError(t, hubClient.Get(context.Background(), ctrlclient.ObjectKey{Namespace: "breakglass", Name: "test-session"}, &updated))
+		require.NotNil(t, updated.Status.KubectlDebugStatus)
+		require.Len(t, updated.Status.KubectlDebugStatus.CopiedPods, 1)
+		assert.Equal(t, "pod-copy", updated.Status.KubectlDebugStatus.CopiedPods[0].CopyName)
+	})
+
 	t.Run("wraps ErrClusterConfigNotFound for reconciler handling", func(t *testing.T) {
 		hubClient := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -368,6 +368,15 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 		cleanupErrors = append(cleanupErrors, err)
 	}
 
+	if len(ds.Status.DeployedResources) == 0 &&
+		len(ds.Status.AuxiliaryResourceStatuses) == 0 &&
+		len(ds.Status.PodTemplateResourceStatuses) == 0 {
+		if err := c.patchDebugSessionCleanupStatus(ctx, ds); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
+		}
+		return errors.Join(cleanupErrors...)
+	}
+
 	// Get spoke cluster client for cleanup
 	restCfg, err := c.ccProvider.GetRESTConfig(ctx, ds.Spec.Cluster)
 	if err != nil {

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -9,7 +9,6 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/ssa"
-	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
@@ -361,6 +360,8 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			ds.Status.DeployedResources = nil
 			ds.Status.AllowedPods = nil
 			ds.Status.KubectlDebugStatus = nil
+			ds.Status.AuxiliaryResourceStatuses = nil
+			ds.Status.PodTemplateResourceStatuses = nil
 			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
 		}
 		log.Errorw("Failed to cleanup kubectl-debug resources", "error", err)
@@ -378,6 +379,8 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			ds.Status.DeployedResources = nil
 			ds.Status.AllowedPods = nil
 			ds.Status.KubectlDebugStatus = nil
+			ds.Status.AuxiliaryResourceStatuses = nil
+			ds.Status.PodTemplateResourceStatuses = nil
 			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
 		}
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to get REST config: %w", err))
@@ -429,6 +432,9 @@ func (c *DebugSessionController) patchDebugSessionCleanupStatus(
 	base *breakglassv1alpha1.DebugSession,
 	ds *breakglassv1alpha1.DebugSession,
 ) error {
+	if ds.Generation > 0 {
+		ds.Status.ObservedGeneration = ds.Generation
+	}
 	return c.client.Status().Patch(ctx, ds, ctrlclient.MergeFrom(base))
 }
 

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -347,6 +347,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	if c.ccProvider == nil {
 		return nil
 	}
+	cleanupBase := ds.DeepCopy()
 
 	// Clean up kubectl-debug resources (if any)
 	kubectlHandler := NewKubectlDebugHandler(c.client, &clusterClientAdapter{ccProvider: c.ccProvider})
@@ -359,7 +360,8 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			// Clear deployed resources since we can't clean them up anyway
 			ds.Status.DeployedResources = nil
 			ds.Status.AllowedPods = nil
-			return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
+			ds.Status.KubectlDebugStatus = nil
+			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
 		}
 		log.Errorw("Failed to cleanup kubectl-debug resources", "error", err)
 		cleanupErrors = append(cleanupErrors, err)
@@ -375,7 +377,8 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			// Clear deployed resources since we can't clean them up anyway
 			ds.Status.DeployedResources = nil
 			ds.Status.AllowedPods = nil
-			return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
+			ds.Status.KubectlDebugStatus = nil
+			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
 		}
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to get REST config: %w", err))
 		return errors.Join(cleanupErrors...)
@@ -406,7 +409,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 
 	if len(ds.Status.DeployedResources) == 0 {
 		// Persist any status changes from auxiliary/pod-template cleanup above
-		if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+		if err := c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds); err != nil {
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
 		}
 		return errors.Join(cleanupErrors...)
@@ -415,10 +418,18 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	if err := c.cleanupDeployedResources(ctx, ds, targetClient, auxiliaryCleanupFailed, len(ds.Status.PodTemplateResourceStatuses) > 0); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
 	}
-	if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+	if err := c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds); err != nil {
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
 	}
 	return errors.Join(cleanupErrors...)
+}
+
+func (c *DebugSessionController) patchDebugSessionCleanupStatus(
+	ctx context.Context,
+	base *breakglassv1alpha1.DebugSession,
+	ds *breakglassv1alpha1.DebugSession,
+) error {
+	return c.client.Status().Patch(ctx, ds, ctrlclient.MergeFrom(base))
 }
 
 func (c *DebugSessionController) cleanupDeployedResources(
@@ -503,10 +514,39 @@ func (c *DebugSessionController) cleanupDeployedResources(
 	}
 
 	ds.Status.DeployedResources = remainingDeployedResources
-	if len(remainingDeployedResources) == 0 && len(ds.Status.PodTemplateResourceStatuses) == 0 {
-		ds.Status.AllowedPods = nil
-	}
+	ds.Status.AllowedPods = allowedPodsForRemainingDeployedPods(ds.Status.AllowedPods, remainingDeployedResources)
 	return errors.Join(cleanupErrors...)
+}
+
+func allowedPodsForRemainingDeployedPods(
+	allowedPods []breakglassv1alpha1.AllowedPodRef,
+	remainingDeployedResources []breakglassv1alpha1.DeployedResourceRef,
+) []breakglassv1alpha1.AllowedPodRef {
+	if len(allowedPods) == 0 {
+		return nil
+	}
+
+	remainingPodRefs := make(map[string]struct{})
+	for _, ref := range remainingDeployedResources {
+		if ref.Kind != "Pod" {
+			continue
+		}
+		remainingPodRefs[ref.Namespace+"\x00"+ref.Name] = struct{}{}
+	}
+	if len(remainingPodRefs) == 0 {
+		return nil
+	}
+
+	filtered := make([]breakglassv1alpha1.AllowedPodRef, 0, len(allowedPods))
+	for _, pod := range allowedPods {
+		if _, ok := remainingPodRefs[pod.Namespace+"\x00"+pod.Name]; ok {
+			filtered = append(filtered, pod)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 // cleanupPodTemplateResources removes resources deployed from multi-document pod templates.

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -346,7 +347,6 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	if c.ccProvider == nil {
 		return nil
 	}
-	cleanupBase := ds.DeepCopy()
 
 	// Clean up kubectl-debug resources (if any)
 	kubectlHandler := NewKubectlDebugHandler(c.client, &clusterClientAdapter{ccProvider: c.ccProvider})
@@ -362,7 +362,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			ds.Status.KubectlDebugStatus = nil
 			ds.Status.AuxiliaryResourceStatuses = nil
 			ds.Status.PodTemplateResourceStatuses = nil
-			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
+			return c.patchDebugSessionCleanupStatus(ctx, ds)
 		}
 		log.Errorw("Failed to cleanup kubectl-debug resources", "error", err)
 		cleanupErrors = append(cleanupErrors, err)
@@ -381,7 +381,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			ds.Status.KubectlDebugStatus = nil
 			ds.Status.AuxiliaryResourceStatuses = nil
 			ds.Status.PodTemplateResourceStatuses = nil
-			return c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds)
+			return c.patchDebugSessionCleanupStatus(ctx, ds)
 		}
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to get REST config: %w", err))
 		return errors.Join(cleanupErrors...)
@@ -412,7 +412,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 
 	if len(ds.Status.DeployedResources) == 0 {
 		// Persist any status changes from auxiliary/pod-template cleanup above
-		if err := c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds); err != nil {
+		if err := c.patchDebugSessionCleanupStatus(ctx, ds); err != nil {
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
 		}
 		return errors.Join(cleanupErrors...)
@@ -421,7 +421,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	if err := c.cleanupDeployedResources(ctx, ds, targetClient, auxiliaryCleanupFailed, len(ds.Status.PodTemplateResourceStatuses) > 0); err != nil {
 		cleanupErrors = append(cleanupErrors, err)
 	}
-	if err := c.patchDebugSessionCleanupStatus(ctx, cleanupBase, ds); err != nil {
+	if err := c.patchDebugSessionCleanupStatus(ctx, ds); err != nil {
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
 	}
 	return errors.Join(cleanupErrors...)
@@ -429,13 +429,42 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 
 func (c *DebugSessionController) patchDebugSessionCleanupStatus(
 	ctx context.Context,
-	base *breakglassv1alpha1.DebugSession,
 	ds *breakglassv1alpha1.DebugSession,
 ) error {
-	if ds.Generation > 0 {
-		ds.Status.ObservedGeneration = ds.Generation
+	desiredStatus := ds.Status
+	var patchedStatus breakglassv1alpha1.DebugSessionStatus
+	var patchedResourceVersion string
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &breakglassv1alpha1.DebugSession{}
+		if err := c.client.Get(ctx, ctrlclient.ObjectKeyFromObject(ds), current); err != nil {
+			return err
+		}
+
+		base := current.DeepCopy()
+		current.Status.DeployedResources = desiredStatus.DeployedResources
+		current.Status.AllowedPods = desiredStatus.AllowedPods
+		current.Status.KubectlDebugStatus = desiredStatus.KubectlDebugStatus
+		current.Status.AuxiliaryResourceStatuses = desiredStatus.AuxiliaryResourceStatuses
+		current.Status.PodTemplateResourceStatuses = desiredStatus.PodTemplateResourceStatuses
+		if current.Generation > 0 {
+			current.Status.ObservedGeneration = current.Generation
+		}
+
+		if err := c.client.Status().Patch(ctx, current, ctrlclient.MergeFromWithOptions(base, ctrlclient.MergeFromWithOptimisticLock{})); err != nil {
+			return err
+		}
+		patchedStatus = current.Status
+		patchedResourceVersion = current.ResourceVersion
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("patch debug session cleanup status: %w", err)
 	}
-	return c.client.Status().Patch(ctx, ds, ctrlclient.MergeFrom(base))
+
+	ds.Status = patchedStatus
+	ds.ResourceVersion = patchedResourceVersion
+	return nil
 }
 
 func (c *DebugSessionController) cleanupDeployedResources(
@@ -510,12 +539,16 @@ func (c *DebugSessionController) cleanupDeployedResources(
 			continue
 		}
 
-		if err := targetClient.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-			log.Warnw("Failed to delete debug resource", "kind", ref.Kind, "name", ref.Name, "error", err)
+		if err := targetClient.Delete(ctx, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debugw("Debug resource already deleted", "kind", ref.Kind, "name", ref.Name, "namespace", ref.Namespace)
+				continue
+			}
+			log.Warnw("Failed to delete debug resource", "kind", ref.Kind, "name", ref.Name, "namespace", ref.Namespace, "error", err)
 			remainingDeployedResources = append(remainingDeployedResources, ref)
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete debug resource %s %s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err))
 		} else {
-			log.Infow("Deleted debug resource", "kind", ref.Kind, "name", ref.Name)
+			log.Infow("Deleted debug resource", "kind", ref.Kind, "name", ref.Name, "namespace", ref.Namespace)
 		}
 	}
 
@@ -532,12 +565,12 @@ func allowedPodsForRemainingDeployedPods(
 		return nil
 	}
 
-	remainingPodRefs := make(map[string]struct{})
+	remainingPodRefs := make(map[[2]string]struct{})
 	for _, ref := range remainingDeployedResources {
 		if ref.Kind != "Pod" {
 			continue
 		}
-		remainingPodRefs[ref.Namespace+"\x00"+ref.Name] = struct{}{}
+		remainingPodRefs[[2]string{ref.Namespace, ref.Name}] = struct{}{}
 	}
 	if len(remainingPodRefs) == 0 {
 		return nil
@@ -545,7 +578,7 @@ func allowedPodsForRemainingDeployedPods(
 
 	filtered := make([]breakglassv1alpha1.AllowedPodRef, 0, len(allowedPods))
 	for _, pod := range allowedPods {
-		if _, ok := remainingPodRefs[pod.Namespace+"\x00"+pod.Name]; ok {
+		if _, ok := remainingPodRefs[[2]string{pod.Namespace, pod.Name}]; ok {
 			filtered = append(filtered, pod)
 		}
 	}

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -542,7 +542,11 @@ func (c *DebugSessionController) cleanupDeployedResources(
 				},
 			}
 		default:
-			log.Warnw("Unknown resource type, skipping cleanup", "kind", ref.Kind, "name", ref.Name)
+			log.Warnw("Unknown resource type, preserving cleanup retry",
+				"apiVersion", ref.APIVersion,
+				"kind", ref.Kind,
+				"name", ref.Name,
+				"namespace", ref.Namespace)
 			remainingDeployedResources = append(remainingDeployedResources, ref)
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("unsupported deployed resource kind %q for %s/%s", ref.Kind, ref.Namespace, ref.Name))
 			continue

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -350,6 +350,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 
 	// Clean up kubectl-debug resources (if any)
 	kubectlHandler := NewKubectlDebugHandler(c.client, &clusterClientAdapter{ccProvider: c.ccProvider})
+	var cleanupErrors []error
 	if err := kubectlHandler.CleanupKubectlDebugResources(ctx, ds); err != nil {
 		// Check if the error is due to missing ClusterConfig - if so, treat as cleanup complete
 		if errors.Is(err, cluster.ErrClusterConfigNotFound) {
@@ -361,7 +362,7 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
 		}
 		log.Errorw("Failed to cleanup kubectl-debug resources", "error", err)
-		// Continue to clean up deployed resources even if this fails
+		cleanupErrors = append(cleanupErrors, err)
 	}
 
 	// Get spoke cluster client for cleanup
@@ -384,10 +385,12 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	}
 
 	// Cleanup auxiliary resources first using the manager
+	auxiliaryCleanupFailed := false
 	if c.auxiliaryMgr != nil && len(ds.Status.AuxiliaryResourceStatuses) > 0 {
 		if err := c.auxiliaryMgr.CleanupAuxiliaryResources(ctx, ds, targetClient); err != nil {
 			log.Warnw("Failed to cleanup auxiliary resources", "error", err)
-			// Continue to clean up main workloads
+			auxiliaryCleanupFailed = true
+			cleanupErrors = append(cleanupErrors, err)
 		}
 	}
 
@@ -395,23 +398,51 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 	if len(ds.Status.PodTemplateResourceStatuses) > 0 {
 		if err := c.cleanupPodTemplateResources(ctx, ds, targetClient); err != nil {
 			log.Warnw("Failed to cleanup pod template resources", "error", err)
-			// Continue to clean up main workloads
+			cleanupErrors = append(cleanupErrors, err)
 		}
 	}
 
 	if len(ds.Status.DeployedResources) == 0 {
 		// Persist any status changes from auxiliary/pod-template cleanup above
-		return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
+		if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
+		}
+		return errors.Join(cleanupErrors...)
 	}
 
-	// Cleanup main workloads (DaemonSet/Deployment)
+	if err := c.cleanupDeployedResources(ctx, ds, targetClient, auxiliaryCleanupFailed, len(ds.Status.PodTemplateResourceStatuses) > 0); err != nil {
+		cleanupErrors = append(cleanupErrors, err)
+	}
+	if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("update cleanup status: %w", err))
+	}
+	return errors.Join(cleanupErrors...)
+}
+
+func (c *DebugSessionController) cleanupDeployedResources(
+	ctx context.Context,
+	ds *breakglassv1alpha1.DebugSession,
+	targetClient ctrlclient.Client,
+	keepAuxiliaryRefs bool,
+	keepPodTemplateRefs bool,
+) error {
+	log := c.log.With("debugSession", ds.Name, "cluster", ds.Spec.Cluster)
+	var cleanupErrors []error
+	remainingDeployedResources := make([]breakglassv1alpha1.DeployedResourceRef, 0, len(ds.Status.DeployedResources))
+
 	for _, ref := range ds.Status.DeployedResources {
 		// Skip auxiliary resources - already cleaned up by manager
 		if strings.HasPrefix(ref.Source, "auxiliary:") {
+			if keepAuxiliaryRefs {
+				remainingDeployedResources = append(remainingDeployedResources, ref)
+			}
 			continue
 		}
 		// Skip pod-template resources - already cleaned up above
 		if ref.Source == "pod-template" {
+			if keepPodTemplateRefs {
+				remainingDeployedResources = append(remainingDeployedResources, ref)
+			}
 			continue
 		}
 
@@ -446,28 +477,42 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 					Namespace: ref.Namespace,
 				},
 			}
+		case "Pod":
+			obj = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ref.Name,
+					Namespace: ref.Namespace,
+				},
+			}
 		default:
 			log.Warnw("Unknown resource type, skipping cleanup", "kind", ref.Kind, "name", ref.Name)
+			remainingDeployedResources = append(remainingDeployedResources, ref)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("unsupported deployed resource kind %q for %s/%s", ref.Kind, ref.Namespace, ref.Name))
 			continue
 		}
 
 		if err := targetClient.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 			log.Warnw("Failed to delete debug resource", "kind", ref.Kind, "name", ref.Name, "error", err)
+			remainingDeployedResources = append(remainingDeployedResources, ref)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete debug resource %s %s/%s: %w", ref.Kind, ref.Namespace, ref.Name, err))
 		} else {
 			log.Infow("Deleted debug resource", "kind", ref.Kind, "name", ref.Name)
 		}
 	}
 
-	// Clear deployed resources from status
-	ds.Status.DeployedResources = nil
-	ds.Status.AllowedPods = nil
-	ds.Status.PodTemplateResourceStatuses = nil
-	return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
+	ds.Status.DeployedResources = remainingDeployedResources
+	if len(remainingDeployedResources) == 0 && len(ds.Status.PodTemplateResourceStatuses) == 0 {
+		ds.Status.AllowedPods = nil
+	}
+	return errors.Join(cleanupErrors...)
 }
 
 // cleanupPodTemplateResources removes resources deployed from multi-document pod templates.
 func (c *DebugSessionController) cleanupPodTemplateResources(ctx context.Context, ds *breakglassv1alpha1.DebugSession, targetClient ctrlclient.Client) error {
 	log := c.log.With("debugSession", ds.Name, "cluster", ds.Spec.Cluster)
+
+	var cleanupErrors []error
+	remainingStatuses := make([]breakglassv1alpha1.PodTemplateResourceStatus, 0, len(ds.Status.PodTemplateResourceStatuses))
 
 	for i := range ds.Status.PodTemplateResourceStatuses {
 		status := &ds.Status.PodTemplateResourceStatuses[i]
@@ -490,6 +535,8 @@ func (c *DebugSessionController) cleanupPodTemplateResources(ctx context.Context
 				"kind", status.Kind,
 				"error", err)
 			status.Error = fmt.Sprintf("failed to parse GVK: %v", err)
+			remainingStatuses = append(remainingStatuses, *status)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("parse GVK for pod template resource %s/%s: %w", status.Namespace, status.ResourceName, err))
 			continue
 		}
 
@@ -509,6 +556,8 @@ func (c *DebugSessionController) cleanupPodTemplateResources(ctx context.Context
 					"name", status.ResourceName,
 					"error", err)
 				status.Error = fmt.Sprintf("delete failed: %v", err)
+				remainingStatuses = append(remainingStatuses, *status)
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("delete pod template resource %s %s/%s: %w", status.Kind, status.Namespace, status.ResourceName, err))
 				continue
 			}
 		} else {
@@ -523,7 +572,8 @@ func (c *DebugSessionController) cleanupPodTemplateResources(ctx context.Context
 		status.DeletedAt = &now
 	}
 
-	return nil
+	ds.Status.PodTemplateResourceStatuses = remainingStatuses
+	return errors.Join(cleanupErrors...)
 }
 
 // parseDuration parses the requested duration with template constraints.

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -377,11 +377,13 @@ func (c *DebugSessionController) cleanupResources(ctx context.Context, ds *break
 			ds.Status.AllowedPods = nil
 			return breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
 		}
-		return fmt.Errorf("failed to get REST config: %w", err)
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to get REST config: %w", err))
+		return errors.Join(cleanupErrors...)
 	}
 	targetClient, err := ctrlclient.New(restCfg, ctrlclient.Options{})
 	if err != nil {
-		return fmt.Errorf("failed to create client: %w", err)
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to create client: %w", err))
+		return errors.Join(cleanupErrors...)
 	}
 
 	// Cleanup auxiliary resources first using the manager

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -4908,6 +4908,80 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to get REST config")
 		assert.Contains(t, err.Error(), "no authentication method configured for cluster test-cluster")
 	})
+
+	t.Run("missing_cluster_config_clears_kubectl_debug_status", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-missing-cluster-kubectl", "test-template", "missing-cluster", "user@example.com")
+		session.Status.KubectlDebugStatus = &breakglassv1alpha1.KubectlDebugStatus{
+			CopiedPods: []breakglassv1alpha1.CopiedPodRef{
+				{
+					OriginalPod:       "app",
+					OriginalNamespace: "default",
+					CopyName:          "app-copy",
+					CopyNamespace:     "default",
+				},
+			},
+		}
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "Pod", Name: "app-copy", Namespace: "default", Source: "kubectl-debug-copy"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "app-copy", Namespace: "default"},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := &DebugSessionController{
+			log:        zap.NewNop().Sugar(),
+			client:     fakeClient,
+			ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+		}
+
+		err := controller.cleanupResources(context.Background(), session)
+		require.NoError(t, err)
+
+		var updated breakglassv1alpha1.DebugSession
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: session.Name, Namespace: session.Namespace}, &updated)
+		require.NoError(t, err)
+		assert.Empty(t, updated.Status.DeployedResources)
+		assert.Empty(t, updated.Status.AllowedPods)
+		assert.Nil(t, updated.Status.KubectlDebugStatus)
+	})
+
+	t.Run("missing_rest_config_clears_deployed_tracking", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-missing-cluster-rest", "test-template", "missing-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "Pod", Name: "node-debug-pod", Namespace: "default", Source: "kubectl-debug-node"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "node-debug-pod", Namespace: "default"},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := &DebugSessionController{
+			log:        zap.NewNop().Sugar(),
+			client:     fakeClient,
+			ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+		}
+
+		err := controller.cleanupResources(context.Background(), session)
+		require.NoError(t, err)
+
+		var updated breakglassv1alpha1.DebugSession
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: session.Name, Namespace: session.Namespace}, &updated)
+		require.NoError(t, err)
+		assert.Empty(t, updated.Status.DeployedResources)
+		assert.Empty(t, updated.Status.AllowedPods)
+		assert.Nil(t, updated.Status.KubectlDebugStatus)
+	})
 }
 
 func TestDebugSessionController_CleanupDeployedResources(t *testing.T) {
@@ -5009,7 +5083,57 @@ func TestDebugSessionController_CleanupDeployedResources(t *testing.T) {
 		require.Len(t, session.Status.DeployedResources, 2)
 		assert.Equal(t, "auxiliary:config", session.Status.DeployedResources[0].Source)
 		assert.Equal(t, "pod-template", session.Status.DeployedResources[1].Source)
-		assert.Len(t, session.Status.AllowedPods, 1, "allowed pods are preserved while cleanup refs remain")
+		assert.Empty(t, session.Status.AllowedPods, "allowed pods are cleared when only non-Pod cleanup refs remain")
+	})
+
+	t.Run("filters allowed pods to remaining pod refs", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-filter-allowed-pods", "test-template", "test-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "Pod", Name: "failed-delete-pod", Namespace: "default", Source: "kubectl-debug-node"},
+			{APIVersion: "v1", Kind: "Pod", Name: "deleted-pod", Namespace: "default", Source: "kubectl-debug-node"},
+			{APIVersion: "v1", Kind: "ConfigMap", Name: "remaining-config", Namespace: "default", Source: "pod-template"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "failed-delete-pod", Namespace: "default"},
+			{Name: "deleted-pod", Namespace: "default"},
+			{Name: "untracked-pod", Namespace: "default"},
+		}
+
+		targetClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "failed-delete-pod",
+						Namespace: "default",
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deleted-pod",
+						Namespace: "default",
+					},
+				},
+			).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if obj.GetName() == "failed-delete-pod" {
+						return apierrors.NewForbidden(corev1.Resource("pods"), obj.GetName(), assert.AnError)
+					}
+					return cl.Delete(ctx, obj, opts...)
+				},
+			}).
+			Build()
+
+		controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+		err := controller.cleanupDeployedResources(context.Background(), session, targetClient, false, true)
+		require.Error(t, err)
+		require.Len(t, session.Status.DeployedResources, 2)
+		assert.Equal(t, "failed-delete-pod", session.Status.DeployedResources[0].Name)
+		assert.Equal(t, "remaining-config", session.Status.DeployedResources[1].Name)
+		require.Len(t, session.Status.AllowedPods, 1)
+		assert.Equal(t, "failed-delete-pod", session.Status.AllowedPods[0].Name)
 	})
 
 	t.Run("preserves unsupported resource kind for retry", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -40,6 +40,7 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 )
 
@@ -4877,6 +4878,35 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 
 		err := controller.cleanupResources(context.Background(), session)
 		assert.NoError(t, err, "Should return nil with nil ccProvider even with pod template resources")
+	})
+
+	t.Run("returns_kubectl_cleanup_error_with_rest_config_error", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-kubectl-rest-config", "test-template", "test-cluster", "user@example.com")
+		session.Status.KubectlDebugStatus = &breakglassv1alpha1.KubectlDebugStatus{}
+		clusterConfig := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session, clusterConfig).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := &DebugSessionController{
+			log:        zap.NewNop().Sugar(),
+			client:     fakeClient,
+			ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+		}
+
+		err := controller.cleanupResources(context.Background(), session)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get client for cluster test-cluster")
+		assert.Contains(t, err.Error(), "failed to get REST config")
+		assert.Contains(t, err.Error(), "no authentication method configured for cluster test-cluster")
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -4947,6 +4947,56 @@ func TestDebugSessionController_CleanupDeployedResources(t *testing.T) {
 		assert.Equal(t, "node-debug-pod", session.Status.DeployedResources[0].Name)
 		assert.Len(t, session.Status.AllowedPods, 1)
 	})
+
+	t.Run("preserves skipped refs while dependent cleanup failed", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-skipped-refs", "test-template", "test-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "ConfigMap", Name: "aux-config", Namespace: "default", Source: "auxiliary:config"},
+			{APIVersion: "v1", Kind: "ConfigMap", Name: "pod-template-config", Namespace: "default", Source: "pod-template"},
+			{APIVersion: "v1", Kind: "Pod", Name: "node-debug-pod", Namespace: "default", Source: "kubectl-debug-node"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "node-debug-pod", Namespace: "default"},
+		}
+		session.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+			{Kind: "ConfigMap", ResourceName: "pod-template-config", Namespace: "default", Created: true},
+		}
+
+		targetClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-debug-pod",
+					Namespace: "default",
+				},
+			}).
+			Build()
+
+		controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+		err := controller.cleanupDeployedResources(context.Background(), session, targetClient, true, true)
+		require.NoError(t, err)
+		require.Len(t, session.Status.DeployedResources, 2)
+		assert.Equal(t, "auxiliary:config", session.Status.DeployedResources[0].Source)
+		assert.Equal(t, "pod-template", session.Status.DeployedResources[1].Source)
+		assert.Len(t, session.Status.AllowedPods, 1, "allowed pods are preserved while cleanup refs remain")
+	})
+
+	t.Run("preserves unsupported resource kind for retry", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-unsupported-kind", "test-template", "test-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "batch/v1", Kind: "Job", Name: "unsupported-job", Namespace: "default", Source: "workload"},
+		}
+
+		targetClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+		err := controller.cleanupDeployedResources(context.Background(), session, targetClient, false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unsupported deployed resource kind "Job"`)
+		require.Len(t, session.Status.DeployedResources, 1)
+		assert.Equal(t, "unsupported-job", session.Status.DeployedResources[0].Name)
+	})
 }
 
 func TestDebugSessionController_CleanupPodTemplateResourcesPreservesFailures(t *testing.T) {
@@ -4984,6 +5034,30 @@ func TestDebugSessionController_CleanupPodTemplateResourcesPreservesFailures(t *
 	assert.Contains(t, err.Error(), "delete pod template resource ConfigMap default/debug-script")
 	require.Len(t, session.Status.PodTemplateResourceStatuses, 1)
 	assert.Contains(t, session.Status.PodTemplateResourceStatuses[0].Error, "forbidden")
+	assert.False(t, session.Status.PodTemplateResourceStatuses[0].Deleted)
+}
+
+func TestDebugSessionController_CleanupPodTemplateResourcesPreservesParseFailures(t *testing.T) {
+	scheme := testScheme()
+	session := newTestDebugSession("cleanup-pod-template-parse-failure", "test-template", "test-cluster", "user@example.com")
+	session.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+		{
+			Kind:         "ConfigMap",
+			APIVersion:   "invalid/group/version",
+			ResourceName: "debug-script",
+			Namespace:    "default",
+			Created:      true,
+		},
+	}
+
+	targetClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+	err := controller.cleanupPodTemplateResources(context.Background(), session, targetClient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse GVK for pod template resource default/debug-script")
+	require.Len(t, session.Status.PodTemplateResourceStatuses, 1)
+	assert.Contains(t, session.Status.PodTemplateResourceStatuses[0].Error, "failed to parse GVK")
 	assert.False(t, session.Status.PodTemplateResourceStatuses[0].Deleted)
 }
 

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -4876,6 +4878,113 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		err := controller.cleanupResources(context.Background(), session)
 		assert.NoError(t, err, "Should return nil with nil ccProvider even with pod template resources")
 	})
+}
+
+func TestDebugSessionController_CleanupDeployedResources(t *testing.T) {
+	scheme := testScheme()
+
+	t.Run("deletes node debug pod and clears tracking", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-node-pod", "test-template", "test-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "Pod", Name: "node-debug-pod", Namespace: "default", Source: "kubectl-debug-node"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "node-debug-pod", Namespace: "default"},
+		}
+
+		targetClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-debug-pod",
+					Namespace: "default",
+				},
+			}).
+			Build()
+
+		controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+		err := controller.cleanupDeployedResources(context.Background(), session, targetClient, false, false)
+		require.NoError(t, err)
+		assert.Empty(t, session.Status.DeployedResources)
+		assert.Empty(t, session.Status.AllowedPods)
+
+		var pod corev1.Pod
+		err = targetClient.Get(context.Background(), types.NamespacedName{Name: "node-debug-pod", Namespace: "default"}, &pod)
+		assert.True(t, apierrors.IsNotFound(err), "node debug pod should be deleted, got: %v", err)
+	})
+
+	t.Run("preserves failed deployed resource for retry", func(t *testing.T) {
+		session := newTestDebugSession("cleanup-delete-failure", "test-template", "test-cluster", "user@example.com")
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{APIVersion: "v1", Kind: "Pod", Name: "node-debug-pod", Namespace: "default", Source: "kubectl-debug-node"},
+		}
+		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
+			{Name: "node-debug-pod", Namespace: "default"},
+		}
+
+		targetClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-debug-pod",
+					Namespace: "default",
+				},
+			}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+					return apierrors.NewForbidden(corev1.Resource("pods"), obj.GetName(), assert.AnError)
+				},
+			}).
+			Build()
+
+		controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+		err := controller.cleanupDeployedResources(context.Background(), session, targetClient, false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete debug resource Pod default/node-debug-pod")
+		require.Len(t, session.Status.DeployedResources, 1)
+		assert.Equal(t, "node-debug-pod", session.Status.DeployedResources[0].Name)
+		assert.Len(t, session.Status.AllowedPods, 1)
+	})
+}
+
+func TestDebugSessionController_CleanupPodTemplateResourcesPreservesFailures(t *testing.T) {
+	scheme := testScheme()
+	session := newTestDebugSession("cleanup-pod-template-failure", "test-template", "test-cluster", "user@example.com")
+	session.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+		{
+			Kind:         "ConfigMap",
+			APIVersion:   "v1",
+			ResourceName: "debug-script",
+			Namespace:    "default",
+			Created:      true,
+		},
+	}
+
+	targetClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "debug-script",
+				Namespace: "default",
+			},
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				return apierrors.NewForbidden(corev1.Resource("configmaps"), obj.GetName(), assert.AnError)
+			},
+		}).
+		Build()
+
+	controller := &DebugSessionController{log: zap.NewNop().Sugar()}
+
+	err := controller.cleanupPodTemplateResources(context.Background(), session, targetClient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete pod template resource ConfigMap default/debug-script")
+	require.Len(t, session.Status.PodTemplateResourceStatuses, 1)
+	assert.Contains(t, session.Status.PodTemplateResourceStatuses[0].Error, "forbidden")
+	assert.False(t, session.Status.PodTemplateResourceStatuses[0].Deleted)
 }
 
 // TestDebugSessionController_Reconcile_FailSessionCleanup tests the full reconcile loop

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -4880,7 +4880,7 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		assert.NoError(t, err, "Should return nil with nil ccProvider even with pod template resources")
 	})
 
-	t.Run("returns_kubectl_cleanup_error_with_rest_config_error", func(t *testing.T) {
+	t.Run("empty_kubectl_cleanup_skips_target_cluster_client", func(t *testing.T) {
 		session := newTestDebugSession("cleanup-kubectl-rest-config", "test-template", "test-cluster", "user@example.com")
 		session.Status.KubectlDebugStatus = &breakglassv1alpha1.KubectlDebugStatus{}
 		clusterConfig := &breakglassv1alpha1.ClusterConfig{
@@ -4903,10 +4903,11 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		}
 
 		err := controller.cleanupResources(context.Background(), session)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get client for cluster test-cluster")
-		assert.Contains(t, err.Error(), "failed to get REST config")
-		assert.Contains(t, err.Error(), "no authentication method configured for cluster test-cluster")
+		require.NoError(t, err)
+
+		current := &breakglassv1alpha1.DebugSession{}
+		require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(session), current))
+		assert.Nil(t, current.Status.KubectlDebugStatus)
 	})
 
 	t.Run("missing_cluster_config_clears_kubectl_debug_status", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -4911,6 +4911,7 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 
 	t.Run("missing_cluster_config_clears_kubectl_debug_status", func(t *testing.T) {
 		session := newTestDebugSession("cleanup-missing-cluster-kubectl", "test-template", "missing-cluster", "user@example.com")
+		session.Generation = 3
 		session.Status.KubectlDebugStatus = &breakglassv1alpha1.KubectlDebugStatus{
 			CopiedPods: []breakglassv1alpha1.CopiedPodRef{
 				{
@@ -4927,6 +4928,12 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
 			{Name: "app-copy", Namespace: "default"},
 		}
+		session.Status.AuxiliaryResourceStatuses = []breakglassv1alpha1.AuxiliaryResourceStatus{
+			{Name: "debug-config", Kind: "ConfigMap", Namespace: "default", Created: true},
+		}
+		session.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+			{Kind: "Secret", ResourceName: "debug-secret", Namespace: "default", Created: true},
+		}
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -4949,16 +4956,26 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		assert.Empty(t, updated.Status.DeployedResources)
 		assert.Empty(t, updated.Status.AllowedPods)
 		assert.Nil(t, updated.Status.KubectlDebugStatus)
+		assert.Empty(t, updated.Status.AuxiliaryResourceStatuses)
+		assert.Empty(t, updated.Status.PodTemplateResourceStatuses)
+		assert.Equal(t, session.Generation, updated.Status.ObservedGeneration)
 	})
 
 	t.Run("missing_rest_config_clears_deployed_tracking", func(t *testing.T) {
 		session := newTestDebugSession("cleanup-missing-cluster-rest", "test-template", "missing-cluster", "user@example.com")
+		session.Generation = 5
 		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
 			{APIVersion: "v1", Kind: "Pod", Name: "node-debug-pod", Namespace: "default", Source: "kubectl-debug-node"},
 		}
 		session.Status.AllowedPods = []breakglassv1alpha1.AllowedPodRef{
 			{Name: "node-debug-pod", Namespace: "default"},
 		}
+		session.Status.AuxiliaryResourceStatuses = []breakglassv1alpha1.AuxiliaryResourceStatus{
+			{Name: "debug-config", Kind: "ConfigMap", Namespace: "default", Created: true},
+		}
+		session.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+			{Kind: "Secret", ResourceName: "debug-secret", Namespace: "default", Created: true},
+		}
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -4981,6 +4998,9 @@ func TestDebugSessionController_CleanupResources(t *testing.T) {
 		assert.Empty(t, updated.Status.DeployedResources)
 		assert.Empty(t, updated.Status.AllowedPods)
 		assert.Nil(t, updated.Status.KubectlDebugStatus)
+		assert.Empty(t, updated.Status.AuxiliaryResourceStatuses)
+		assert.Empty(t, updated.Status.PodTemplateResourceStatuses)
+		assert.Equal(t, session.Generation, updated.Status.ObservedGeneration)
 	})
 }
 


### PR DESCRIPTION
## Summary
- delete tracked node-debug pods during DebugSession cleanup
- preserve copied-pod, pod-template, and deployed-resource status entries when delete calls fail
- return aggregate cleanup errors so reconciliation retries instead of clearing tracking state

## Evidence
- `CreateNodeDebugPod` tracks privileged node debug pods as `DeployedResourceRef{Kind: "Pod"}`, but cleanup did not handle `Pod` resources.
- Main debug cleanup logged non-NotFound delete failures and then cleared `status.deployedResources`, `status.allowedPods`, and pod-template status, removing retry visibility.
- `CleanupKubectlDebugResources` ignored copied-pod delete failures and then cleared `status.kubectlDebugStatus`.

## Duplicate check
- `gh search prs --repo telekom/k8s-breakglass "DebugSession cleanup deployedResources delete failure CleanupKubectlDebugResources copiedPods node debug Pod" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "deployedResources cleanup Pod DebugSession" --state open` -> `[]`
- `gh search prs --repo telekom/k8s-breakglass "node-debugger deployedResources Pod cleanup" --state closed` -> `[]`

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -run 'TestKubectlDebugHandler_CleanupKubectlDebugResources|TestDebugSessionController_CleanupDeployedResources|TestDebugSessionController_CleanupPodTemplateResourcesPreservesFailures|TestDebugSessionController_CleanupResources' -count=1 -timeout=120s`\n- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -count=1 -timeout=180s`\n- `git -c core.fsmonitor=false diff --check`