### PR TITLE
fix: skip stale scheduled activation states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scheduled activation stale-state guard**: Scheduled activation now re-reads each waiting session before granting access and skips sessions that already left `WaitingForScheduledTime`, preserving concurrent terminal transitions.
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -57,6 +57,7 @@ Once a session enters a terminal state (**Rejected**, **Withdrawn**, **Expired**
 - The state field is the only determinant for terminal state detection
 - Automatic expiry routines re-check live state before writing terminal status, so a concurrent withdraw, rejection, drop, or cancellation keeps its original terminal audit reason.
 - Scheduled sessions whose `expiresAt` is already in the past when cleanup reaches their `scheduledStartTime` are marked `Expired` instead of being activated
+- Scheduled activation re-reads the live session before granting access and skips the object if it has already left `WaitingForScheduledTime`.
 
 ### Timestamp Semantics
 

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ScheduledSessionActivator handles activation of scheduled sessions.
@@ -67,8 +68,10 @@ func (ssa *ScheduledSessionActivator) WithAuditService(auditService AuditEmitter
 // Sessions whose ScheduledStartTime has arrived transition to Approved so the RBAC group can be applied.
 // Sessions that can no longer be valid are expired instead of being activated late.
 func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
+	ctx := context.Background()
+
 	// Use indexed query to fetch only sessions waiting for scheduled time
-	sessions, err := ssa.sessionManager.GetSessionsByState(context.Background(), breakglassv1alpha1.SessionStateWaitingForScheduledTime)
+	sessions, err := ssa.sessionManager.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateWaitingForScheduledTime)
 	if err != nil {
 		ssa.log.Error("error listing sessions for scheduled activation", zap.String("error", err.Error()))
 		return
@@ -76,6 +79,12 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 
 	now := time.Now()
 	for _, ses := range sessions {
+		var ok bool
+		ses, ok = ssa.currentWaitingScheduledSession(ctx, ses)
+		if !ok {
+			continue
+		}
+
 		// Sanity check: session should have a scheduledStartTime
 		if ses.Spec.ScheduledStartTime == nil || ses.Spec.ScheduledStartTime.IsZero() {
 			ssa.log.Errorw("expiring session in WaitingForScheduledTime state with no ScheduledStartTime",
@@ -169,6 +178,28 @@ func (ssa *ScheduledSessionActivator) expireScheduledSession(session breakglassv
 		return
 	}
 	metrics.SessionExpired.WithLabelValues(session.Spec.Cluster).Inc()
+}
+
+func (ssa *ScheduledSessionActivator) currentWaitingScheduledSession(
+	ctx context.Context,
+	listed breakglassv1alpha1.BreakglassSession,
+) (breakglassv1alpha1.BreakglassSession, bool) {
+	current := breakglassv1alpha1.BreakglassSession{}
+	if err := ssa.sessionManager.Reader().Get(ctx, client.ObjectKey{Name: listed.Name, Namespace: listed.Namespace}, &current); err != nil {
+		ssa.log.Errorw("skipping scheduled session activation because live session could not be read",
+			"session", listed.Name,
+			"namespace", listed.Namespace,
+			"error", err)
+		return listed, false
+	}
+	if current.Status.State != breakglassv1alpha1.SessionStateWaitingForScheduledTime {
+		ssa.log.Infow("skipping scheduled session activation because state changed",
+			"session", current.Name,
+			"namespace", current.Namespace,
+			"state", current.Status.State)
+		return current, false
+	}
+	return current, true
 }
 
 func (ssa *ScheduledSessionActivator) emitSessionActivatedAuditEvent(session breakglassv1alpha1.BreakglassSession) {

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -28,6 +28,8 @@ import (
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -74,17 +76,28 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 	// Use indexed query to fetch only sessions waiting for scheduled time
 	sessions, err := ssa.sessionManager.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateWaitingForScheduledTime)
 	if err != nil {
-		ssa.log.Error("error listing sessions for scheduled activation", zap.String("error", err.Error()))
+		ssa.log.Errorw("error listing sessions for scheduled activation", "error", err)
 		return
 	}
 
 	now := time.Now()
 	for _, ses := range sessions {
-		var ok bool
-		ses, ok = ssa.currentWaitingScheduledSession(ctx, ses)
+		listedMissingScheduledTime := ses.Spec.ScheduledStartTime == nil || ses.Spec.ScheduledStartTime.IsZero()
+		if !listedMissingScheduledTime && now.Before(ses.Spec.ScheduledStartTime.Time) {
+			// Not yet time for this session; avoid a live read until the cached
+			// scheduledStartTime says this session may need a state transition.
+			continue
+		}
+
+		operation := "activation"
+		if listedMissingScheduledTime {
+			operation = "expiry"
+		}
+		current, ok := ssa.currentWaitingScheduledSession(ctx, ses, operation)
 		if !ok {
 			continue
 		}
+		ses = current
 
 		// Sanity check: session should have a scheduledStartTime
 		if ses.Spec.ScheduledStartTime == nil || ses.Spec.ScheduledStartTime.IsZero() {
@@ -97,7 +110,7 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 
 		scheduledTime := ses.Spec.ScheduledStartTime.Time
 		if now.Before(scheduledTime) {
-			// Not yet time for this session
+			// Live state moved the scheduled start into the future after the list read.
 			continue
 		}
 		if !ses.Status.ExpiresAt.IsZero() && !now.Before(ses.Status.ExpiresAt.Time) {
@@ -167,8 +180,25 @@ func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
 	ctx context.Context,
 	session breakglassv1alpha1.BreakglassSession,
 ) error {
-	session.Status.ObservedGeneration = session.Generation
-	return ssa.sessionManager.Client.Status().Update(ctx, &session)
+	key := client.ObjectKeyFromObject(&session)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := breakglassv1alpha1.BreakglassSession{}
+		if err := ssa.sessionManager.Reader().Get(ctx, key, &current); err != nil {
+			return err
+		}
+		if current.Status.State != breakglassv1alpha1.SessionStateWaitingForScheduledTime {
+			return apierrors.NewConflict(schema.GroupResource{
+				Group:    breakglassv1alpha1.GroupVersion.Group,
+				Resource: "breakglasssessions",
+			}, current.Name, fmt.Errorf("session state changed to %s", current.Status.State))
+		}
+
+		base := current.DeepCopy()
+		current.Status = session.Status
+		current.Status.ObservedGeneration = current.Generation
+		patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+		return ssa.sessionManager.Client.Status().Patch(ctx, &current, patch)
+	})
 }
 
 func (ssa *ScheduledSessionActivator) expireScheduledSession(ctx context.Context, session breakglassv1alpha1.BreakglassSession, now time.Time, reasonEnded, conditionReason, message string) {
@@ -202,15 +232,16 @@ func (ssa *ScheduledSessionActivator) expireScheduledSession(ctx context.Context
 func (ssa *ScheduledSessionActivator) currentWaitingScheduledSession(
 	ctx context.Context,
 	listed breakglassv1alpha1.BreakglassSession,
+	operation string,
 ) (breakglassv1alpha1.BreakglassSession, bool) {
 	current := breakglassv1alpha1.BreakglassSession{}
 	if err := ssa.sessionManager.Reader().Get(ctx, client.ObjectKey{Name: listed.Name, Namespace: listed.Namespace}, &current); err != nil {
 		if apierrors.IsNotFound(err) {
-			ssa.log.Infow("skipping scheduled session activation because live session was deleted",
+			ssa.log.Infow("skipping scheduled session "+operation+" because live session was deleted",
 				"session", listed.Name,
 				"namespace", listed.Namespace)
 		} else {
-			ssa.log.Errorw("skipping scheduled session activation because live session could not be read",
+			ssa.log.Errorw("skipping scheduled session "+operation+" because live session could not be read",
 				"session", listed.Name,
 				"namespace", listed.Namespace,
 				"error", err)
@@ -218,7 +249,7 @@ func (ssa *ScheduledSessionActivator) currentWaitingScheduledSession(
 		return listed, false
 	}
 	if current.Status.State != breakglassv1alpha1.SessionStateWaitingForScheduledTime {
-		ssa.log.Infow("skipping scheduled session activation because state changed",
+		ssa.log.Infow("skipping scheduled session "+operation+" because state changed",
 			"session", current.Name,
 			"namespace", current.Namespace,
 			"state", current.Status.State)

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -18,6 +18,7 @@ package breakglass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,15 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type scheduledSessionStateChangedError struct {
+	name  string
+	state breakglassv1alpha1.BreakglassSessionState
+}
+
+func (e *scheduledSessionStateChangedError) Error() string {
+	return fmt.Sprintf("session state changed to %s", e.state)
+}
 
 // ScheduledSessionActivator handles activation of scheduled sessions.
 // When a session's ScheduledStartTime is reached, it transitions from WaitingForScheduledTime to Approved
@@ -181,16 +191,13 @@ func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
 	session breakglassv1alpha1.BreakglassSession,
 ) error {
 	key := client.ObjectKeyFromObject(&session)
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := breakglassv1alpha1.BreakglassSession{}
 		if err := ssa.sessionManager.Reader().Get(ctx, key, &current); err != nil {
 			return err
 		}
 		if current.Status.State != breakglassv1alpha1.SessionStateWaitingForScheduledTime {
-			return apierrors.NewConflict(schema.GroupResource{
-				Group:    breakglassv1alpha1.GroupVersion.Group,
-				Resource: "breakglasssessions",
-			}, current.Name, fmt.Errorf("session state changed to %s", current.Status.State))
+			return &scheduledSessionStateChangedError{name: current.Name, state: current.Status.State}
 		}
 
 		base := current.DeepCopy()
@@ -199,6 +206,17 @@ func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
 		patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
 		return ssa.sessionManager.Client.Status().Patch(ctx, &current, patch)
 	})
+	if err == nil {
+		return nil
+	}
+	var stateChanged *scheduledSessionStateChangedError
+	if errors.As(err, &stateChanged) {
+		return apierrors.NewConflict(schema.GroupResource{
+			Group:    breakglassv1alpha1.GroupVersion.Group,
+			Resource: "breakglasssessions",
+		}, stateChanged.name, stateChanged)
+	}
+	return err
 }
 
 func (ssa *ScheduledSessionActivator) expireScheduledSession(ctx context.Context, session breakglassv1alpha1.BreakglassSession, now time.Time, reasonEnded, conditionReason, message string) {

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -26,6 +26,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -90,7 +91,7 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 			ssa.log.Errorw("expiring session in WaitingForScheduledTime state with no ScheduledStartTime",
 				"session", ses.Name,
 				"namespace", ses.Namespace)
-			ssa.expireScheduledSession(ses, now, "missingScheduledStartTime", "MissingScheduledStartTime", "Session expired: WaitingForScheduledTime with no ScheduledStartTime set")
+			ssa.expireScheduledSession(ctx, ses, now, "missingScheduledStartTime", "MissingScheduledStartTime", "Session expired: WaitingForScheduledTime with no ScheduledStartTime set")
 			continue
 		}
 
@@ -106,7 +107,7 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 				"scheduledStartTime", scheduledTime,
 				"expiresAt", ses.Status.ExpiresAt.Time,
 				"now", now)
-			ssa.expireScheduledSession(ses, now, "scheduledSessionExpiredBeforeActivation", "ScheduledSessionExpiredBeforeActivation", "Session expired before its scheduled activation was processed")
+			ssa.expireScheduledSession(ctx, ses, now, "scheduledSessionExpiredBeforeActivation", "ScheduledSessionExpiredBeforeActivation", "Session expired before its scheduled activation was processed")
 			continue
 		}
 
@@ -131,11 +132,16 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 		})
 
 		// Update session status in cluster
-		if err := ssa.sessionManager.UpdateBreakglassSessionStatus(context.Background(), ses); err != nil {
-			ssa.log.Errorw("failed to activate scheduled session",
-				"session", ses.Name,
-				"namespace", ses.Namespace,
-				"error", err)
+		if err := ssa.updateWaitingScheduledSessionStatus(ctx, ses); err != nil {
+			if apierrors.IsConflict(err) {
+				ssa.log.Infow("skipping scheduled session activation because state changed before update",
+					"session", ses.Name, "namespace", ses.Namespace, "error", err)
+			} else {
+				ssa.log.Errorw("failed to activate scheduled session",
+					"session", ses.Name,
+					"namespace", ses.Namespace,
+					"error", err)
+			}
 			continue
 		}
 
@@ -157,7 +163,15 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 	}
 }
 
-func (ssa *ScheduledSessionActivator) expireScheduledSession(session breakglassv1alpha1.BreakglassSession, now time.Time, reasonEnded, conditionReason, message string) {
+func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
+	ctx context.Context,
+	session breakglassv1alpha1.BreakglassSession,
+) error {
+	session.Status.ObservedGeneration = session.Generation
+	return ssa.sessionManager.Client.Status().Update(ctx, &session)
+}
+
+func (ssa *ScheduledSessionActivator) expireScheduledSession(ctx context.Context, session breakglassv1alpha1.BreakglassSession, now time.Time, reasonEnded, conditionReason, message string) {
 	session.Status.State = breakglassv1alpha1.SessionStateExpired
 	session.Status.ReasonEnded = reasonEnded
 	if session.Status.ExpiresAt.IsZero() || now.Before(session.Status.ExpiresAt.Time) {
@@ -172,9 +186,14 @@ func (ssa *ScheduledSessionActivator) expireScheduledSession(session breakglassv
 		Reason:             conditionReason,
 		Message:            message,
 	})
-	if err := ssa.sessionManager.UpdateBreakglassSessionStatus(context.Background(), session); err != nil {
-		ssa.log.Errorw("failed to expire scheduled session",
-			"session", session.Name, "namespace", session.Namespace, "reason", reasonEnded, "error", err)
+	if err := ssa.updateWaitingScheduledSessionStatus(ctx, session); err != nil {
+		if apierrors.IsConflict(err) {
+			ssa.log.Infow("skipping scheduled session expiry because state changed before update",
+				"session", session.Name, "namespace", session.Namespace, "reason", reasonEnded, "error", err)
+		} else {
+			ssa.log.Errorw("failed to expire scheduled session",
+				"session", session.Name, "namespace", session.Namespace, "reason", reasonEnded, "error", err)
+		}
 		return
 	}
 	metrics.SessionExpired.WithLabelValues(session.Spec.Cluster).Inc()
@@ -186,10 +205,16 @@ func (ssa *ScheduledSessionActivator) currentWaitingScheduledSession(
 ) (breakglassv1alpha1.BreakglassSession, bool) {
 	current := breakglassv1alpha1.BreakglassSession{}
 	if err := ssa.sessionManager.Reader().Get(ctx, client.ObjectKey{Name: listed.Name, Namespace: listed.Namespace}, &current); err != nil {
-		ssa.log.Errorw("skipping scheduled session activation because live session could not be read",
-			"session", listed.Name,
-			"namespace", listed.Namespace,
-			"error", err)
+		if apierrors.IsNotFound(err) {
+			ssa.log.Infow("skipping scheduled session activation because live session was deleted",
+				"session", listed.Name,
+				"namespace", listed.Namespace)
+		} else {
+			ssa.log.Errorw("skipping scheduled session activation because live session could not be read",
+				"session", listed.Name,
+				"namespace", listed.Namespace,
+				"error", err)
+		}
 		return listed, false
 	}
 	if current.Status.State != breakglassv1alpha1.SessionStateWaitingForScheduledTime {

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -28,6 +28,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/retry"
@@ -201,8 +202,7 @@ func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
 		}
 
 		base := current.DeepCopy()
-		current.Status = session.Status
-		current.Status.ObservedGeneration = current.Generation
+		applyScheduledSessionStatusTransition(&current, session)
 		patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
 		return ssa.sessionManager.Client.Status().Patch(ctx, &current, patch)
 	})
@@ -217,6 +217,25 @@ func (ssa *ScheduledSessionActivator) updateWaitingScheduledSessionStatus(
 		}, stateChanged.name, stateChanged)
 	}
 	return err
+}
+
+func applyScheduledSessionStatusTransition(current *breakglassv1alpha1.BreakglassSession, desired breakglassv1alpha1.BreakglassSession) {
+	current.Status.State = desired.Status.State
+	current.Status.ObservedGeneration = current.Generation
+	if !desired.Status.ActualStartTime.IsZero() {
+		current.Status.ActualStartTime = desired.Status.ActualStartTime
+	}
+	if desired.Status.State == breakglassv1alpha1.SessionStateExpired {
+		current.Status.ReasonEnded = desired.Status.ReasonEnded
+		current.Status.ExpiresAt = desired.Status.ExpiresAt
+		current.Status.RetainedUntil = desired.Status.RetainedUntil
+	}
+	for _, condition := range desired.Status.Conditions {
+		switch condition.Type {
+		case "ScheduledStartTimeReached", string(breakglassv1alpha1.SessionConditionTypeExpired):
+			meta.SetStatusCondition(&current.Status.Conditions, condition)
+		}
+	}
 }
 
 func (ssa *ScheduledSessionActivator) expireScheduledSession(ctx context.Context, session breakglassv1alpha1.BreakglassSession, now time.Time, reasonEnded, conditionReason, message string) {

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -95,6 +95,14 @@ type conflictingStatusWriter struct {
 }
 
 func (w *conflictingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return w.failStatusWrite(ctx, obj)
+}
+
+func (w *conflictingStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	return w.failStatusWrite(ctx, obj)
+}
+
+func (w *conflictingStatusWriter) failStatusWrite(ctx context.Context, obj client.Object) error {
 	if w.mutate != nil {
 		w.mutate(ctx)
 	}
@@ -119,6 +127,16 @@ type getErrorActivationClient struct {
 
 func (c *getErrorActivationClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	return c.err
+}
+
+type countingGetActivationClient struct {
+	client.Client
+	count int
+}
+
+func (c *countingGetActivationClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.count++
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 func TestActivateScheduledSessions(t *testing.T) {
@@ -217,22 +235,12 @@ func TestActivateScheduledSessions(t *testing.T) {
 			},
 		}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(Scheme).
-			WithObjects(session).
-			WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
-			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", stateIndexerActivation).
-			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerActivation).
-			WithInterceptorFuncs(interceptor.Funcs{
-				SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-					if subResource == "status" {
-						return assert.AnError
-					}
-					return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
-				},
-			}).
-			Build()
-		mgr := NewSessionManagerWithClient(fakeClient)
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client:          baseClient,
+			statusUpdateErr: assert.AnError,
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
 
 		activator := NewScheduledSessionActivator(logger, mgr).
 			WithMailService(nil, "TestBranding", true)
@@ -240,7 +248,7 @@ func TestActivateScheduledSessions(t *testing.T) {
 		activator.ActivateScheduledSessions()
 
 		var updated breakglassv1alpha1.BreakglassSession
-		err := fakeClient.Get(context.Background(),
+		err := baseClient.Get(context.Background(),
 			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-update-fails"},
 			&updated)
 		require.NoError(t, err)
@@ -319,22 +327,12 @@ func TestActivateScheduledSessions(t *testing.T) {
 			},
 		}
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(Scheme).
-			WithObjects(session).
-			WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
-			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", stateIndexerActivation).
-			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerActivation).
-			WithInterceptorFuncs(interceptor.Funcs{
-				SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-					if subResource == "status" {
-						return assert.AnError
-					}
-					return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
-				},
-			}).
-			Build()
-		mgr := NewSessionManagerWithClient(fakeClient)
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client:          baseClient,
+			statusUpdateErr: assert.AnError,
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
 
 		activator := NewScheduledSessionActivator(logger, mgr).
 			WithMailService(nil, "TestBranding", true)
@@ -342,7 +340,7 @@ func TestActivateScheduledSessions(t *testing.T) {
 		activator.ActivateScheduledSessions()
 
 		var updated breakglassv1alpha1.BreakglassSession
-		err := fakeClient.Get(context.Background(),
+		err := baseClient.Get(context.Background(),
 			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-expire-update-fails"},
 			&updated)
 		require.NoError(t, err)
@@ -402,6 +400,44 @@ func TestActivateScheduledSessions(t *testing.T) {
 		for _, condition := range updated.Status.Conditions {
 			assert.NotEqual(t, "ScheduledStartTimeReached", condition.Type)
 		}
+	})
+
+	t.Run("skips future scheduled session before live read", func(t *testing.T) {
+		scheduledTime := time.Now().Add(30 * time.Minute)
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduled-future",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:               "test@example.com",
+				Cluster:            "test-cluster",
+				GrantedGroup:       "admin",
+				ScheduledStartTime: &metav1.Time{Time: scheduledTime},
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(time.Now()),
+				ExpiresAt:  metav1.NewTime(scheduledTime.Add(1 * time.Hour)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		countingClient := &countingGetActivationClient{Client: baseClient}
+		mgr := NewSessionManagerWithClient(countingClient)
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		assert.Zero(t, countingClient.count, "future scheduled sessions should not require a live APIReader Get")
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-future"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWaitingForScheduledTime, updated.Status.State)
+		assert.True(t, updated.Status.ActualStartTime.IsZero())
 	})
 
 	t.Run("skips session whose live state changes before status update", func(t *testing.T) {
@@ -908,7 +944,7 @@ func TestCurrentWaitingScheduledSession(t *testing.T) {
 		mgr := NewSessionManagerWithClient(fakeClient)
 		activator := NewScheduledSessionActivator(logger, mgr)
 
-		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed)
+		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed, "activation")
 
 		assert.False(t, ok)
 		assert.Equal(t, listed.Name, current.Name)
@@ -922,7 +958,7 @@ func TestCurrentWaitingScheduledSession(t *testing.T) {
 		})
 		activator := NewScheduledSessionActivator(logger, mgr)
 
-		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed)
+		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed, "activation")
 
 		assert.False(t, ok)
 		assert.Equal(t, listed.Name, current.Name)

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -6,6 +6,7 @@ package breakglass
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -14,7 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap/zaptest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -47,8 +51,10 @@ func newFakeActivationClient(objects ...client.Object) client.Client {
 
 type staleScheduledActivationClient struct {
 	client.Client
-	mutateOnce sync.Once
-	mutate     func(context.Context, client.Client)
+	mutateOnce              sync.Once
+	mutate                  func(context.Context, client.Client)
+	statusMutateOnce        sync.Once
+	mutateBeforeStatusWrite func(context.Context, client.Client)
 }
 
 func (c *staleScheduledActivationClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
@@ -61,6 +67,39 @@ func (c *staleScheduledActivationClient) List(ctx context.Context, list client.O
 		}
 	}
 	return err
+}
+
+func (c *staleScheduledActivationClient) Status() client.SubResourceWriter {
+	base := c.Client.Status()
+	if c.mutateBeforeStatusWrite == nil {
+		return base
+	}
+	return &conflictingStatusWriter{
+		SubResourceWriter: base,
+		mutate: func(ctx context.Context) {
+			c.statusMutateOnce.Do(func() {
+				c.mutateBeforeStatusWrite(ctx, c.Client)
+			})
+		},
+	}
+}
+
+type conflictingStatusWriter struct {
+	client.SubResourceWriter
+	mutate func(context.Context)
+}
+
+func (w *conflictingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	w.mutate(ctx)
+	return apierrors.NewConflict(
+		schema.GroupResource{Group: breakglassv1alpha1.GroupVersion.Group, Resource: "breakglasssessions"},
+		obj.GetName(),
+		fmt.Errorf("status changed before scheduled activation update"),
+	)
+}
+
+func (w *conflictingStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	return w.SubResourceWriter.Apply(ctx, obj, opts...)
 }
 
 func TestActivateScheduledSessions(t *testing.T) {
@@ -340,6 +379,59 @@ func TestActivateScheduledSessions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, updated.Status.State)
 		assert.True(t, updated.Status.ActualStartTime.IsZero(), "stale scheduled activation must not reactivate withdrawn sessions")
+
+		for _, condition := range updated.Status.Conditions {
+			assert.NotEqual(t, "ScheduledStartTimeReached", condition.Type)
+		}
+	})
+
+	t.Run("skips session whose live state changes before status update", func(t *testing.T) {
+		scheduledTime := time.Now().Add(-5 * time.Minute)
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduled-withdrawn-before-update",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:               "test@example.com",
+				Cluster:            "test-cluster",
+				GrantedGroup:       "admin",
+				ScheduledStartTime: &metav1.Time{Time: scheduledTime},
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(scheduledTime.Add(-30 * time.Minute)),
+				ExpiresAt:  metav1.NewTime(time.Now().Add(1 * time.Hour)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client: baseClient,
+			mutateBeforeStatusWrite: func(ctx context.Context, c client.Client) {
+				current := &breakglassv1alpha1.BreakglassSession{}
+				err := c.Get(ctx, client.ObjectKey{Namespace: "breakglass", Name: "scheduled-withdrawn-before-update"}, current)
+				require.NoError(t, err)
+				current.Status.State = breakglassv1alpha1.SessionStateWithdrawn
+				current.Status.WithdrawnAt = metav1.NewTime(time.Now())
+				err = c.Status().Update(ctx, current)
+				require.NoError(t, err)
+			},
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
+
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-withdrawn-before-update"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, updated.Status.State)
+		assert.True(t, updated.Status.ActualStartTime.IsZero(), "conflicted scheduled activation must not reactivate withdrawn sessions")
 
 		for _, condition := range updated.Status.Conditions {
 			assert.NotEqual(t, "ScheduledStartTimeReached", condition.Type)

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -55,6 +55,7 @@ type staleScheduledActivationClient struct {
 	mutate                  func(context.Context, client.Client)
 	statusMutateOnce        sync.Once
 	mutateBeforeStatusWrite func(context.Context, client.Client)
+	statusUpdateErr         error
 }
 
 func (c *staleScheduledActivationClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
@@ -71,15 +72,18 @@ func (c *staleScheduledActivationClient) List(ctx context.Context, list client.O
 
 func (c *staleScheduledActivationClient) Status() client.SubResourceWriter {
 	base := c.Client.Status()
-	if c.mutateBeforeStatusWrite == nil {
+	if c.mutateBeforeStatusWrite == nil && c.statusUpdateErr == nil {
 		return base
 	}
 	return &conflictingStatusWriter{
 		SubResourceWriter: base,
+		err:               c.statusUpdateErr,
 		mutate: func(ctx context.Context) {
-			c.statusMutateOnce.Do(func() {
-				c.mutateBeforeStatusWrite(ctx, c.Client)
-			})
+			if c.mutateBeforeStatusWrite != nil {
+				c.statusMutateOnce.Do(func() {
+					c.mutateBeforeStatusWrite(ctx, c.Client)
+				})
+			}
 		},
 	}
 }
@@ -87,10 +91,16 @@ func (c *staleScheduledActivationClient) Status() client.SubResourceWriter {
 type conflictingStatusWriter struct {
 	client.SubResourceWriter
 	mutate func(context.Context)
+	err    error
 }
 
 func (w *conflictingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-	w.mutate(ctx)
+	if w.mutate != nil {
+		w.mutate(ctx)
+	}
+	if w.err != nil {
+		return w.err
+	}
 	return apierrors.NewConflict(
 		schema.GroupResource{Group: breakglassv1alpha1.GroupVersion.Group, Resource: "breakglasssessions"},
 		obj.GetName(),
@@ -100,6 +110,15 @@ func (w *conflictingStatusWriter) Update(ctx context.Context, obj client.Object,
 
 func (w *conflictingStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
 	return w.SubResourceWriter.Apply(ctx, obj, opts...)
+}
+
+type getErrorActivationClient struct {
+	client.Client
+	err error
+}
+
+func (c *getErrorActivationClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return c.err
 }
 
 func TestActivateScheduledSessions(t *testing.T) {
@@ -438,6 +457,47 @@ func TestActivateScheduledSessions(t *testing.T) {
 		}
 	})
 
+	t.Run("skips activation when status update returns non-conflict error", func(t *testing.T) {
+		scheduledTime := time.Now().Add(-5 * time.Minute)
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduled-update-error",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:               "test@example.com",
+				Cluster:            "test-cluster",
+				GrantedGroup:       "admin",
+				ScheduledStartTime: &metav1.Time{Time: scheduledTime},
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(scheduledTime.Add(-30 * time.Minute)),
+				ExpiresAt:  metav1.NewTime(time.Now().Add(1 * time.Hour)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client:          baseClient,
+			statusUpdateErr: fmt.Errorf("status writer unavailable"),
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
+
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-update-error"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWaitingForScheduledTime, updated.Status.State)
+		assert.True(t, updated.Status.ActualStartTime.IsZero(), "failed status writes must not activate the persisted session")
+	})
+
 	t.Run("does not activate session before scheduledStartTime", func(t *testing.T) {
 		futureTime := time.Now().Add(1 * time.Hour)
 		session := &breakglassv1alpha1.BreakglassSession{
@@ -520,6 +580,90 @@ func TestActivateScheduledSessions(t *testing.T) {
 			}
 		}
 		assert.True(t, hasCondition, "expected Expired condition")
+	})
+
+	t.Run("skips expiry when status update conflicts", func(t *testing.T) {
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-schedule-conflict",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:         "test@example.com",
+				Cluster:      "test-cluster",
+				GrantedGroup: "admin",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client: baseClient,
+			mutateBeforeStatusWrite: func(ctx context.Context, c client.Client) {
+				current := &breakglassv1alpha1.BreakglassSession{}
+				err := c.Get(ctx, client.ObjectKey{Namespace: "breakglass", Name: "no-schedule-conflict"}, current)
+				require.NoError(t, err)
+				current.Status.State = breakglassv1alpha1.SessionStateWithdrawn
+				current.Status.WithdrawnAt = metav1.NewTime(time.Now())
+				err = c.Status().Update(ctx, current)
+				require.NoError(t, err)
+			},
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
+
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "no-schedule-conflict"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, updated.Status.State)
+		assert.True(t, updated.Status.RetainedUntil.IsZero(), "conflicted expiry must not stamp retention")
+	})
+
+	t.Run("keeps session waiting when nil scheduledStartTime update fails", func(t *testing.T) {
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-schedule-update-error",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:         "test@example.com",
+				Cluster:      "test-cluster",
+				GrantedGroup: "admin",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client:          baseClient,
+			statusUpdateErr: fmt.Errorf("status writer unavailable"),
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
+
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "no-schedule-update-error"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWaitingForScheduledTime, updated.Status.State)
+		assert.True(t, updated.Status.RetainedUntil.IsZero(), "failed expiry writes must not persist terminal retention")
 	})
 
 	t.Run("expires session with zero scheduledStartTime", func(t *testing.T) {
@@ -744,6 +888,44 @@ func TestActivateScheduledSessions(t *testing.T) {
 		require.NoError(t, err)
 		// Should still activate even if far in the past
 		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, updated.Status.State)
+	})
+}
+
+func TestCurrentWaitingScheduledSession(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	listed := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "listed-session",
+			Namespace: "breakglass",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+		},
+	}
+
+	t.Run("returns false when live session was deleted", func(t *testing.T) {
+		fakeClient := newFakeActivationClient()
+		mgr := NewSessionManagerWithClient(fakeClient)
+		activator := NewScheduledSessionActivator(logger, mgr)
+
+		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed)
+
+		assert.False(t, ok)
+		assert.Equal(t, listed.Name, current.Name)
+	})
+
+	t.Run("returns false when live session read fails", func(t *testing.T) {
+		baseClient := newFakeActivationClient()
+		mgr := NewSessionManagerWithClient(&getErrorActivationClient{
+			Client: baseClient,
+			err:    fmt.Errorf("reader unavailable"),
+		})
+		activator := NewScheduledSessionActivator(logger, mgr)
+
+		current, ok := activator.currentWaitingScheduledSession(context.Background(), listed)
+
+		assert.False(t, ok)
+		assert.Equal(t, listed.Name, current.Name)
 	})
 }
 

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -965,6 +965,50 @@ func TestCurrentWaitingScheduledSession(t *testing.T) {
 	})
 }
 
+func TestApplyScheduledSessionStatusTransitionPreservesUnrelatedLiveStatus(t *testing.T) {
+	current := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "scheduled-session",
+			Generation: 7,
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+			Conditions: []metav1.Condition{{
+				Type:               "UnrelatedMaintenance",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+				Reason:             "StillOwnedElsewhere",
+				Message:            "must survive scheduled transition patch",
+			}},
+		},
+	}
+	desired := current.DeepCopy()
+	desired.Status.State = breakglassv1alpha1.SessionStateApproved
+	desired.Status.ActualStartTime = metav1.Now()
+	desired.SetCondition(metav1.Condition{
+		Type:               "ScheduledStartTimeReached",
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "ActivationTriggered",
+		Message:            "Session activated at scheduled start time",
+	})
+
+	applyScheduledSessionStatusTransition(current, *desired)
+
+	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, current.Status.State)
+	assert.Equal(t, int64(7), current.Status.ObservedGeneration)
+	assert.False(t, current.Status.ActualStartTime.IsZero())
+	assert.Len(t, current.Status.Conditions, 2)
+	assert.Condition(t, func() bool {
+		for _, condition := range current.Status.Conditions {
+			if condition.Type == "UnrelatedMaintenance" && condition.Reason == "StillOwnedElsewhere" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func TestNewScheduledSessionActivator(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	fakeClient := newFakeActivationClient()

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -6,6 +6,7 @@ package breakglass
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,24 @@ func newFakeActivationClient(objects ...client.Object) client.Client {
 		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", stateIndexerActivation).
 		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerActivation).
 		Build()
+}
+
+type staleScheduledActivationClient struct {
+	client.Client
+	mutateOnce sync.Once
+	mutate     func(context.Context, client.Client)
+}
+
+func (c *staleScheduledActivationClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	err := c.Client.List(ctx, list, opts...)
+	if err == nil {
+		if _, ok := list.(*breakglassv1alpha1.BreakglassSessionList); ok && c.mutate != nil {
+			c.mutateOnce.Do(func() {
+				c.mutate(ctx, c.Client)
+			})
+		}
+	}
+	return err
 }
 
 func TestActivateScheduledSessions(t *testing.T) {
@@ -272,6 +291,59 @@ func TestActivateScheduledSessions(t *testing.T) {
 		assert.Equal(t, breakglassv1alpha1.SessionStateWaitingForScheduledTime, updated.Status.State)
 		assert.Empty(t, updated.Status.ReasonEnded)
 		assert.True(t, updated.Status.RetainedUntil.IsZero(), "failed expiry update must not persist retention")
+	})
+
+	t.Run("skips session whose live state changed after list", func(t *testing.T) {
+		scheduledTime := time.Now().Add(-5 * time.Minute)
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduled-withdrawn-after-list",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:               "test@example.com",
+				Cluster:            "test-cluster",
+				GrantedGroup:       "admin",
+				ScheduledStartTime: &metav1.Time{Time: scheduledTime},
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(scheduledTime.Add(-30 * time.Minute)),
+				ExpiresAt:  metav1.NewTime(time.Now().Add(1 * time.Hour)),
+			},
+		}
+
+		baseClient := newFakeActivationClient(session)
+		staleClient := &staleScheduledActivationClient{
+			Client: baseClient,
+			mutate: func(ctx context.Context, c client.Client) {
+				current := &breakglassv1alpha1.BreakglassSession{}
+				err := c.Get(ctx, client.ObjectKey{Namespace: "breakglass", Name: "scheduled-withdrawn-after-list"}, current)
+				require.NoError(t, err)
+				current.Status.State = breakglassv1alpha1.SessionStateWithdrawn
+				current.Status.WithdrawnAt = metav1.NewTime(time.Now())
+				err = c.Status().Update(ctx, current)
+				require.NoError(t, err)
+			},
+		}
+		mgr := NewSessionManagerWithClient(staleClient)
+
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+
+		activator.ActivateScheduledSessions()
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := baseClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-withdrawn-after-list"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, updated.Status.State)
+		assert.True(t, updated.Status.ActualStartTime.IsZero(), "stale scheduled activation must not reactivate withdrawn sessions")
+
+		for _, condition := range updated.Status.Conditions {
+			assert.NotEqual(t, "ScheduledStartTimeReached", condition.Type)
+		}
 	})
 
 	t.Run("does not activate session before scheduledStartTime", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- re-read each scheduled BreakglassSession from the live client before activation decisions
- skip sessions that have already left `WaitingForScheduledTime` instead of applying stale status updates
- add a regression test that mutates a listed scheduled session to `Withdrawn` before activation revalidation
- document the terminal-state protection and add a changelog entry

## Evidence
The scheduled activator listed `WaitingForScheduledTime` sessions and then updated the listed object to `Approved`. Because the status update path fetches the current object only to fill metadata and then applies the caller-provided status, a stale cached/listed object could overwrite a live `Withdrawn` or terminal state if that state changed after the list but before activation.

Duplicate check: searched open/recent PRs for `scheduled activation state revalidation BreakglassSession WaitingForScheduledTime stale cache` and `WaitingForScheduledTime withdrawn terminal reactivating`; no matching PR exists. PR #841 is adjacent but only handles scheduled sessions whose `expiresAt` elapsed before activation.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -run 'TestActivateScheduledSessions|TestScheduledSessionActivator' -count=1 -timeout=120s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -count=1 -timeout=180s`
- `git -c core.fsmonitor=false diff --check`

## Screenshots
Not applicable: backend lifecycle guard and documentation only; no UI changed.
