### PR TITLE
fix: fail debug sessions on required auxiliary errors

### DIFF
--- a/api/v1alpha1/applyconfiguration/ssa/patchhelper.go
+++ b/api/v1alpha1/applyconfiguration/ssa/patchhelper.go
@@ -93,6 +93,7 @@ func patchApplyStatusViaUnstructuredWithOwner(ctx context.Context, c client.Clie
 	if err := json.Unmarshal(data, u); err != nil {
 		return 0, fmt.Errorf("failed to unmarshal apply configuration: %w", err)
 	}
+	ensureExplicitDebugSessionEmptyStatusLists(applyConfig, u)
 
 	// Clear managed fields.
 	u.SetManagedFields(nil)
@@ -144,6 +145,22 @@ func patchApplyStatusViaUnstructuredWithOwner(ctx context.Context, c client.Clie
 	}
 
 	return PatchApplyResultPatched, nil
+}
+
+func ensureExplicitDebugSessionEmptyStatusLists(applyConfig runtime.ApplyConfiguration, u *unstructured.Unstructured) {
+	dsConfig, ok := applyConfig.(*ac.DebugSessionApplyConfiguration)
+	if !ok || dsConfig.Status == nil {
+		return
+	}
+	if dsConfig.Status.AuxiliaryResourceStatuses == nil || len(dsConfig.Status.AuxiliaryResourceStatuses) > 0 {
+		return
+	}
+	status, _ := u.Object["status"].(map[string]interface{})
+	if status == nil {
+		status = map[string]interface{}{}
+		u.Object["status"] = status
+	}
+	status["auxiliaryResourceStatuses"] = []interface{}{}
 }
 
 // ---------------------------------------------------------------------------

--- a/api/v1alpha1/applyconfiguration/ssa/ssa.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa.go
@@ -223,6 +223,11 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 		result.WithDeployedResources(DeployedResourceRefFrom(&status.DeployedResources[i]))
 	}
 
+	// Set auxiliary resource statuses
+	for i := range status.AuxiliaryResourceStatuses {
+		result.WithAuxiliaryResourceStatuses(AuxiliaryResourceStatusFrom(&status.AuxiliaryResourceStatuses[i]))
+	}
+
 	// Set allowed pods
 	for i := range status.AllowedPods {
 		result.WithAllowedPods(AllowedPodRefFrom(&status.AllowedPods[i]))
@@ -536,6 +541,79 @@ func AllowedPodRefFrom(p *breakglassv1alpha1.AllowedPodRef) *ac.AllowedPodRefApp
 	}
 	if p.ContainerStatus != nil {
 		result.WithContainerStatus(PodContainerStatusFrom(p.ContainerStatus))
+	}
+
+	return result
+}
+
+// AuxiliaryResourceStatusFrom converts an AuxiliaryResourceStatus to its ApplyConfiguration.
+func AuxiliaryResourceStatusFrom(s *breakglassv1alpha1.AuxiliaryResourceStatus) *ac.AuxiliaryResourceStatusApplyConfiguration {
+	if s == nil {
+		return nil
+	}
+	result := ac.AuxiliaryResourceStatus().
+		WithName(s.Name).
+		WithCreated(s.Created).
+		WithReady(s.Ready).
+		WithDeleted(s.Deleted)
+
+	if s.Category != "" {
+		result.WithCategory(s.Category)
+	}
+	if s.Kind != "" {
+		result.WithKind(s.Kind)
+	}
+	if s.APIVersion != "" {
+		result.WithAPIVersion(s.APIVersion)
+	}
+	if s.ResourceName != "" {
+		result.WithResourceName(s.ResourceName)
+	}
+	if s.Namespace != "" {
+		result.WithNamespace(s.Namespace)
+	}
+	if s.CreatedAt != nil {
+		result.WithCreatedAt(*s.CreatedAt)
+	}
+	if s.ReadyAt != nil {
+		result.WithReadyAt(*s.ReadyAt)
+	}
+	if s.ReadinessStatus != "" {
+		result.WithReadinessStatus(s.ReadinessStatus)
+	}
+	if s.DeletedAt != nil {
+		result.WithDeletedAt(*s.DeletedAt)
+	}
+	if s.Error != "" {
+		result.WithError(s.Error)
+	}
+	for i := range s.AdditionalResources {
+		result.WithAdditionalResources(AdditionalResourceRefFrom(&s.AdditionalResources[i]))
+	}
+
+	return result
+}
+
+// AdditionalResourceRefFrom converts an AdditionalResourceRef to its ApplyConfiguration.
+func AdditionalResourceRefFrom(r *breakglassv1alpha1.AdditionalResourceRef) *ac.AdditionalResourceRefApplyConfiguration {
+	if r == nil {
+		return nil
+	}
+	result := ac.AdditionalResourceRef().
+		WithKind(r.Kind).
+		WithAPIVersion(r.APIVersion).
+		WithResourceName(r.ResourceName).
+		WithReady(r.Ready).
+		WithDeleted(r.Deleted)
+
+	if r.Namespace != "" {
+		result.WithNamespace(r.Namespace)
+	}
+	if r.ReadinessStatus != "" {
+		result.WithReadinessStatus(r.ReadinessStatus)
+	}
+	if r.Error != "" {
+		result.WithError(r.Error)
 	}
 
 	return result

--- a/api/v1alpha1/applyconfiguration/ssa/ssa.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa.go
@@ -224,6 +224,9 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 	}
 
 	// Set auxiliary resource statuses
+	if status.AuxiliaryResourceStatuses != nil {
+		result.AuxiliaryResourceStatuses = []ac.AuxiliaryResourceStatusApplyConfiguration{}
+	}
 	for i := range status.AuxiliaryResourceStatuses {
 		result.WithAuxiliaryResourceStatuses(AuxiliaryResourceStatusFrom(&status.AuxiliaryResourceStatuses[i]))
 	}

--- a/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
@@ -20,13 +20,16 @@ package ssa
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	ac "github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -475,6 +478,41 @@ func TestApplyDebugSessionStatus(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get object for status update")
 	})
+}
+
+func TestDebugSessionStatusFromPreservesExplicitEmptyAuxiliaryStatuses(t *testing.T) {
+	status := &breakglassv1alpha1.DebugSessionStatus{
+		State:                     breakglassv1alpha1.DebugSessionStateActive,
+		AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{},
+	}
+	applyConfig := ac.DebugSession("test-debug", "default").
+		WithStatus(DebugSessionStatusFrom(status))
+
+	data, err := json.Marshal(applyConfig)
+	require.NoError(t, err)
+
+	u := &unstructured.Unstructured{}
+	require.NoError(t, json.Unmarshal(data, u))
+	ensureExplicitDebugSessionEmptyStatusLists(applyConfig, u)
+
+	desiredStatus, ok := u.Object["status"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, []interface{}{}, desiredStatus["auxiliaryResourceStatuses"])
+
+	currentStatus := map[string]interface{}{
+		"state": string(breakglassv1alpha1.DebugSessionStateActive),
+		"auxiliaryResourceStatuses": []interface{}{
+			map[string]interface{}{
+				"name":         "old-config",
+				"kind":         "ConfigMap",
+				"apiVersion":   "v1",
+				"resourceName": "old-config",
+				"namespace":    "default",
+				"created":      true,
+			},
+		},
+	}
+	assert.False(t, statusSubsetMatch(currentStatus, desiredStatus))
 }
 
 // TestApplyAuditConfigStatus tests SSA status updates for AuditConfig.

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1145,6 +1145,8 @@ auxiliaryResources:
 | `ignore` | Continue session regardless of failure |
 | `warn` | Log warning and continue |
 
+The controller also treats an omitted `failurePolicy` as `fail`. The deprecated `optional: true` field is honored as `ignore` for backwards compatibility.
+
 ### Cluster Binding Overrides
 
 Cluster bindings can require specific auxiliary resource categories:

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1091,7 +1091,7 @@ spec:
 
 All resources from multi-document YAML are:
 - Tracked in the session status for observability
-- Cleaned up automatically when the session ends
+- Cleaned up automatically when the session ends unless `deleteAfter: false`
 - Monitored for readiness using kstatus
 
 > **Note:** `template` (structured) and `templateString` (Go template) are mutually exclusive. Use `templateString` when you need multi-document YAML or dynamic templating.
@@ -1124,8 +1124,8 @@ Auxiliary resource templates support Go templating with [Sprig functions](https:
 
 ### Lifecycle
 
-1. **Creation**: Auxiliary resources are created BEFORE debug pods start (when `createBefore: true`, the default)
-2. **Cleanup**: Resources are deleted when the session ends (when `deleteAfter: true`, the default)
+1. **Creation**: Auxiliary resources are created before debug pods start when `createBefore: true` (the default), or after the debug workload is applied when `createBefore: false`
+2. **Cleanup**: Resources are deleted when the session ends when `deleteAfter: true` (the default), and retained when `deleteAfter: false`
 
 ### Failure Policies
 

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -96,13 +96,11 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 		statuses = append(statuses, status)
 
 		if err != nil {
-			log.Warnw("Failed to deploy auxiliary resource",
-				"resource", auxRes.Name,
-				"category", auxRes.Category,
-				"error", err)
+			failurePolicy := effectiveAuxiliaryResourceFailurePolicy(auxRes)
+			logAuxiliaryResourceDeployFailure(log, auxRes, failurePolicy, err)
 			deployErrors = append(deployErrors, err)
 
-			if effectiveAuxiliaryResourceFailurePolicy(auxRes) == breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail {
+			if failurePolicy == breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail {
 				metrics.AuxiliaryResourceDeployments.WithLabelValues(session.Spec.Cluster, auxRes.Category, "failure").Inc()
 				return statuses, fmt.Errorf("failed to deploy required auxiliary resource %s: %w", auxRes.Name, err)
 			}
@@ -283,6 +281,30 @@ func effectiveAuxiliaryResourceFailurePolicy(auxRes breakglassv1alpha1.Auxiliary
 		return breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail
 	}
 	return auxRes.FailurePolicy
+}
+
+func logAuxiliaryResourceDeployFailure(
+	log *zap.SugaredLogger,
+	auxRes breakglassv1alpha1.AuxiliaryResource,
+	failurePolicy breakglassv1alpha1.AuxiliaryResourceFailurePolicy,
+	err error,
+) {
+	fields := []interface{}{
+		"resource", auxRes.Name,
+		"category", auxRes.Category,
+		"failurePolicy", failurePolicy,
+		"error", err,
+	}
+
+	switch failurePolicy {
+	case breakglassv1alpha1.AuxiliaryResourceFailurePolicyWarn:
+		log.Warnw("Auxiliary resource deployment failed", fields...)
+	case breakglassv1alpha1.AuxiliaryResourceFailurePolicyIgnore:
+		log.Debugw("Ignoring auxiliary resource deployment failure", fields...)
+	case breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail:
+	default:
+		log.Warnw("Auxiliary resource deployment failed with unknown failure policy", fields...)
+	}
 }
 
 // buildRenderContext creates the context used for template rendering.

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -73,8 +73,8 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 	return m.deployAuxiliaryResources(ctx, session, template, binding, targetClient, targetNamespace, nil)
 }
 
-// DeployAuxiliaryResourcesForCreateBefore deploys enabled auxiliary resources for one createBefore phase.
-func (m *AuxiliaryResourceManager) DeployAuxiliaryResourcesForCreateBefore(
+// DeployAuxiliaryResourcesForPhase deploys enabled auxiliary resources for one createBefore phase.
+func (m *AuxiliaryResourceManager) DeployAuxiliaryResourcesForPhase(
 	ctx context.Context,
 	session *breakglassv1alpha1.DebugSession,
 	template *breakglassv1alpha1.DebugSessionTemplateSpec,

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -348,6 +348,7 @@ func logAuxiliaryResourceDeployFailure(
 	case breakglassv1alpha1.AuxiliaryResourceFailurePolicyIgnore:
 		log.Debugw("Ignoring auxiliary resource deployment failure", fields...)
 	case breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail:
+		log.Errorw("Required auxiliary resource deployment failed", fields...)
 	default:
 		log.Warnw("Auxiliary resource deployment failed with unknown failure policy", fields...)
 	}

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -580,6 +580,9 @@ func (m *AuxiliaryResourceManager) deployResource(
 			status.APIVersion = obj.GetAPIVersion()
 			status.ResourceName = obj.GetName()
 			status.Namespace = obj.GetNamespace()
+			status.Created = true
+			now := time.Now().UTC().Format(time.RFC3339)
+			status.CreatedAt = &now
 		} else {
 			// Track additional resources from multi-document YAML
 			status.AdditionalResources = append(status.AdditionalResources, breakglassv1alpha1.AdditionalResourceRef{
@@ -590,10 +593,6 @@ func (m *AuxiliaryResourceManager) deployResource(
 			})
 		}
 	}
-
-	status.Created = true
-	now := time.Now().UTC().Format(time.RFC3339)
-	status.CreatedAt = &now
 
 	if len(deployedResources) > 1 {
 		m.log.Infow("Deployed multiple resources from single auxiliary resource",

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -897,61 +897,62 @@ func (m *AuxiliaryResourceManager) CheckAuxiliaryResourcesReadiness(
 	log := m.log.With("session", session.Name, "namespace", session.Namespace)
 
 	allReady = true
-	for i, status := range session.Status.AuxiliaryResourceStatuses {
-		// Skip if not created, already ready, or deleted
-		if !status.Created || status.Ready || status.Deleted {
-			if status.Created && !status.Ready && !status.Deleted {
-				allReady = false
-			}
+	for i := range session.Status.AuxiliaryResourceStatuses {
+		status := &session.Status.AuxiliaryResourceStatuses[i]
+		// Skip if not created or deleted.
+		if !status.Created || status.Deleted {
 			continue
 		}
 
 		// Check primary resource readiness
-		primaryReady := m.checkSingleResourceReadiness(ctx, log, targetClient, status.APIVersion, status.Kind, status.ResourceName, status.Namespace)
-		session.Status.AuxiliaryResourceStatuses[i].ReadinessStatus = primaryReady.readinessStatus
-		if primaryReady.ready {
-			session.Status.AuxiliaryResourceStatuses[i].Ready = true
-			now := time.Now().UTC().Format(time.RFC3339)
-			session.Status.AuxiliaryResourceStatuses[i].ReadyAt = &now
-			log.Infow("Auxiliary resource is ready",
-				"resource", status.Name,
-				"kind", status.Kind,
-				"name", status.ResourceName)
-		} else if primaryReady.failed {
-			session.Status.AuxiliaryResourceStatuses[i].Error = primaryReady.message
-			log.Warnw("Auxiliary resource failed",
-				"resource", status.Name,
-				"kind", status.Kind,
-				"name", status.ResourceName,
-				"message", primaryReady.message)
-			allReady = false
-		} else {
-			log.Debugw("Auxiliary resource not ready yet",
-				"resource", status.Name,
-				"kind", status.Kind,
-				"name", status.ResourceName,
-				"status", primaryReady.readinessStatus,
-				"message", primaryReady.message)
-			allReady = false
+		if !status.Ready {
+			primaryReady := m.checkSingleResourceReadiness(ctx, log, targetClient, status.APIVersion, status.Kind, status.ResourceName, status.Namespace)
+			status.ReadinessStatus = primaryReady.readinessStatus
+			if primaryReady.ready {
+				status.Ready = true
+				now := time.Now().UTC().Format(time.RFC3339)
+				status.ReadyAt = &now
+				log.Infow("Auxiliary resource is ready",
+					"resource", status.Name,
+					"kind", status.Kind,
+					"name", status.ResourceName)
+			} else if primaryReady.failed {
+				status.Error = primaryReady.message
+				log.Warnw("Auxiliary resource failed",
+					"resource", status.Name,
+					"kind", status.Kind,
+					"name", status.ResourceName,
+					"message", primaryReady.message)
+				allReady = false
+			} else {
+				log.Debugw("Auxiliary resource not ready yet",
+					"resource", status.Name,
+					"kind", status.Kind,
+					"name", status.ResourceName,
+					"status", primaryReady.readinessStatus,
+					"message", primaryReady.message)
+				allReady = false
+			}
 		}
 
 		// Check additional resources from multi-document YAML templates
-		for j, addlRes := range status.AdditionalResources {
+		for j := range status.AdditionalResources {
+			addlRes := &status.AdditionalResources[j]
 			if addlRes.Ready || addlRes.Deleted {
 				continue
 			}
 
 			addlReady := m.checkSingleResourceReadiness(ctx, log, targetClient, addlRes.APIVersion, addlRes.Kind, addlRes.ResourceName, addlRes.Namespace)
-			session.Status.AuxiliaryResourceStatuses[i].AdditionalResources[j].ReadinessStatus = addlReady.readinessStatus
+			addlRes.ReadinessStatus = addlReady.readinessStatus
 
 			if addlReady.ready {
-				session.Status.AuxiliaryResourceStatuses[i].AdditionalResources[j].Ready = true
+				addlRes.Ready = true
 				log.Infow("Additional auxiliary resource is ready",
 					"resource", status.Name,
 					"kind", addlRes.Kind,
 					"name", addlRes.ResourceName)
 			} else if addlReady.failed {
-				session.Status.AuxiliaryResourceStatuses[i].AdditionalResources[j].Error = addlReady.message
+				addlRes.Error = addlReady.message
 				log.Warnw("Additional auxiliary resource failed",
 					"resource", status.Name,
 					"kind", addlRes.Kind,

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -102,7 +102,7 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 				"error", err)
 			deployErrors = append(deployErrors, err)
 
-			if auxRes.FailurePolicy == breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail {
+			if effectiveAuxiliaryResourceFailurePolicy(auxRes) == breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail {
 				metrics.AuxiliaryResourceDeployments.WithLabelValues(session.Spec.Cluster, auxRes.Category, "failure").Inc()
 				return statuses, fmt.Errorf("failed to deploy required auxiliary resource %s: %w", auxRes.Name, err)
 			}
@@ -273,6 +273,16 @@ func (m *AuxiliaryResourceManager) filterEnabledResources(
 	}
 
 	return enabled
+}
+
+func effectiveAuxiliaryResourceFailurePolicy(auxRes breakglassv1alpha1.AuxiliaryResource) breakglassv1alpha1.AuxiliaryResourceFailurePolicy {
+	if auxRes.Optional {
+		return breakglassv1alpha1.AuxiliaryResourceFailurePolicyIgnore
+	}
+	if auxRes.FailurePolicy == "" {
+		return breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail
+	}
+	return auxRes.FailurePolicy
 }
 
 // buildRenderContext creates the context used for template rendering.

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -70,6 +70,33 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 	targetClient client.Client,
 	targetNamespace string,
 ) ([]breakglassv1alpha1.AuxiliaryResourceStatus, error) {
+	return m.deployAuxiliaryResources(ctx, session, template, binding, targetClient, targetNamespace, nil)
+}
+
+// DeployAuxiliaryResourcesForCreateBefore deploys enabled auxiliary resources for one createBefore phase.
+func (m *AuxiliaryResourceManager) DeployAuxiliaryResourcesForCreateBefore(
+	ctx context.Context,
+	session *breakglassv1alpha1.DebugSession,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+	targetClient client.Client,
+	targetNamespace string,
+	createBefore bool,
+) ([]breakglassv1alpha1.AuxiliaryResourceStatus, error) {
+	return m.deployAuxiliaryResources(ctx, session, template, binding, targetClient, targetNamespace, func(auxRes breakglassv1alpha1.AuxiliaryResource) bool {
+		return auxRes.CreateBefore == createBefore
+	})
+}
+
+func (m *AuxiliaryResourceManager) deployAuxiliaryResources(
+	ctx context.Context,
+	session *breakglassv1alpha1.DebugSession,
+	template *breakglassv1alpha1.DebugSessionTemplateSpec,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+	targetClient client.Client,
+	targetNamespace string,
+	shouldDeploy func(breakglassv1alpha1.AuxiliaryResource) bool,
+) ([]breakglassv1alpha1.AuxiliaryResourceStatus, error) {
 	if template == nil || len(template.AuxiliaryResources) == 0 {
 		return nil, nil
 	}
@@ -86,9 +113,9 @@ func (m *AuxiliaryResourceManager) DeployAuxiliaryResources(
 	var statuses []breakglassv1alpha1.AuxiliaryResourceStatus
 	var deployErrors []error
 
-	// Deploy resources that should be created before debug pods
+	// Deploy selected resources. Callers can pass a phase filter to honor createBefore.
 	for _, auxRes := range enabledResources {
-		if !auxRes.CreateBefore {
+		if shouldDeploy != nil && !shouldDeploy(auxRes) {
 			continue
 		}
 
@@ -135,6 +162,13 @@ func (m *AuxiliaryResourceManager) CleanupAuxiliaryResources(
 
 	for i, status := range session.Status.AuxiliaryResourceStatuses {
 		if !status.Created || status.Deleted {
+			continue
+		}
+		if !shouldDeleteAuxiliaryResource(session, status.Name) {
+			log.Debugw("Skipping auxiliary resource cleanup because deleteAfter is false",
+				"resource", status.Name,
+				"resourceName", status.ResourceName,
+				"namespace", status.Namespace)
 			continue
 		}
 
@@ -193,6 +227,18 @@ func (m *AuxiliaryResourceManager) CleanupAuxiliaryResources(
 
 	log.Info("All auxiliary resources cleaned up")
 	return nil
+}
+
+func shouldDeleteAuxiliaryResource(session *breakglassv1alpha1.DebugSession, name string) bool {
+	if session.Status.ResolvedTemplate == nil {
+		return true
+	}
+	for _, auxRes := range session.Status.ResolvedTemplate.AuxiliaryResources {
+		if auxRes.Name == name {
+			return auxRes.DeleteAfter
+		}
+	}
+	return true
 }
 
 // filterEnabledResources determines which auxiliary resources should be deployed.

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -427,6 +427,63 @@ func TestDeployAuxiliaryResources_FailurePolicy(t *testing.T) {
 	}
 }
 
+func TestDeployAuxiliaryResources_ReturnsPartialStatusesOnRequiredFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	mgr := NewAuxiliaryResourceManager(zap.NewNop().Sugar(), fakeClient)
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-session",
+			Namespace: "breakglass-system",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster: "prod",
+		},
+	}
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
+			{
+				Name:         "created-config",
+				Category:     "config",
+				CreateBefore: true,
+				TemplateString: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: created-config
+`,
+			},
+			{
+				Name:         "required-fail",
+				Category:     "config",
+				CreateBefore: true,
+			},
+		},
+		AuxiliaryResourceDefaults: map[string]bool{
+			"created-config": true,
+			"required-fail":  true,
+		},
+	}
+
+	statuses, err := mgr.DeployAuxiliaryResources(context.Background(), session, template, nil, fakeClient, "debug-ns")
+
+	require.Error(t, err)
+	require.Len(t, statuses, 2)
+	assert.Equal(t, "created-config", statuses[0].Name)
+	assert.True(t, statuses[0].Created)
+	assert.Equal(t, "ConfigMap", statuses[0].Kind)
+	assert.Equal(t, "created-config", statuses[0].ResourceName)
+	assert.Equal(t, "debug-ns", statuses[0].Namespace)
+	assert.Equal(t, "required-fail", statuses[1].Name)
+	assert.False(t, statuses[1].Created)
+	assert.Contains(t, statuses[1].Error, "no template defined")
+}
+
 func TestCleanupAuxiliaryResources_NoResources(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -333,6 +333,100 @@ func TestDeployAuxiliaryResources_EmptyResources(t *testing.T) {
 	assert.Nil(t, statuses)
 }
 
+func TestDeployAuxiliaryResources_FailurePolicy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name        string
+		resource    breakglassv1alpha1.AuxiliaryResource
+		expectError bool
+	}{
+		{
+			name: "default policy fails closed",
+			resource: breakglassv1alpha1.AuxiliaryResource{
+				Name:         "default-fail",
+				Category:     "config",
+				CreateBefore: true,
+			},
+			expectError: true,
+		},
+		{
+			name: "explicit fail policy returns error",
+			resource: breakglassv1alpha1.AuxiliaryResource{
+				Name:          "explicit-fail",
+				Category:      "config",
+				CreateBefore:  true,
+				FailurePolicy: breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail,
+			},
+			expectError: true,
+		},
+		{
+			name: "ignore policy continues",
+			resource: breakglassv1alpha1.AuxiliaryResource{
+				Name:          "ignore",
+				Category:      "config",
+				CreateBefore:  true,
+				FailurePolicy: breakglassv1alpha1.AuxiliaryResourceFailurePolicyIgnore,
+			},
+		},
+		{
+			name: "warn policy continues",
+			resource: breakglassv1alpha1.AuxiliaryResource{
+				Name:          "warn",
+				Category:      "config",
+				CreateBefore:  true,
+				FailurePolicy: breakglassv1alpha1.AuxiliaryResourceFailurePolicyWarn,
+			},
+		},
+		{
+			name: "deprecated optional continues",
+			resource: breakglassv1alpha1.AuxiliaryResource{
+				Name:          "optional",
+				Category:      "config",
+				CreateBefore:  true,
+				FailurePolicy: breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail,
+				Optional:      true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			mgr := NewAuxiliaryResourceManager(zap.NewNop().Sugar(), fakeClient)
+			session := &breakglassv1alpha1.DebugSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-session",
+					Namespace: "breakglass-system",
+				},
+				Spec: breakglassv1alpha1.DebugSessionSpec{
+					Cluster: "prod",
+				},
+			}
+			template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+				AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{tt.resource},
+				AuxiliaryResourceDefaults: map[string]bool{
+					tt.resource.Name: true,
+				},
+			}
+
+			statuses, err := mgr.DeployAuxiliaryResources(context.Background(), session, template, nil, fakeClient, "debug-ns")
+			require.Len(t, statuses, 1)
+			assert.Contains(t, statuses[0].Error, "no template defined")
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to deploy required auxiliary resource")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCleanupAuxiliaryResources_NoResources(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -333,6 +333,41 @@ func TestDeployAuxiliaryResources_EmptyResources(t *testing.T) {
 	assert.Nil(t, statuses)
 }
 
+func TestDeployAuxiliaryResources_AllResourcesDisabledClearsStaleStatuses(t *testing.T) {
+	mgr := newTestAuxiliaryResourceManager()
+
+	session := &breakglassv1alpha1.DebugSession{
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
+				{Name: "old-config", Kind: "ConfigMap", Created: true},
+			},
+		},
+	}
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
+			{
+				Name:           "new-config",
+				Category:       "debug-config",
+				TemplateString: "kind: ConfigMap\nmetadata:\n  name: new-config\n",
+			},
+		},
+	}
+
+	statuses, err := mgr.DeployAuxiliaryResources(
+		context.Background(),
+		session,
+		template,
+		nil,
+		nil,
+		"target-ns",
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, statuses)
+	session.Status.AuxiliaryResourceStatuses = statuses
+	assert.Empty(t, session.Status.AuxiliaryResourceStatuses)
+}
+
 func TestDeployAuxiliaryResources_FailurePolicy(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -368,7 +368,7 @@ func TestDeployAuxiliaryResources_AllResourcesDisabledClearsStaleStatuses(t *tes
 	assert.Empty(t, session.Status.AuxiliaryResourceStatuses)
 }
 
-func TestDeployAuxiliaryResourcesForCreateBeforeHonorsPhase(t *testing.T) {
+func TestDeployAuxiliaryResourcesForPhaseHonorsCreateBefore(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
@@ -400,12 +400,12 @@ func TestDeployAuxiliaryResourcesForCreateBeforeHonorsPhase(t *testing.T) {
 		},
 	}
 
-	beforeStatuses, err := mgr.DeployAuxiliaryResourcesForCreateBefore(context.Background(), session, template, nil, fakeClient, "debug-ns", true)
+	beforeStatuses, err := mgr.DeployAuxiliaryResourcesForPhase(context.Background(), session, template, nil, fakeClient, "debug-ns", true)
 	require.NoError(t, err)
 	require.Len(t, beforeStatuses, 1)
 	assert.Equal(t, "before-config", beforeStatuses[0].Name)
 
-	afterStatuses, err := mgr.DeployAuxiliaryResourcesForCreateBefore(context.Background(), session, template, nil, fakeClient, "debug-ns", false)
+	afterStatuses, err := mgr.DeployAuxiliaryResourcesForPhase(context.Background(), session, template, nil, fakeClient, "debug-ns", false)
 	require.NoError(t, err)
 	require.Len(t, afterStatuses, 1)
 	assert.Equal(t, "after-config", afterStatuses[0].Name)

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -1996,6 +1996,14 @@ name: invalid - no indentation
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "doc 2")
 	assert.Contains(t, status.Error, "YAML parsing failed")
+	assert.True(t, status.Created, "first applied document must remain cleanup-visible after a later document fails")
+	assert.NotNil(t, status.CreatedAt)
+	assert.Equal(t, "ConfigMap", status.Kind)
+	assert.Equal(t, "valid-config", status.ResourceName)
+	assert.Equal(t, "debug-ns", status.Namespace)
+
+	var applied corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "debug-ns", Name: "valid-config"}, &applied))
 }
 
 func TestDeployResource_MultiDocumentYAML_ConditionalAllExcluded(t *testing.T) {

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -1719,6 +1719,67 @@ func TestCheckAuxiliaryResourcesReadiness_AlreadyReady(t *testing.T) {
 	assert.True(t, allReady)
 }
 
+func TestCheckAuxiliaryResourcesReadiness_RechecksAdditionalResourcesWhenPrimaryReady(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	mgr := newTestAuxiliaryResourceManager()
+	readyAt := "2024-01-01T00:00:00Z"
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-session",
+			Namespace: "breakglass-system",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
+				{
+					Name:         "multi-doc-config",
+					Created:      true,
+					Ready:        true,
+					ReadyAt:      &readyAt,
+					Kind:         "ConfigMap",
+					APIVersion:   "v1",
+					ResourceName: "primary-cm",
+					Namespace:    "default",
+					AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
+						{
+							Kind:         "ConfigMap",
+							APIVersion:   "v1",
+							ResourceName: "late-cm",
+							Namespace:    "default",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	allReady, err := mgr.CheckAuxiliaryResourcesReadiness(ctx, session, fakeClient)
+	require.NoError(t, err)
+	assert.False(t, allReady)
+	assert.False(t, session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].Ready)
+	assert.Equal(t, "NotFound", session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].ReadinessStatus)
+
+	require.NoError(t, fakeClient.Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "late-cm",
+			Namespace: "default",
+		},
+	}))
+
+	allReady, err = mgr.CheckAuxiliaryResourcesReadiness(ctx, session, fakeClient)
+	require.NoError(t, err)
+	assert.True(t, allReady)
+	assert.True(t, session.Status.AuxiliaryResourceStatuses[0].Ready)
+	assert.True(t, session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].Ready)
+	assert.Equal(t, "Current", session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].ReadinessStatus)
+}
+
 func TestCheckAuxiliaryResourcesReadiness_NotCreated(t *testing.T) {
 	mgr := newTestAuxiliaryResourceManager()
 

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -368,6 +368,54 @@ func TestDeployAuxiliaryResources_AllResourcesDisabledClearsStaleStatuses(t *tes
 	assert.Empty(t, session.Status.AuxiliaryResourceStatuses)
 }
 
+func TestDeployAuxiliaryResourcesForCreateBeforeHonorsPhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgr := newTestAuxiliaryResourceManager()
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "phase-session", Namespace: "breakglass"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "user@example.com",
+		},
+	}
+	template := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		RequiredAuxiliaryResourceCategories: []string{"before", "after"},
+		AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
+			{
+				Name:           "before-config",
+				Category:       "before",
+				CreateBefore:   true,
+				TemplateString: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: before-config\n",
+			},
+			{
+				Name:           "after-config",
+				Category:       "after",
+				CreateBefore:   false,
+				TemplateString: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: after-config\n",
+			},
+		},
+	}
+
+	beforeStatuses, err := mgr.DeployAuxiliaryResourcesForCreateBefore(context.Background(), session, template, nil, fakeClient, "debug-ns", true)
+	require.NoError(t, err)
+	require.Len(t, beforeStatuses, 1)
+	assert.Equal(t, "before-config", beforeStatuses[0].Name)
+
+	afterStatuses, err := mgr.DeployAuxiliaryResourcesForCreateBefore(context.Background(), session, template, nil, fakeClient, "debug-ns", false)
+	require.NoError(t, err)
+	require.Len(t, afterStatuses, 1)
+	assert.Equal(t, "after-config", afterStatuses[0].Name)
+
+	var beforeCM corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "debug-ns", Name: "before-config"}, &beforeCM))
+	var afterCM corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "debug-ns", Name: "after-config"}, &afterCM))
+}
+
 func TestDeployAuxiliaryResources_FailurePolicy(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
@@ -549,6 +597,44 @@ func TestCleanupAuxiliaryResources_AlreadyDeleted(t *testing.T) {
 
 	err := mgr.CleanupAuxiliaryResources(context.Background(), session, nil)
 	assert.NoError(t, err)
+}
+
+func TestCleanupAuxiliaryResources_RespectsDeleteAfterFalse(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kept-config", Namespace: "debug-ns"},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	mgr := newTestAuxiliaryResourceManager()
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "cleanup-session", Namespace: "breakglass"},
+		Spec:       breakglassv1alpha1.DebugSessionSpec{Cluster: "test-cluster"},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				AuxiliaryResources: []breakglassv1alpha1.AuxiliaryResource{
+					{Name: "keep-config", DeleteAfter: false},
+				},
+			},
+			AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
+				{
+					Name:         "keep-config",
+					Kind:         "ConfigMap",
+					APIVersion:   "v1",
+					ResourceName: "kept-config",
+					Namespace:    "debug-ns",
+					Created:      true,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, mgr.CleanupAuxiliaryResources(context.Background(), session, fakeClient))
+	require.False(t, session.Status.AuxiliaryResourceStatuses[0].Deleted)
+	var fetched corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "debug-ns", Name: "kept-config"}, &fetched))
 }
 
 func TestAddAuxiliaryResourceToDeployedResources(t *testing.T) {

--- a/pkg/breakglass/debug/auxiliary_resource_manager_test.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -508,6 +509,30 @@ func TestDeployAuxiliaryResources_FailurePolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogAuxiliaryResourceDeployFailure_FailPolicyLogsError(t *testing.T) {
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core).Sugar()
+	resource := breakglassv1alpha1.AuxiliaryResource{
+		Name:     "required-config",
+		Category: "debug-config",
+	}
+
+	logAuxiliaryResourceDeployFailure(
+		logger,
+		resource,
+		breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail,
+		assert.AnError,
+	)
+
+	entries := logs.FilterMessage("Required auxiliary resource deployment failed").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "required-config", fields["resource"])
+	assert.Equal(t, "debug-config", fields["category"])
+	assert.Equal(t, breakglassv1alpha1.AuxiliaryResourceFailurePolicyFail, fields["failurePolicy"])
+	assert.Equal(t, assert.AnError.Error(), fields["error"])
 }
 
 func TestDeployAuxiliaryResources_ReturnsPartialStatusesOnRequiredFailure(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -155,7 +155,27 @@ func (c *DebugSessionController) updateAllowedPods(ctx context.Context, ds *brea
 		}
 	}
 
+	ds.Status.AllowedPods = allowedPods
+	patchAuxiliaryResourceStatuses := c.auxiliaryMgr != nil && len(ds.Status.AuxiliaryResourceStatuses) > 0
+	if err := c.updateAuxiliaryResourceReadiness(ctx, ds, targetClient); err != nil {
+		return err
+	}
+	if patchAuxiliaryResourceStatuses {
+		return c.patchDebugSessionAllowedPodsAndAuxiliaryStatuses(ctx, ds, allowedPods, ds.Status.AuxiliaryResourceStatuses)
+	}
 	return c.patchDebugSessionAllowedPods(ctx, ds, allowedPods)
+}
+
+func (c *DebugSessionController) updateAuxiliaryResourceReadiness(
+	ctx context.Context,
+	ds *breakglassv1alpha1.DebugSession,
+	targetClient ctrlclient.Client,
+) error {
+	if c.auxiliaryMgr == nil || len(ds.Status.AuxiliaryResourceStatuses) == 0 {
+		return nil
+	}
+	_, err := c.auxiliaryMgr.CheckAuxiliaryResourcesReadiness(ctx, ds, targetClient)
+	return err
 }
 
 // monitorPodHealth checks pod status and emits audit events for failures/restarts

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -847,7 +847,10 @@ func TestDebugSessionController_UpdateAuxiliaryResourceReadiness(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "ready-config", Namespace: "debug-ns"},
 	}
-	targetClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ready-secret", Namespace: "debug-ns"},
+	}
+	targetClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
 	session := newTestDebugSession("aux-readiness", "test-template", "test-cluster", "user@example.com")
 	session.Status.AuxiliaryResourceStatuses = []breakglassv1alpha1.AuxiliaryResourceStatus{
 		{
@@ -857,8 +860,21 @@ func TestDebugSessionController_UpdateAuxiliaryResourceReadiness(t *testing.T) {
 			ResourceName: "ready-config",
 			Namespace:    "debug-ns",
 			Created:      true,
+			AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
+				{
+					Kind:         "Secret",
+					APIVersion:   "v1",
+					ResourceName: "ready-secret",
+					Namespace:    "debug-ns",
+				},
+			},
 		},
 	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
 	controller := &DebugSessionController{
 		log:          zap.NewNop().Sugar(),
 		auxiliaryMgr: NewAuxiliaryResourceManager(zap.NewNop().Sugar(), nil),
@@ -867,6 +883,22 @@ func TestDebugSessionController_UpdateAuxiliaryResourceReadiness(t *testing.T) {
 	require.NoError(t, controller.updateAuxiliaryResourceReadiness(context.Background(), session, targetClient))
 	require.True(t, session.Status.AuxiliaryResourceStatuses[0].Ready)
 	require.Equal(t, "Current", session.Status.AuxiliaryResourceStatuses[0].ReadinessStatus)
+	require.True(t, session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].Ready)
+	require.Equal(t, "Current", session.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].ReadinessStatus)
+
+	require.NoError(t, breakglass.ApplyDebugSessionStatus(context.Background(), fakeClient, session))
+
+	var persisted breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      "aux-readiness",
+		Namespace: "breakglass",
+	}, &persisted))
+	require.Len(t, persisted.Status.AuxiliaryResourceStatuses, 1)
+	assert.True(t, persisted.Status.AuxiliaryResourceStatuses[0].Ready)
+	assert.Equal(t, "Current", persisted.Status.AuxiliaryResourceStatuses[0].ReadinessStatus)
+	require.Len(t, persisted.Status.AuxiliaryResourceStatuses[0].AdditionalResources, 1)
+	assert.True(t, persisted.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].Ready)
+	assert.Equal(t, "Current", persisted.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].ReadinessStatus)
 }
 
 func TestDebugSessionReconciler_TerminalSharing(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -842,6 +842,33 @@ func TestDebugSessionReconciler_UpdateAllowedPodsDoesNotOverwriteRenewalOrPartic
 	assert.Equal(t, allowedPods, fetchedSession.Status.AllowedPods)
 }
 
+func TestDebugSessionController_UpdateAuxiliaryResourceReadiness(t *testing.T) {
+	scheme := testScheme()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "ready-config", Namespace: "debug-ns"},
+	}
+	targetClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+	session := newTestDebugSession("aux-readiness", "test-template", "test-cluster", "user@example.com")
+	session.Status.AuxiliaryResourceStatuses = []breakglassv1alpha1.AuxiliaryResourceStatus{
+		{
+			Name:         "ready-config",
+			Kind:         "ConfigMap",
+			APIVersion:   "v1",
+			ResourceName: "ready-config",
+			Namespace:    "debug-ns",
+			Created:      true,
+		},
+	}
+	controller := &DebugSessionController{
+		log:          zap.NewNop().Sugar(),
+		auxiliaryMgr: NewAuxiliaryResourceManager(zap.NewNop().Sugar(), nil),
+	}
+
+	require.NoError(t, controller.updateAuxiliaryResourceReadiness(context.Background(), session, targetClient))
+	require.True(t, session.Status.AuxiliaryResourceStatuses[0].Ready)
+	require.Equal(t, "Current", session.Status.AuxiliaryResourceStatuses[0].ReadinessStatus)
+}
+
 func TestDebugSessionReconciler_TerminalSharing(t *testing.T) {
 	scheme := testScheme()
 

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -901,6 +901,32 @@ func TestDebugSessionController_UpdateAuxiliaryResourceReadiness(t *testing.T) {
 	assert.Equal(t, "Current", persisted.Status.AuxiliaryResourceStatuses[0].AdditionalResources[0].ReadinessStatus)
 }
 
+func TestStartAuxiliaryStatusTracking(t *testing.T) {
+	t.Run("configured resources force explicit empty status list", func(t *testing.T) {
+		session := newTestDebugSession("aux-empty-status", "test-template", "test-cluster", "user@example.com")
+
+		statuses := startAuxiliaryStatusTracking(session, true)
+
+		if statuses == nil {
+			t.Fatal("expected non-nil auxiliary status slice")
+		}
+		if session.Status.AuxiliaryResourceStatuses == nil {
+			t.Fatal("expected non-nil session auxiliary status slice")
+		}
+		assert.Empty(t, statuses)
+		assert.Empty(t, session.Status.AuxiliaryResourceStatuses)
+	})
+
+	t.Run("unconfigured resources leave status untouched", func(t *testing.T) {
+		session := newTestDebugSession("aux-no-status", "test-template", "test-cluster", "user@example.com")
+
+		statuses := startAuxiliaryStatusTracking(session, false)
+
+		assert.Nil(t, statuses)
+		assert.Nil(t, session.Status.AuxiliaryResourceStatuses)
+	})
+}
+
 func TestDebugSessionReconciler_TerminalSharing(t *testing.T) {
 	scheme := testScheme()
 

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -225,9 +225,7 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	// Deploy auxiliary resources if configured
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
 		auxStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResources(ctx, ds, &template.Spec, binding, targetClient, targetNs)
-		if len(auxStatuses) > 0 {
-			ds.Status.AuxiliaryResourceStatuses = auxStatuses
-		}
+		ds.Status.AuxiliaryResourceStatuses = auxStatuses
 		if auxErr != nil {
 			return fmt.Errorf("failed to deploy auxiliary resources: %w", auxErr)
 		}

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -200,6 +200,16 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 		}
 	}
 
+	var auxStatuses []breakglassv1alpha1.AuxiliaryResourceStatus
+	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
+		beforeStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForCreateBefore(ctx, ds, &template.Spec, binding, targetClient, targetNs, true)
+		auxStatuses = append(auxStatuses, beforeStatuses...)
+		ds.Status.AuxiliaryResourceStatuses = auxStatuses
+		if auxErr != nil {
+			return fmt.Errorf("failed to deploy auxiliary resources before workload: %w", auxErr)
+		}
+	}
+
 	// Capture GVK before Apply call as Kubernetes client may clear TypeMeta
 	gvk := workload.GetObjectKind().GroupVersionKind()
 
@@ -222,12 +232,12 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 		"namespace", targetNs,
 		"kind", gvk.Kind)
 
-	// Deploy auxiliary resources if configured
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
-		auxStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResources(ctx, ds, &template.Spec, binding, targetClient, targetNs)
+		afterStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForCreateBefore(ctx, ds, &template.Spec, binding, targetClient, targetNs, false)
+		auxStatuses = append(auxStatuses, afterStatuses...)
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses
 		if auxErr != nil {
-			return fmt.Errorf("failed to deploy auxiliary resources: %w", auxErr)
+			return fmt.Errorf("failed to deploy auxiliary resources after workload: %w", auxErr)
 		}
 	}
 

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -226,8 +226,8 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
 		auxStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResources(ctx, ds, &template.Spec, binding, targetClient, targetNs)
 		if auxErr != nil {
-			// Log but don't fail the session - auxiliary resources are optional
 			log.Warnw("Failed to deploy some auxiliary resources", "error", auxErr)
+			return fmt.Errorf("failed to deploy auxiliary resources: %w", auxErr)
 		}
 		// Add deployed auxiliary resources to status
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -225,12 +225,12 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	// Deploy auxiliary resources if configured
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
 		auxStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResources(ctx, ds, &template.Spec, binding, targetClient, targetNs)
+		if len(auxStatuses) > 0 {
+			ds.Status.AuxiliaryResourceStatuses = auxStatuses
+		}
 		if auxErr != nil {
-			log.Warnw("Failed to deploy some auxiliary resources", "error", auxErr)
 			return fmt.Errorf("failed to deploy auxiliary resources: %w", auxErr)
 		}
-		// Add deployed auxiliary resources to status
-		ds.Status.AuxiliaryResourceStatuses = auxStatuses
 	}
 
 	return nil

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -200,8 +200,9 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 		}
 	}
 
-	var auxStatuses []breakglassv1alpha1.AuxiliaryResourceStatus
-	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
+	auxiliaryResourcesConfigured := c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0
+	auxStatuses := startAuxiliaryStatusTracking(ds, auxiliaryResourcesConfigured)
+	if auxiliaryResourcesConfigured {
 		beforeStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForPhase(ctx, ds, &template.Spec, binding, targetClient, targetNs, true)
 		auxStatuses = append(auxStatuses, beforeStatuses...)
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses
@@ -232,7 +233,7 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 		"namespace", targetNs,
 		"kind", gvk.Kind)
 
-	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
+	if auxiliaryResourcesConfigured {
 		afterStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForPhase(ctx, ds, &template.Spec, binding, targetClient, targetNs, false)
 		auxStatuses = append(auxStatuses, afterStatuses...)
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses
@@ -242,6 +243,15 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	}
 
 	return nil
+}
+
+func startAuxiliaryStatusTracking(ds *breakglassv1alpha1.DebugSession, auxiliaryResourcesConfigured bool) []breakglassv1alpha1.AuxiliaryResourceStatus {
+	if !auxiliaryResourcesConfigured {
+		return nil
+	}
+	statuses := []breakglassv1alpha1.AuxiliaryResourceStatus{}
+	ds.Status.AuxiliaryResourceStatuses = statuses
+	return statuses
 }
 
 // buildWorkload creates the DaemonSet or Deployment for debug pods.

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -202,7 +202,7 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 
 	var auxStatuses []breakglassv1alpha1.AuxiliaryResourceStatus
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
-		beforeStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForCreateBefore(ctx, ds, &template.Spec, binding, targetClient, targetNs, true)
+		beforeStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForPhase(ctx, ds, &template.Spec, binding, targetClient, targetNs, true)
 		auxStatuses = append(auxStatuses, beforeStatuses...)
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses
 		if auxErr != nil {
@@ -233,7 +233,7 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 		"kind", gvk.Kind)
 
 	if c.auxiliaryMgr != nil && len(template.Spec.AuxiliaryResources) > 0 {
-		afterStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForCreateBefore(ctx, ds, &template.Spec, binding, targetClient, targetNs, false)
+		afterStatuses, auxErr := c.auxiliaryMgr.DeployAuxiliaryResourcesForPhase(ctx, ds, &template.Spec, binding, targetClient, targetNs, false)
 		auxStatuses = append(auxStatuses, afterStatuses...)
 		ds.Status.AuxiliaryResourceStatuses = auxStatuses
 		if auxErr != nil {

--- a/pkg/breakglass/debug/debug_session_status_patch.go
+++ b/pkg/breakglass/debug/debug_session_status_patch.go
@@ -60,3 +60,40 @@ func (c *DebugSessionController) patchDebugSessionAllowedPods(
 	}
 	return nil
 }
+
+func (c *DebugSessionController) patchDebugSessionAllowedPodsAndAuxiliaryStatuses(
+	ctx context.Context,
+	ds *breakglassv1alpha1.DebugSession,
+	allowedPods []breakglassv1alpha1.AllowedPodRef,
+	auxiliaryResourceStatuses []breakglassv1alpha1.AuxiliaryResourceStatus,
+) error {
+	patch := struct {
+		Status struct {
+			AllowedPods               []breakglassv1alpha1.AllowedPodRef           `json:"allowedPods"`
+			AuxiliaryResourceStatuses []breakglassv1alpha1.AuxiliaryResourceStatus `json:"auxiliaryResourceStatuses"`
+		} `json:"status"`
+	}{}
+	patch.Status.AllowedPods = allowedPods
+	patch.Status.AuxiliaryResourceStatuses = auxiliaryResourceStatuses
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshal DebugSession allowed pods and auxiliary statuses patch: %w", err)
+	}
+
+	target := &breakglassv1alpha1.DebugSession{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: breakglassv1alpha1.GroupVersion.String(),
+			Kind:       "DebugSession",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ds.Name,
+			Namespace: ds.Namespace,
+		},
+	}
+
+	if err := c.client.Status().Patch(ctx, target, ctrlclient.RawPatch(types.MergePatchType, patchBytes)); err != nil {
+		return fmt.Errorf("patch DebugSession allowed pods and auxiliary statuses: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- propagate `failurePolicy=fail` auxiliary deployment errors from the reconciler so DebugSessions fail instead of activating
- treat omitted auxiliary `failurePolicy` as fail in controller code and preserve deprecated `optional: true` as ignore
- add focused manager regression coverage for default, fail, ignore, warn, and optional policies
- update docs/changelog to state the enforced default and optional compatibility behavior

## Evidence
`AuxiliaryResourceManager.DeployAuxiliaryResources` already returned an error when a required auxiliary resource failed, but `deployDebugResources` only logged `auxErr` and continued to mark the DebugSession active. That contradicted the CRD default and docs for `failurePolicy: fail`, allowing debug sessions to run without required scoped/audited auxiliary controls such as NetworkPolicies or config resources.

Duplicate check: searched open/recent PRs for `auxiliary resource failurePolicy fail DebugSession active`; no matching PR exists.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -run 'TestDeployAuxiliaryResources_FailurePolicy|TestDeployAuxiliaryResources_NilTemplate|TestDeployAuxiliaryResources_EmptyResources|TestDeployResource_NoTemplateDefinedError|TestDebugSessionController_Reconcile_FailSessionCleanup' -count=1 -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass/debug -count=1 -timeout=240s`
- `git -c core.fsmonitor=false diff --check`

## Screenshots
Not applicable: backend DebugSession lifecycle and docs only; no UI changed.
