### PR TITLE
fix: respect session ownership filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.
 - **Scheduled activation stale-state guard**: Scheduled activation now re-reads each waiting session before granting access and skips sessions that already left `WaitingForScheduledTime`, preserving concurrent terminal transitions.
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - **BreakglassSession state filters**: `GET /api/breakglassSessions` now returns `400 Bad Request` for unknown non-empty `state` filter tokens.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -168,7 +168,7 @@ Authorization: Bearer <token>
 | `group` | string | Filter by granted group |
 | `mine` | boolean | Own sessions only (default: `false`; set `true` to include requester-owned sessions). Matches the authenticated user's email, preferred username, or subject/user ID; requests with no usable identity return `401 Unauthorized`. |
 | `approver` | boolean | Sessions user can approve. Defaults to `true` only when neither `mine=true` nor `approvedByMe=true` is requested; set `approver=true` explicitly to combine filters. |
-| `approvedByMe` | boolean | Sessions the user has already approved. Requires an email claim because approval history is stored by approver email; missing email returns `401 Unauthorized`. |
+| `approvedByMe` | boolean | Sessions the caller has already approved. This filter matches the caller's email claim against recorded approver identifiers; missing email returns `401 Unauthorized`. |
 | `activeOnly` | boolean | Only return currently running sessions that are in `Approved` state and granting access; pending approval and scheduled-wait sessions are excluded |
 | `state` | string | Accepts a single value, comma-separated list, or repeated parameter. Supported tokens: `all`, `pending`, `approved`, `active`, `waiting`, `waitingforscheduledtime`, `scheduled`, `rejected`, `withdrawn`, `expired`, `idleexpired`, `timeout`, `approvaltimeout`. The `active` token matches only currently running `Approved` sessions. Unknown non-empty tokens return `400 Bad Request`. |
 | `token` | string | Validate approval-link metadata for a session name. This mode returns metadata for one session instead of the normal session list. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -166,9 +166,9 @@ Authorization: Bearer <token>
 | `cluster` | string | Filter by cluster name |
 | `user` | string | Filter by user |
 | `group` | string | Filter by granted group |
-| `mine` | boolean | Own sessions only (default: `false`; set `true` to include requester-owned sessions) |
-| `approver` | boolean | Sessions user can approve (default: `true`) |
-| `approvedByMe` | boolean | Sessions the user has already approved |
+| `mine` | boolean | Own sessions only (default: `false`; set `true` to include requester-owned sessions). Matches the authenticated user's email, preferred username, or subject/user ID; requests with no usable identity return `401 Unauthorized`. |
+| `approver` | boolean | Sessions user can approve. Defaults to `true` only when neither `mine=true` nor `approvedByMe=true` is requested; set `approver=true` explicitly to combine filters. |
+| `approvedByMe` | boolean | Sessions the user has already approved. Requires an email claim because approval history is stored by approver email; missing email returns `401 Unauthorized`. |
 | `activeOnly` | boolean | Only return currently running sessions that are in `Approved` state and granting access; pending approval and scheduled-wait sessions are excluded |
 | `state` | string | Accepts a single value, comma-separated list, or repeated parameter. Supported tokens: `all`, `pending`, `approved`, `active`, `waiting`, `waitingforscheduledtime`, `scheduled`, `rejected`, `withdrawn`, `expired`, `idleexpired`, `timeout`, `approvaltimeout`. The `active` token matches only currently running `Approved` sessions. Unknown non-empty tokens return `400 Bad Request`. |
 | `token` | string | Validate approval-link metadata for a session name. This mode returns metadata for one session instead of the normal session list. |
@@ -225,6 +225,10 @@ endpoint returns `401 Unauthorized`.
 # Your pending sessions
 curl -H "Authorization: Bearer <token>" \
   "https://breakglass.example.com/api/breakglassSessions?cluster=prod&mine=true&state=pending"
+
+# Your sessions plus sessions you can approve
+curl -H "Authorization: Bearer <token>" \
+  "https://breakglass.example.com/api/breakglassSessions?mine=true&approver=true"
 
 # All approved sessions for a group
 curl -H "Authorization: Bearer <token>" \

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -717,11 +717,12 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	}
 
 	var userEmail string
+	var emailErr error
 	if includeMine || includeApprovedByMe {
-		userEmail, err = wc.identityProvider.GetEmail(c)
-		if err != nil {
-			reqLog.Error("Error getting user identity email", zap.Error(err))
-			apiresponses.RespondInternalError(c, "extract email from token", err, reqLog)
+		userEmail, emailErr = wc.identityProvider.GetEmail(c)
+		if includeApprovedByMe && emailErr != nil {
+			reqLog.Warnw("Email claim required for approvedByMe session filter", "error", emailErr)
+			apiresponses.RespondUnauthorizedWithMessage(c, "email claim is required for approvedByMe filter")
 			return
 		}
 	}
@@ -730,7 +731,11 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	if includeMine {
 		authIdentifiers = collectAuthIdentifiers(userEmail, wc.identityProvider.GetUsername(c), wc.identityProvider.GetIdentity(c))
 		if len(authIdentifiers) == 0 {
-			reqLog.Error("No authenticated identity claims found for session ownership filtering")
+			if emailErr != nil {
+				reqLog.Warnw("No authenticated identity claims found for session ownership filtering", "error", emailErr)
+			} else {
+				reqLog.Warn("No authenticated identity claims found for session ownership filtering")
+			}
 			apiresponses.RespondUnauthorizedWithMessage(c, "user identity not found")
 			return
 		}

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -850,17 +850,20 @@ func (wc *BreakglassSessionController) getSessionApprovalMeta(c *gin.Context, se
 		SessionState: string(session.Status.State),
 	}
 
-	// Get user email
-	email, err := wc.identityProvider.GetEmail(c)
-	if err != nil {
-		reqLog.Warnw("Failed to get user email for approval meta", "error", err)
+	email, emailErr := wc.identityProvider.GetUserIdentifier(c, breakglassv1alpha1.UserIdentifierClaimEmail)
+	authIdentifiers := collectAuthIdentifiers(email, wc.identityProvider.GetUsername(c), wc.identityProvider.GetIdentity(c))
+	if len(authIdentifiers) == 0 {
+		if emailErr != nil {
+			reqLog.Warnw("Failed to get authenticated identity for approval meta", "error", emailErr)
+		} else {
+			reqLog.Warn("Failed to get authenticated identity for approval meta")
+		}
 		meta.DenialReason = "Unable to verify your identity"
 		return meta
 	}
 
 	// Check if user is the requester. Sessions can store the requester by email,
 	// preferred_username, or sub depending on the spoke cluster identity claim.
-	authIdentifiers := collectAuthIdentifiers(email, wc.identityProvider.GetUsername(c), wc.identityProvider.GetIdentity(c))
 	meta.IsRequester = matchesAuthIdentifier(session.Spec.User, authIdentifiers)
 
 	// Check session state first
@@ -930,12 +933,14 @@ func (wc *BreakglassSessionController) getSessionApprovalMeta(c *gin.Context, se
 }
 
 func (wc *BreakglassSessionController) canReadBreakglassSession(c *gin.Context, session breakglassv1alpha1.BreakglassSession, approvalMeta SessionApprovalMeta) (bool, error) {
-	email, err := wc.identityProvider.GetEmail(c)
-	if err != nil {
-		return false, err
-	}
-
+	email, emailErr := wc.identityProvider.GetUserIdentifier(c, breakglassv1alpha1.UserIdentifierClaimEmail)
 	authIdentifiers := collectAuthIdentifiers(email, wc.identityProvider.GetUsername(c), wc.identityProvider.GetIdentity(c))
+	if len(authIdentifiers) == 0 {
+		if emailErr != nil {
+			return false, emailErr
+		}
+		return false, errAuthenticatedIdentityNotFound
+	}
 	if matchesAuthIdentifier(session.Spec.User, authIdentifiers) {
 		return true, nil
 	}
@@ -944,7 +949,7 @@ func (wc *BreakglassSessionController) canReadBreakglassSession(c *gin.Context, 
 		return true, nil
 	}
 
-	if userHasApprovedSession(session, email) {
+	if email != "" && userHasApprovedSession(session, email) {
 		return true, nil
 	}
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -719,7 +719,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	var userEmail string
 	var emailErr error
 	if includeMine || includeApprovedByMe {
-		userEmail, emailErr = wc.identityProvider.GetEmail(c)
+		userEmail, emailErr = wc.identityProvider.GetUserIdentifier(c, breakglassv1alpha1.UserIdentifierClaimEmail)
 		if includeApprovedByMe && emailErr != nil {
 			reqLog.Warnw("Email claim required for approvedByMe session filter", "error", emailErr)
 			apiresponses.RespondUnauthorizedWithMessage(c, "email claim is required for approvedByMe filter")

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -672,8 +672,9 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	// Ownership and state filters are request-local, so validate them before
 	// listing sessions from Kubernetes.
 	includeMine := ParseBoolQuery(c.Query("mine"), false)
-	includeApprover := ParseBoolQuery(c.Query("approver"), true)
 	includeApprovedByMe := ParseBoolQuery(c.Query("approvedByMe"), false)
+	includeApproverDefault := !includeMine && !includeApprovedByMe
+	includeApprover := ParseBoolQuery(c.Query("approver"), includeApproverDefault)
 	activeOnly := ParseBoolQuery(c.Query("activeOnly"), false)
 	stateFilters := normalizeStateFilters(c)
 	if invalidFilters := validateStateFilterTokens(stateFilters); len(invalidFilters) > 0 {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1957,6 +1957,14 @@ func TestFilterBreakglassSessionsMineUsesAlternateIdentifiersWhenEmailMissing(t 
 		c.Next()
 	}
 	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, ctxSetup, "/config/config.yaml", nil, cli)
+	identityProvider := &trackingIdentityProvider{
+		username: "bob",
+		identity: "subject-123",
+		userIdentifierErr: map[breakglassv1alpha1.UserIdentifierClaimType]error{
+			breakglassv1alpha1.UserIdentifierClaimEmail: fmt.Errorf("email claim not found in token"),
+		},
+	}
+	ctrl.identityProvider = identityProvider
 	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
 		return []string{"system:authenticated"}, nil
 	}
@@ -1975,6 +1983,62 @@ func TestFilterBreakglassSessionsMineUsesAlternateIdentifiersWhenEmailMissing(t 
 		got = append(got, session.Name)
 	}
 	assert.ElementsMatch(t, []string{"username-owned-session", "subject-owned-session"}, got)
+	assert.Zero(t, identityProvider.getEmailCalls)
+	assert.Equal(t, 1, identityProvider.userIdentifierCalls[breakglassv1alpha1.UserIdentifierClaimEmail])
+}
+
+type trackingIdentityProvider struct {
+	email               string
+	username            string
+	identity            string
+	getEmailCalls       int
+	userIdentifierCalls map[breakglassv1alpha1.UserIdentifierClaimType]int
+	userIdentifierErr   map[breakglassv1alpha1.UserIdentifierClaimType]error
+}
+
+func (p *trackingIdentityProvider) GetEmail(_ *gin.Context) (string, error) {
+	p.getEmailCalls++
+	if p.email == "" {
+		return "", fmt.Errorf("email claim not found in token")
+	}
+	return p.email, nil
+}
+
+func (p *trackingIdentityProvider) GetUsername(_ *gin.Context) string {
+	return p.username
+}
+
+func (p *trackingIdentityProvider) GetIdentity(_ *gin.Context) string {
+	return p.identity
+}
+
+func (p *trackingIdentityProvider) GetUserIdentifier(_ *gin.Context, claimType breakglassv1alpha1.UserIdentifierClaimType) (string, error) {
+	if p.userIdentifierCalls == nil {
+		p.userIdentifierCalls = map[breakglassv1alpha1.UserIdentifierClaimType]int{}
+	}
+	p.userIdentifierCalls[claimType]++
+	if err := p.userIdentifierErr[claimType]; err != nil {
+		return "", err
+	}
+	switch claimType {
+	case breakglassv1alpha1.UserIdentifierClaimEmail:
+		if p.email == "" {
+			return "", fmt.Errorf("email claim not found in token")
+		}
+		return p.email, nil
+	case breakglassv1alpha1.UserIdentifierClaimPreferredUsername:
+		if p.username == "" {
+			return "", fmt.Errorf("preferred_username claim not found in token")
+		}
+		return p.username, nil
+	case breakglassv1alpha1.UserIdentifierClaimSub:
+		if p.identity == "" {
+			return "", fmt.Errorf("sub claim not found in token")
+		}
+		return p.identity, nil
+	default:
+		return "", fmt.Errorf("unsupported user identifier claim type: %s", claimType)
+	}
 }
 
 func TestFilterBreakglassSessionsApprovedByMeRequiresEmailClaim(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -5425,9 +5425,23 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 			return
 		}
 		email := c.GetHeader("X-Test-Email")
-		c.Set("email", email)
-		c.Set("username", strings.TrimSuffix(email, "@example.com"))
-		c.Set("user_id", email)
+		username := c.GetHeader("X-Test-Username")
+		userID := c.GetHeader("X-Test-User-ID")
+		if email != "" {
+			c.Set("email", email)
+		}
+		if username == "" && email != "" {
+			username = strings.TrimSuffix(email, "@example.com")
+		}
+		if username != "" {
+			c.Set("username", username)
+		}
+		if userID == "" && email != "" {
+			userID = email
+		}
+		if userID != "" {
+			c.Set("user_id", userID)
+		}
 		c.Set("groups", []string{"system:authenticated"})
 		c.Next()
 	}
@@ -5442,6 +5456,17 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 	serveAs := func(email, sessionName string) (int, map[string]any) {
 		req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions/"+sessionName, nil)
 		req.Header.Set("X-Test-Email", email)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		return w.Result().StatusCode, body
+	}
+	serveWithIdentity := func(username, userID, sessionName string) (int, map[string]any) {
+		req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions/"+sessionName, nil)
+		req.Header.Set("X-Test-Username", username)
+		req.Header.Set("X-Test-User-ID", userID)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 
@@ -5480,6 +5505,11 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "reader-sess-3", sessionNameFromBody(body))
 	require.True(t, isRequesterFromBody(body), "expected approval metadata to recognize username-based requester")
+
+	status, body = serveWithIdentity("alice", "alice-subject", "reader-sess-3")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "reader-sess-3", sessionNameFromBody(body))
+	require.True(t, isRequesterFromBody(body), "expected approval metadata to recognize requester without email claim")
 }
 
 func TestGetBreakglassSessionByNameApprovalTimedOutMetadata(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1807,6 +1807,228 @@ func TestFilterBreakglassSessionsByUser(t *testing.T) {
 	}
 }
 
+func TestFilterBreakglassSessionsExplicitOwnershipFiltersDoNotIncludeImplicitApproverMatches(t *testing.T) {
+	now := time.Now()
+	owned := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "owned-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "bob@example.com",
+			GrantedGroup: "owned",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStatePending,
+			TimeoutAt: metav1.NewTime(now.Add(time.Hour)),
+		},
+	}
+	approvable := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approvable-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "alice@example.com",
+			GrantedGroup: "approvable",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStatePending,
+			TimeoutAt: metav1.NewTime(now.Add(time.Hour)),
+		},
+	}
+	approvedByMe := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-by-me-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "carol@example.com",
+			GrantedGroup: "approved",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(now.Add(time.Hour)),
+			Approvers: []string{"bob@example.com"},
+		},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-approvable"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"cl-filter"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup: "approvable",
+			Approvers:      breakglassv1alpha1.BreakglassEscalationApprovers{Users: []string{"bob@example.com"}},
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.WithObjects(owned, approvable, approvedByMe, escalation).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctxSetup := func(c *gin.Context) {
+		if c.Request.Method == http.MethodOptions {
+			c.Next()
+			return
+		}
+		c.Set("email", "bob@example.com")
+		c.Set("username", "bob")
+		c.Next()
+	}
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, ctxSetup, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	assertSessionNames := func(path string, want []string) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+		res := w.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		var sessions []breakglassv1alpha1.BreakglassSession
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
+
+		got := make([]string, 0, len(sessions))
+		for _, session := range sessions {
+			got = append(got, session.Name)
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	assertSessionNames("/breakglassSessions?mine=true", []string{"owned-session"})
+	assertSessionNames("/breakglassSessions?mine=true&approver=true", []string{"owned-session", "approvable-session"})
+	assertSessionNames("/breakglassSessions?approvedByMe=true", []string{"approved-by-me-session"})
+	assertSessionNames("/breakglassSessions?approvedByMe=true&approver=true", []string{"approved-by-me-session", "approvable-session"})
+}
+
+func TestFilterBreakglassSessionsMineUsesAlternateIdentifiersWhenEmailMissing(t *testing.T) {
+	usernameOwned := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "username-owned-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "bob",
+			GrantedGroup: "owned",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	subjectOwned := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "subject-owned-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "subject-123",
+			GrantedGroup: "owned",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	emailOnly := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "email-only-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "bob@example.com",
+			GrantedGroup: "owned",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.WithObjects(usernameOwned, subjectOwned, emailOnly).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctxSetup := func(c *gin.Context) {
+		if c.Request.Method == http.MethodOptions {
+			c.Next()
+			return
+		}
+		c.Set("username", "bob")
+		c.Set("user_id", "subject-123")
+		c.Next()
+	}
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, ctxSetup, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?mine=true", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var sessions []breakglassv1alpha1.BreakglassSession
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
+	got := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		got = append(got, session.Name)
+	}
+	assert.ElementsMatch(t, []string{"username-owned-session", "subject-owned-session"}, got)
+}
+
+func TestFilterBreakglassSessionsApprovedByMeRequiresEmailClaim(t *testing.T) {
+	approved := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-by-me-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-filter",
+			User:         "carol@example.com",
+			GrantedGroup: "approved",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			Approvers: []string{"bob@example.com"},
+		},
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.WithObjects(approved).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctxSetup := func(c *gin.Context) {
+		if c.Request.Method == http.MethodOptions {
+			c.Next()
+			return
+		}
+		c.Set("username", "bob")
+		c.Set("user_id", "subject-123")
+		c.Next()
+	}
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, ctxSetup, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?approvedByMe=true", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "UNAUTHORIZED")
+	assert.Contains(t, string(body), "email claim is required")
+}
+
 // TestApproveByNonApprover_ReturnsUnauthorized
 //
 // Purpose:
@@ -5410,9 +5632,9 @@ func TestOwnerRejectRecordsSubjectActorWhenEmailAndUsernameMissing(t *testing.T)
 	require.Equal(t, "owner-subject", events[0].Actor.User)
 }
 
-// Test that when identity provider fails to return email and mine=true is requested,
-// the handler returns HTTP 500.
-func TestGetSessions_IdentityProviderErrorReturns500(t *testing.T) {
+// Test that when no usable identity is available and mine=true is requested,
+// the handler returns HTTP 401 instead of treating the auth-negative case as internal.
+func TestGetSessions_MissingIdentityForMineReturns401(t *testing.T) {
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
 		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
@@ -5440,9 +5662,11 @@ func TestGetSessions_IdentityProviderErrorReturns500(t *testing.T) {
 	w := httptest.NewRecorder()
 	engine.ServeHTTP(w, req)
 	res := w.Result()
-	if res.StatusCode != http.StatusInternalServerError {
-		t.Fatalf("expected 500 InternalServerError when identity provider fails, got %d", res.StatusCode)
-	}
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "UNAUTHORIZED")
+	assert.Contains(t, string(body), "user identity not found")
 }
 
 // Test that blockSelfApproval in ClusterConfig prevents a user from approving their own session

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -1889,8 +1889,7 @@ func TestFilterBreakglassSessionsExplicitOwnershipFiltersDoNotIncludeImplicitApp
 		engine.ServeHTTP(w, req)
 		res := w.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
-		var sessions []breakglassv1alpha1.BreakglassSession
-		require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
+		sessions := decodeBreakglassSessionListEnvelope(t, res.Body)
 
 		got := make([]string, 0, len(sessions))
 		for _, session := range sessions {
@@ -1970,8 +1969,7 @@ func TestFilterBreakglassSessionsMineUsesAlternateIdentifiersWhenEmailMissing(t 
 	res := w.Result()
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	var sessions []breakglassv1alpha1.BreakglassSession
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
+	sessions := decodeBreakglassSessionListEnvelope(t, res.Body)
 	got := make([]string, 0, len(sessions))
 	for _, session := range sessions {
 		got = append(got, session.Name)


### PR DESCRIPTION
## Summary
- Treat `mine=true` and `approvedByMe=true` as explicit ownership/history filters instead of also applying the default approver filter.
- Preserve the combined view when callers explicitly add `approver=true`.
- Document the defaulting behavior in the API reference and changelog.

## Evidence
- Duplicate check before implementation: `gh search prs "breakglassSessions mine approver filter owner-only" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Related duplicate check: `gh search prs "approvedByMe approver default filter" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Reproduction from source: `GET /api/breakglassSessions?mine=true` parsed `approver` with default `true`, so owned sessions were ORed with sessions the caller can approve.

## Validation
- `go test ./pkg/breakglass -run ^TestFilterBreakglassSessionsExplicitOwnershipFiltersDoNotIncludeImplicitApproverMatches$`
- `go test ./pkg/breakglass -run TestFilterBreakglassSessions|TestApproverCanSeePendingSessions|TestBreakglassSessionListFilters|TestListSessionsApprovedByMe`
- `go test ./pkg/breakglass`
- `git diff --check`
- `make test`

## UI Screenshots
- Not applicable: this PR changes backend API filtering, tests, and docs only; no UI files changed.