### PR TITLE
fix: preserve debug session status fields

### DIFF
--- a/api/v1alpha1/applyconfiguration/ssa/patchhelper.go
+++ b/api/v1alpha1/applyconfiguration/ssa/patchhelper.go
@@ -152,7 +152,9 @@ func ensureExplicitDebugSessionEmptyStatusLists(applyConfig runtime.ApplyConfigu
 	if !ok || dsConfig.Status == nil {
 		return
 	}
-	if dsConfig.Status.AuxiliaryResourceStatuses == nil || len(dsConfig.Status.AuxiliaryResourceStatuses) > 0 {
+	needsAuxiliary := dsConfig.Status.AuxiliaryResourceStatuses != nil && len(dsConfig.Status.AuxiliaryResourceStatuses) == 0
+	needsPodTemplate := dsConfig.Status.PodTemplateResourceStatuses != nil && len(dsConfig.Status.PodTemplateResourceStatuses) == 0
+	if !needsAuxiliary && !needsPodTemplate {
 		return
 	}
 	status, _ := u.Object["status"].(map[string]interface{})
@@ -160,7 +162,12 @@ func ensureExplicitDebugSessionEmptyStatusLists(applyConfig runtime.ApplyConfigu
 		status = map[string]interface{}{}
 		u.Object["status"] = status
 	}
-	status["auxiliaryResourceStatuses"] = []interface{}{}
+	if needsAuxiliary {
+		status["auxiliaryResourceStatuses"] = []interface{}{}
+	}
+	if needsPodTemplate {
+		status["podTemplateResourceStatuses"] = []interface{}{}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/api/v1alpha1/applyconfiguration/ssa/ssa.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa.go
@@ -236,6 +236,11 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 		result.WithAllowedPods(AllowedPodRefFrom(&status.AllowedPods[i]))
 	}
 
+	// Set resolved pod operations used by the authorization webhook
+	if status.AllowedPodOperations != nil {
+		result.WithAllowedPodOperations(AllowedPodOperationsFrom(status.AllowedPodOperations))
+	}
+
 	// Set kubectl debug status
 	if status.KubectlDebugStatus != nil {
 		result.WithKubectlDebugStatus(KubectlDebugStatusFrom(status.KubectlDebugStatus))
@@ -272,6 +277,13 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 	// Set resolved binding
 	if status.ResolvedBinding != nil {
 		result.WithResolvedBinding(ResolvedBindingRefFrom(status.ResolvedBinding))
+	}
+
+	for i := range status.AuxiliaryResourceStatuses {
+		result.WithAuxiliaryResourceStatuses(AuxiliaryResourceStatusFrom(&status.AuxiliaryResourceStatuses[i]))
+	}
+	for i := range status.PodTemplateResourceStatuses {
+		result.WithPodTemplateResourceStatuses(PodTemplateResourceStatusFrom(&status.PodTemplateResourceStatuses[i]))
 	}
 
 	return result
@@ -549,6 +561,27 @@ func AllowedPodRefFrom(p *breakglassv1alpha1.AllowedPodRef) *ac.AllowedPodRefApp
 	return result
 }
 
+// AllowedPodOperationsFrom converts an AllowedPodOperations to its ApplyConfiguration.
+func AllowedPodOperationsFrom(o *breakglassv1alpha1.AllowedPodOperations) *ac.AllowedPodOperationsApplyConfiguration {
+	if o == nil {
+		return nil
+	}
+	result := ac.AllowedPodOperations()
+	if o.Exec != nil {
+		result.WithExec(*o.Exec)
+	}
+	if o.Attach != nil {
+		result.WithAttach(*o.Attach)
+	}
+	if o.Logs != nil {
+		result.WithLogs(*o.Logs)
+	}
+	if o.PortForward != nil {
+		result.WithPortForward(*o.PortForward)
+	}
+	return result
+}
+
 // AuxiliaryResourceStatusFrom converts an AuxiliaryResourceStatus to its ApplyConfiguration.
 func AuxiliaryResourceStatusFrom(s *breakglassv1alpha1.AuxiliaryResourceStatus) *ac.AuxiliaryResourceStatusApplyConfiguration {
 	if s == nil {
@@ -619,6 +652,48 @@ func AdditionalResourceRefFrom(r *breakglassv1alpha1.AdditionalResourceRef) *ac.
 		result.WithError(r.Error)
 	}
 
+	return result
+}
+
+// PodTemplateResourceStatusFrom converts a PodTemplateResourceStatus to its ApplyConfiguration.
+func PodTemplateResourceStatusFrom(s *breakglassv1alpha1.PodTemplateResourceStatus) *ac.PodTemplateResourceStatusApplyConfiguration {
+	if s == nil {
+		return nil
+	}
+	result := ac.PodTemplateResourceStatus().
+		WithCreated(s.Created).
+		WithReady(s.Ready).
+		WithDeleted(s.Deleted)
+	if s.Kind != "" {
+		result.WithKind(s.Kind)
+	}
+	if s.APIVersion != "" {
+		result.WithAPIVersion(s.APIVersion)
+	}
+	if s.ResourceName != "" {
+		result.WithResourceName(s.ResourceName)
+	}
+	if s.Namespace != "" {
+		result.WithNamespace(s.Namespace)
+	}
+	if s.Source != "" {
+		result.WithSource(s.Source)
+	}
+	if s.CreatedAt != nil {
+		result.WithCreatedAt(*s.CreatedAt)
+	}
+	if s.ReadyAt != nil {
+		result.WithReadyAt(*s.ReadyAt)
+	}
+	if s.ReadinessStatus != "" {
+		result.WithReadinessStatus(s.ReadinessStatus)
+	}
+	if s.DeletedAt != nil {
+		result.WithDeletedAt(*s.DeletedAt)
+	}
+	if s.Error != "" {
+		result.WithError(s.Error)
+	}
 	return result
 }
 

--- a/api/v1alpha1/applyconfiguration/ssa/ssa.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa.go
@@ -231,6 +231,14 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 		result.WithAuxiliaryResourceStatuses(AuxiliaryResourceStatusFrom(&status.AuxiliaryResourceStatuses[i]))
 	}
 
+	// Set pod template resource statuses
+	if status.PodTemplateResourceStatuses != nil {
+		result.PodTemplateResourceStatuses = []ac.PodTemplateResourceStatusApplyConfiguration{}
+	}
+	for i := range status.PodTemplateResourceStatuses {
+		result.WithPodTemplateResourceStatuses(PodTemplateResourceStatusFrom(&status.PodTemplateResourceStatuses[i]))
+	}
+
 	// Set allowed pods
 	for i := range status.AllowedPods {
 		result.WithAllowedPods(AllowedPodRefFrom(&status.AllowedPods[i]))
@@ -277,13 +285,6 @@ func DebugSessionStatusFrom(status *breakglassv1alpha1.DebugSessionStatus) *ac.D
 	// Set resolved binding
 	if status.ResolvedBinding != nil {
 		result.WithResolvedBinding(ResolvedBindingRefFrom(status.ResolvedBinding))
-	}
-
-	for i := range status.AuxiliaryResourceStatuses {
-		result.WithAuxiliaryResourceStatuses(AuxiliaryResourceStatusFrom(&status.AuxiliaryResourceStatuses[i]))
-	}
-	for i := range status.PodTemplateResourceStatuses {
-		result.WithPodTemplateResourceStatuses(PodTemplateResourceStatusFrom(&status.PodTemplateResourceStatuses[i]))
 	}
 
 	return result
@@ -620,9 +621,7 @@ func AuxiliaryResourceStatusFrom(s *breakglassv1alpha1.AuxiliaryResourceStatus) 
 	if s.DeletedAt != nil {
 		result.WithDeletedAt(*s.DeletedAt)
 	}
-	if s.Error != "" {
-		result.WithError(s.Error)
-	}
+	result.WithError(s.Error)
 	for i := range s.AdditionalResources {
 		result.WithAdditionalResources(AdditionalResourceRefFrom(&s.AdditionalResources[i]))
 	}
@@ -648,10 +647,7 @@ func AdditionalResourceRefFrom(r *breakglassv1alpha1.AdditionalResourceRef) *ac.
 	if r.ReadinessStatus != "" {
 		result.WithReadinessStatus(r.ReadinessStatus)
 	}
-	if r.Error != "" {
-		result.WithError(r.Error)
-	}
-
+	result.WithError(r.Error)
 	return result
 }
 
@@ -691,9 +687,7 @@ func PodTemplateResourceStatusFrom(s *breakglassv1alpha1.PodTemplateResourceStat
 	if s.DeletedAt != nil {
 		result.WithDeletedAt(*s.DeletedAt)
 	}
-	if s.Error != "" {
-		result.WithError(s.Error)
-	}
+	result.WithError(s.Error)
 	return result
 }
 

--- a/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
@@ -461,6 +461,116 @@ func TestApplyDebugSessionStatus(t *testing.T) {
 		assert.Equal(t, "Session is running", updated.Status.Message)
 	})
 
+	t.Run("preserves debug authorization and resource status fields", func(t *testing.T) {
+		execAllowed := false
+		attachAllowed := false
+		logsAllowed := true
+		portForwardAllowed := false
+		createdAt := "2026-06-27T18:00:00Z"
+		readyAt := "2026-06-27T18:01:00Z"
+		deletedAt := "2026-06-27T18:02:00Z"
+		ds := &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-debug-fields",
+				Namespace: "default",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster:     "test-cluster",
+				TemplateRef: "test-template",
+				RequestedBy: "test@example.com",
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ds).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		ds.Status.AllowedPodOperations = &breakglassv1alpha1.AllowedPodOperations{
+			Exec:        &execAllowed,
+			Attach:      &attachAllowed,
+			Logs:        &logsAllowed,
+			PortForward: &portForwardAllowed,
+		}
+		ds.Status.AuxiliaryResourceStatuses = []breakglassv1alpha1.AuxiliaryResourceStatus{
+			{
+				Name:            "debug-rbac",
+				Category:        "rbac",
+				Kind:            "ServiceAccount",
+				APIVersion:      "v1",
+				ResourceName:    "debug-sa",
+				Namespace:       "debug-ns",
+				Created:         true,
+				CreatedAt:       &createdAt,
+				Ready:           true,
+				ReadyAt:         &readyAt,
+				ReadinessStatus: "Current",
+				Deleted:         false,
+				AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
+					{
+						Kind:            "Role",
+						APIVersion:      "rbac.authorization.k8s.io/v1",
+						ResourceName:    "debug-role",
+						Namespace:       "debug-ns",
+						Ready:           true,
+						ReadinessStatus: "Current",
+						Deleted:         false,
+					},
+				},
+			},
+		}
+		ds.Status.PodTemplateResourceStatuses = []breakglassv1alpha1.PodTemplateResourceStatus{
+			{
+				Kind:            "ConfigMap",
+				APIVersion:      "v1",
+				ResourceName:    "debug-config",
+				Namespace:       "debug-ns",
+				Source:          "podTemplateString",
+				Created:         true,
+				CreatedAt:       &createdAt,
+				Ready:           false,
+				ReadinessStatus: "InProgress",
+				Deleted:         true,
+				DeletedAt:       &deletedAt,
+				Error:           "cleanup pending",
+			},
+		}
+
+		err := ApplyDebugSessionStatus(context.Background(), c, ds)
+		require.NoError(t, err)
+
+		var updated breakglassv1alpha1.DebugSession
+		err = c.Get(context.Background(), client.ObjectKeyFromObject(ds), &updated)
+		require.NoError(t, err)
+
+		require.NotNil(t, updated.Status.AllowedPodOperations)
+		assert.False(t, *updated.Status.AllowedPodOperations.Exec)
+		assert.False(t, *updated.Status.AllowedPodOperations.Attach)
+		assert.True(t, *updated.Status.AllowedPodOperations.Logs)
+		assert.False(t, *updated.Status.AllowedPodOperations.PortForward)
+
+		require.Len(t, updated.Status.AuxiliaryResourceStatuses, 1)
+		auxiliaryStatus := updated.Status.AuxiliaryResourceStatuses[0]
+		assert.Equal(t, "debug-rbac", auxiliaryStatus.Name)
+		assert.Equal(t, "debug-sa", auxiliaryStatus.ResourceName)
+		assert.True(t, auxiliaryStatus.Created)
+		assert.True(t, auxiliaryStatus.Ready)
+		assert.False(t, auxiliaryStatus.Deleted)
+		require.Len(t, auxiliaryStatus.AdditionalResources, 1)
+		assert.Equal(t, "debug-role", auxiliaryStatus.AdditionalResources[0].ResourceName)
+		assert.False(t, auxiliaryStatus.AdditionalResources[0].Deleted)
+
+		require.Len(t, updated.Status.PodTemplateResourceStatuses, 1)
+		podTemplateStatus := updated.Status.PodTemplateResourceStatuses[0]
+		assert.Equal(t, "ConfigMap", podTemplateStatus.Kind)
+		assert.Equal(t, "debug-config", podTemplateStatus.ResourceName)
+		assert.True(t, podTemplateStatus.Created)
+		assert.False(t, podTemplateStatus.Ready)
+		assert.True(t, podTemplateStatus.Deleted)
+		assert.Equal(t, "cleanup pending", podTemplateStatus.Error)
+	})
+
 	t.Run("returns error when debug session does not exist", func(t *testing.T) {
 		c := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -513,6 +623,90 @@ func TestDebugSessionStatusFromPreservesExplicitEmptyAuxiliaryStatuses(t *testin
 		},
 	}
 	assert.False(t, statusSubsetMatch(currentStatus, desiredStatus))
+}
+
+func TestDebugSessionStatusFromPreservesAuthorizationAndResourceFields(t *testing.T) {
+	execAllowed := false
+	attachAllowed := false
+	logsAllowed := true
+	portForwardAllowed := false
+	createdAt := "2026-06-27T18:00:00Z"
+	deletedAt := "2026-06-27T18:02:00Z"
+	status := &breakglassv1alpha1.DebugSessionStatus{
+		AllowedPodOperations: &breakglassv1alpha1.AllowedPodOperations{
+			Exec:        &execAllowed,
+			Attach:      &attachAllowed,
+			Logs:        &logsAllowed,
+			PortForward: &portForwardAllowed,
+		},
+		AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
+			{
+				Name:            "debug-rbac",
+				Category:        "rbac",
+				Kind:            "ServiceAccount",
+				APIVersion:      "v1",
+				ResourceName:    "debug-sa",
+				Namespace:       "debug-ns",
+				Created:         true,
+				CreatedAt:       &createdAt,
+				Ready:           true,
+				ReadinessStatus: "Current",
+				AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
+					{
+						Kind:            "Role",
+						APIVersion:      "rbac.authorization.k8s.io/v1",
+						ResourceName:    "debug-role",
+						Namespace:       "debug-ns",
+						Ready:           true,
+						ReadinessStatus: "Current",
+					},
+				},
+			},
+		},
+		PodTemplateResourceStatuses: []breakglassv1alpha1.PodTemplateResourceStatus{
+			{
+				Kind:            "ConfigMap",
+				APIVersion:      "v1",
+				ResourceName:    "debug-config",
+				Namespace:       "debug-ns",
+				Source:          "podTemplateString",
+				Created:         true,
+				Ready:           false,
+				ReadinessStatus: "InProgress",
+				Deleted:         true,
+				DeletedAt:       &deletedAt,
+				Error:           "cleanup pending",
+			},
+		},
+	}
+
+	result := DebugSessionStatusFrom(status)
+	require.NotNil(t, result)
+
+	require.NotNil(t, result.AllowedPodOperations)
+	assert.False(t, *result.AllowedPodOperations.Exec)
+	assert.False(t, *result.AllowedPodOperations.Attach)
+	assert.True(t, *result.AllowedPodOperations.Logs)
+	assert.False(t, *result.AllowedPodOperations.PortForward)
+
+	require.Len(t, result.AuxiliaryResourceStatuses, 1)
+	auxiliaryStatus := result.AuxiliaryResourceStatuses[0]
+	assert.Equal(t, "debug-rbac", *auxiliaryStatus.Name)
+	assert.Equal(t, "debug-sa", *auxiliaryStatus.ResourceName)
+	assert.True(t, *auxiliaryStatus.Created)
+	assert.True(t, *auxiliaryStatus.Ready)
+	assert.False(t, *auxiliaryStatus.Deleted)
+	require.Len(t, auxiliaryStatus.AdditionalResources, 1)
+	assert.Equal(t, "debug-role", *auxiliaryStatus.AdditionalResources[0].ResourceName)
+
+	require.Len(t, result.PodTemplateResourceStatuses, 1)
+	podTemplateStatus := result.PodTemplateResourceStatuses[0]
+	assert.Equal(t, "ConfigMap", *podTemplateStatus.Kind)
+	assert.Equal(t, "debug-config", *podTemplateStatus.ResourceName)
+	assert.True(t, *podTemplateStatus.Created)
+	assert.False(t, *podTemplateStatus.Ready)
+	assert.True(t, *podTemplateStatus.Deleted)
+	assert.Equal(t, "cleanup pending", *podTemplateStatus.Error)
 }
 
 // TestApplyAuditConfigStatus tests SSA status updates for AuditConfig.

--- a/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
@@ -545,10 +545,10 @@ func TestApplyDebugSessionStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, updated.Status.AllowedPodOperations)
-		assert.False(t, *updated.Status.AllowedPodOperations.Exec)
-		assert.False(t, *updated.Status.AllowedPodOperations.Attach)
-		assert.True(t, *updated.Status.AllowedPodOperations.Logs)
-		assert.False(t, *updated.Status.AllowedPodOperations.PortForward)
+		assert.Equal(t, &execAllowed, updated.Status.AllowedPodOperations.Exec)
+		assert.Equal(t, &attachAllowed, updated.Status.AllowedPodOperations.Attach)
+		assert.Equal(t, &logsAllowed, updated.Status.AllowedPodOperations.Logs)
+		assert.Equal(t, &portForwardAllowed, updated.Status.AllowedPodOperations.PortForward)
 
 		require.Len(t, updated.Status.AuxiliaryResourceStatuses, 1)
 		auxiliaryStatus := updated.Status.AuxiliaryResourceStatuses[0]
@@ -684,10 +684,10 @@ func TestDebugSessionStatusFromPreservesAuthorizationAndResourceFields(t *testin
 	require.NotNil(t, result)
 
 	require.NotNil(t, result.AllowedPodOperations)
-	assert.False(t, *result.AllowedPodOperations.Exec)
-	assert.False(t, *result.AllowedPodOperations.Attach)
-	assert.True(t, *result.AllowedPodOperations.Logs)
-	assert.False(t, *result.AllowedPodOperations.PortForward)
+	assert.Equal(t, &execAllowed, result.AllowedPodOperations.Exec)
+	assert.Equal(t, &attachAllowed, result.AllowedPodOperations.Attach)
+	assert.Equal(t, &logsAllowed, result.AllowedPodOperations.Logs)
+	assert.Equal(t, &portForwardAllowed, result.AllowedPodOperations.PortForward)
 
 	require.Len(t, result.AuxiliaryResourceStatuses, 1)
 	auxiliaryStatus := result.AuxiliaryResourceStatuses[0]

--- a/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
@@ -709,6 +709,51 @@ func TestDebugSessionStatusFromPreservesAuthorizationAndResourceFields(t *testin
 	assert.Equal(t, "cleanup pending", *podTemplateStatus.Error)
 }
 
+func TestDebugSessionStatusFromIncludesEmptyErrorFields(t *testing.T) {
+	status := &breakglassv1alpha1.DebugSessionStatus{
+		AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{
+			{
+				Name:         "debug-rbac",
+				Kind:         "ServiceAccount",
+				APIVersion:   "v1",
+				ResourceName: "debug-sa",
+				AdditionalResources: []breakglassv1alpha1.AdditionalResourceRef{
+					{
+						Kind:         "Role",
+						APIVersion:   "rbac.authorization.k8s.io/v1",
+						ResourceName: "debug-role",
+					},
+				},
+			},
+		},
+		PodTemplateResourceStatuses: []breakglassv1alpha1.PodTemplateResourceStatus{
+			{
+				Kind:         "ConfigMap",
+				APIVersion:   "v1",
+				ResourceName: "debug-config",
+			},
+		},
+	}
+
+	result := DebugSessionStatusFrom(status)
+	require.NotNil(t, result)
+
+	require.Len(t, result.AuxiliaryResourceStatuses, 1)
+	auxiliaryStatus := result.AuxiliaryResourceStatuses[0]
+	require.NotNil(t, auxiliaryStatus.Error)
+	assert.Empty(t, *auxiliaryStatus.Error)
+
+	require.Len(t, auxiliaryStatus.AdditionalResources, 1)
+	additionalResource := auxiliaryStatus.AdditionalResources[0]
+	require.NotNil(t, additionalResource.Error)
+	assert.Empty(t, *additionalResource.Error)
+
+	require.Len(t, result.PodTemplateResourceStatuses, 1)
+	podTemplateStatus := result.PodTemplateResourceStatuses[0]
+	require.NotNil(t, podTemplateStatus.Error)
+	assert.Empty(t, *podTemplateStatus.Error)
+}
+
 // TestApplyAuditConfigStatus tests SSA status updates for AuditConfig.
 func TestApplyAuditConfigStatus(t *testing.T) {
 	scheme := newTestScheme()

--- a/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
+++ b/api/v1alpha1/applyconfiguration/ssa/ssa_test.go
@@ -590,10 +590,11 @@ func TestApplyDebugSessionStatus(t *testing.T) {
 	})
 }
 
-func TestDebugSessionStatusFromPreservesExplicitEmptyAuxiliaryStatuses(t *testing.T) {
+func TestDebugSessionStatusFromPreservesExplicitEmptyResourceStatuses(t *testing.T) {
 	status := &breakglassv1alpha1.DebugSessionStatus{
-		State:                     breakglassv1alpha1.DebugSessionStateActive,
-		AuxiliaryResourceStatuses: []breakglassv1alpha1.AuxiliaryResourceStatus{},
+		State:                       breakglassv1alpha1.DebugSessionStateActive,
+		AuxiliaryResourceStatuses:   []breakglassv1alpha1.AuxiliaryResourceStatus{},
+		PodTemplateResourceStatuses: []breakglassv1alpha1.PodTemplateResourceStatus{},
 	}
 	applyConfig := ac.DebugSession("test-debug", "default").
 		WithStatus(DebugSessionStatusFrom(status))
@@ -608,6 +609,7 @@ func TestDebugSessionStatusFromPreservesExplicitEmptyAuxiliaryStatuses(t *testin
 	desiredStatus, ok := u.Object["status"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, []interface{}{}, desiredStatus["auxiliaryResourceStatuses"])
+	assert.Equal(t, []interface{}{}, desiredStatus["podTemplateResourceStatuses"])
 
 	currentStatus := map[string]interface{}{
 		"state": string(breakglassv1alpha1.DebugSessionStateActive),
@@ -617,6 +619,16 @@ func TestDebugSessionStatusFromPreservesExplicitEmptyAuxiliaryStatuses(t *testin
 				"kind":         "ConfigMap",
 				"apiVersion":   "v1",
 				"resourceName": "old-config",
+				"namespace":    "default",
+				"created":      true,
+			},
+		},
+		"podTemplateResourceStatuses": []interface{}{
+			map[string]interface{}{
+				"name":         "old-template",
+				"kind":         "ConfigMap",
+				"apiVersion":   "v1",
+				"resourceName": "old-template",
 				"namespace":    "default",
 				"created":      true,
 			},

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -690,6 +690,10 @@ The `get` command shows the full session details including `status.allowedPodOpe
 bgctl debug session get debug-abc123 -o yaml
 ```
 
+The controller persists the resolved operation set in `status.allowedPodOperations`.
+Webhook checks read this status field, so controller status updates preserve it
+across requeues while the session remains active.
+
 **Web UI**: The session details page displays an "Allowed Pod Operations" card showing which operations are enabled (✓) or disabled (✗) for the session.
 
 ### DebugSession
@@ -1099,6 +1103,12 @@ All resources from multi-document YAML are:
 - Tracked in the session status for observability
 - Cleaned up automatically when the session ends unless `deleteAfter: false`
 - Monitored for readiness using kstatus
+
+Auxiliary resource lifecycle is reflected in
+`status.auxiliaryResourceStatuses`. Additional objects produced by
+multi-document pod templates are reflected in
+`status.podTemplateResourceStatuses`, allowing cleanup and audit workflows to
+continue from persisted status after controller requeues or restarts.
 
 > **Note:** `template` (structured) and `templateString` (Go template) are mutually exclusive. Use `templateString` when you need multi-document YAML or dynamic templating.
 


### PR DESCRIPTION
## Summary
- Preserve `status.allowedPodOperations`, `status.auxiliaryResourceStatuses`, and `status.podTemplateResourceStatuses` in DebugSession server-side-apply status patches.
- Add regression coverage for direct `DebugSessionStatusFrom` conversion and fake-client status apply persistence.
- Document the persisted status fields used by webhook enforcement, cleanup, and audit workflows.

## Evidence
- `DebugSessionStatus` and generated apply configurations already include these fields, but `DebugSessionStatusFrom` omitted them.
- Without these setters, controller status apply paths can drop resolved pod-operation restrictions and auxiliary/multi-document resource status during requeues.
- Duplicate check before opening: searched open and merged PRs for `DebugSessionStatusFrom`, `allowedPodOperations`, `auxiliaryResourceStatuses`, `podTemplateResourceStatuses`, and `ssa`; no open or merged PR covers this SSA helper gap.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./api/v1alpha1/applyconfiguration/ssa -run 'Test(ApplyDebugSessionStatus|DebugSessionStatusFromPreservesAuthorizationAndResourceFields)$' -count=1 -timeout=180s`\n- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./api/v1alpha1/applyconfiguration/ssa -count=1 -timeout=240s`\n- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./api/v1alpha1 -count=1 -timeout=240s`\n- `git diff --check`\n\n## UI screenshots\n- Not applicable: backend/controller status persistence only; no frontend files changed.