### PR TITLE
fix: match debug approvers by email

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1327,7 +1327,7 @@ options are omitted.
 | `clusters[].approval` | object | Approval requirements |
 | `clusters[].approval.required` | boolean | Whether the session requires approval |
 | `clusters[].approval.approverGroups` | string[] | Groups that can approve sessions |
-| `clusters[].approval.approverUsers` | string[] | Individual users that can approve sessions |
+| `clusters[].approval.approverUsers` | string[] | Individual users that can approve sessions; matched against username and email claims |
 | `clusters[].approval.canAutoApprove` | boolean | Whether the requesting user qualifies for auto-approval |
 | `clusters[].status` | object | Cluster health status |
 

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -191,6 +191,10 @@ approvers:
 autoApprove: false  # Require manual approval
 ```
 
+Entries in `approvers.users` are matched against the authenticated approver's
+username and email claims. This allows templates and bindings to list email
+addresses even when the OIDC `preferred_username` claim is an opaque subject.
+
 ### impersonation
 
 Configure ServiceAccount impersonation:

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -194,6 +194,9 @@ autoApprove: false  # Require manual approval
 Entries in `approvers.users` are matched against the authenticated approver's
 username and email claims. This allows templates and bindings to list email
 addresses even when the OIDC `preferred_username` claim is an opaque subject.
+Exact entries are trimmed and matched case-insensitively. Entries containing
+glob metacharacters (`*`, `?`, or `[]`) are trimmed and matched with
+case-sensitive glob semantics.
 
 ### impersonation
 

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -412,11 +412,17 @@ func debugSessionGroupsFromContext(groupsValue interface{}) []string {
 }
 
 func debugSessionIdentityMatches(identity debugSessionReadIdentity, values ...string) bool {
+	username := strings.TrimSpace(identity.username)
+	email := strings.TrimSpace(identity.email)
 	for _, value := range values {
+		value = strings.TrimSpace(value)
 		if value == "" {
 			continue
 		}
-		if value == identity.username || (identity.email != "" && value == identity.email) {
+		if username != "" && strings.EqualFold(value, username) {
+			return true
+		}
+		if email != "" && strings.EqualFold(value, email) {
 			return true
 		}
 	}
@@ -1378,13 +1384,7 @@ func (a *debugSessionReadAuthorizer) isExplicitDebugSessionApprover(ctx context.
 }
 
 func (a *debugSessionReadAuthorizer) approverAuthorizationMatches(approvers *breakglassv1alpha1.DebugSessionApprovers) bool {
-	identity := a.identity
-	if a.controller.checkApproverAuthorization(approvers, identity.username, identity.groups) {
-		return true
-	}
-	return identity.email != "" &&
-		identity.email != identity.username &&
-		a.controller.checkApproverAuthorization(approvers, identity.email, identity.groups)
+	return a.controller.checkApproverAuthorizationForIdentity(approvers, a.identity)
 }
 
 func (a *debugSessionReadAuthorizer) readApproversFromBinding(ctx context.Context, session *breakglassv1alpha1.DebugSession) (*breakglassv1alpha1.DebugSessionApprovers, error) {

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -987,10 +987,11 @@ func TestCheckApproverAuthorization_GlobUserMatchKeepsPatternSemantics(t *testin
 	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
 
 	approvers := &breakglassv1alpha1.DebugSessionApprovers{
-		Users: []string{"*@Example.COM"},
+		Users: []string{" *@Example.COM "},
 	}
 
 	assert.True(t, ctrl.checkApproverAuthorization(approvers, "approver@Example.COM", nil))
+	assert.True(t, ctrl.checkApproverAuthorization(approvers, " approver@Example.COM ", nil))
 	assert.False(t, ctrl.checkApproverAuthorization(approvers, "approver@example.com", nil))
 }
 

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -832,6 +832,96 @@ func TestIsUserAuthorizedToApprove_GroupsAsInterfaceSlice(t *testing.T) {
 	assert.True(t, result, "should handle []interface{} groups")
 }
 
+func TestIsIdentityAuthorizedToApprove_EmailListedApprover(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "email-approver-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:       "test",
+			RequestedBy:       "requester-subject",
+			RequestedByEmail:  "requester@example.com",
+			TargetNamespace:   "default",
+			RequestedDuration: "30m",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+		},
+	}
+
+	result := ctrl.isIdentityAuthorizedToApprove(context.Background(), session, debugSessionReadIdentity{
+		username: "opaque-approver-subject",
+		email:    "approver@example.com",
+	})
+	assert.True(t, result, "email-listed approver should be authorized when username differs")
+}
+
+func TestIsIdentityAuthorizedToApprove_BlocksSelfApprovalByEmail(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "self-email-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:       "test",
+			RequestedBy:       "requester-subject",
+			RequestedByEmail:  "requester@example.com",
+			TargetNamespace:   "default",
+			RequestedDuration: "30m",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"requester@example.com"},
+				},
+			},
+		},
+	}
+
+	result := ctrl.isIdentityAuthorizedToApprove(context.Background(), session, debugSessionReadIdentity{
+		username: "opaque-requester-subject",
+		email:    "requester@example.com",
+	})
+	assert.False(t, result, "requester should not self-approve through email-listed approver match")
+}
+
+func TestIsIdentityAuthorizedToApprove_BlocksSelfApprovalByEmailCaseInsensitive(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "self-email-case-session"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			TemplateRef:       "test",
+			RequestedBy:       "requester-subject",
+			RequestedByEmail:  " requester@example.com ",
+			TargetNamespace:   "default",
+			RequestedDuration: "30m",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"REQUESTER@EXAMPLE.COM"},
+				},
+			},
+		},
+	}
+
+	result := ctrl.isIdentityAuthorizedToApprove(context.Background(), session, debugSessionReadIdentity{
+		username: "opaque-requester-subject",
+		email:    "Requester@Example.com",
+	})
+	assert.False(t, result, "requester email self-approval should be blocked despite casing or surrounding whitespace")
+}
+
 func TestIsUserAuthorizedToApprove_EmptyApproversAllowsAll(t *testing.T) {
 	// When approvers has empty users and groups, allow any authenticated user
 

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -967,6 +967,33 @@ func TestCheckApproverAuthorization_DirectUserMatch(t *testing.T) {
 	assert.False(t, ctrl.checkApproverAuthorization(approvers, "user3@example.com", nil))
 }
 
+func TestCheckApproverAuthorization_DirectUserMatchNormalizesExactEntries(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	approvers := &breakglassv1alpha1.DebugSessionApprovers{
+		Users: []string{" Approver@Example.COM "},
+	}
+
+	assert.True(t, ctrl.checkApproverAuthorization(approvers, "approver@example.com", nil))
+	assert.True(t, ctrl.checkApproverAuthorization(approvers, " APPROVER@example.com ", nil))
+	assert.False(t, ctrl.checkApproverAuthorization(approvers, "other@example.com", nil))
+}
+
+func TestCheckApproverAuthorization_GlobUserMatchKeepsPatternSemantics(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+	approvers := &breakglassv1alpha1.DebugSessionApprovers{
+		Users: []string{"*@Example.COM"},
+	}
+
+	assert.True(t, ctrl.checkApproverAuthorization(approvers, "approver@Example.COM", nil))
+	assert.False(t, ctrl.checkApproverAuthorization(approvers, "approver@example.com", nil))
+}
+
 func TestCheckApproverAuthorization_DirectGroupMatch(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -644,7 +644,7 @@ func (c *DebugSessionAPIController) checkApproverAuthorizationForIdentity(
 		return true
 	}
 	return identity.email != "" &&
-		!strings.EqualFold(strings.TrimSpace(identity.email), strings.TrimSpace(identity.username)) &&
+		strings.TrimSpace(identity.email) != strings.TrimSpace(identity.username) &&
 		c.checkApproverAuthorization(approvers, identity.email, identity.groups)
 }
 

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -686,7 +686,7 @@ func (c *DebugSessionAPIController) canActOnDebugSessionApproval(
 func (c *DebugSessionAPIController) checkApproverAuthorization(approvers *breakglassv1alpha1.DebugSessionApprovers, username string, userGroupsInterface interface{}) bool {
 	// Check if user is in allowed users list
 	for _, allowedUser := range approvers.Users {
-		if matchPattern(allowedUser, username) {
+		if matchApproverUser(allowedUser, username) {
 			return true
 		}
 	}
@@ -720,6 +720,13 @@ func (c *DebugSessionAPIController) checkApproverAuthorization(approvers *breakg
 	}
 
 	return false
+}
+
+func matchApproverUser(pattern, username string) bool {
+	if strings.ContainsAny(pattern, "*?[") {
+		return matchPattern(pattern, username)
+	}
+	return strings.EqualFold(strings.TrimSpace(pattern), strings.TrimSpace(username))
 }
 
 // matchPattern checks if a string matches a glob pattern.

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -554,19 +554,27 @@ func (c *DebugSessionAPIController) newDebugSessionApprovalAuthorizer() *debugSe
 // The user must be in one of the approver groups/users defined in the session's template or binding.
 // Additionally, the requester of the session is not allowed to self-approve.
 func (c *DebugSessionAPIController) isUserAuthorizedToApprove(ctx context.Context, session *breakglassv1alpha1.DebugSession, username string, userGroupsInterface interface{}) bool {
-	return c.newDebugSessionApprovalAuthorizer().isUserIdentityAuthorizedToApprove(ctx, session, username, "", userGroupsInterface)
+	return c.isUserIdentityAuthorizedToApprove(ctx, session, username, "", userGroupsInterface)
 }
 
 func (c *DebugSessionAPIController) isUserIdentityAuthorizedToApprove(ctx context.Context, session *breakglassv1alpha1.DebugSession, username, email string, userGroupsInterface interface{}) bool {
-	return c.newDebugSessionApprovalAuthorizer().isUserIdentityAuthorizedToApprove(ctx, session, username, email, userGroupsInterface)
+	return c.newDebugSessionApprovalAuthorizer().isIdentityAuthorizedToApprove(ctx, session, debugSessionReadIdentity{
+		username: username,
+		email:    email,
+		groups:   debugSessionGroupsFromContext(userGroupsInterface),
+	})
 }
 
-func (a *debugSessionApprovalAuthorizer) isUserIdentityAuthorizedToApprove(ctx context.Context, session *breakglassv1alpha1.DebugSession, username, email string, userGroupsInterface interface{}) bool {
+func (c *DebugSessionAPIController) isIdentityAuthorizedToApprove(ctx context.Context, session *breakglassv1alpha1.DebugSession, identity debugSessionReadIdentity) bool {
+	return c.newDebugSessionApprovalAuthorizer().isIdentityAuthorizedToApprove(ctx, session, identity)
+}
+
+func (a *debugSessionApprovalAuthorizer) isIdentityAuthorizedToApprove(ctx context.Context, session *breakglassv1alpha1.DebugSession, identity debugSessionReadIdentity) bool {
 	c := a.controller
 	// Block self-approval: the user who requested the session cannot approve it
-	if debugSessionRequesterMatches(session, username, email) {
+	if debugSessionIdentityMatches(identity, session.Spec.RequestedBy, session.Spec.RequestedByEmail) {
 		c.log.Infow("Blocking self-approval attempt",
-			"session", session.Name, "requester", session.Spec.RequestedBy, "requesterEmail", session.Spec.RequestedByEmail, "approver", username, "approverEmail", email)
+			"session", session.Name, "requester", session.Spec.RequestedBy, "requesterEmail", session.Spec.RequestedByEmail, "approver", identity.username, "approverEmail", identity.email)
 		return false
 	}
 
@@ -587,7 +595,7 @@ func (a *debugSessionApprovalAuthorizer) isUserIdentityAuthorizedToApprove(ctx c
 			return false
 		}
 		if debugSessionApproversConfigured(binding.Spec.Approvers) {
-			return c.checkApproverIdentityAuthorization(binding.Spec.Approvers, username, email, userGroupsInterface)
+			return c.checkApproverAuthorizationForIdentity(binding.Spec.Approvers, identity)
 		}
 	}
 
@@ -607,11 +615,11 @@ func (a *debugSessionApprovalAuthorizer) isUserIdentityAuthorizedToApprove(ctx c
 			return true
 		}
 
-		return c.checkApproverIdentityAuthorization(template.Spec.Approvers, username, email, userGroupsInterface)
+		return c.checkApproverAuthorizationForIdentity(template.Spec.Approvers, identity)
 	}
 
 	// Use resolved template from status
-	return c.checkApproverIdentityAuthorization(session.Status.ResolvedTemplate.Approvers, username, email, userGroupsInterface)
+	return c.checkApproverAuthorizationForIdentity(session.Status.ResolvedTemplate.Approvers, identity)
 }
 
 func (a *debugSessionApprovalAuthorizer) getBinding(ctx context.Context, key ctrlclient.ObjectKey) (*breakglassv1alpha1.DebugSessionClusterBinding, error) {
@@ -628,32 +636,16 @@ func (a *debugSessionApprovalAuthorizer) getBinding(ctx context.Context, key ctr
 	return binding, nil
 }
 
-func debugSessionRequesterMatches(session *breakglassv1alpha1.DebugSession, username, email string) bool {
-	requesterIDs := []string{session.Spec.RequestedBy, session.Spec.RequestedByEmail}
-	callerIDs := []string{username, email}
-	for _, requesterID := range requesterIDs {
-		requesterID = strings.TrimSpace(requesterID)
-		if requesterID == "" {
-			continue
-		}
-		for _, callerID := range callerIDs {
-			callerID = strings.TrimSpace(callerID)
-			if callerID != "" && strings.EqualFold(requesterID, callerID) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (c *DebugSessionAPIController) checkApproverIdentityAuthorization(approvers *breakglassv1alpha1.DebugSessionApprovers, username, email string, userGroupsInterface interface{}) bool {
-	if c.checkApproverAuthorization(approvers, username, userGroupsInterface) {
+func (c *DebugSessionAPIController) checkApproverAuthorizationForIdentity(
+	approvers *breakglassv1alpha1.DebugSessionApprovers,
+	identity debugSessionReadIdentity,
+) bool {
+	if c.checkApproverAuthorization(approvers, identity.username, identity.groups) {
 		return true
 	}
-	if email == "" || strings.TrimSpace(username) == strings.TrimSpace(email) {
-		return false
-	}
-	return c.checkApproverAuthorization(approvers, email, userGroupsInterface)
+	return identity.email != "" &&
+		strings.TrimSpace(identity.email) != strings.TrimSpace(identity.username) &&
+		c.checkApproverAuthorization(approvers, identity.email, identity.groups)
 }
 
 func (a *debugSessionApprovalAuthorizer) getTemplate(ctx context.Context, name string) (*breakglassv1alpha1.DebugSessionTemplate, error) {
@@ -681,13 +673,13 @@ func (c *DebugSessionAPIController) canActOnDebugSessionApproval(
 	if identity.username == "" {
 		return false
 	}
-	if debugSessionRequesterMatches(session, identity.username, identity.email) {
+	if debugSessionIdentityMatches(identity, session.Spec.RequestedBy, session.Spec.RequestedByEmail) {
 		return false
 	}
 	if authorizer == nil {
 		authorizer = c.newDebugSessionApprovalAuthorizer()
 	}
-	return authorizer.isUserIdentityAuthorizedToApprove(ctx, session, identity.username, identity.email, identity.groups)
+	return authorizer.isIdentityAuthorizedToApprove(ctx, session, identity)
 }
 
 // checkApproverAuthorization checks if user is in the approved users/groups

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -723,10 +723,12 @@ func (c *DebugSessionAPIController) checkApproverAuthorization(approvers *breakg
 }
 
 func matchApproverUser(pattern, username string) bool {
+	pattern = strings.TrimSpace(pattern)
+	username = strings.TrimSpace(username)
 	if strings.ContainsAny(pattern, "*?[") {
 		return matchPattern(pattern, username)
 	}
-	return strings.EqualFold(strings.TrimSpace(pattern), strings.TrimSpace(username))
+	return strings.EqualFold(pattern, username)
 }
 
 // matchPattern checks if a string matches a glob pattern.

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -644,7 +644,7 @@ func (c *DebugSessionAPIController) checkApproverAuthorizationForIdentity(
 		return true
 	}
 	return identity.email != "" &&
-		strings.TrimSpace(identity.email) != strings.TrimSpace(identity.username) &&
+		!strings.EqualFold(strings.TrimSpace(identity.email), strings.TrimSpace(identity.username)) &&
 		c.checkApproverAuthorization(approvers, identity.email, identity.groups)
 }
 

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -390,10 +390,12 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	username, ok := requireDebugSessionUsername(ctx)
+	identity, ok := debugSessionRequestIdentity(ctx)
 	if !ok {
+		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
+	currentUser := identity.username
 
 	var req ApprovalRequest
 	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
@@ -424,12 +426,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		return
 	}
 	// Check if user is authorized to approve (in allowed approver groups)
-	userGroups, _ := ctx.Get("groups")
-	currentUserEmail := ""
-	if email, exists := ctx.Get("email"); exists && email != nil {
-		currentUserEmail, _ = email.(string)
-	}
-	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
+	if !c.isIdentityAuthorizedToApprove(apiCtx, session, identity) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to approve this session")
 		return
 	}
@@ -440,7 +437,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 
 	timeoutNow := time.Now()
 	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, username, reason, timeoutNow); err != nil {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser, reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return
@@ -469,7 +466,7 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 		existingApproval := *session.Status.Approval
 		approval = &existingApproval
 	}
-	approval.ApprovedBy = username
+	approval.ApprovedBy = currentUser
 	approval.ApprovedAt = &now
 	approval.Reason = req.Reason
 
@@ -484,9 +481,9 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 	c.sendDebugSessionApprovalEmail(apiCtx, session)
 
 	// Emit audit event for session approval
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionStarted, session, username, "Debug session approved")
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionStarted, session, currentUser, "Debug session approved")
 
-	reqLog.Infow("Debug session approved", "session", name, "approver", username)
+	reqLog.Infow("Debug session approved", "session", name, "approver", currentUser)
 	metrics.DebugSessionApproved.WithLabelValues(session.Spec.Cluster, "user").Inc()
 
 	// Return updated session - client expects the session object, not just a message
@@ -499,10 +496,12 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	name := ctx.Param("name")
 	namespaceHint := ctx.Query("namespace")
 
-	username, ok := requireDebugSessionUsername(ctx)
+	identity, ok := debugSessionRequestIdentity(ctx)
 	if !ok {
+		apiresponses.RespondUnauthorized(ctx)
 		return
 	}
+	currentUser := identity.username
 
 	var req ApprovalRequest
 	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
@@ -533,12 +532,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		return
 	}
 	// Check if user is authorized to reject (in allowed approver groups)
-	userGroups, _ := ctx.Get("groups")
-	currentUserEmail := ""
-	if email, exists := ctx.Get("email"); exists && email != nil {
-		currentUserEmail, _ = email.(string)
-	}
-	if !c.isUserIdentityAuthorizedToApprove(apiCtx, session, username, currentUserEmail, userGroups) {
+	if !c.isIdentityAuthorizedToApprove(apiCtx, session, identity) {
 		apiresponses.RespondForbidden(ctx, "user is not authorized to reject this session")
 		return
 	}
@@ -549,7 +543,7 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	timeoutNow := time.Now()
 	if timedOut, reason := debugSessionApprovalTimedOut(session, timeoutNow); timedOut {
-		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, username, reason, timeoutNow); err != nil {
+		if err := c.failTimedOutDebugSessionApproval(apiCtx, session, currentUser, reason, timeoutNow); err != nil {
 			if apierrors.IsConflict(err) {
 				apiresponses.RespondConflict(ctx, "debug session approval has already been decided")
 				return
@@ -580,14 +574,14 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 		existingApproval := *session.Status.Approval
 		approval = &existingApproval
 	}
-	approval.RejectedBy = username
+	approval.RejectedBy = currentUser
 	approval.RejectedAt = &now
 	approval.Reason = sanitizedReason
 
 	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
 		status.Approval = approval
 		status.State = breakglassv1alpha1.DebugSessionStateTerminated
-		status.Message = fmt.Sprintf("Rejected by %s: %s", username, sanitizedReason)
+		status.Message = fmt.Sprintf("Rejected by %s: %s", currentUser, sanitizedReason)
 	}); err != nil {
 		respondDebugSessionStatusPatchError(ctx, reqLog, "reject session", "failed to reject session", name, err)
 		return
@@ -597,9 +591,9 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 	c.sendDebugSessionRejectionEmail(apiCtx, session)
 
 	// Emit audit event for session rejection
-	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, username, fmt.Sprintf("Debug session rejected: %s", req.Reason))
+	c.emitDebugSessionAuditEvent(apiCtx, audit.EventDebugSessionTerminated, session, currentUser, fmt.Sprintf("Debug session rejected: %s", req.Reason))
 
-	reqLog.Infow("Debug session rejected", "session", name, "rejector", username, "reason", req.Reason)
+	reqLog.Infow("Debug session rejected", "session", name, "rejector", currentUser, "reason", req.Reason)
 	metrics.DebugSessionRejected.WithLabelValues(session.Spec.Cluster, "user_rejected").Inc()
 
 	// Return updated session - client expects the session object, not just a message

--- a/pkg/breakglass/debug/debug_session_security_test.go
+++ b/pkg/breakglass/debug/debug_session_security_test.go
@@ -128,6 +128,17 @@ func TestDebugSessionSecurity_ApprovalAuthorization(t *testing.T) {
 		assert.True(t, authorized, "Configured approver email should be checked when username casing differs")
 	})
 
+	t.Run("email glob can approve when username only differs by case", func(t *testing.T) {
+		authorized := controller.checkApproverAuthorizationForIdentity(
+			&breakglassv1alpha1.DebugSessionApprovers{Users: []string{"*@example.com"}},
+			debugSessionReadIdentity{
+				username: "Approver@Example.com",
+				email:    "approver@example.com",
+			},
+		)
+		assert.True(t, authorized, "Email claim should be checked for case-sensitive approver glob patterns")
+	})
+
 	t.Run("unauthorized user cannot approve", func(t *testing.T) {
 		authorized := controller.isUserAuthorizedToApprove(
 			ctx,


### PR DESCRIPTION
## Finding
DebugSession approval authorization was inconsistent with read visibility: `approvers.users` could be matched by email for read access, but approve/reject checked only the authenticated username. In OIDC setups where `preferred_username` is an opaque subject and templates list email addresses, an explicitly listed email approver could see the request but receive 403 when approving or rejecting it.

## Fix
- Reuse a shared identity-aware approver check for read, approve, and reject paths.
- Match `approvers.users` against both username and email claims.
- Keep requester self-approval blocked across both requested-by subject and requested-by email.
- Document the matching behavior and add a changelog entry.

## Duplicate check
- Open PR search for `DebugSession approvers.users email preferred_username approve`: no results.
- Merged PR search for `DebugSession approvers.users email preferred_username approve`: no results.
- Open PR search for `debug session approver email username 403 approve`: no results.
- Merged PR search for `debug session approver email username 403 approve`: only unrelated #403 copy-command UI PR.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-debug-approver-cache go test ./pkg/breakglass/debug -run 'Test(IsIdentityAuthorizedToApprove_EmailListedApprover|IsIdentityAuthorizedToApprove_BlocksSelfApprovalByEmail|IsUserAuthorizedToApprove|CheckApproverAuthorization)' -count=1 -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-debug-approver-cache go test ./pkg/breakglass/debug -count=1 -timeout=240s`
- `git diff --check`

UI screenshots: not applicable, backend/API authorization fix only.
