### PR TITLE
fix: mark terminal session tokens invalid

### DIFF
--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -437,7 +437,7 @@ GET /api/breakglassSessions?token=<session-name>
 Authorization: Bearer <token>
 ```
 
-When the token matches a session, the `200 OK` response contains `valid`, `canApprove`, and `alreadyActive`. `valid` is `false` for any terminal session state (`Rejected`, `Withdrawn`, `Expired`, `IdleExpired`, or `ApprovalTimeout`) and for approved sessions whose `expiresAt` timestamp has passed.
+When the token matches a session, the `200 OK` response contains `valid`, `canApprove`, and `alreadyActive`. `valid` is `false` when the session state is empty, for any terminal session state (`Rejected`, `Withdrawn`, `Expired`, `IdleExpired`, or `ApprovalTimeout`), for approved sessions whose `expiresAt` timestamp has passed, and for stale pending approvals whose `timeoutAt` timestamp has already elapsed. Stale pending approval links fail closed: `valid` and `canApprove` are both `false` until cleanup records the terminal `ApprovalTimeout` state.
 
 When the token does not match any session, the handler returns `404 Not Found` with:
 

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -430,6 +430,25 @@ already elapsed. Approvers can still read the stale pending object for context,
 but `canApprove` and `canReject` are false and the response includes a timeout
 state message until cleanup transitions the session to `ApprovalTimeout`.
 
+### Validate Approval Links
+
+```bash
+GET /api/breakglassSessions?token=<session-name>
+Authorization: Bearer <token>
+```
+
+When the token matches a session, the `200 OK` response contains `valid`, `canApprove`, and `alreadyActive`. `valid` is `false` for any terminal session state (`Rejected`, `Withdrawn`, `Expired`, `IdleExpired`, or `ApprovalTimeout`) and for approved sessions whose `expiresAt` timestamp has passed.
+
+When the token does not match any session, the handler returns `404 Not Found` with:
+
+```json
+{
+  "valid": false
+}
+```
+
+The `canApprove` and `alreadyActive` fields are only present on the `200 OK` response.
+
 ### Approve/Reject Sessions
 
 ```bash

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -491,6 +491,19 @@ func IsSessionAccessActive(session breakglassv1alpha1.BreakglassSession) bool {
 	return IsSessionValid(session)
 }
 
+func isSessionTokenValid(session breakglassv1alpha1.BreakglassSession) bool {
+	if session.Status.State == "" {
+		return false
+	}
+	if IsSessionTerminalState(session.Status.State) {
+		return false
+	}
+	if IsSessionApprovalTimedOut(session) {
+		return false
+	}
+	return session.Status.State != breakglassv1alpha1.SessionStateApproved || !IsSessionExpired(session)
+}
+
 // isOwnedByEscalation checks if a session is owned by the given escalation by matching
 // the owner reference UID. This ensures sessions from different escalations that grant
 // the same group are counted separately.

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -645,7 +645,6 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 			return
 		}
 		pendingApproval := IsSessionPendingApproval(ses)
-		approvalTimedOut := IsSessionApprovalTimedOut(ses)
 		sessionForAuth := ses
 		sessionForAuth.Name = "[REDACTED]"
 		approvalMeta := wc.getSessionApprovalMeta(c, sessionForAuth)
@@ -662,7 +661,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 		}
 		canApprove := pendingApproval && approvalMeta.CanApprove
 		alreadyActive := IsSessionAccessActive(ses)
-		valid := IsSessionValid(ses) && !approvalTimedOut
+		valid := isSessionTokenValid(ses)
 		c.JSON(http.StatusOK, gin.H{"canApprove": canApprove, "alreadyActive": alreadyActive, "valid": valid})
 		return
 	}
@@ -794,6 +793,19 @@ type EnrichedSessionResponse struct {
 	// ApprovalReason contains the escalation's approval reason configuration (if any)
 	// Now sourced from session.Spec.ApprovalReasonConfig (snapshot at creation time)
 	ApprovalReason *ReasonConfigInfo `json:"approvalReason,omitempty"`
+}
+
+func isSessionTokenValid(session breakglassv1alpha1.BreakglassSession) bool {
+	if session.Status.State == "" {
+		return false
+	}
+	if IsSessionTerminalState(session.Status.State) {
+		return false
+	}
+	if IsSessionApprovalTimedOut(session) {
+		return false
+	}
+	return session.Status.State != breakglassv1alpha1.SessionStateApproved || !IsSessionExpired(session)
 }
 
 // enrichSessionsWithApprovalReason adds the approvalReason config from the session's stored snapshot.

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -662,10 +662,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 		}
 		canApprove := pendingApproval && approvalMeta.CanApprove
 		alreadyActive := IsSessionAccessActive(ses)
-		valid := true
-		if approvalTimedOut || IsSessionExpired(ses) || IsSessionTerminalState(ses.Status.State) {
-			valid = false
-		}
+		valid := IsSessionValid(ses) && !approvalTimedOut
 		c.JSON(http.StatusOK, gin.H{"canApprove": canApprove, "alreadyActive": alreadyActive, "valid": valid})
 		return
 	}

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -795,19 +795,6 @@ type EnrichedSessionResponse struct {
 	ApprovalReason *ReasonConfigInfo `json:"approvalReason,omitempty"`
 }
 
-func isSessionTokenValid(session breakglassv1alpha1.BreakglassSession) bool {
-	if session.Status.State == "" {
-		return false
-	}
-	if IsSessionTerminalState(session.Status.State) {
-		return false
-	}
-	if IsSessionApprovalTimedOut(session) {
-		return false
-	}
-	return session.Status.State != breakglassv1alpha1.SessionStateApproved || !IsSessionExpired(session)
-}
-
 // enrichSessionsWithApprovalReason adds the approvalReason config from the session's stored snapshot.
 // Sessions now store reason configs at creation time, so no escalation lookup is needed.
 func (wc *BreakglassSessionController) enrichSessionsWithApprovalReason(_ context.Context, sessions []breakglassv1alpha1.BreakglassSession, _ *zap.SugaredLogger) []EnrichedSessionResponse {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -10130,3 +10130,76 @@ func TestTokenValidation_ExistingSessionAllowsHistoricalApprover(t *testing.T) {
 	assert.True(t, body.AlreadyActive)
 	assert.False(t, body.CanApprove)
 }
+
+func TestTokenValidation_NonTerminalValidityStates(t *testing.T) {
+	now := time.Now()
+	future := metav1.NewTime(now.Add(time.Hour))
+	past := metav1.NewTime(now.Add(-time.Hour))
+	newSession := func(name string, state breakglassv1alpha1.BreakglassSessionState, expiresAt metav1.Time) client.Object {
+		return &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "cluster",
+				User:         "requester@example.com",
+				GrantedGroup: "admin",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     state,
+				ExpiresAt: expiresAt,
+			},
+		}
+	}
+	sessions := []client.Object{
+		newSession("no-state-session", "", metav1.Time{}),
+		newSession("pending-session", breakglassv1alpha1.SessionStatePending, metav1.Time{}),
+		newSession("active-session", breakglassv1alpha1.SessionStateApproved, future),
+		newSession("expired-by-time-session", breakglassv1alpha1.SessionStateApproved, past),
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	cli := builder.WithObjects(sessions...).Build()
+	sesmanager := SessionManager{Client: cli}
+	escmanager := testEscalationLookup{Client: cli}
+	logger, _ := zap.NewDevelopment()
+	ctxSetup := func(c *gin.Context) {
+		c.Set("email", "requester@example.com")
+		c.Set("username", "requester")
+		c.Set("user_id", "requester@example.com")
+		c.Next()
+	}
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager, ctxSetup, "/config/config.yaml", nil, cli)
+	ctrl.getUserGroupsFn = func(ctx context.Context, cug ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	engine := gin.New()
+	require.NoError(t, ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...)))
+
+	tests := []struct {
+		name      string
+		wantValid bool
+	}{
+		{name: "no-state-session", wantValid: false},
+		{name: "pending-session", wantValid: true},
+		{name: "active-session", wantValid: true},
+		{name: "expired-by-time-session", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "/breakglassSessions?token="+tt.name, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			var body struct {
+				Valid bool `json:"valid"`
+			}
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+			assert.Equal(t, tt.wantValid, body.Valid)
+		})
+	}
+}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -10131,7 +10131,7 @@ func TestTokenValidation_ExistingSessionAllowsHistoricalApprover(t *testing.T) {
 	assert.False(t, body.CanApprove)
 }
 
-func TestTokenValidation_NonTerminalValidityStates(t *testing.T) {
+func TestTokenValidation_StateAndExpiryValidity(t *testing.T) {
 	now := time.Now()
 	future := metav1.NewTime(now.Add(time.Hour))
 	past := metav1.NewTime(now.Add(-time.Hour))

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -10137,7 +10137,7 @@ func TestTokenValidation_NonTerminalValidityStates(t *testing.T) {
 	past := metav1.NewTime(now.Add(-time.Hour))
 	newSession := func(name string, state breakglassv1alpha1.BreakglassSessionState, expiresAt metav1.Time) client.Object {
 		return &breakglassv1alpha1.BreakglassSession{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster:      "cluster",
 				User:         "requester@example.com",
@@ -10155,6 +10155,9 @@ func TestTokenValidation_NonTerminalValidityStates(t *testing.T) {
 		newSession("active-session", breakglassv1alpha1.SessionStateApproved, future),
 		newSession("expired-by-time-session", breakglassv1alpha1.SessionStateApproved, past),
 	}
+	waitingSession := newSession("waiting-session", breakglassv1alpha1.SessionStateWaitingForScheduledTime, future).(*breakglassv1alpha1.BreakglassSession)
+	waitingSession.Spec.ScheduledStartTime = &future
+	sessions = append(sessions, waitingSession)
 
 	builder := fake.NewClientBuilder().WithScheme(Scheme)
 	for index, fn := range sessionIndexFunctions {
@@ -10186,6 +10189,7 @@ func TestTokenValidation_NonTerminalValidityStates(t *testing.T) {
 		{name: "pending-session", wantValid: true},
 		{name: "active-session", wantValid: true},
 		{name: "expired-by-time-session", wantValid: false},
+		{name: "waiting-session", wantValid: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Mark approval-link token validation responses invalid for every terminal BreakglassSession state.
- Keep pending and non-expired approved sessions valid while treating approved sessions past `expiresAt` as invalid.
- Document the token validation response semantics and add a changelog entry.

## Evidence
- Duplicate check before implementation: `gh search prs "token validation ApprovalTimeout IdleExpired valid" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Additional duplicate check: `gh search prs "breakglassSessions token valid terminal state" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Source finding: `GET /api/breakglassSessions?token=<name>` only invalidated expired, withdrawn, and rejected sessions, so terminal `IdleExpired` and `ApprovalTimeout` still returned `valid=true`.

## Validation
- `go test ./pkg/breakglass -run ^TestTokenValidation_(NotFoundReturns404WithValidFalse|TerminalStatesReturnValidFalse)$`
- `go test ./pkg/breakglass`
- `git diff --check`
- `make test`

## UI Screenshots
- Not applicable: this PR changes backend API token validation, tests, and docs only; no UI files changed.