### PR TITLE
fix: retry clusterconfig session cleanup failures

### DIFF
--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -21,7 +21,7 @@ When a `ClusterConfig` is created, the controller automatically adds a finalizer
 **What happens when a ClusterConfig is deleted:**
 
 1. The finalizer prevents immediate deletion
-2. All active `BreakglassSession` resources targeting this cluster through `spec.cluster` or `spec.clusterConfigRef` are marked as **Expired** and receive terminal retention
+2. All non-terminal `BreakglassSession` resources targeting this cluster through `spec.cluster` or `spec.clusterConfigRef` are marked as **Expired** and receive terminal retention
 3. All non-terminal `DebugSession` resources targeting this cluster are marked as **Terminated** so their controller cleanup removes debug pods and auxiliary resources
 4. If any session status update fails, the finalizer remains and reconciliation retries
 5. The finalizer is removed, allowing the `ClusterConfig` to be deleted
@@ -32,7 +32,7 @@ This ensures that:
 - Session state is accurately reflected in the UI
 
 **Terminal states that are preserved:**
-- BreakglassSessions in `Expired`, `Rejected`, `Withdrawn`, or `ApprovalTimeout` states are not modified
+- BreakglassSessions in `Expired`, `Rejected`, `Withdrawn`, `IdleExpired`, or `ApprovalTimeout` states are not modified
 - DebugSessions in `Terminated` or `Expired` states are not modified; `Failed` sessions are transitioned to `Terminated` so cleanup can remove any remaining debug resources.
 
 ### Metrics

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -21,9 +21,10 @@ When a `ClusterConfig` is created, the controller automatically adds a finalizer
 **What happens when a ClusterConfig is deleted:**
 
 1. The finalizer prevents immediate deletion
-2. All active `BreakglassSession` resources targeting this cluster are marked as **Expired**
-3. All active `DebugSession` resources targeting this cluster are marked as **Failed**
-4. The finalizer is removed, allowing the `ClusterConfig` to be deleted
+2. All active `BreakglassSession` resources targeting this cluster through `spec.cluster` or `spec.clusterConfigRef` are marked as **Expired** and receive terminal retention
+3. All active `DebugSession` resources targeting this cluster are marked as **Terminated** so their controller cleanup removes debug pods and auxiliary resources
+4. If any session status update fails, the finalizer remains and reconciliation retries
+5. The finalizer is removed, allowing the `ClusterConfig` to be deleted
 
 This ensures that:
 - Users don't retain privileges to a cluster that no longer exists
@@ -40,7 +41,7 @@ The following Prometheus metrics are updated during cluster deletion:
 
 - `breakglass_clusterconfigs_deleted_total{cluster}` - Counter for deleted ClusterConfigs
 - `breakglass_session_expired_total{cluster}` - Incremented for each session expired due to cluster deletion
-- `breakglass_debug_sessions_failed_total{cluster,reason="cluster_deleted"}` - Incremented for each debug session failed due to cluster deletion
+- `breakglass_debug_sessions_terminated_total{cluster,reason="cluster_deleted"}` - Incremented for each debug session terminated due to cluster deletion
 
 ## Authentication Methods
 

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -22,7 +22,7 @@ When a `ClusterConfig` is created, the controller automatically adds a finalizer
 
 1. The finalizer prevents immediate deletion
 2. All active `BreakglassSession` resources targeting this cluster through `spec.cluster` or `spec.clusterConfigRef` are marked as **Expired** and receive terminal retention
-3. All active `DebugSession` resources targeting this cluster are marked as **Terminated** so their controller cleanup removes debug pods and auxiliary resources
+3. All non-terminal `DebugSession` resources targeting this cluster are marked as **Terminated** so their controller cleanup removes debug pods and auxiliary resources
 4. If any session status update fails, the finalizer remains and reconciliation retries
 5. The finalizer is removed, allowing the `ClusterConfig` to be deleted
 
@@ -33,7 +33,7 @@ This ensures that:
 
 **Terminal states that are preserved:**
 - BreakglassSessions in `Expired`, `Rejected`, `Withdrawn`, or `ApprovalTimeout` states are not modified
-- DebugSessions in `Failed`, `Terminated`, or `Expired` states are not modified
+- DebugSessions in `Terminated` or `Expired` states are not modified; `Failed` sessions are transitioned to `Terminated` so cleanup can remove any remaining debug resources.
 
 ### Metrics
 

--- a/pkg/breakglass/duration_helpers.go
+++ b/pkg/breakglass/duration_helpers.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	durationutils "github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -27,28 +28,28 @@ import (
 // Returns DefaultRetainForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
 func ParseRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
-	return parseDurationWithDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
+	return durationutils.ParseRetainFor(spec, log)
 }
 
 // ParseMaxValidFor parses the MaxValidFor duration from a session spec.
 // Returns DefaultValidForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
 func ParseMaxValidFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
-	return parseDurationWithDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
+	return durationutils.ParseDurationOrDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
 }
 
 // ParseEscalationMaxValidFor parses the MaxValidFor duration from an escalation spec.
 // Returns DefaultValidForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
 func ParseEscalationMaxValidFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
-	return parseDurationWithDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
+	return durationutils.ParseDurationOrDefault(spec.MaxValidFor, DefaultValidForDuration, "MaxValidFor", log)
 }
 
 // ParseEscalationRetainFor parses the RetainFor duration from an escalation spec.
 // Returns DefaultRetainForDuration if the value is empty or invalid.
 // Logs a warning if the value is present but invalid.
 func ParseEscalationRetainFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
-	return parseDurationWithDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
+	return durationutils.ParseEscalationRetainFor(spec, log)
 }
 
 // ParseApprovalTimeout parses the ApprovalTimeout duration from an escalation spec.
@@ -56,46 +57,12 @@ func ParseEscalationRetainFor(spec breakglassv1alpha1.BreakglassEscalationSpec, 
 // Logs a warning if the value is present but invalid.
 func ParseApprovalTimeout(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
 	const defaultApprovalTimeout = time.Hour
-	return parseDurationWithDefault(spec.ApprovalTimeout, defaultApprovalTimeout, "ApprovalTimeout", log)
-}
-
-// parseDurationWithDefault is the internal helper that parses a duration string.
-// If the value is empty, returns defaultValue without logging.
-// If the value is present but invalid, logs a warning and returns defaultValue.
-// If the value is valid but <= 0, logs a warning and returns defaultValue.
-// Supports extended duration units including days (e.g., "7d", "90d").
-func parseDurationWithDefault(value string, defaultValue time.Duration, fieldName string, log *zap.SugaredLogger) time.Duration {
-	if value == "" {
-		return defaultValue
-	}
-
-	d, err := breakglassv1alpha1.ParseDuration(value)
-	if err != nil {
-		if log != nil {
-			log.Warnw("Invalid "+fieldName+" in spec; falling back to default",
-				"value", value,
-				"error", err,
-				"default", defaultValue.String())
-		}
-		return defaultValue
-	}
-
-	if d <= 0 {
-		if log != nil {
-			log.Warnw("Non-positive "+fieldName+" in spec; falling back to default",
-				"value", value,
-				"parsedDuration", d,
-				"default", defaultValue.String())
-		}
-		return defaultValue
-	}
-
-	return d
+	return durationutils.ParseDurationOrDefault(spec.ApprovalTimeout, defaultApprovalTimeout, "ApprovalTimeout", log)
 }
 
 // ParseDurationOrDefault is a generic helper for parsing any duration string with a default.
 // Useful for one-off duration parsing where the specific field helpers don't apply.
 // If log is nil, no warning is logged for invalid values.
 func ParseDurationOrDefault(value string, defaultValue time.Duration, fieldName string, log *zap.SugaredLogger) time.Duration {
-	return parseDurationWithDefault(value, defaultValue, fieldName, log)
+	return durationutils.ParseDurationOrDefault(value, defaultValue, fieldName, log)
 }

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -21,15 +21,16 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/ratelimit"
 	"github.com/telekom/k8s-breakglass/pkg/system"
+	durationutils "github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 )
 
 const (
-	MonthDuration            = time.Hour * 24 * 30
-	WeekDuration             = time.Hour * 24 * 7
-	DefaultValidForDuration  = time.Hour
-	DefaultRetainForDuration = MonthDuration
+	MonthDuration            = durationutils.MonthDuration
+	WeekDuration             = durationutils.WeekDuration
+	DefaultValidForDuration  = durationutils.DefaultValidForDuration
+	DefaultRetainForDuration = durationutils.DefaultRetainForDuration
 	APIContextTimeout        = 30 * time.Second // Timeout for API operations like session listing
 
 	// MaxApproverGroupMembers limits the number of members resolved from a single approver group.

--- a/pkg/config/cluster_config_cleanup_test.go
+++ b/pkg/config/cluster_config_cleanup_test.go
@@ -173,7 +173,7 @@ func TestClusterConfigReconciler_ListFailureBlocksCleanup(t *testing.T) {
 
 // TestClusterConfigReconciler_MixedSessionAndDebugSessionCleanup tests that when
 // both BreakglassSessions and DebugSessions exist, both are properly terminated.
-// Note: DebugSessions are set to "Failed" state when cluster is deleted.
+// DebugSessions are set to "Terminated" so their controller cleanup path removes resources.
 func TestClusterConfigReconciler_MixedSessionAndDebugSessionCleanup(t *testing.T) {
 	scheme := newTestClusterConfigReconcilerScheme()
 	ctx := context.Background()
@@ -240,12 +240,12 @@ func TestClusterConfigReconciler_MixedSessionAndDebugSessionCleanup(t *testing.T
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, updatedBgSession.Status.State,
 		"BreakglassSession should be marked as Expired")
 
-	// Verify DebugSession is failed (cluster deletion sets state to Failed)
+	// Verify DebugSession is terminated so cleanup can run
 	var updatedDebugSession breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "debug-session-1", Namespace: "default"}, &updatedDebugSession)
 	require.NoError(t, err)
-	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updatedDebugSession.Status.State,
-		"DebugSession should be marked as Failed (cluster deleted)")
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, updatedDebugSession.Status.State,
+		"DebugSession should be marked as Terminated (cluster deleted)")
 	assert.Contains(t, updatedDebugSession.Status.Message, "test-cluster",
 		"DebugSession message should reference the deleted cluster")
 }

--- a/pkg/config/cluster_config_cleanup_test.go
+++ b/pkg/config/cluster_config_cleanup_test.go
@@ -159,10 +159,10 @@ func TestClusterConfigReconciler_ListFailureBlocksCleanup(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "test-cluster", Namespace: "default"},
 	})
 
-	// Should return error and requeue after delay
+	// Should return error; controller-runtime retries errors through its rate limiter.
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "simulated list failure")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	// Verify the ClusterConfig still exists with its finalizer
 	var updated breakglassv1alpha1.ClusterConfig
@@ -574,7 +574,7 @@ func TestClusterConfigReconciler_GetListError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "simulated network timeout")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	// Finalizer should still be present
 	var updated breakglassv1alpha1.ClusterConfig

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	ssa "github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/ssa"
@@ -88,15 +87,17 @@ func (r *ClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// Terminate all BreakglassSessions for this cluster
 			if err := r.terminateBreakglassSessionsForCluster(ctx, clusterName, log); err != nil {
 				log.Errorw("Failed to terminate BreakglassSessions for cluster", "cluster", clusterName, "error", err)
-				// Requeue to retry cleanup
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+				// Returning the error keeps deletion blocked and lets controller-runtime
+				// retry through its rate limiter.
+				return ctrl.Result{}, err
 			}
 
 			// Terminate all DebugSessions for this cluster
 			if err := r.terminateDebugSessionsForCluster(ctx, clusterName, log); err != nil {
 				log.Errorw("Failed to terminate DebugSessions for cluster", "cluster", clusterName, "error", err)
-				// Requeue to retry cleanup
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+				// Returning the error keeps deletion blocked and lets controller-runtime
+				// retry through its rate limiter.
+				return ctrl.Result{}, err
 			}
 
 			// Remove the finalizer to allow deletion (retry on conflict)

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -249,9 +249,8 @@ func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.C
 	for i := range sessionList.Items {
 		session := &sessionList.Items[i]
 
-		// Skip already terminal sessions
-		if session.Status.State == breakglassv1alpha1.DebugSessionStateFailed ||
-			session.Status.State == breakglassv1alpha1.DebugSessionStateTerminated ||
+		// Skip sessions that are already in cleanup or already cleaned up.
+		if session.Status.State == breakglassv1alpha1.DebugSessionStateTerminated ||
 			session.Status.State == breakglassv1alpha1.DebugSessionStateExpired {
 			continue
 		}

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -41,8 +41,6 @@ const (
 	// ClusterConfigFinalizer is the finalizer added to ClusterConfig resources
 	// to ensure proper cleanup of associated sessions when the cluster is deleted.
 	ClusterConfigFinalizer = "breakglass.t-caas.telekom.com/cluster-cleanup"
-
-	clusterConfigDefaultRetainFor = 720 * time.Hour
 )
 
 // ClusterConfigReconciler reconciles ClusterConfig objects.
@@ -197,7 +195,7 @@ func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx cont
 		// Update the session status to Expired
 		session.Status.State = breakglassv1alpha1.SessionStateExpired
 		session.Status.ExpiresAt = now
-		retainFor := parseClusterConfigRetainFor(session.Spec, log)
+		retainFor := utils.ParseRetainFor(session.Spec, log)
 		session.Status.RetainedUntil = metav1.NewTime(now.Time.Add(retainFor))
 
 		if err := ssa.ApplyBreakglassSessionStatus(ctx, r.Client, session); err != nil {
@@ -282,23 +280,6 @@ func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.C
 	}
 
 	return errors.Join(terminateErrs...)
-}
-
-func parseClusterConfigRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
-	if spec.RetainFor == "" {
-		return clusterConfigDefaultRetainFor
-	}
-	retainFor, err := breakglassv1alpha1.ParseDuration(spec.RetainFor)
-	if err != nil || retainFor <= 0 {
-		if log != nil {
-			log.Warnw("Invalid BreakglassSession retainFor during ClusterConfig cleanup; falling back to default",
-				"retainFor", spec.RetainFor,
-				"default", clusterConfigDefaultRetainFor.String(),
-				"error", err)
-		}
-		return clusterConfigDefaultRetainFor
-	}
-	return retainFor
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,7 @@ const (
 	// to ensure proper cleanup of associated sessions when the cluster is deleted.
 	ClusterConfigFinalizer = "breakglass.t-caas.telekom.com/cluster-cleanup"
 
-	clusterConfigDefaultRetainFor = 30 * 24 * time.Hour
+	clusterConfigDefaultRetainFor = 720 * time.Hour
 )
 
 // ClusterConfigReconciler reconciles ClusterConfig objects.
@@ -170,23 +171,16 @@ func (r *ClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // terminateBreakglassSessionsForCluster finds all BreakglassSessions targeting the given cluster
 // and terminates them by setting their state to Expired.
 func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx context.Context, clusterName string, log *zap.SugaredLogger) error {
-	// List all BreakglassSessions. ClusterConfig deletion is rare and full listing also
-	// catches direct CRD-created sessions that use spec.clusterConfigRef instead of
-	// the display-oriented spec.cluster value.
-	sessionList := &breakglassv1alpha1.BreakglassSessionList{}
-	if err := r.List(ctx, sessionList); err != nil {
+	sessionList, err := r.listBreakglassSessionsForCluster(ctx, clusterName)
+	if err != nil {
 		return fmt.Errorf("failed to list BreakglassSessions for cluster %s: %w", clusterName, err)
 	}
 
 	now := metav1.Now()
 	terminatedCount := 0
 	var terminateErrs []error
-	for i := range sessionList.Items {
-		session := &sessionList.Items[i]
-		if session.Spec.Cluster != clusterName && session.Spec.ClusterConfigRef != clusterName {
-			continue
-		}
-
+	for i := range sessionList {
+		session := &sessionList[i]
 		// Skip already terminal sessions
 		if session.Status.State == breakglassv1alpha1.SessionStateExpired ||
 			session.Status.State == breakglassv1alpha1.SessionStateIdleExpired ||
@@ -221,6 +215,25 @@ func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx cont
 	}
 
 	return errors.Join(terminateErrs...)
+}
+
+func (r *ClusterConfigReconciler) listBreakglassSessionsForCluster(ctx context.Context, clusterName string) ([]breakglassv1alpha1.BreakglassSession, error) {
+	sessionsByName := make(map[types.NamespacedName]breakglassv1alpha1.BreakglassSession)
+	for _, field := range []string{"spec.cluster", "spec.clusterConfigRef"} {
+		sessionList := &breakglassv1alpha1.BreakglassSessionList{}
+		if err := r.List(ctx, sessionList, client.MatchingFields{field: clusterName}); err != nil {
+			return nil, fmt.Errorf("list BreakglassSessions by %s: %w", field, err)
+		}
+		for _, session := range sessionList.Items {
+			sessionsByName[types.NamespacedName{Namespace: session.Namespace, Name: session.Name}] = session
+		}
+	}
+
+	sessions := make([]breakglassv1alpha1.BreakglassSession, 0, len(sessionsByName))
+	for _, session := range sessionsByName {
+		sessions = append(sessions, session)
+	}
+	return sessions, nil
 }
 
 // terminateDebugSessionsForCluster finds all DebugSessions targeting the given cluster

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -84,17 +84,20 @@ func (r *ClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if controllerutil.ContainsFinalizer(clusterConfig, ClusterConfigFinalizer) {
 			log.Infow("ClusterConfig is being deleted, cleaning up sessions", "cluster", clusterName)
 
+			var cleanupErrs []error
 			// Terminate all BreakglassSessions for this cluster
 			if err := r.terminateBreakglassSessionsForCluster(ctx, clusterName, log); err != nil {
 				log.Errorw("Failed to terminate BreakglassSessions for cluster", "cluster", clusterName, "error", err)
-				// Returning the error keeps deletion blocked and lets controller-runtime
-				// retry through its rate limiter.
-				return ctrl.Result{}, err
+				cleanupErrs = append(cleanupErrs, err)
 			}
 
 			// Terminate all DebugSessions for this cluster
 			if err := r.terminateDebugSessionsForCluster(ctx, clusterName, log); err != nil {
 				log.Errorw("Failed to terminate DebugSessions for cluster", "cluster", clusterName, "error", err)
+				cleanupErrs = append(cleanupErrs, err)
+			}
+
+			if err := errors.Join(cleanupErrs...); err != nil {
 				// Returning the error keeps deletion blocked and lets controller-runtime
 				// retry through its rate limiter.
 				return ctrl.Result{}, err
@@ -196,6 +199,14 @@ func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx cont
 		// Update the session status to Expired
 		session.Status.State = breakglassv1alpha1.SessionStateExpired
 		session.Status.ExpiresAt = now
+		session.Status.ReasonEnded = "clusterDeleted"
+		session.SetCondition(metav1.Condition{
+			Type:               string(breakglassv1alpha1.SessionConditionTypeExpired),
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "ExpiredByClusterDeletion",
+			Message:            "Session expired because its ClusterConfig is being deleted.",
+		})
 		retainFor := utils.ParseRetainFor(session.Spec, log)
 		session.Status.RetainedUntil = metav1.NewTime(now.Time.Add(retainFor))
 

--- a/pkg/config/cluster_config_reconciler.go
+++ b/pkg/config/cluster_config_reconciler.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -39,6 +40,8 @@ const (
 	// ClusterConfigFinalizer is the finalizer added to ClusterConfig resources
 	// to ensure proper cleanup of associated sessions when the cluster is deleted.
 	ClusterConfigFinalizer = "breakglass.t-caas.telekom.com/cluster-cleanup"
+
+	clusterConfigDefaultRetainFor = 30 * 24 * time.Hour
 )
 
 // ClusterConfigReconciler reconciles ClusterConfig objects.
@@ -167,16 +170,22 @@ func (r *ClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // terminateBreakglassSessionsForCluster finds all BreakglassSessions targeting the given cluster
 // and terminates them by setting their state to Expired.
 func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx context.Context, clusterName string, log *zap.SugaredLogger) error {
-	// List all BreakglassSessions for this cluster using the spec.cluster index
+	// List all BreakglassSessions. ClusterConfig deletion is rare and full listing also
+	// catches direct CRD-created sessions that use spec.clusterConfigRef instead of
+	// the display-oriented spec.cluster value.
 	sessionList := &breakglassv1alpha1.BreakglassSessionList{}
-	if err := r.List(ctx, sessionList, client.MatchingFields{"spec.cluster": clusterName}); err != nil {
+	if err := r.List(ctx, sessionList); err != nil {
 		return fmt.Errorf("failed to list BreakglassSessions for cluster %s: %w", clusterName, err)
 	}
 
 	now := metav1.Now()
 	terminatedCount := 0
+	var terminateErrs []error
 	for i := range sessionList.Items {
 		session := &sessionList.Items[i]
+		if session.Spec.Cluster != clusterName && session.Spec.ClusterConfigRef != clusterName {
+			continue
+		}
 
 		// Skip already terminal sessions
 		if session.Status.State == breakglassv1alpha1.SessionStateExpired ||
@@ -194,10 +203,12 @@ func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx cont
 		// Update the session status to Expired
 		session.Status.State = breakglassv1alpha1.SessionStateExpired
 		session.Status.ExpiresAt = now
+		retainFor := parseClusterConfigRetainFor(session.Spec, log)
+		session.Status.RetainedUntil = metav1.NewTime(now.Time.Add(retainFor))
 
 		if err := ssa.ApplyBreakglassSessionStatus(ctx, r.Client, session); err != nil {
 			log.Warnw("Failed to terminate BreakglassSession", "session", session.Name, "error", err)
-			// Continue with other sessions even if one fails
+			terminateErrs = append(terminateErrs, fmt.Errorf("terminate BreakglassSession %s/%s: %w", session.Namespace, session.Name, err))
 			continue
 		}
 		terminatedCount++
@@ -209,11 +220,12 @@ func (r *ClusterConfigReconciler) terminateBreakglassSessionsForCluster(ctx cont
 			"cluster", clusterName, "count", terminatedCount)
 	}
 
-	return nil
+	return errors.Join(terminateErrs...)
 }
 
 // terminateDebugSessionsForCluster finds all DebugSessions targeting the given cluster
-// and terminates them by setting their state to Failed.
+// and terminates them. Terminated sessions are reconciled through the DebugSession
+// cleanup path, so deployed debug pods and auxiliary resources are removed.
 func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.Context, clusterName string, log *zap.SugaredLogger) error {
 	// List all DebugSessions for this cluster using the spec.cluster index
 	sessionList := &breakglassv1alpha1.DebugSessionList{}
@@ -222,6 +234,7 @@ func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.C
 	}
 
 	terminatedCount := 0
+	var terminateErrs []error
 	for i := range sessionList.Items {
 		session := &sessionList.Items[i]
 
@@ -236,17 +249,18 @@ func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.C
 			"session", session.Name, "namespace", session.Namespace, "cluster", clusterName,
 			"previousState", session.Status.State)
 
-		// Update the session status to Failed
-		session.Status.State = breakglassv1alpha1.DebugSessionStateFailed
+		// Update the session status to Terminated so the debug-session reconciler
+		// performs resource cleanup.
+		session.Status.State = breakglassv1alpha1.DebugSessionStateTerminated
 		session.Status.Message = fmt.Sprintf("Session terminated: ClusterConfig %q was deleted", clusterName)
 
 		if err := ssa.ApplyDebugSessionStatus(ctx, r.Client, session); err != nil {
 			log.Warnw("Failed to terminate DebugSession", "session", session.Name, "error", err)
-			// Continue with other sessions even if one fails
+			terminateErrs = append(terminateErrs, fmt.Errorf("terminate DebugSession %s/%s: %w", session.Namespace, session.Name, err))
 			continue
 		}
 		terminatedCount++
-		metrics.DebugSessionsFailed.WithLabelValues(clusterName, "cluster_deleted").Inc()
+		metrics.DebugSessionsTerminated.WithLabelValues(clusterName, "cluster_deleted").Inc()
 	}
 
 	if terminatedCount > 0 {
@@ -254,7 +268,24 @@ func (r *ClusterConfigReconciler) terminateDebugSessionsForCluster(ctx context.C
 			"cluster", clusterName, "count", terminatedCount)
 	}
 
-	return nil
+	return errors.Join(terminateErrs...)
+}
+
+func parseClusterConfigRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
+	if spec.RetainFor == "" {
+		return clusterConfigDefaultRetainFor
+	}
+	retainFor, err := breakglassv1alpha1.ParseDuration(spec.RetainFor)
+	if err != nil || retainFor <= 0 {
+		if log != nil {
+			log.Warnw("Invalid BreakglassSession retainFor during ClusterConfig cleanup; falling back to default",
+				"retainFor", spec.RetainFor,
+				"default", clusterConfigDefaultRetainFor.String(),
+				"error", err)
+		}
+		return clusterConfigDefaultRetainFor
+	}
+	return retainFor
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -437,7 +438,7 @@ func TestClusterConfigReconciler_BreakglassCleanupUsesIndexedLists(t *testing.T)
 	}
 }
 
-func TestParseClusterConfigRetainFor(t *testing.T) {
+func TestClusterConfigCleanupRetainForUsesBreakglassParser(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 
 	tests := []struct {
@@ -450,7 +451,7 @@ func TestParseClusterConfigRetainFor(t *testing.T) {
 			name:     "empty uses default",
 			retain:   "",
 			log:      logger,
-			expected: clusterConfigDefaultRetainFor,
+			expected: utils.DefaultRetainForDuration,
 		},
 		{
 			name:     "valid duration",
@@ -462,13 +463,13 @@ func TestParseClusterConfigRetainFor(t *testing.T) {
 			name:     "invalid duration with logger uses default",
 			retain:   "not-a-duration",
 			log:      logger,
-			expected: clusterConfigDefaultRetainFor,
+			expected: utils.DefaultRetainForDuration,
 		},
 		{
 			name:     "non-positive duration without logger uses default",
 			retain:   "0s",
 			log:      nil,
-			expected: clusterConfigDefaultRetainFor,
+			expected: utils.DefaultRetainForDuration,
 		},
 	}
 
@@ -476,7 +477,7 @@ func TestParseClusterConfigRetainFor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := breakglassv1alpha1.BreakglassSessionSpec{RetainFor: tt.retain}
 
-			assert.Equal(t, tt.expected, parseClusterConfigRetainFor(spec, tt.log))
+			assert.Equal(t, tt.expected, utils.ParseRetainFor(spec, tt.log))
 		})
 	}
 }

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -236,11 +236,27 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 			Namespace: "default",
 		},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
-			Cluster: "test-cluster",
-			User:    "test-user2@example.com",
+			Cluster:   "test-cluster",
+			User:      "test-user2@example.com",
+			RetainFor: "2h",
 		},
 		Status: breakglassv1alpha1.BreakglassSessionStatus{
 			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+
+	refSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clusterconfig-ref-session",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:          "display-cluster-name",
+			ClusterConfigRef: "test-cluster",
+			User:             "test-user-ref@example.com",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
 		},
 	}
 
@@ -275,7 +291,7 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 	}
 
 	fakeClient := newTestClusterConfigFakeClient(scheme,
-		clusterConfig, pendingSession, approvedSession, otherClusterSession, expiredSession)
+		clusterConfig, pendingSession, approvedSession, refSession, otherClusterSession, expiredSession)
 	logger := zap.NewNop().Sugar()
 
 	r := &ClusterConfigReconciler{
@@ -296,12 +312,21 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "pending-session", Namespace: "default"}, &pending)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, pending.Status.State)
+	assert.False(t, pending.Status.RetainedUntil.IsZero(), "terminated session should get retention")
 
 	// Verify approved session was terminated (expired)
 	var approved breakglassv1alpha1.BreakglassSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "approved-session", Namespace: "default"}, &approved)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, approved.Status.State)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), approved.Status.RetainedUntil.Time, 5*time.Second)
+
+	// Verify session linked by spec.clusterConfigRef was terminated even when spec.cluster differs
+	var byRef breakglassv1alpha1.BreakglassSession
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "clusterconfig-ref-session", Namespace: "default"}, &byRef)
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, byRef.Status.State)
+	assert.False(t, byRef.Status.RetainedUntil.IsZero(), "clusterConfigRef-linked session should get retention")
 
 	// Verify other cluster session was NOT touched
 	var other breakglassv1alpha1.BreakglassSession
@@ -411,19 +436,19 @@ func TestClusterConfigReconciler_DeleteTerminatesDebugSessions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 
-	// Verify active debug session was terminated (failed)
+	// Verify active debug session was terminated so cleanup can run
 	var active breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "active-debug", Namespace: "default"}, &active)
 	require.NoError(t, err)
-	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, active.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, active.Status.State)
 	assert.Contains(t, active.Status.Message, "ClusterConfig")
 	assert.Contains(t, active.Status.Message, "deleted")
 
-	// Verify pending debug session was terminated (failed)
+	// Verify pending debug session was terminated so cleanup can run
 	var pending breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "pending-debug", Namespace: "default"}, &pending)
 	require.NoError(t, err)
-	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, pending.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, pending.Status.State)
 
 	// Verify other cluster session was NOT touched
 	var other breakglassv1alpha1.DebugSession
@@ -508,7 +533,7 @@ func TestClusterConfigReconciler_DeleteTerminatesBothSessionTypes(t *testing.T) 
 	var debug breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "debug-session", Namespace: "default"}, &debug)
 	require.NoError(t, err)
-	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, debug.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, debug.Status.State)
 
 	// When finalizer is removed from an object with DeletionTimestamp,
 	// the fake client automatically deletes the object
@@ -709,7 +734,7 @@ func TestClusterConfigReconciler_MultipleNamespaces(t *testing.T) {
 // TestClusterConfigReconciler_CleanupFailureBlocksDeletion tests that when session listing
 // fails, the finalizer is NOT removed and deletion is blocked with a requeue.
 // This ensures the ClusterConfig cannot be deleted until all sessions are properly cleaned up.
-// Note: Individual session update failures are logged but don't block deletion (best-effort cleanup).
+// Individual session update failures block deletion so cleanup can retry.
 func TestClusterConfigReconciler_CleanupFailureBlocksDeletion(t *testing.T) {
 	scheme := newTestClusterConfigReconcilerScheme()
 	ctx := context.Background()
@@ -767,6 +792,134 @@ func TestClusterConfigReconciler_CleanupFailureBlocksDeletion(t *testing.T) {
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updated)
 	require.NoError(t, err, "ClusterConfig should still exist because cleanup failed")
 	assert.Contains(t, updated.Finalizers, ClusterConfigFinalizer, "Finalizer should still be present")
+}
+
+func TestClusterConfigReconciler_BreakglassStatusPatchFailureBlocksDeletion(t *testing.T) {
+	scheme := newTestClusterConfigReconcilerScheme()
+	ctx := context.Background()
+
+	now := metav1.Now()
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-cluster",
+			Namespace:         "default",
+			Finalizers:        []string{ClusterConfigFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: breakglassv1alpha1.ClusterConfigSpec{ClusterID: "test-cluster-id"},
+	}
+	failingSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failing-session", Namespace: "default"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "test-cluster"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved},
+	}
+	okSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "ok-session", Namespace: "default"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "test-cluster"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+
+	statusPatchError := errors.New("simulated breakglass status patch failure")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clusterConfig, failingSession, okSession).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}, &breakglassv1alpha1.DebugSession{}).
+		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.DebugSession); ok && s.Spec.Cluster != "" {
+				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, client client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if subResource == "status" && obj.GetName() == "failing-session" {
+					return statusPatchError
+				}
+				return client.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := &ClusterConfigReconciler{Client: fakeClient, Scheme: scheme, Log: zap.NewNop().Sugar()}
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-cluster", Namespace: "default"}})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "simulated breakglass status patch failure")
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+
+	var updatedCluster breakglassv1alpha1.ClusterConfig
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updatedCluster)
+	require.NoError(t, err)
+	assert.Contains(t, updatedCluster.Finalizers, ClusterConfigFinalizer)
+
+	var ok breakglassv1alpha1.BreakglassSession
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "ok-session", Namespace: "default"}, &ok)
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, ok.Status.State)
+}
+
+func TestClusterConfigReconciler_DebugStatusPatchFailureBlocksDeletion(t *testing.T) {
+	scheme := newTestClusterConfigReconcilerScheme()
+	ctx := context.Background()
+
+	now := metav1.Now()
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-cluster",
+			Namespace:         "default",
+			Finalizers:        []string{ClusterConfigFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: breakglassv1alpha1.ClusterConfigSpec{ClusterID: "test-cluster-id"},
+	}
+	failingSession := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "failing-debug", Namespace: "default"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "test-cluster"},
+		Status:     breakglassv1alpha1.DebugSessionStatus{State: breakglassv1alpha1.DebugSessionStateActive},
+	}
+	okSession := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "ok-debug", Namespace: "default"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "test-cluster"},
+		Status:     breakglassv1alpha1.DebugSessionStatus{State: breakglassv1alpha1.DebugSessionStatePending},
+	}
+
+	statusPatchError := errors.New("simulated debug status patch failure")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clusterConfig, failingSession, okSession).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}, &breakglassv1alpha1.DebugSession{}).
+		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.DebugSession); ok && s.Spec.Cluster != "" {
+				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, client client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if subResource == "status" && obj.GetName() == "failing-debug" {
+					return statusPatchError
+				}
+				return client.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := &ClusterConfigReconciler{Client: fakeClient, Scheme: scheme, Log: zap.NewNop().Sugar()}
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-cluster", Namespace: "default"}})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "simulated debug status patch failure")
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+
+	var updatedCluster breakglassv1alpha1.ClusterConfig
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updatedCluster)
+	require.NoError(t, err)
+	assert.Contains(t, updatedCluster.Finalizers, ClusterConfigFinalizer)
+
+	var ok breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "ok-debug", Namespace: "default"}, &ok)
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, ok.Status.State)
 }
 
 // TestClusterConfigReconciler_DebugSessionCleanupFailureBlocksDeletion tests that when DebugSession

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -319,13 +319,19 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "pending-session", Namespace: "default"}, &pending)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, pending.Status.State)
+	assert.Equal(t, "clusterDeleted", pending.Status.ReasonEnded)
 	assert.False(t, pending.Status.RetainedUntil.IsZero(), "terminated session should get retention")
+	expiredCondition := pending.GetCondition(string(breakglassv1alpha1.SessionConditionTypeExpired))
+	require.NotNil(t, expiredCondition)
+	assert.Equal(t, metav1.ConditionTrue, expiredCondition.Status)
+	assert.Equal(t, "ExpiredByClusterDeletion", expiredCondition.Reason)
 
 	// Verify approved session was terminated (expired)
 	var approved breakglassv1alpha1.BreakglassSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "approved-session", Namespace: "default"}, &approved)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, approved.Status.State)
+	assert.Equal(t, "clusterDeleted", approved.Status.ReasonEnded)
 	require.False(t, approved.Status.ExpiresAt.IsZero(), "terminated session should get expiry")
 	assert.WithinDuration(t, approved.Status.ExpiresAt.Time.Add(2*time.Hour), approved.Status.RetainedUntil.Time, time.Second)
 
@@ -956,11 +962,16 @@ func TestClusterConfigReconciler_BreakglassStatusPatchFailureBlocksDeletion(t *t
 		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "test-cluster"},
 		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
 	}
+	debugSession := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "debug-session", Namespace: "default"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "test-cluster"},
+		Status:     breakglassv1alpha1.DebugSessionStatus{State: breakglassv1alpha1.DebugSessionStateActive},
+	}
 
 	statusPatchError := errors.New("simulated breakglass status patch failure")
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(clusterConfig, failingSession, okSession).
+		WithObjects(clusterConfig, failingSession, okSession, debugSession).
 		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}, &breakglassv1alpha1.DebugSession{}).
 		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
 			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
@@ -1006,6 +1017,11 @@ func TestClusterConfigReconciler_BreakglassStatusPatchFailureBlocksDeletion(t *t
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "ok-session", Namespace: "default"}, &ok)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, ok.Status.State)
+
+	var debug breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "debug-session", Namespace: "default"}, &debug)
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, debug.Status.State)
 }
 
 func TestClusterConfigReconciler_DebugStatusPatchFailureBlocksDeletion(t *testing.T) {

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -54,6 +54,12 @@ func newTestClusterConfigFakeClient(scheme *runtime.Scheme, objs ...client.Objec
 			}
 			return nil
 		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
+			}
+			return nil
+		}).
 		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
 			if s, ok := obj.(*breakglassv1alpha1.DebugSession); ok && s.Spec.Cluster != "" {
 				return []string{s.Spec.Cluster}
@@ -345,6 +351,90 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 	var updated breakglassv1alpha1.ClusterConfig
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updated)
 	assert.True(t, apierrors.IsNotFound(err), "ClusterConfig should be deleted after finalizer removal")
+}
+
+func TestClusterConfigReconciler_BreakglassCleanupUsesIndexedLists(t *testing.T) {
+	scheme := newTestClusterConfigReconcilerScheme()
+	ctx := context.Background()
+	var breakglassSessionSelectors []string
+
+	byCluster := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "by-cluster", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster: "test-cluster",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	byRef := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "by-ref", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:          "display-cluster",
+			ClusterConfigRef: "test-cluster",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+	byBoth := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "by-both", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:          "test-cluster",
+			ClusterConfigRef: "test-cluster",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(byCluster, byRef, byBoth).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
+				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
+			}
+			return nil
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, innerClient client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*breakglassv1alpha1.BreakglassSessionList); ok {
+					listOptions := &client.ListOptions{}
+					for _, opt := range opts {
+						opt.ApplyToList(listOptions)
+					}
+					if listOptions.FieldSelector == nil {
+						return errors.New("BreakglassSession cleanup used an unfiltered list")
+					}
+					breakglassSessionSelectors = append(breakglassSessionSelectors, listOptions.FieldSelector.String())
+				}
+				return innerClient.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := &ClusterConfigReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Log:    zap.NewNop().Sugar(),
+	}
+
+	require.NoError(t, r.terminateBreakglassSessionsForCluster(ctx, "test-cluster", zap.NewNop().Sugar()))
+	assert.ElementsMatch(t, []string{"spec.cluster=test-cluster", "spec.clusterConfigRef=test-cluster"}, breakglassSessionSelectors)
+
+	for _, name := range []string{"by-cluster", "by-ref", "by-both"} {
+		var session breakglassv1alpha1.BreakglassSession
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &session))
+		assert.Equal(t, breakglassv1alpha1.SessionStateExpired, session.Status.State, name)
+	}
 }
 
 func TestClusterConfigReconciler_DeleteTerminatesDebugSessions(t *testing.T) {
@@ -824,6 +914,18 @@ func TestClusterConfigReconciler_BreakglassStatusPatchFailureBlocksDeletion(t *t
 		WithScheme(scheme).
 		WithObjects(clusterConfig, failingSession, okSession).
 		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}, &breakglassv1alpha1.DebugSession{}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
+				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
+			}
+			return nil
+		}).
 		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
 			if s, ok := obj.(*breakglassv1alpha1.DebugSession); ok && s.Spec.Cluster != "" {
 				return []string{s.Spec.Cluster}
@@ -888,6 +990,18 @@ func TestClusterConfigReconciler_DebugStatusPatchFailureBlocksDeletion(t *testin
 		WithScheme(scheme).
 		WithObjects(clusterConfig, failingSession, okSession).
 		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}, &breakglassv1alpha1.DebugSession{}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
+				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
+			}
+			return nil
+		}).
 		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
 			if s, ok := obj.(*breakglassv1alpha1.DebugSession); ok && s.Spec.Cluster != "" {
 				return []string{s.Spec.Cluster}
@@ -950,6 +1064,12 @@ func TestClusterConfigReconciler_DebugSessionCleanupFailureBlocksDeletion(t *tes
 		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
 			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.Cluster != "" {
 				return []string{s.Spec.Cluster}
+			}
+			return nil
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
 			}
 			return nil
 		}).

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -326,7 +326,8 @@ func TestClusterConfigReconciler_DeleteTerminatesBreakglassSessions(t *testing.T
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "approved-session", Namespace: "default"}, &approved)
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.SessionStateExpired, approved.Status.State)
-	assert.WithinDuration(t, time.Now().Add(2*time.Hour), approved.Status.RetainedUntil.Time, 5*time.Second)
+	require.False(t, approved.Status.ExpiresAt.IsZero(), "terminated session should get expiry")
+	assert.WithinDuration(t, approved.Status.ExpiresAt.Time.Add(2*time.Hour), approved.Status.RetainedUntil.Time, time.Second)
 
 	// Verify session linked by spec.clusterConfigRef was terminated even when spec.cluster differs
 	var byRef breakglassv1alpha1.BreakglassSession
@@ -869,7 +870,7 @@ func TestClusterConfigReconciler_MultipleNamespaces(t *testing.T) {
 }
 
 // TestClusterConfigReconciler_CleanupFailureBlocksDeletion tests that when session listing
-// fails, the finalizer is NOT removed and deletion is blocked with a requeue.
+// fails, the finalizer is NOT removed and deletion is blocked for retry.
 // This ensures the ClusterConfig cannot be deleted until all sessions are properly cleaned up.
 // Individual session update failures block deletion so cleanup can retry.
 func TestClusterConfigReconciler_CleanupFailureBlocksDeletion(t *testing.T) {
@@ -918,10 +919,10 @@ func TestClusterConfigReconciler_CleanupFailureBlocksDeletion(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "test-cluster", Namespace: "default"},
 	})
 
-	// Should return error and requeue after delay
+	// Should return error; controller-runtime retries errors through its rate limiter.
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "simulated list failure")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	// Verify the ClusterConfig still exists with its finalizer
 	// (deletion should be blocked because cleanup failed)
@@ -994,7 +995,7 @@ func TestClusterConfigReconciler_BreakglassStatusPatchFailureBlocksDeletion(t *t
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "simulated breakglass status patch failure")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	var updatedCluster breakglassv1alpha1.ClusterConfig
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updatedCluster)
@@ -1070,7 +1071,7 @@ func TestClusterConfigReconciler_DebugStatusPatchFailureBlocksDeletion(t *testin
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "simulated debug status patch failure")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	var updatedCluster breakglassv1alpha1.ClusterConfig
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "default"}, &updatedCluster)
@@ -1143,10 +1144,10 @@ func TestClusterConfigReconciler_DebugSessionCleanupFailureBlocksDeletion(t *tes
 		NamespacedName: types.NamespacedName{Name: "test-cluster", Namespace: "default"},
 	})
 
-	// Should return error and requeue after delay
+	// Should return error; controller-runtime retries errors through its rate limiter.
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "simulated debug session list failure")
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	// Verify the ClusterConfig still exists with its finalizer
 	var updated breakglassv1alpha1.ClusterConfig

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -437,6 +437,50 @@ func TestClusterConfigReconciler_BreakglassCleanupUsesIndexedLists(t *testing.T)
 	}
 }
 
+func TestParseClusterConfigRetainFor(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	tests := []struct {
+		name     string
+		retain   string
+		log      *zap.SugaredLogger
+		expected time.Duration
+	}{
+		{
+			name:     "empty uses default",
+			retain:   "",
+			log:      logger,
+			expected: clusterConfigDefaultRetainFor,
+		},
+		{
+			name:     "valid duration",
+			retain:   "2h",
+			log:      logger,
+			expected: 2 * time.Hour,
+		},
+		{
+			name:     "invalid duration with logger uses default",
+			retain:   "not-a-duration",
+			log:      logger,
+			expected: clusterConfigDefaultRetainFor,
+		},
+		{
+			name:     "non-positive duration without logger uses default",
+			retain:   "0s",
+			log:      nil,
+			expected: clusterConfigDefaultRetainFor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := breakglassv1alpha1.BreakglassSessionSpec{RetainFor: tt.retain}
+
+			assert.Equal(t, tt.expected, parseClusterConfigRetainFor(spec, tt.log))
+		})
+	}
+}
+
 func TestClusterConfigReconciler_DeleteTerminatesDebugSessions(t *testing.T) {
 	scheme := newTestClusterConfigReconcilerScheme()
 	ctx := context.Background()

--- a/pkg/config/cluster_config_reconciler_test.go
+++ b/pkg/config/cluster_config_reconciler_test.go
@@ -540,7 +540,8 @@ func TestClusterConfigReconciler_DeleteTerminatesDebugSessions(t *testing.T) {
 		},
 	}
 
-	// Already failed session - should be skipped
+	// Failed sessions may still have tracked resources, so they should be
+	// moved into the terminated cleanup path.
 	failedDebugSession := &breakglassv1alpha1.DebugSession{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "failed-debug",
@@ -591,11 +592,13 @@ func TestClusterConfigReconciler_DeleteTerminatesDebugSessions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, other.Status.State)
 
-	// Verify already failed session state unchanged
+	// Verify failed session was terminated so cleanup can run
 	var failed breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(ctx, types.NamespacedName{Name: "failed-debug", Namespace: "default"}, &failed)
 	require.NoError(t, err)
-	assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, failed.Status.State)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, failed.Status.State)
+	assert.Contains(t, failed.Status.Message, "ClusterConfig")
+	assert.Contains(t, failed.Status.Message, "deleted")
 }
 
 func TestClusterConfigReconciler_DeleteTerminatesBothSessionTypes(t *testing.T) {
@@ -724,12 +727,11 @@ func TestClusterConfigReconciler_SkipsTerminalStates(t *testing.T) {
 		})
 	}
 
-	// Add debug sessions in terminal states
+	// Add debug sessions that are already in cleanup terminal states.
 	debugTerminalStates := []struct {
 		name  string
 		state breakglassv1alpha1.DebugSessionState
 	}{
-		{"debug-failed", breakglassv1alpha1.DebugSessionStateFailed},
 		{"debug-terminated", breakglassv1alpha1.DebugSessionStateTerminated},
 		{"debug-expired", breakglassv1alpha1.DebugSessionStateExpired},
 	}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -16,7 +16,7 @@ import (
 
 // ExpectedIndexCount is the number of field indexes that should be registered.
 // Update this constant when adding or removing indexes.
-const ExpectedIndexCount = 19
+const ExpectedIndexCount = 20
 
 // registeredIndexes tracks which indexes have been successfully registered.
 // Uses sync.Map because RegisterCommonFieldIndexes may be called concurrently

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -63,6 +63,17 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
+	if err := register("BreakglassSession", "spec.clusterConfigRef", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(rawObj client.Object) []string {
+			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Spec.ClusterConfigRef != "" {
+				return []string{bs.Spec.ClusterConfigRef}
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
 	if err := register("BreakglassSession", "spec.user", func() error {
 		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassSession{}, "spec.user", func(rawObj client.Object) []string {
 			if bs, ok := rawObj.(*breakglassv1alpha1.BreakglassSession); ok && bs.Spec.User != "" {

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -75,6 +75,7 @@ func TestRegisterCommonFieldIndexes_Success(t *testing.T) {
 	// Verify all expected fields were indexed
 	expectedFields := []string{
 		"spec.cluster",
+		"spec.clusterConfigRef",
 		"spec.user",
 		"spec.grantedGroup",
 		"metadata.name",
@@ -126,6 +127,10 @@ func TestRegisterCommonFieldIndexes_FailureOnField(t *testing.T) {
 		{
 			name:        "fail on spec.cluster",
 			failOnField: "spec.cluster",
+		},
+		{
+			name:        "fail on spec.clusterConfigRef",
+			failOnField: "spec.clusterConfigRef",
 		},
 		{
 			name:        "fail on spec.user",
@@ -187,9 +192,10 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
-			Cluster:      "test-cluster",
-			User:         "test-user@example.com",
-			GrantedGroup: "admin-access",
+			Cluster:          "test-cluster",
+			ClusterConfigRef: "test-cluster-config",
+			User:             "test-user@example.com",
+			GrantedGroup:     "admin-access",
 		},
 	}
 
@@ -201,6 +207,19 @@ func TestIndexerFunctions_BreakglassSession(t *testing.T) {
 		assert.Equal(t, []string{"test-cluster"}, result)
 
 		// Test with empty cluster
+		emptySession := &breakglassv1alpha1.BreakglassSession{}
+		result = fn(emptySession)
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.clusterConfigRef index", func(t *testing.T) {
+		fn := indexer.indexedFields["spec.clusterConfigRef"]
+		require.NotNil(t, fn)
+
+		result := fn(session)
+		assert.Equal(t, []string{"test-cluster-config"}, result)
+
+		// Test with empty clusterConfigRef
 		emptySession := &breakglassv1alpha1.BreakglassSession{}
 		result = fn(emptySession)
 		assert.Nil(t, result)
@@ -522,9 +541,10 @@ func TestRegisterCommonFieldIndexes_WithFakeClient(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
-			Cluster:      "indexed-cluster",
-			User:         "indexed-user@example.com",
-			GrantedGroup: "indexed-group",
+			Cluster:          "indexed-cluster",
+			ClusterConfigRef: "indexed-cluster-config-ref",
+			User:             "indexed-user@example.com",
+			GrantedGroup:     "indexed-group",
 		},
 	}
 
@@ -561,12 +581,24 @@ func TestRegisterCommonFieldIndexes_WithFakeClient(t *testing.T) {
 			}
 			return nil
 		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.clusterConfigRef", func(obj client.Object) []string {
+			if s, ok := obj.(*breakglassv1alpha1.BreakglassSession); ok && s.Spec.ClusterConfigRef != "" {
+				return []string{s.Spec.ClusterConfigRef}
+			}
+			return nil
+		}).
 		Build()
 
 	// Verify we can query by indexed field
 	ctx := context.Background()
 	var sessions breakglassv1alpha1.BreakglassSessionList
 	err = cli.List(ctx, &sessions, client.MatchingFields{"spec.cluster": "indexed-cluster"})
+	require.NoError(t, err)
+	assert.Len(t, sessions.Items, 1)
+	assert.Equal(t, "indexed-session", sessions.Items[0].Name)
+
+	sessions = breakglassv1alpha1.BreakglassSessionList{}
+	err = cli.List(ctx, &sessions, client.MatchingFields{"spec.clusterConfigRef": "indexed-cluster-config-ref"})
 	require.NoError(t, err)
 	assert.Len(t, sessions.Items, 1)
 	assert.Equal(t, "indexed-session", sessions.Items[0].Name)
@@ -628,6 +660,7 @@ func TestIsIndexRegistered(t *testing.T) {
 
 	// After registration
 	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.cluster"))
+	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.clusterConfigRef"))
 	assert.True(t, IsIndexRegistered("BreakglassEscalation", "spec.allowed.cluster"))
 	assert.True(t, IsIndexRegistered("ClusterConfig", "metadata.name"))
 	assert.False(t, IsIndexRegistered("NonExistent", "field"))

--- a/pkg/utils/duration_helpers.go
+++ b/pkg/utils/duration_helpers.go
@@ -66,7 +66,7 @@ func ParseDurationOrDefault(value string, defaultValue time.Duration, fieldName 
 		if log != nil {
 			log.Warnw("Non-positive "+fieldName+" in spec; falling back to default",
 				"value", value,
-				"parsedDuration", d,
+				"parsedDuration", d.String(),
 				"default", defaultValue.String())
 		}
 		return defaultValue

--- a/pkg/utils/duration_helpers.go
+++ b/pkg/utils/duration_helpers.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"time"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"go.uber.org/zap"
+)
+
+const (
+	MonthDuration            = time.Hour * 24 * 30
+	WeekDuration             = time.Hour * 24 * 7
+	DefaultValidForDuration  = time.Hour
+	DefaultRetainForDuration = MonthDuration
+)
+
+// ParseRetainFor parses the RetainFor duration from a session spec.
+// Returns DefaultRetainForDuration if the value is empty or invalid.
+// Logs a warning if the value is present but invalid.
+func ParseRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
+	return ParseDurationOrDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
+}
+
+// ParseEscalationRetainFor parses the RetainFor duration from an escalation spec.
+// Returns DefaultRetainForDuration if the value is empty or invalid.
+// Logs a warning if the value is present but invalid.
+func ParseEscalationRetainFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
+	return ParseDurationOrDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
+}
+
+// ParseDurationOrDefault parses a duration with the repository's extended duration syntax.
+// If the value is empty, invalid, or non-positive, defaultValue is returned.
+func ParseDurationOrDefault(value string, defaultValue time.Duration, fieldName string, log *zap.SugaredLogger) time.Duration {
+	if value == "" {
+		return defaultValue
+	}
+
+	d, err := breakglassv1alpha1.ParseDuration(value)
+	if err != nil {
+		if log != nil {
+			log.Warnw("Invalid "+fieldName+" in spec; falling back to default",
+				"value", value,
+				"error", err,
+				"default", defaultValue.String())
+		}
+		return defaultValue
+	}
+
+	if d <= 0 {
+		if log != nil {
+			log.Warnw("Non-positive "+fieldName+" in spec; falling back to default",
+				"value", value,
+				"parsedDuration", d,
+				"default", defaultValue.String())
+		}
+		return defaultValue
+	}
+
+	return d
+}

--- a/pkg/utils/duration_helpers.go
+++ b/pkg/utils/duration_helpers.go
@@ -1,18 +1,6 @@
-/*
-Copyright 2026.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/pkg/utils/duration_helpers.go
+++ b/pkg/utils/duration_helpers.go
@@ -20,20 +20,21 @@ const (
 
 // ParseRetainFor parses the RetainFor duration from a session spec.
 // Returns DefaultRetainForDuration if the value is empty or invalid.
-// Logs a warning if the value is present but invalid.
+// Logs a warning if the value is present but invalid and log is non-nil.
 func ParseRetainFor(spec breakglassv1alpha1.BreakglassSessionSpec, log *zap.SugaredLogger) time.Duration {
 	return ParseDurationOrDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
 }
 
 // ParseEscalationRetainFor parses the RetainFor duration from an escalation spec.
 // Returns DefaultRetainForDuration if the value is empty or invalid.
-// Logs a warning if the value is present but invalid.
+// Logs a warning if the value is present but invalid and log is non-nil.
 func ParseEscalationRetainFor(spec breakglassv1alpha1.BreakglassEscalationSpec, log *zap.SugaredLogger) time.Duration {
 	return ParseDurationOrDefault(spec.RetainFor, DefaultRetainForDuration, "RetainFor", log)
 }
 
 // ParseDurationOrDefault parses a duration with the repository's extended duration syntax.
 // If the value is empty, invalid, or non-positive, defaultValue is returned.
+// Logs a warning for invalid and non-positive values when log is non-nil.
 func ParseDurationOrDefault(value string, defaultValue time.Duration, fieldName string, log *zap.SugaredLogger) time.Duration {
 	if value == "" {
 		return defaultValue


### PR DESCRIPTION
## Summary
- Keep the ClusterConfig finalizer when any BreakglassSession or DebugSession status update fails, so cleanup is retried instead of allowing deletion to complete with active sessions left behind.
- Mark DebugSessions as `Terminated` on ClusterConfig deletion so the DebugSession controller cleanup path removes debug pods and auxiliary resources.
- Set terminal retention for forced BreakglassSession expiry and include sessions linked through `spec.clusterConfigRef`.
- Use indexed BreakglassSession lookups for both `spec.cluster` and `spec.clusterConfigRef` to avoid full cluster-wide session lists during ClusterConfig deletion.
- Update ClusterConfig docs and changelog for the corrected cleanup semantics.

## Evidence
The ClusterConfig finalizer path previously logged individual status apply failures and returned nil, allowing the finalizer to be removed. It also set DebugSessions to `Failed`, but the DebugSession reconciler treats `Failed` as terminal with no cleanup action.

Duplicate check before opening:
- `gh search prs --repo telekom/k8s-breakglass "ClusterConfig finalizer DebugSession Failed cleanup retainedUntil" --state open` -> no matches
- `gh search prs --repo telekom/k8s-breakglass "terminateDebugSessionsForCluster terminateBreakglassSessionsForCluster finalizer" --state open` -> no matches
- Reviewed active PRs #839-#848; #847 is adjacent cleanup retry work but does not touch ClusterConfig finalizer termination behavior.

## Validation
- `gofmt -w pkg/config/cluster_config_reconciler.go pkg/config/cluster_config_reconciler_test.go pkg/config/cluster_config_cleanup_test.go`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/config -run 'TestClusterConfigReconciler_(DeleteTerminatesBreakglassSessions|DeleteTerminatesDebugSessions|DeleteTerminatesBothSessionTypes|MixedSessionAndDebugSessionCleanup|BreakglassStatusPatchFailureBlocksDeletion|DebugStatusPatchFailureBlocksDeletion|CleanupFailureBlocksDeletion|DebugSessionCleanupFailureBlocksDeletion|SkipsTerminalStates)' -count=1 -timeout=120s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/config -count=1 -timeout=120s`
- `gofmt -w pkg/config/cluster_config_reconciler.go pkg/config/cluster_config_reconciler_test.go pkg/indexer/indexer.go pkg/indexer/indexer_test.go`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/config ./pkg/indexer -count=1 -timeout=180s`
- `git -c core.fsmonitor=false diff --check`

No UI changed; screenshots are not applicable.
