### PR TITLE
fix: block stale session approval timeouts

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,7 +338,9 @@ learning whether the session is terminal, timed out, or has malformed request
 details.
 
 **Request validation:** `reason` is required when the session's stored
-`approvalReasonConfig.mandatory` is `true`.
+`approvalReasonConfig.mandatory` is `true`. If `status.timeoutAt` has already
+elapsed, approval fails with `400 Bad Request` and the stale pending session is
+left unchanged for cleanup to transition to `ApprovalTimeout`.
 
 If the pending session's approval timeout has already elapsed, the endpoint returns
 `409 Conflict` and leaves the session pending until cleanup records the
@@ -406,7 +408,9 @@ Approver authorization is checked before request-body validation and
 state-specific responses; unrelated callers receive only authorization errors.
 
 **Request validation:** `reason` is required when the session's stored
-`approvalReasonConfig.mandatory` is `true`.
+`approvalReasonConfig.mandatory` is `true`. If `status.timeoutAt` has already
+elapsed, rejection fails with `400 Bad Request` and the stale pending session is
+left unchanged for cleanup to transition to `ApprovalTimeout`.
 
 **Response:** Complete updated `BreakglassSession` resource with rejected status:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -342,10 +342,6 @@ details.
 elapsed, approval fails with `400 Bad Request` and the stale pending session is
 left unchanged for cleanup to transition to `ApprovalTimeout`.
 
-If the pending session's approval timeout has already elapsed, the endpoint returns
-`409 Conflict` and leaves the session pending until cleanup records the
-`ApprovalTimeout` terminal state.
-
 **Response:** Complete updated `BreakglassSession` resource with approved status.
 
 When the approval notification email is successfully enqueued, the response includes an `X-Notification-Sent: true` header.

--- a/pkg/breakglass/session_approval_timeout.go
+++ b/pkg/breakglass/session_approval_timeout.go
@@ -8,6 +8,10 @@ import (
 )
 
 func IsSessionApprovalTimedOut(session breakglassv1alpha1.BreakglassSession) bool {
+	return isSessionApprovalTimedOutAt(session, time.Now())
+}
+
+func isSessionApprovalTimedOutAt(session breakglassv1alpha1.BreakglassSession, now time.Time) bool {
 	// Only Pending sessions can newly time out; all other states are state-machine
 	// outcomes that must not be reclassified by a stale TimeoutAt timestamp.
 	if session.Status.State != breakglassv1alpha1.SessionStatePending {
@@ -18,5 +22,5 @@ func IsSessionApprovalTimedOut(session breakglassv1alpha1.BreakglassSession) boo
 		return false
 	}
 	// Timeout must be set and must have passed
-	return !session.Status.TimeoutAt.IsZero() && time.Now().After(session.Status.TimeoutAt.Time)
+	return !session.Status.TimeoutAt.IsZero() && !now.Before(session.Status.TimeoutAt.Time)
 }

--- a/pkg/breakglass/session_approval_timeout.go
+++ b/pkg/breakglass/session_approval_timeout.go
@@ -1,4 +1,3 @@
-// IsSessionApprovalTimedOut returns true if the session is still pending and TimeoutAt has passed.
 package breakglass
 
 import (
@@ -7,6 +6,7 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
+// IsSessionApprovalTimedOut returns true if the session is still pending and TimeoutAt has passed.
 func IsSessionApprovalTimedOut(session breakglassv1alpha1.BreakglassSession) bool {
 	return isSessionApprovalTimedOutAt(session, time.Now())
 }

--- a/pkg/breakglass/session_approval_timeout.go
+++ b/pkg/breakglass/session_approval_timeout.go
@@ -8,8 +8,9 @@ import (
 )
 
 func IsSessionApprovalTimedOut(session breakglassv1alpha1.BreakglassSession) bool {
-	// If session is already in timeout state, it's not "approval timed out" anymore - it's already timed out
-	if session.Status.State == breakglassv1alpha1.SessionStateTimeout {
+	// Only Pending sessions can newly time out; all other states are state-machine
+	// outcomes that must not be reclassified by a stale TimeoutAt timestamp.
+	if session.Status.State != breakglassv1alpha1.SessionStatePending {
 		return false
 	}
 	// Session must be pending (not approved or rejected)

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -171,21 +171,6 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 		}
 	}
 
-	if sesCondition == breakglassv1alpha1.SessionConditionTypeApproved &&
-		!bs.Status.TimeoutAt.IsZero() &&
-		!time.Now().Before(bs.Status.TimeoutAt.Time) {
-		c.JSON(http.StatusConflict, struct {
-			Error   string                               `json:"error"`
-			Code    string                               `json:"code"`
-			Session breakglassv1alpha1.BreakglassSession `json:"session"`
-		}{
-			Error:   "session approval timeout has elapsed",
-			Code:    "CONFLICT",
-			Session: bs,
-		})
-		return
-	}
-
 	approverReasonAction := "approval"
 	if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
 		approverReasonAction = "rejection"

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -128,6 +128,22 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 	//   because approved sessions may later transition to expired/dropped by owner or canceled by approver.
 	currState := bs.Status.State
 	if sesCondition == breakglassv1alpha1.SessionConditionTypeApproved || sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
+		if IsSessionApprovalTimedOut(bs) {
+			action := "approval"
+			if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
+				action = "rejection"
+			}
+			c.JSON(http.StatusBadRequest, struct {
+				Error   string                               `json:"error"`
+				Code    string                               `json:"code"`
+				Session breakglassv1alpha1.BreakglassSession `json:"session"`
+			}{
+				Error:   fmt.Sprintf("session approval timeout has elapsed; cannot perform %s", action),
+				Code:    "BAD_REQUEST",
+				Session: bs,
+			})
+			return
+		}
 		if currState != breakglassv1alpha1.SessionStatePending {
 			c.JSON(http.StatusBadRequest, struct {
 				Error   string                               `json:"error"`

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -368,6 +368,7 @@ func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 			res := w.Result()
+			defer res.Body.Close()
 			if res.StatusCode != http.StatusBadRequest {
 				t.Fatalf("expected 400 for timed-out pending session, got %d", res.StatusCode)
 			}
@@ -393,6 +394,22 @@ func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("pending_timeout_at_current_instant", func(t *testing.T) {
+		session := breakglassv1alpha1.BreakglassSession{
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStatePending,
+				ApprovedAt: metav1.Time{},
+				RejectedAt: metav1.Time{},
+				TimeoutAt:  metav1.NewTime(now),
+			},
+		}
+
+		result := isSessionApprovalTimedOutAt(session, now)
+		if !result {
+			t.Errorf("expected timeout to be elapsed at the exact timeout instant")
+		}
+	})
 }
 
 // Test that approving a session records the approver email in Status.Approver and
@@ -1691,7 +1708,7 @@ func TestSessionApproveRejectInvalidOptionalBody(t *testing.T) {
 	}
 }
 
-func TestApproveExpiredPendingSessionReturnsConflict(t *testing.T) {
+func TestApproveExpiredPendingSessionReturnsBadRequest(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -291,6 +291,110 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 	}
 }
 
+func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
+	now := time.Now()
+	makeTimedOutSession := func(name string) *breakglassv1alpha1.BreakglassSession {
+		return &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "timeout-cluster",
+				User:         "requester@example.com",
+				GrantedGroup: "breakglass-admin",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStatePending,
+				TimeoutAt: metav1.NewTime(now.Add(-time.Minute)),
+			},
+		}
+	}
+
+	approveSession := makeTimedOutSession("timed-out-approve")
+	rejectSession := makeTimedOutSession("timed-out-reject")
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "timeout-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"timeout-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup: "breakglass-admin",
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Users: []string{"approver@example.com"},
+			},
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.
+		WithObjects(approveSession, rejectSession, escalation).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			if c.Request.Method == http.MethodOptions {
+				c.Next()
+				return
+			}
+			c.Set("email", "approver@example.com")
+			c.Set("username", "Approver")
+			c.Next()
+		}, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+	cases := []struct {
+		name       string
+		session    string
+		actionPath string
+	}{
+		{name: "approve", session: "timed-out-approve", actionPath: "approve"},
+		{name: "reject", session: "timed-out-reject", actionPath: "reject"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost,
+				fmt.Sprintf("/breakglassSessions/%s/%s", tc.session, tc.actionPath),
+				nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+			res := w.Result()
+			if res.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400 for timed-out pending session, got %d", res.StatusCode)
+			}
+			var body struct {
+				Error string `json:"error"`
+			}
+			if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if !strings.Contains(body.Error, "approval timeout") {
+				t.Fatalf("expected timeout error, got %q", body.Error)
+			}
+
+			var got breakglassv1alpha1.BreakglassSession
+			if err := cli.Get(context.Background(), client.ObjectKey{Name: tc.session}, &got); err != nil {
+				t.Fatalf("failed to get session: %v", err)
+			}
+			if got.Status.State != breakglassv1alpha1.SessionStatePending {
+				t.Fatalf("expected stale session to remain pending for cleanup, got %s", got.Status.State)
+			}
+			if !got.Status.ApprovedAt.IsZero() || !got.Status.RejectedAt.IsZero() || got.Status.TimeoutAt.IsZero() {
+				t.Fatalf("expected approve/reject timestamps unchanged, got status %#v", got.Status)
+			}
+		})
+	}
+}
+
 // Test that approving a session records the approver email in Status.Approver and
 // appends it to Status.Approvers, and that rejecting updates the approver and
 // appends the rejector to the history as well.
@@ -1447,6 +1551,7 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
 	}
 
+	futureTimeout := metav1.NewTime(time.Now().UTC().Add(time.Hour))
 	pending := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "pending-1"},
 		Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -1454,7 +1559,7 @@ func TestApproveByNonApprover_ReturnsUnauthorized(t *testing.T) {
 			User:         "requester@example.com",
 			GrantedGroup: "g1",
 		},
-		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending, TimeoutAt: metav1.NewTime(time.Now().UTC().Add(time.Hour)), RetainedUntil: metav1.NewTime(time.Now().UTC().Add(MonthDuration))},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending, TimeoutAt: futureTimeout, RetainedUntil: metav1.NewTime(time.Now().UTC().Add(MonthDuration))},
 	}
 
 	// Escalation exists but approver user is different
@@ -2074,6 +2179,7 @@ func TestApprovalReasonMandatoryEnforced(t *testing.T) {
 			builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
 		}
 
+		futureTimeout := metav1.NewTime(time.Now().UTC().Add(time.Hour))
 		pending := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: sessionName},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -2087,7 +2193,7 @@ func TestApprovalReasonMandatoryEnforced(t *testing.T) {
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:         breakglassv1alpha1.SessionStatePending,
-				TimeoutAt:     metav1.NewTime(time.Now().UTC().Add(time.Hour)),
+				TimeoutAt:     futureTimeout,
 				RetainedUntil: metav1.NewTime(time.Now().UTC().Add(MonthDuration)),
 			},
 		}
@@ -2294,6 +2400,7 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 			}
 
 			// Create a pending session
+			futureTimeout := metav1.NewTime(time.Now().UTC().Add(time.Hour))
 			session := &breakglassv1alpha1.BreakglassSession{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-session", Namespace: esc.Namespace},
 				Spec: breakglassv1alpha1.BreakglassSessionSpec{
@@ -2303,7 +2410,7 @@ func TestApprovalAuthorizationDetailedResponses(t *testing.T) {
 				},
 				Status: breakglassv1alpha1.BreakglassSessionStatus{
 					State:         breakglassv1alpha1.SessionStatePending,
-					TimeoutAt:     metav1.NewTime(time.Now().UTC().Add(time.Hour)),
+					TimeoutAt:     futureTimeout,
 					RetainedUntil: metav1.NewTime(time.Now().UTC().Add(MonthDuration)),
 				},
 			}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1745,7 +1745,7 @@ func TestApproveExpiredPendingSessionReturnsConflict(t *testing.T) {
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusConflict, w.Code)
+	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "approval timeout has elapsed")
 
 	var fetched breakglassv1alpha1.BreakglassSession
@@ -6522,6 +6522,19 @@ func TestIsSessionApprovalTimedOut(t *testing.T) {
 			},
 			expected: false,
 			reason:   "session state is already marked as timeout",
+		},
+		{
+			name: "non_pending_stale_timeout_without_terminal_timestamp",
+			session: breakglassv1alpha1.BreakglassSession{
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+					ApprovedAt: metav1.Time{},
+					RejectedAt: metav1.Time{},
+					TimeoutAt:  metav1.NewTime(now.Add(-1 * time.Hour)),
+				},
+			},
+			expected: false,
+			reason:   "non-pending state must not be reclassified by stale timeout",
 		},
 	}
 

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -293,9 +293,10 @@ func TestRequestApproveRejectGetSession(t *testing.T) {
 
 func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
 	now := time.Now()
+	namespace := "default"
 	makeTimedOutSession := func(name string) *breakglassv1alpha1.BreakglassSession {
 		return &breakglassv1alpha1.BreakglassSession{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster:      "timeout-cluster",
 				User:         "requester@example.com",
@@ -311,7 +312,7 @@ func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
 	approveSession := makeTimedOutSession("timed-out-approve")
 	rejectSession := makeTimedOutSession("timed-out-reject")
 	escalation := &breakglassv1alpha1.BreakglassEscalation{
-		ObjectMeta: metav1.ObjectMeta{Name: "timeout-escalation"},
+		ObjectMeta: metav1.ObjectMeta{Name: "timeout-escalation", Namespace: namespace},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
 				Clusters: []string{"timeout-cluster"},
@@ -383,7 +384,7 @@ func TestApproveRejectTimedOutPendingSessionBlocked(t *testing.T) {
 			}
 
 			var got breakglassv1alpha1.BreakglassSession
-			if err := cli.Get(context.Background(), client.ObjectKey{Name: tc.session}, &got); err != nil {
+			if err := cli.Get(context.Background(), client.ObjectKey{Name: tc.session, Namespace: namespace}, &got); err != nil {
 				t.Fatalf("failed to get session: %v", err)
 			}
 			if got.Status.State != breakglassv1alpha1.SessionStatePending {


### PR DESCRIPTION
## Finding
A `BreakglassSession` can remain in `Pending` after `status.timeoutAt` has elapsed until cleanup processes it. During that window, the approve/reject endpoint only checked `status.state == Pending`, so a late approval could clear `timeoutAt` and revive a request that should have reached `ApprovalTimeout`.

## Fix
- Reject approve/reject actions when a pending session's approval timeout has elapsed.
- Leave the stale session unchanged so cleanup can transition it to `ApprovalTimeout` and emit the existing timeout side effects.
- Update API docs and changelog with the timeout validation behavior.
- Add HTTP-level regression coverage for both approve and reject, plus update unrelated auth/reason fixtures to use future timeouts.

## Duplicate check
- Open PR search for `approval timeout pending approve reject session`: no results.
- Merged PR search for `approval timeout pending approve reject session`: no results.

## Validation
- `GOCACHE=/private/tmp/k8s-breakglass-timeout-guard-cache go test ./pkg/breakglass -run 'Test(ApproveRejectTimedOutPendingSessionBlocked|ApproveByNonApprover_ReturnsUnauthorized|ApprovalReasonMandatoryEnforced|ApprovalAuthorizationDetailedResponses)$' -count=1 -timeout=240s`
- `GOCACHE=/private/tmp/k8s-breakglass-timeout-guard-cache go test ./pkg/breakglass -run '^TestApproveRejectTimedOutPendingSessionBlocked$' -count=1 -timeout=180s`
- `GOCACHE=/private/tmp/k8s-breakglass-timeout-guard-cache go test ./pkg/breakglass -count=1 -timeout=300s`
- `git diff --check`

UI screenshots: not applicable, backend/API lifecycle fix only.
