### PR TITLE
fix: reject unexpected debug operation bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **BreakglassSession approval body validation**: Classic session approve and reject endpoints now reject malformed optional approver bodies, unknown JSON fields, and trailing JSON values instead of approving or rejecting with silently discarded payloads.
-- **DebugSession API request body validation**: Debug session create, approve, and reject endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional approval bodies instead of silently ignoring client typos or invalid payloads.
+- **DebugSession API request body validation**: Debug session create, join, renew, approve, reject, and kubectl-debug operation endpoints now reject unknown JSON fields, trailing JSON values, and malformed optional bodies instead of silently ignoring client typos or invalid payloads.
 - **DebugSession cluster authorization precedence**: Debug session creation now checks template or binding access before returning ClusterConfig readiness, missing-cluster, or tenant-alias errors, preventing unauthorized callers from probing cluster state through error messages.
 - **Debug session read authorization**: `GET /api/v1/debugSessions` now returns only sessions visible to the authenticated caller, and `GET /api/v1/debugSessions/{name}` rejects unrelated authenticated users with `403 Forbidden` instead of exposing debug session spec/status details.
 - **DebugSession binding label hardening**: `DebugSessionClusterBinding.spec.labels` can no longer overwrite controller-owned DebugSession identity labels, preserving name-based lookup, template/cluster attribution, and audit correlation while still propagating ordinary custom labels.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -923,6 +923,8 @@ JSON bodies for debug-session create requests must contain only known field name
 
 ClusterConfig readiness, missing-cluster, and tenant-alias errors are returned only after the request is authorized by the selected template or binding.
 
+The same strict JSON parsing applies to DebugSession join, renew, approve, reject, and kubectl-debug operation bodies. Optional bodies may be omitted only where the endpoint documents that behavior; non-empty bodies must contain only known fields and one JSON object.
+
 **Response:** Created `DebugSession` object (201 Created).
 
 **Error Responses:**

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1522,6 +1522,11 @@ debug session when they are the requester, an active participant, an invited
 participant, a configured approver, or a recorded approver/rejector for that
 session.
 
+Mutating DebugSession endpoints that accept JSON bodies use strict decoding:
+unknown fields, malformed JSON, and trailing JSON values return `400 Bad
+Request`. The join endpoint may omit its body and defaults to the `viewer` role;
+non-empty join bodies must still be strict JSON.
+
 ### Kubectl Debug API Endpoints
 
 These endpoints are available for sessions in `kubectl-debug` or `hybrid` mode:

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -225,6 +225,13 @@ type RenewDebugSessionRequest struct {
 	ExtendBy string `json:"extendBy" binding:"required"` // Duration like "1h", "30m"
 }
 
+func validateRenewDebugSessionRequest(req RenewDebugSessionRequest) error {
+	if req.ExtendBy == "" {
+		return fmt.Errorf("extendBy is required")
+	}
+	return nil
+}
+
 // ApprovalRequest represents the request body for approve/reject actions
 type ApprovalRequest struct {
 	Reason string `json:"reason,omitempty"`
@@ -254,6 +261,21 @@ type InjectEphemeralContainerRequest struct {
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 
+func validateInjectEphemeralContainerRequest(req InjectEphemeralContainerRequest) error {
+	switch {
+	case req.Namespace == "":
+		return fmt.Errorf("namespace is required")
+	case req.PodName == "":
+		return fmt.Errorf("podName is required")
+	case req.ContainerName == "":
+		return fmt.Errorf("containerName is required")
+	case req.Image == "":
+		return fmt.Errorf("image is required")
+	default:
+		return nil
+	}
+}
+
 // CreatePodCopyRequest represents the request to create a debug copy of a pod
 type CreatePodCopyRequest struct {
 	Namespace  string `json:"namespace" binding:"required"`
@@ -261,9 +283,27 @@ type CreatePodCopyRequest struct {
 	DebugImage string `json:"debugImage,omitempty"` // Optional debug container image
 }
 
+func validateCreatePodCopyRequest(req CreatePodCopyRequest) error {
+	switch {
+	case req.Namespace == "":
+		return fmt.Errorf("namespace is required")
+	case req.PodName == "":
+		return fmt.Errorf("podName is required")
+	default:
+		return nil
+	}
+}
+
 // CreateNodeDebugPodRequest represents the request to create a node debug pod
 type CreateNodeDebugPodRequest struct {
 	NodeName string `json:"nodeName" binding:"required"`
+}
+
+func validateCreateNodeDebugPodRequest(req CreateNodeDebugPodRequest) error {
+	if req.NodeName == "" {
+		return fmt.Errorf("nodeName is required")
+	}
+	return nil
 }
 
 // DebugSessionListResponse represents the response for listing debug sessions

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -329,7 +329,11 @@ func (c *DebugSessionAPIController) handleInjectEphemeralContainer(ctx *gin.Cont
 	namespaceHint := ctx.Query("namespace")
 
 	var req InjectEphemeralContainerRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+		return
+	}
+	if err := validateInjectEphemeralContainerRequest(req); err != nil {
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}
@@ -417,7 +421,11 @@ func (c *DebugSessionAPIController) handleCreatePodCopy(ctx *gin.Context) {
 	namespaceHint := ctx.Query("namespace")
 
 	var req CreatePodCopyRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+		return
+	}
+	if err := validateCreatePodCopyRequest(req); err != nil {
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}
@@ -500,7 +508,11 @@ func (c *DebugSessionAPIController) handleCreateNodeDebugPod(ctx *gin.Context) {
 	namespaceHint := ctx.Query("namespace")
 
 	var req CreateNodeDebugPodRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+		return
+	}
+	if err := validateCreateNodeDebugPodRequest(req); err != nil {
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -129,6 +129,30 @@ func TestDebugKubectlOperationsStrictJSON(t *testing.T) {
 			wantText: "invalid request body",
 		},
 		{
+			name:     "inject rejects missing namespace",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"podName":"pod-1","containerName":"debug","image":"busybox"}`,
+			wantText: "namespace is required",
+		},
+		{
+			name:     "inject rejects missing podName",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"namespace":"default","containerName":"debug","image":"busybox"}`,
+			wantText: "podName is required",
+		},
+		{
+			name:     "inject rejects missing containerName",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"namespace":"default","podName":"pod-1","image":"busybox"}`,
+			wantText: "containerName is required",
+		},
+		{
+			name:     "inject rejects missing image",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"namespace":"default","podName":"pod-1","containerName":"debug"}`,
+			wantText: "image is required",
+		},
+		{
 			name:     "pod copy rejects unknown fields",
 			path:     "/api/debugSessions/test-session/createPodCopy",
 			body:     `{"namespace":"default","podName":"pod-1","ignored":true}`,
@@ -141,6 +165,18 @@ func TestDebugKubectlOperationsStrictJSON(t *testing.T) {
 			wantText: "invalid request body",
 		},
 		{
+			name:     "pod copy rejects missing namespace",
+			path:     "/api/debugSessions/test-session/createPodCopy",
+			body:     `{"podName":"pod-1"}`,
+			wantText: "namespace is required",
+		},
+		{
+			name:     "pod copy rejects missing podName",
+			path:     "/api/debugSessions/test-session/createPodCopy",
+			body:     `{"namespace":"default"}`,
+			wantText: "podName is required",
+		},
+		{
 			name:     "node debug rejects unknown fields",
 			path:     "/api/debugSessions/test-session/createNodeDebugPod",
 			body:     `{"nodeName":"node-1","ignored":true}`,
@@ -151,6 +187,12 @@ func TestDebugKubectlOperationsStrictJSON(t *testing.T) {
 			path:     "/api/debugSessions/test-session/createNodeDebugPod",
 			body:     `{"nodeName":"node-1"} {"nodeName":"node-2"}`,
 			wantText: "invalid request body",
+		},
+		{
+			name:     "node debug rejects missing nodeName",
+			path:     "/api/debugSessions/test-session/createNodeDebugPod",
+			body:     `{}`,
+			wantText: "nodeName is required",
 		},
 	}
 

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -107,6 +107,68 @@ func TestHandleInjectEphemeralContainer_BadRequest(t *testing.T) {
 	assertErrorResponse(t, rr, "BAD_REQUEST")
 }
 
+func TestDebugKubectlOperationsStrictJSON(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	tests := []struct {
+		name     string
+		path     string
+		body     string
+		wantText string
+	}{
+		{
+			name:     "inject rejects unknown fields",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"namespace":"default","podName":"pod-1","containerName":"debug","image":"busybox","ignored":true}`,
+			wantText: "unknown field",
+		},
+		{
+			name:     "inject rejects trailing JSON",
+			path:     "/api/debugSessions/test-session/injectEphemeralContainer",
+			body:     `{"namespace":"default","podName":"pod-1","containerName":"debug","image":"busybox"} {"namespace":"other"}`,
+			wantText: "invalid request body",
+		},
+		{
+			name:     "pod copy rejects unknown fields",
+			path:     "/api/debugSessions/test-session/createPodCopy",
+			body:     `{"namespace":"default","podName":"pod-1","ignored":true}`,
+			wantText: "unknown field",
+		},
+		{
+			name:     "pod copy rejects trailing JSON",
+			path:     "/api/debugSessions/test-session/createPodCopy",
+			body:     `{"namespace":"default","podName":"pod-1"} {"podName":"other"}`,
+			wantText: "invalid request body",
+		},
+		{
+			name:     "node debug rejects unknown fields",
+			path:     "/api/debugSessions/test-session/createNodeDebugPod",
+			body:     `{"nodeName":"node-1","ignored":true}`,
+			wantText: "unknown field",
+		},
+		{
+			name:     "node debug rejects trailing JSON",
+			path:     "/api/debugSessions/test-session/createNodeDebugPod",
+			body:     `{"nodeName":"node-1"} {"nodeName":"node-2"}`,
+			wantText: "invalid request body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assertErrorResponse(t, rr, "BAD_REQUEST")
+			assert.Contains(t, rr.Body.String(), tt.wantText)
+		})
+	}
+}
+
 func TestHandleInjectEphemeralContainer_Unauthorized(t *testing.T) {
 	router, _ := setupTestRouter(t)
 

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -27,10 +26,10 @@ func (c *DebugSessionAPIController) handleJoinDebugSession(ctx *gin.Context) {
 	namespaceHint := ctx.Query("namespace")
 
 	var req JoinDebugSessionRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		// Allow empty body (EOF) — default to viewer role.
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		// Allow an empty body — default to viewer role.
 		// Reject malformed JSON with 400 to surface client bugs.
-		if !errors.Is(err, io.EOF) {
+		if !errors.Is(err, jsonutil.ErrEmptyBody) {
 			apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
 			return
 		}
@@ -170,7 +169,11 @@ func (c *DebugSessionAPIController) handleRenewDebugSession(ctx *gin.Context) {
 	username := currentUser.(string)
 
 	var req RenewDebugSessionRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
+	if err := decodeDebugJSONStrict(ctx.Request.Body, &req); err != nil {
+		apiresponses.RespondBadRequest(ctx, "invalid request body: "+err.Error())
+		return
+	}
+	if err := validateRenewDebugSessionRequest(req); err != nil {
 		apiresponses.RespondBadRequest(ctx, err.Error())
 		return
 	}

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -4866,6 +4866,61 @@ func TestDebugSessionAPIController_HandleJoinDebugSession(t *testing.T) {
 	})
 }
 
+func TestDebugSessionAPIController_SessionOperationStrictJSON(t *testing.T) {
+	scheme := testScheme()
+	logger := zap.NewNop().Sugar()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	router := debugSessionAPITestRouter(t, ctrl, "alice@example.com", "alice@example.com", nil)
+
+	tests := []struct {
+		name     string
+		path     string
+		body     string
+		wantText string
+	}{
+		{
+			name:     "join rejects unknown fields",
+			path:     "/api/v1/debugSessions/test-session/join",
+			body:     `{"role":"viewer","ignored":true}`,
+			wantText: "unknown field",
+		},
+		{
+			name:     "join rejects trailing JSON",
+			path:     "/api/v1/debugSessions/test-session/join",
+			body:     `{"role":"viewer"} {"role":"viewer"}`,
+			wantText: "invalid request body",
+		},
+		{
+			name:     "renew rejects unknown fields",
+			path:     "/api/v1/debugSessions/test-session/renew",
+			body:     `{"extendBy":"1h","ignored":true}`,
+			wantText: "unknown field",
+		},
+		{
+			name:     "renew rejects trailing JSON",
+			path:     "/api/v1/debugSessions/test-session/renew",
+			body:     `{"extendBy":"1h"} {"extendBy":"24h"}`,
+			wantText: "invalid request body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			assert.Contains(t, w.Body.String(), tt.wantText)
+		})
+	}
+}
+
 // TestDebugSessionAPIController_HandleLeaveDebugSession tests the handleLeaveDebugSession handler
 func TestDebugSessionAPIController_HandleLeaveDebugSession(t *testing.T) {
 	scheme := testScheme()

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -4906,6 +4906,12 @@ func TestDebugSessionAPIController_SessionOperationStrictJSON(t *testing.T) {
 			body:     `{"extendBy":"1h"} {"extendBy":"24h"}`,
 			wantText: "invalid request body",
 		},
+		{
+			name:     "renew rejects missing extendBy",
+			path:     "/api/v1/debugSessions/test-session/renew",
+			body:     `{}`,
+			wantText: "extendBy is required",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Use the existing strict JSON decoder for DebugSession join, renew, and kubectl-debug operation bodies.
- Preserve empty-body join defaulting to `viewer`, while rejecting unknown fields, malformed JSON, and trailing JSON on non-empty bodies.
- Add explicit required-field validation where Gin binding previously enforced required fields, plus regression coverage and docs.

## Evidence
- Duplicate check before implementation: `gh search prs "DebugSession ShouldBindJSON DecodeStrict join renew kubectl debug unknown field" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Additional duplicate check: `gh search prs "strict JSON join renew injectEphemeralContainer createPodCopy createNodeDebugPod" --repo telekom/k8s-breakglass --state open` -> `[]`; merged search -> `[]`.
- Source finding: join/renew/inject/createPodCopy/createNodeDebugPod used Gin `ShouldBindJSON`, so unknown fields and trailing JSON were accepted before the request reached authorization/business logic.

## Validation
- `go test ./pkg/breakglass/debug -run TestDebugSessionAPIController_SessionOperationStrictJSON|TestDebugKubectlOperationsStrictJSON`
- `go test ./pkg/breakglass/debug`
- `git diff --check`
- `make test`

## UI Screenshots
- Not applicable: this PR changes backend DebugSession request validation, tests, and docs only; no UI files changed.