### PR TITLE
fix: enforce approver identity providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **BreakglassSession approver IDP enforcement**: Approval and rejection requests now enforce `BreakglassEscalation.spec.allowedIdentityProvidersForApprovers`, denying approvers whose authenticated IdentityProvider is missing or not allowed.
 - **Frontend debug logging hardening**: Production builds no longer enable verbose debug logging from URL or localStorage flags, group and claim refresh diagnostics log only counts and claim keys instead of sensitive group memberships or full profile claims, and stale OIDC refresh tokens are removed from browser session state before silent renew.
 - **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed, scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present, and checks approval/rejection authorization before body validation or state-specific errors so unrelated callers cannot infer session details.
 - **DebugSession leave access revocation**: Debug session participant indexes, webhook pod-operation authorization, and kubectl-debug active-session lookup now ignore participants after `status.participants[].leftAt` is set, ensuring leaving a session revokes debug pod access immediately.

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -478,7 +478,7 @@ allowedIdentityProvidersForApprovers:
   `status.approverGroupMembers` contains an approver group entry, that resolved
   member list is authoritative for that group.
 - Approval endpoints deny requests when an approver allowlist is configured but
-  the authenticated caller's IDP is missing or not listed
+  the authenticated caller's IDP is missing or not listed.
 
 #### Example: Restrict to Corporate OIDC only
 

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -477,6 +477,8 @@ allowedIdentityProvidersForApprovers:
   Kubernetes `system:*` groups, the authenticated request-token groups are used. Once
   `status.approverGroupMembers` contains an approver group entry, that resolved
   member list is authoritative for that group.
+- Approval endpoints deny requests when an approver allowlist is configured but
+  the authenticated caller's IDP is missing or not listed
 
 #### Example: Restrict to Corporate OIDC only
 

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -474,9 +474,9 @@ allowedIdentityProvidersForApprovers:
 - While approver group membership status is not populated yet, approval falls
   back to target-cluster group lookup for the missing groups. If that lookup
   cannot expose identity-provider groups and returns no groups or only
-  Kubernetes `system:*` groups, the authenticated request-token groups are used. Once
-  `status.approverGroupMembers` contains an approver group entry, that resolved
-  member list is authoritative for that group.
+  Kubernetes `system:*` groups, the authenticated request-token groups are used.
+  Once `status.approverGroupMembers` contains an approver group entry, that
+  resolved member list is authoritative for that group.
 - Approval endpoints deny requests when an approver allowlist is configured but
   the authenticated caller's IDP is missing or not listed.
 

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -72,6 +72,8 @@ const (
 	ApprovalDenialSelfApprovalBlocked ApprovalDenialReason = "SELF_APPROVAL_BLOCKED"
 	// ApprovalDenialDomainNotAllowed indicates the approver's email domain is not in the allowed list.
 	ApprovalDenialDomainNotAllowed ApprovalDenialReason = "DOMAIN_NOT_ALLOWED"
+	// ApprovalDenialIdentityProviderNotAllowed indicates the approver authenticated through a disallowed IdentityProvider.
+	ApprovalDenialIdentityProviderNotAllowed ApprovalDenialReason = "IDP_NOT_ALLOWED"
 	// ApprovalDenialNotAnApprover indicates the user is not in any approver group/list for matching escalations.
 	ApprovalDenialNotAnApprover ApprovalDenialReason = "NOT_AN_APPROVER"
 	// ApprovalDenialNoMatchingEscalation indicates no escalation was found for the session's granted group.

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -114,9 +114,11 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 	}
 
 	// Track the most specific denial reason encountered during evaluation.
-	// Priority: SelfApprovalBlocked > DomainNotAllowed > IdentityProviderNotAllowed.
-	// NotAnApprover replaces IdentityProviderNotAllowed when no otherwise matching escalation
-	// has an allowed approver identity provider, then falls back to NoMatchingEscalation.
+	// Priority: SelfApprovalBlocked > DomainNotAllowed > IdentityProviderNotAllowed
+	// until a matching escalation allows the approver identity provider. If that
+	// escalation still does not list the caller as an approver, NotAnApprover
+	// replaces IdentityProviderNotAllowed. NoMatchingEscalation is returned only
+	// when no escalation matches the session's granted group.
 	var mostSpecificDenial ApprovalCheckResult
 	foundMatchingEscalation := false
 	foundMatchingEscalationWithAllowedApproverIDP := false

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -45,6 +45,7 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 	approverID := ClusterUserGroup{Username: email, Clustername: session.Spec.Cluster}
 	authIdentifiers := collectAuthIdentifiers(email, wc.identityProvider.GetUsername(c), wc.identityProvider.GetIdentity(c))
 	requestContextGroups := approverGroupsFromRequestContext(c)
+	approverIdentityProvider := c.GetString("identity_provider_name")
 
 	// Base defaults for escalation evaluation
 	var baseBlockSelfApproval bool
@@ -172,6 +173,22 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 				}
 				continue
 			}
+		}
+
+		if !isApproverIdentityProviderAllowed(approverIdentityProvider, esc.Spec.AllowedIdentityProvidersForApprovers) {
+			reqLog.Warnw("Approver authenticated with disallowed identity provider",
+				"escalation", esc.Name,
+				"approver", email,
+				"identityProvider", approverIdentityProvider,
+				"allowedIdentityProviderCount", len(esc.Spec.AllowedIdentityProvidersForApprovers))
+			if mostSpecificDenial.Reason != ApprovalDenialSelfApprovalBlocked && mostSpecificDenial.Reason != ApprovalDenialDomainNotAllowed {
+				mostSpecificDenial = ApprovalCheckResult{
+					Allowed: false,
+					Reason:  ApprovalDenialIdentityProviderNotAllowed,
+					Message: "Your identity provider is not allowed to approve this escalation",
+				}
+			}
+			continue
 		}
 
 		// Direct user approver check
@@ -308,6 +325,16 @@ func shouldUseRequestContextApproverGroups(targetClusterGroups, requestContextGr
 		}
 	}
 	return true
+}
+
+func isApproverIdentityProviderAllowed(identityProvider string, allowedIdentityProviders []string) bool {
+	if len(allowedIdentityProviders) == 0 {
+		return true
+	}
+	if identityProvider == "" {
+		return false
+	}
+	return slices.Contains(allowedIdentityProviders, identityProvider)
 }
 
 // isSessionApprover returns true if the current user is authorized to approve/reject the session.

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -114,7 +114,9 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 	}
 
 	// Track the most specific denial reason encountered during evaluation.
-	// Priority: SelfApprovalBlocked > DomainNotAllowed > NotAnApprover > NoMatchingEscalation
+	// Priority: SelfApprovalBlocked > DomainNotAllowed > IdentityProviderNotAllowed.
+	// NotAnApprover replaces IdentityProviderNotAllowed when no otherwise matching escalation
+	// has an allowed approver identity provider, then falls back to NoMatchingEscalation.
 	var mostSpecificDenial ApprovalCheckResult
 	foundMatchingEscalation := false
 	foundMatchingEscalationWithAllowedApproverIDP := false

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -117,6 +117,7 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 	// Priority: SelfApprovalBlocked > DomainNotAllowed > NotAnApprover > NoMatchingEscalation
 	var mostSpecificDenial ApprovalCheckResult
 	foundMatchingEscalation := false
+	foundMatchingEscalationWithAllowedApproverIDP := false
 
 	reqLog.Debugw("Approver evaluation context", "session", session.Name, "sessionGroup", system.RedactGroupName(session.Spec.GrantedGroup), "candidateEscalationCount", len(escalations), "approverEmail", email)
 	for _, esc := range escalations {
@@ -181,7 +182,9 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 				"approver", email,
 				"identityProvider", approverIdentityProvider,
 				"allowedIdentityProviderCount", len(esc.Spec.AllowedIdentityProvidersForApprovers))
-			if mostSpecificDenial.Reason != ApprovalDenialSelfApprovalBlocked && mostSpecificDenial.Reason != ApprovalDenialDomainNotAllowed {
+			if !foundMatchingEscalationWithAllowedApproverIDP &&
+				mostSpecificDenial.Reason != ApprovalDenialSelfApprovalBlocked &&
+				mostSpecificDenial.Reason != ApprovalDenialDomainNotAllowed {
 				mostSpecificDenial = ApprovalCheckResult{
 					Allowed: false,
 					Reason:  ApprovalDenialIdentityProviderNotAllowed,
@@ -190,6 +193,7 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 			}
 			continue
 		}
+		foundMatchingEscalationWithAllowedApproverIDP = true
 
 		// Direct user approver check
 		if slices.Contains(esc.Spec.Approvers.Users, email) {
@@ -247,7 +251,8 @@ func (wc *BreakglassSessionController) checkApprovalAuthorization(c *gin.Context
 				"session", session.Name, "escalation", esc.Name, "user", email, "userGroupCount", len(approverGroups), "approverUserCount", len(esc.Spec.Approvers.Users), "approverGroupCount", len(esc.Spec.Approvers.Groups))
 		}
 		// Track not-an-approver as lowest priority denial
-		if mostSpecificDenial.Reason == ApprovalDenialNone {
+		if mostSpecificDenial.Reason == ApprovalDenialNone ||
+			mostSpecificDenial.Reason == ApprovalDenialIdentityProviderNotAllowed {
 			mostSpecificDenial = ApprovalCheckResult{
 				Allowed: false,
 				Reason:  ApprovalDenialNotAnApprover,

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -67,6 +67,8 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 				apiresponses.RespondForbidden(c, authResult.Message)
 			case ApprovalDenialDomainNotAllowed:
 				apiresponses.RespondForbidden(c, authResult.Message)
+			case ApprovalDenialIdentityProviderNotAllowed:
+				apiresponses.RespondForbidden(c, authResult.Message)
 			case ApprovalDenialNotAnApprover:
 				apiresponses.RespondForbidden(c, authResult.Message)
 			case ApprovalDenialNoMatchingEscalation:

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -2766,6 +2766,7 @@ func TestApprovalAuthorizationPrefersTargetClusterGroupsOverRequestGroups(t *tes
 	c.Set("email", "approver@example.com")
 	c.Set("username", "approver@example.com")
 	c.Set("groups", []string{"unrelated-request-group"})
+	c.Set("identity_provider_name", "approver-idp")
 
 	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "default"},
@@ -2819,6 +2820,7 @@ func TestApprovalAuthorizationUsesResolvedApproverGroupMembers(t *testing.T) {
 	c.Set("email", "approver@example.com")
 	c.Set("username", "approver@example.com")
 	c.Set("groups", []string{"unrelated-request-group"})
+	c.Set("identity_provider_name", "approver-idp")
 
 	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "default"},
@@ -2869,6 +2871,7 @@ func TestApprovalAuthorizationFallsBackToTargetGroupsWhenResolvedApproverMembers
 	c.Set("email", "approver@example.com")
 	c.Set("username", "approver@example.com")
 	c.Set("groups", []string{"unrelated-request-group"})
+	c.Set("identity_provider_name", "approver-idp")
 
 	session := breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "default"},

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -961,6 +961,141 @@ func TestEscalation_AllowedApproverDomains_OverridesCluster(t *testing.T) {
 	}
 }
 
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_DeniesDirectUserFromWrongIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, escalation)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "requester-idp")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.False(t, result.Allowed)
+	require.Equal(t, ApprovalDenialIdentityProviderNotAllowed, result.Reason)
+	require.Contains(t, result.Message, "identity provider is not allowed")
+}
+
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_AllowsDirectUserFromAllowedIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-allowed-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-allowed-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, escalation)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "approver-idp")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.True(t, result.Allowed)
+	require.Equal(t, ApprovalDenialNone, result.Reason)
+}
+
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_DeniesGroupMemberFromWrongIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-idp-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-idp-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Groups: []string{"idp-approvers"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"idp-approvers": {"approver@example.com"},
+			},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, escalation)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "requester-idp")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.False(t, result.Allowed)
+	require.Equal(t, ApprovalDenialIdentityProviderNotAllowed, result.Reason)
+}
+
+func newApprovalAuthorizationTestController(t *testing.T, objects ...client.Object) *BreakglassSessionController {
+	t.Helper()
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(objects...)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
+		c.Next()
+	}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(context.Context, ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated", "idp-approvers"}, nil
+	}
+	return ctrl
+}
+
+func newApprovalAuthorizationTestContext(email, identityProvider string) *gin.Context {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/breakglassSessions/test/approve", nil)
+	c.Set("email", email)
+	c.Set("username", strings.Split(email, "@")[0])
+	c.Set("user_id", email)
+	if identityProvider != "" {
+		c.Set("identity_provider_name", identityProvider)
+	}
+	return c
+}
+
 // Test that a BreakglassSession created via the controller is stored in the
 // same namespace as the matched BreakglassEscalation when a match exists.
 func TestSessionCreatedUsesEscalationNamespace(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -994,6 +994,39 @@ func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_DeniesDirect
 	require.Contains(t, result.Message, "identity provider is not allowed")
 }
 
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_DeniesDirectUserWithMissingIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-missing-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-missing-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, escalation)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.False(t, result.Allowed)
+	require.Equal(t, ApprovalDenialIdentityProviderNotAllowed, result.Reason)
+	require.Contains(t, result.Message, "identity provider is not allowed")
+}
+
 func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_AllowsDirectUserFromAllowedIDP(t *testing.T) {
 	session := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "direct-idp-allowed-session"},
@@ -1061,6 +1094,99 @@ func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_DeniesGroupM
 
 	require.False(t, result.Allowed)
 	require.Equal(t, ApprovalDenialIdentityProviderNotAllowed, result.Reason)
+}
+
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_AllowsGroupMemberFromAllowedIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-idp-allowed-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-idp-allowed-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Groups: []string{"idp-approvers"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"idp-approvers": {"approver@example.com"},
+			},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, escalation)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "approver-idp")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.True(t, result.Allowed)
+	require.Equal(t, ApprovalDenialNone, result.Reason)
+}
+
+func TestApprovalAuthorization_AllowedIdentityProvidersForApprovers_PrefersNotApproverWhenAnyMatchingEscalationAllowsIDP(t *testing.T) {
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "mixed-idp-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "idp-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "idp-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	allowsIDPButNotCaller := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "allowed-idp-non-member"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Groups: []string{"idp-approvers"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"idp-approvers": {"other@example.com"},
+			},
+		},
+	}
+	rejectsIDP := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "rejected-idp"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"idp-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup:                       "idp-admin",
+			Approvers:                            breakglassv1alpha1.BreakglassEscalationApprovers{Groups: []string{"idp-approvers"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"other-idp"},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"idp-approvers": {"approver@example.com"},
+			},
+		},
+	}
+	ctrl := newApprovalAuthorizationTestController(t, session, allowsIDPButNotCaller, rejectsIDP)
+	c := newApprovalAuthorizationTestContext("approver@example.com", "approver-idp")
+
+	result := ctrl.checkApprovalAuthorization(c, *session)
+
+	require.False(t, result.Allowed)
+	require.Equal(t, ApprovalDenialNotAnApprover, result.Reason)
+	require.Contains(t, result.Message, "not in an approver group")
 }
 
 func newApprovalAuthorizationTestController(t *testing.T, objects ...client.Object) *BreakglassSessionController {


### PR DESCRIPTION
## Summary
- enforce `allowedIdentityProvidersForApprovers` against the authenticated caller's `identity_provider_name`
- deny callers from missing or disallowed approver IDPs before accepting direct-user or group approver matches
- add direct-user, group-member, and positive allowed-IDP regression tests
- document the runtime fail-closed behavior and add a changelog entry

## Evidence
`checkApprovalAuthorization` previously collected only email, username, and subject. A caller authenticated through a requester-only IDP could still approve when their email matched `approvers.users` or deduplicated `status.approverGroupMembers`, even when the escalation configured a different `allowedIdentityProvidersForApprovers` list.

## Duplicate Check
- Open PR search: `allowedIdentityProvidersForApprovers checkApprovalAuthorization identity_provider_name` -> no matches
- Open PR search: `approver IDP approval caller identity_provider_name` -> no matches
- Closed PR search: `allowedIdentityProvidersForApprovers checkApprovalAuthorization identity_provider_name` -> no matches
- Related open PRs #840, #848, and #858 were checked; they do not enforce the caller's authenticated approver IDP.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -run 'TestApprovalAuthorization_AllowedIdentityProvidersForApprovers' -count=1 -timeout=240s`
- `GOCACHE=/private/tmp/k8s-breakglass-go-build-cache go test ./pkg/breakglass -count=1 -timeout=240s`
- `git diff --check`

## UI Screenshots
Not applicable. This PR changes backend authorization, backend tests, and docs only.

## Evidence / duplicate check

Refresh before PR body update on 2026-06-27:
- Target verified: `gh repo view telekom/k8s-breakglass --json nameWithOwner,isFork,defaultBranchRef,url` -> `telekom/k8s-breakglass`, `isFork=false`, default branch `main`, URL `https://github.com/telekom/k8s-breakglass`.
- PR target verified: `gh api repos/telekom/k8s-breakglass/pulls/860` -> base `telekom/k8s-breakglass:main`, head `telekom/k8s-breakglass:codex/approver-idp-authorization`.
- Head-branch duplicate search: `gh pr list --repo telekom/k8s-breakglass --state open --search "head:codex/approver-idp-authorization"` -> #860.
- Open duplicate search: `gh search prs --repo telekom/k8s-breakglass "enforce approver identity providers" --state open` -> #860.
- Recently merged duplicate search: `gh search prs --repo telekom/k8s-breakglass "enforce approver identity providers updated:>=2026-06-13" --merged` -> none.

