### PR TITLE
fix: match owner actions by auth identifiers

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -401,6 +401,7 @@ Authorization: Bearer <token>
 **Status Code:** `200 OK`
 
 **Authorization:** Approvers can reject any pending request. Session requesters can also reject their own pending requests.
+Requester ownership is matched against the authenticated email, `preferred_username`, or subject claim so sessions created with a non-email `userIdentifierClaim` remain manageable by their owner.
 Approver authorization is checked before request-body validation and
 state-specific responses; unrelated callers receive only authorization errors.
 
@@ -523,7 +524,7 @@ This action does not accept a request body. Non-empty bodies return `400 Bad Req
 
 **Status Code:** `200 OK`
 
-**Authorization:** Only the session requester can withdraw a pending request
+**Authorization:** Only the session requester can withdraw a pending request. Requester ownership is matched against the authenticated email, `preferred_username`, or subject claim so sessions created with a non-email `userIdentifierClaim` remain manageable by their owner.
 
 **Response:** Complete updated `BreakglassSession` resource with withdrawn status:
 
@@ -583,6 +584,8 @@ This action does not accept a request body. Non-empty bodies return `400 Bad Req
 
 - **Session owner/requester**: Can drop pending, approved scheduled, or active
   non-terminal sessions
+
+Requester/owner matching uses the authenticated email, `preferred_username`, or subject claim so sessions created with a non-email `userIdentifierClaim` remain manageable by their owner.
 
 Terminal sessions (`Rejected`, `Withdrawn`, `Expired`, `IdleExpired`, `ApprovalTimeout`)
 return `400 Bad Request` and are not modified.

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -19,6 +19,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func (wc *BreakglassSessionController) authenticatedUserIdentifiers(c *gin.Context) (string, []string, error) {
+	email, err := wc.identityProvider.GetEmail(c)
+	if err != nil {
+		return "", nil, err
+	}
+	username := wc.identityProvider.GetUsername(c)
+	userID := wc.identityProvider.GetIdentity(c)
+	return firstNonEmpty(email, username, userID), collectAuthIdentifiers(email, username, userID), nil
+}
+
 // handleWithdrawMyRequest allows the session requester to withdraw their own pending request
 func (wc *BreakglassSessionController) handleWithdrawMyRequest(c *gin.Context) {
 	reqLog := system.GetReqLogger(c, wc.log)
@@ -37,13 +47,13 @@ func (wc *BreakglassSessionController) handleWithdrawMyRequest(c *gin.Context) {
 	}
 
 	// Only allow the original requester to withdraw
-	requesterEmail, err := wc.identityProvider.GetEmail(c)
+	requester, authIdentifiers, err := wc.authenticatedUserIdentifiers(c)
 	if err != nil {
 		reqLog.Error("error getting user identity email", zap.Error(err))
 		apiresponses.RespondInternalError(c, "extract email from token", err, reqLog)
 		return
 	}
-	if bs.Spec.User != requesterEmail {
+	if !matchesAuthIdentifier(bs.Spec.User, authIdentifiers) {
 		// User is authenticated but not the session owner - return 403 Forbidden
 		apiresponses.RespondForbidden(c, "only the session requester can withdraw")
 		return
@@ -94,7 +104,7 @@ func (wc *BreakglassSessionController) handleWithdrawMyRequest(c *gin.Context) {
 	}
 
 	// Emit audit event for session withdrawal by requester
-	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionWithdrawn, &bs, requesterEmail, "Session withdrawn by requester")
+	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionWithdrawn, &bs, requester, "Session withdrawn by requester")
 
 	c.JSON(http.StatusOK, bs)
 }
@@ -118,13 +128,13 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 	}
 
 	// Only allow the original requester to drop
-	requesterEmail, err := wc.identityProvider.GetEmail(c)
+	requester, authIdentifiers, err := wc.authenticatedUserIdentifiers(c)
 	if err != nil {
 		reqLog.Error("error getting user identity email", zap.Error(err))
 		apiresponses.RespondInternalError(c, "extract email from token", err, reqLog)
 		return
 	}
-	if bs.Spec.User != requesterEmail {
+	if !matchesAuthIdentifier(bs.Spec.User, authIdentifiers) {
 		// User is authenticated but not the session owner - return 403 Forbidden
 		apiresponses.RespondForbidden(c, "only the session requester can drop")
 		return
@@ -193,7 +203,7 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 	}
 
 	// Emit audit event for session dropped by owner
-	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionDropped, &bs, requesterEmail, "Session dropped by owner")
+	wc.emitSessionAuditEvent(c.Request.Context(), audit.EventSessionDropped, &bs, requester, "Session dropped by owner")
 
 	c.JSON(http.StatusOK, bs)
 }

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -2,6 +2,7 @@ package breakglass
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,14 +20,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var errAuthenticatedIdentityNotFound = errors.New("authenticated identity claims not found in token")
+
 func (wc *BreakglassSessionController) authenticatedUserIdentifiers(c *gin.Context) (string, []string, error) {
-	email, err := wc.identityProvider.GetEmail(c)
-	username := wc.identityProvider.GetUsername(c)
-	userID := wc.identityProvider.GetIdentity(c)
-	if err != nil && username == "" && userID == "" {
-		return "", nil, err
+	email := c.GetString("email")
+	username := c.GetString("username")
+	userID := c.GetString("user_id")
+	authIdentifiers := collectAuthIdentifiers(email, username, userID)
+	if len(authIdentifiers) == 0 {
+		return "", nil, errAuthenticatedIdentityNotFound
 	}
-	return firstNonEmpty(email, username, userID), collectAuthIdentifiers(email, username, userID), nil
+	return firstNonEmpty(email, username, userID), authIdentifiers, nil
 }
 
 // handleWithdrawMyRequest allows the session requester to withdraw their own pending request
@@ -49,8 +53,12 @@ func (wc *BreakglassSessionController) handleWithdrawMyRequest(c *gin.Context) {
 	// Only allow the original requester to withdraw
 	requester, authIdentifiers, err := wc.authenticatedUserIdentifiers(c)
 	if err != nil {
-		reqLog.Error("error getting user identity email", zap.Error(err))
-		apiresponses.RespondInternalError(c, "extract email from token", err, reqLog)
+		reqLog.Error("error getting authenticated user identifiers", zap.Error(err))
+		if errors.Is(err, errAuthenticatedIdentityNotFound) {
+			apiresponses.RespondUnauthorizedWithMessage(c, "authenticated identity claims not found in token")
+			return
+		}
+		apiresponses.RespondInternalError(c, "extract authenticated user identifiers from token", err, reqLog)
 		return
 	}
 	if !matchesAuthIdentifier(bs.Spec.User, authIdentifiers) {
@@ -130,8 +138,12 @@ func (wc *BreakglassSessionController) handleDropMySession(c *gin.Context) {
 	// Only allow the original requester to drop
 	requester, authIdentifiers, err := wc.authenticatedUserIdentifiers(c)
 	if err != nil {
-		reqLog.Error("error getting user identity email", zap.Error(err))
-		apiresponses.RespondInternalError(c, "extract email from token", err, reqLog)
+		reqLog.Error("error getting authenticated user identifiers", zap.Error(err))
+		if errors.Is(err, errAuthenticatedIdentityNotFound) {
+			apiresponses.RespondUnauthorizedWithMessage(c, "authenticated identity claims not found in token")
+			return
+		}
+		apiresponses.RespondInternalError(c, "extract authenticated user identifiers from token", err, reqLog)
 		return
 	}
 	if !matchesAuthIdentifier(bs.Spec.User, authIdentifiers) {

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -21,11 +21,11 @@ import (
 
 func (wc *BreakglassSessionController) authenticatedUserIdentifiers(c *gin.Context) (string, []string, error) {
 	email, err := wc.identityProvider.GetEmail(c)
-	if err != nil {
-		return "", nil, err
-	}
 	username := wc.identityProvider.GetUsername(c)
 	userID := wc.identityProvider.GetIdentity(c)
+	if err != nil && username == "" && userID == "" {
+		return "", nil, err
+	}
 	return firstNonEmpty(email, username, userID), collectAuthIdentifiers(email, username, userID), nil
 }
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -243,8 +243,7 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		bs.Status.RetainedUntil = metav1.NewTime(time.Now().UTC().Add(retainFor))
 
 		// record approver (rejector)
-		rejectorEmail := c.GetString("email")
-		rejector := firstNonEmpty(rejectorEmail, authenticatedActor)
+		rejector := authenticatedActor
 		if rejector != "" {
 			bs.Status.Approver = rejector
 			bs.Status.Approvers = addIfNotPresent(bs.Status.Approvers, rejector)

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -45,8 +45,8 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	// terminal-state or malformed-body errors.
 	allowOwnerReject := false
 	if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
-		if requesterEmail, err := wc.identityProvider.GetEmail(c); err == nil {
-			if requesterEmail == bs.Spec.User && IsSessionPendingApproval(bs) {
+		if _, authIdentifiers, err := wc.authenticatedUserIdentifiers(c); err == nil {
+			if matchesAuthIdentifier(bs.Spec.User, authIdentifiers) && IsSessionPendingApproval(bs) {
 				allowOwnerReject = true
 			}
 		}

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -44,8 +44,10 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	// responses so unauthorized callers cannot learn session details from
 	// terminal-state or malformed-body errors.
 	allowOwnerReject := false
+	authenticatedActor := ""
 	if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
-		if _, authIdentifiers, err := wc.authenticatedUserIdentifiers(c); err == nil {
+		if actor, authIdentifiers, err := wc.authenticatedUserIdentifiers(c); err == nil {
+			authenticatedActor = actor
 			if matchesAuthIdentifier(bs.Spec.User, authIdentifiers) && IsSessionPendingApproval(bs) {
 				allowOwnerReject = true
 			}
@@ -219,10 +221,11 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		}
 		// record approver
 		approverEmail, _ := wc.identityProvider.GetEmail(c)
-		if approverEmail != "" {
-			bs.Status.Approver = approverEmail
+		approver := firstNonEmpty(approverEmail, authenticatedActor)
+		if approver != "" {
+			bs.Status.Approver = approver
 			// append to approvers history if not already present
-			bs.Status.Approvers = addIfNotPresent(bs.Status.Approvers, approverEmail)
+			bs.Status.Approvers = addIfNotPresent(bs.Status.Approvers, approver)
 		}
 		// store approver reason if provided
 		if strings.TrimSpace(approverPayload.Reason) != "" {
@@ -240,10 +243,11 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		bs.Status.RetainedUntil = metav1.NewTime(time.Now().UTC().Add(retainFor))
 
 		// record approver (rejector)
-		rejectorEmail, _ := wc.identityProvider.GetEmail(c)
-		if rejectorEmail != "" {
-			bs.Status.Approver = rejectorEmail
-			bs.Status.Approvers = addIfNotPresent(bs.Status.Approvers, rejectorEmail)
+		rejectorEmail := c.GetString("email")
+		rejector := firstNonEmpty(rejectorEmail, authenticatedActor)
+		if rejector != "" {
+			bs.Status.Approver = rejector
+			bs.Status.Approvers = addIfNotPresent(bs.Status.Approvers, rejector)
 		}
 		// store approver reason if provided
 		if strings.TrimSpace(approverPayload.Reason) != "" {
@@ -259,7 +263,8 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		return
 	}
 
-	username, _ := wc.identityProvider.GetEmail(c)
+	username := c.GetString("email")
+	username = firstNonEmpty(username, authenticatedActor)
 	bs.SetCondition(metav1.Condition{
 		Type:               string(sesCondition),
 		Status:             metav1.ConditionTrue,
@@ -283,10 +288,11 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	// Get approver identity for audit events
 	approver := wc.identityProvider.GetUsername(c)
 	if approver == "" {
-		if email, err := wc.identityProvider.GetEmail(c); err == nil {
+		if email := c.GetString("email"); email != "" {
 			approver = email
 		}
 	}
+	approver = firstNonEmpty(approver, authenticatedActor)
 
 	// Track metrics for session lifecycle events
 	switch sesCondition {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -3144,6 +3144,90 @@ func TestDropTerminalSessionRejected(t *testing.T) {
 	}
 }
 
+func TestOwnerActionsMatchAlternateAuthIdentifiers(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+
+	approvedAt := metav1.NewTime(time.Now().Add(-time.Minute))
+	withdrawByUsername := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner-username-withdraw"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-a",
+			User:         "owner-username",
+			GrantedGroup: "g",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	dropByUsername := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner-username-drop"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-a",
+			User:         "owner-username",
+			GrantedGroup: "g",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:      breakglassv1alpha1.SessionStateApproved,
+			ApprovedAt: approvedAt,
+		},
+	}
+	rejectBySubject := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner-subject-reject"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-a",
+			User:         "owner-subject",
+			GrantedGroup: "g",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+
+	cli := builder.WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		WithObjects(withdrawByUsername, dropByUsername, rejectBySubject).
+		Build()
+	ss := SessionManager{Client: cli}
+	es := testEscalationLookup{Client: cli}
+
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &ss, &es, func(c *gin.Context) {
+		c.Set("email", "owner@example.com")
+		c.Set("username", "owner-username")
+		c.Set("user_id", "owner-subject")
+		c.Next()
+	}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/owner-username-withdraw/withdraw", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	var got breakglassv1alpha1.BreakglassSession
+	require.NoError(t, ss.Get(context.Background(), client.ObjectKey{Name: "owner-username-withdraw"}, &got))
+	require.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, got.Status.State)
+
+	req, _ = http.NewRequest(http.MethodPost, "/breakglassSessions/owner-username-drop/drop", nil)
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	require.NoError(t, ss.Get(context.Background(), client.ObjectKey{Name: "owner-username-drop"}, &got))
+	require.Equal(t, breakglassv1alpha1.SessionStateExpired, got.Status.State)
+
+	req, _ = http.NewRequest(http.MethodPost, "/breakglassSessions/owner-subject-reject/reject", nil)
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	require.NoError(t, ss.Get(context.Background(), client.ObjectKey{Name: "owner-subject-reject"}, &got))
+	require.Equal(t, breakglassv1alpha1.SessionStateRejected, got.Status.State)
+}
+
 // TestApproverCancelRunningSession verifies that an approver can cancel a running session
 // and that a non-approver is forbidden to do so.
 // TestApproverCancelRunningSession

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -4845,6 +4845,139 @@ func (e ErrIdentityProvider) GetUserIdentifier(c *gin.Context, claimType breakgl
 	return "", fmt.Errorf("simulated idp error")
 }
 
+type failOnEmailIdentityProvider struct {
+	t *testing.T
+}
+
+func (p failOnEmailIdentityProvider) GetEmail(c *gin.Context) (string, error) {
+	p.t.Fatal("GetEmail must not be called when alternate authenticated identifiers are present")
+	return "", nil
+}
+func (p failOnEmailIdentityProvider) GetUsername(c *gin.Context) string { return "" }
+func (p failOnEmailIdentityProvider) GetIdentity(c *gin.Context) string { return "" }
+func (p failOnEmailIdentityProvider) GetUserIdentifier(c *gin.Context, claimType breakglassv1alpha1.UserIdentifierClaimType) (string, error) {
+	return "", fmt.Errorf("simulated idp error")
+}
+
+func TestAuthenticatedUserIdentifiersUsesContextClaimsWithoutEmailLookup(t *testing.T) {
+	ctrl := &BreakglassSessionController{
+		identityProvider: failOnEmailIdentityProvider{t: t},
+	}
+
+	t.Run("username and subject without email", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set("username", "owner-username")
+		c.Set("user_id", "owner-subject")
+
+		requester, identifiers, err := ctrl.authenticatedUserIdentifiers(c)
+
+		require.NoError(t, err)
+		require.Equal(t, "owner-username", requester)
+		require.Equal(t, []string{"owner-username", "owner-subject"}, identifiers)
+	})
+
+	t.Run("no authenticated identifiers", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+		requester, identifiers, err := ctrl.authenticatedUserIdentifiers(c)
+
+		require.ErrorIs(t, err, errAuthenticatedIdentityNotFound)
+		require.Empty(t, requester)
+		require.Nil(t, identifiers)
+	})
+}
+
+func TestRequesterActionsReturnUnauthorizedWhenIdentityMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "withdraw", path: "withdraw"},
+		{name: "drop", path: "drop"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(Scheme)
+			for index, fn := range sessionIndexFunctions {
+				builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+			}
+			session := &breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.name + "-missing-identity"},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster:      "identity-cluster",
+					User:         "owner@example.com",
+					GrantedGroup: "breakglass-admin",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+			}
+			cli := builder.WithObjects(session).WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).Build()
+			sesmanager := SessionManager{Client: cli}
+			escmanager := testEscalationLookup{Client: cli}
+			logger, _ := zap.NewDevelopment()
+			ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
+				c.Next()
+			}, "/config/config.yaml", nil, cli)
+
+			engine := gin.New()
+			_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+			req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/breakglassSessions/%s/%s", session.Name, tc.path), nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+			require.Contains(t, w.Body.String(), "authenticated identity claims")
+		})
+	}
+}
+
+func TestOwnerRejectRecordsSubjectActorWhenEmailAndUsernameMissing(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "subject-owner-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "subject-cluster",
+			User:         "owner-subject",
+			GrantedGroup: "breakglass-admin",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+	}
+	cli := builder.WithObjects(session).WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	mockAudit := NewMockAuditEmitter(true)
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, func(c *gin.Context) {
+		c.Set("user_id", "owner-subject")
+		c.Next()
+	}, "/config/config.yaml", nil, cli).WithAuditService(mockAudit)
+
+	engine := gin.New()
+	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+	req, _ := http.NewRequest(http.MethodPost, "/breakglassSessions/subject-owner-session/reject", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	var got breakglassv1alpha1.BreakglassSession
+	require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&got))
+	require.Equal(t, breakglassv1alpha1.SessionStateRejected, got.Status.State)
+	require.Equal(t, "owner-subject", got.Status.Approver)
+	require.Contains(t, got.Status.Approvers, "owner-subject")
+	require.NotEmpty(t, got.Status.Conditions)
+	require.Contains(t, got.Status.Conditions[len(got.Status.Conditions)-1].Message, "owner-subject")
+
+	events := mockAudit.GetEvents()
+	require.Len(t, events, 1)
+	require.Equal(t, audit.EventSessionDenied, events[0].Type)
+	require.Equal(t, "owner-subject", events[0].Actor.User)
+}
+
 // Test that when identity provider fails to return email and mine=true is requested,
 // the handler returns HTTP 500.
 func TestGetSessions_IdentityProviderErrorReturns500(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -3190,7 +3190,6 @@ func TestOwnerActionsMatchAlternateAuthIdentifiers(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &ss, &es, func(c *gin.Context) {
-		c.Set("email", "owner@example.com")
 		c.Set("username", "owner-username")
 		c.Set("user_id", "owner-subject")
 		c.Next()


### PR DESCRIPTION
## Summary
- Match BreakglassSession requester-owned `withdraw`, `drop`, and owner-`reject` actions against all authenticated identity claims (`email`, `preferred_username`, and `sub`) instead of email only.
- Preserve existing email behavior and audit actor recording while allowing sessions whose `spec.user` was created from a non-email `userIdentifierClaim` to remain manageable by their owner.
- Allow owner actions to proceed when the email claim is absent but `preferred_username` or `sub` is present and matches the session owner.
- Add regression coverage for withdraw/drop by `preferred_username` and owner-reject by subject claim, including the missing-email claim path.
- Update API docs and changelog for the ownership matching behavior.

## Evidence / duplicate check

The list/detail paths already use `collectAuthIdentifiers` + `matchesAuthIdentifier`, but owner lifecycle actions still compared `bs.Spec.User != requesterEmail` or `requesterEmail == bs.Spec.User`. A session created with `ClusterConfig.spec.userIdentifierClaim: preferred_username` or `sub` could be visible as the owner's session but could not be withdrawn, dropped, or self-rejected by the same authenticated user.

Duplicate check before implementation:
- `gh search prs --repo telekom/k8s-breakglass "owner withdraw drop preferred_username spec.user" --state open` -> no matches
- `gh search prs --repo telekom/k8s-breakglass "session owner identity email username subject" --state open` -> no matches
- `gh search prs --repo telekom/k8s-breakglass "drop withdraw reject requester identity" --state open` -> no matches

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-owner-action-cache go test ./pkg/breakglass -run 'Test(WithdrawMyRequest_Scenarios|DropApprovedSessionExpires|DropTerminalSessionRejected|OwnerCanRejectPendingSession|OwnerActionsMatchAlternateAuthIdentifiers|MatchesAuthIdentifier)$' -count=1 -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-owner-action-cache go test ./pkg/breakglass -run 'Test(OwnerActionsMatchAlternateAuthIdentifiers|WithdrawMyRequest_Scenarios|DropApprovedSessionExpires|OwnerCanRejectPendingSession)$' -count=1 -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-owner-action-cache go test ./pkg/breakglass -count=1 -timeout=240s`
- `git -c core.fsmonitor=false diff --check`

No UI changed; screenshots are not applicable.
