### PR TITLE
fix: enforce debug template discovery ACLs

### DIFF
--- a/api/v1alpha1/extra_deploy_validation.go
+++ b/api/v1alpha1/extra_deploy_validation.go
@@ -119,8 +119,8 @@ func ValidateExtraDeployValues(
 	variables []ExtraDeployVariable,
 	fldPath *field.Path,
 ) field.ErrorList {
-	// Call the full validation without group restrictions
-	return ValidateExtraDeployValuesWithGroups(values, variables, nil, fldPath)
+	// Call the shared validation without group restrictions.
+	return validateExtraDeployValues(values, variables, nil, false, fldPath)
 }
 
 // ValidateExtraDeployValuesWithGroups validates user-provided values against variable definitions,
@@ -132,12 +132,20 @@ func ValidateExtraDeployValues(
 // - Select/multiSelect values are from allowed options
 // - User has access to restricted variables (via allowedGroups on variable)
 // - User has access to restricted options (via allowedGroups on SelectOption)
-//
-// If userGroups is nil or empty, group restrictions are not enforced.
 func ValidateExtraDeployValuesWithGroups(
 	values map[string]apiextensionsv1.JSON,
 	variables []ExtraDeployVariable,
 	userGroups []string,
+	fldPath *field.Path,
+) field.ErrorList {
+	return validateExtraDeployValues(values, variables, userGroups, true, fldPath)
+}
+
+func validateExtraDeployValues(
+	values map[string]apiextensionsv1.JSON,
+	variables []ExtraDeployVariable,
+	userGroups []string,
+	enforceGroupRestrictions bool,
 	fldPath *field.Path,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -172,7 +180,7 @@ func ValidateExtraDeployValuesWithGroups(
 		}
 
 		// Check allowedGroups on the variable itself (applies to all input types)
-		if len(varDef.AllowedGroups) > 0 && len(userGroups) > 0 {
+		if enforceGroupRestrictions && len(varDef.AllowedGroups) > 0 {
 			if !groupsIntersect(userGroups, varDef.AllowedGroups) {
 				allErrs = append(allErrs, field.Forbidden(valuePath,
 					fmt.Sprintf("variable %q is restricted; requires membership in one of: %v", name, varDef.AllowedGroups)))
@@ -181,7 +189,7 @@ func ValidateExtraDeployValuesWithGroups(
 		}
 
 		// Validate value type and constraints (including allowedGroups on SelectOptions)
-		errs := validateVariableValue(jsonVal, varDef, userGroups, valuePath)
+		errs := validateVariableValue(jsonVal, varDef, userGroups, enforceGroupRestrictions, valuePath)
 		allErrs = append(allErrs, errs...)
 	}
 
@@ -207,6 +215,7 @@ func validateVariableValue(
 	value apiextensionsv1.JSON,
 	varDef ExtraDeployVariable,
 	userGroups []string,
+	enforceGroupRestrictions bool,
 	fldPath *field.Path,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -230,10 +239,10 @@ func validateVariableValue(
 		allErrs = append(allErrs, validateStorageSizeValue(value, varDef.Validation, fldPath)...)
 
 	case InputTypeSelect:
-		allErrs = append(allErrs, validateSelectValue(value, varDef.Options, userGroups, fldPath)...)
+		allErrs = append(allErrs, validateSelectValue(value, varDef.Options, userGroups, enforceGroupRestrictions, fldPath)...)
 
 	case InputTypeMultiSelect:
-		allErrs = append(allErrs, validateMultiSelectValue(value, varDef.Options, varDef.Validation, userGroups, fldPath)...)
+		allErrs = append(allErrs, validateMultiSelectValue(value, varDef.Options, varDef.Validation, userGroups, enforceGroupRestrictions, fldPath)...)
 	}
 
 	return allErrs
@@ -392,7 +401,7 @@ func validateStorageSizeValue(value apiextensionsv1.JSON, validation *VariableVa
 }
 
 // validateSelectValue validates a select input value.
-func validateSelectValue(value apiextensionsv1.JSON, options []SelectOption, userGroups []string, fldPath *field.Path) field.ErrorList {
+func validateSelectValue(value apiextensionsv1.JSON, options []SelectOption, userGroups []string, enforceGroupRestrictions bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	var strVal string
@@ -414,7 +423,7 @@ func validateSelectValue(value apiextensionsv1.JSON, options []SelectOption, use
 				return allErrs
 			}
 			// Check allowedGroups on the selected option
-			if len(opt.AllowedGroups) > 0 && len(userGroups) > 0 {
+			if enforceGroupRestrictions && len(opt.AllowedGroups) > 0 {
 				if !groupsIntersect(userGroups, opt.AllowedGroups) {
 					allErrs = append(allErrs, field.Forbidden(fldPath,
 						fmt.Sprintf("option %q is restricted; requires membership in one of: %v", strVal, opt.AllowedGroups)))
@@ -434,7 +443,7 @@ func validateSelectValue(value apiextensionsv1.JSON, options []SelectOption, use
 }
 
 // validateMultiSelectValue validates a multiSelect input value.
-func validateMultiSelectValue(value apiextensionsv1.JSON, options []SelectOption, validation *VariableValidation, userGroups []string, fldPath *field.Path) field.ErrorList {
+func validateMultiSelectValue(value apiextensionsv1.JSON, options []SelectOption, validation *VariableValidation, userGroups []string, enforceGroupRestrictions bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	var arrVal []string
@@ -469,7 +478,7 @@ func validateMultiSelectValue(value apiextensionsv1.JSON, options []SelectOption
 			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i), sel, validList))
 		} else if opt, exists := optionMap[sel]; exists {
 			// Check allowedGroups on the selected option
-			if len(opt.AllowedGroups) > 0 && len(userGroups) > 0 {
+			if enforceGroupRestrictions && len(opt.AllowedGroups) > 0 {
 				if !groupsIntersect(userGroups, opt.AllowedGroups) {
 					allErrs = append(allErrs, field.Forbidden(fldPath.Index(i),
 						fmt.Sprintf("option %q is restricted; requires membership in one of: %v", sel, opt.AllowedGroups)))

--- a/api/v1alpha1/extra_deploy_validation_test.go
+++ b/api/v1alpha1/extra_deploy_validation_test.go
@@ -549,7 +549,7 @@ func TestValidateSelectValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validateSelectValue(tt.value, tt.options, nil, field.NewPath("test"))
+			errs := validateSelectValue(tt.value, tt.options, nil, false, field.NewPath("test"))
 			if tt.wantErr {
 				assert.NotEmpty(t, errs)
 			} else {
@@ -606,7 +606,7 @@ func TestValidateMultiSelectValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validateMultiSelectValue(tt.value, tt.options, tt.validation, nil, field.NewPath("test"))
+			errs := validateMultiSelectValue(tt.value, tt.options, tt.validation, nil, false, field.NewPath("test"))
 			if tt.wantErr {
 				assert.NotEmpty(t, errs)
 			} else {
@@ -727,7 +727,7 @@ func TestValidateExtraDeployValuesWithGroups(t *testing.T) {
 			wantErrors: 0,
 		},
 		{
-			name:   "nil userGroups skips group checks",
+			name:   "nil userGroups denied for restricted variable",
 			values: map[string]apiextensionsv1.JSON{"sensitive": {Raw: []byte(`true`)}},
 			variables: []ExtraDeployVariable{
 				{
@@ -737,10 +737,11 @@ func TestValidateExtraDeployValuesWithGroups(t *testing.T) {
 				},
 			},
 			userGroups: nil,
-			wantErrors: 0,
+			wantErrors: 1,
+			errContain: "restricted",
 		},
 		{
-			name:   "empty userGroups skips group checks",
+			name:   "empty userGroups denied for restricted variable",
 			values: map[string]apiextensionsv1.JSON{"sensitive": {Raw: []byte(`true`)}},
 			variables: []ExtraDeployVariable{
 				{
@@ -750,7 +751,42 @@ func TestValidateExtraDeployValuesWithGroups(t *testing.T) {
 				},
 			},
 			userGroups: []string{},
-			wantErrors: 0,
+			wantErrors: 1,
+			errContain: "restricted",
+		},
+		{
+			name:   "nil userGroups denied for restricted select option",
+			values: map[string]apiextensionsv1.JSON{"nodeType": {Raw: []byte(`"gpu"`)}},
+			variables: []ExtraDeployVariable{
+				{
+					Name:      "nodeType",
+					InputType: InputTypeSelect,
+					Options: []SelectOption{
+						{Value: "standard"},
+						{Value: "gpu", AllowedGroups: []string{"gpu-users"}},
+					},
+				},
+			},
+			userGroups: nil,
+			wantErrors: 1,
+			errContain: "gpu",
+		},
+		{
+			name:   "empty userGroups denied for restricted multiSelect option",
+			values: map[string]apiextensionsv1.JSON{"features": {Raw: []byte(`["basic","privileged"]`)}},
+			variables: []ExtraDeployVariable{
+				{
+					Name:      "features",
+					InputType: InputTypeMultiSelect,
+					Options: []SelectOption{
+						{Value: "basic"},
+						{Value: "privileged", AllowedGroups: []string{"admin"}},
+					},
+				},
+			},
+			userGroups: []string{},
+			wantErrors: 1,
+			errContain: "privileged",
 		},
 		{
 			name:   "production environment requires platform team",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1098,7 +1098,10 @@ configured `minLength` after sanitization.
 GET /api/debugSessions/templates
 ```
 
-Returns templates the current user has access to (based on group membership).
+Returns templates the current requester can use directly through
+`DebugSessionTemplate.spec.allowed` or indirectly through at least one active
+matching `DebugSessionClusterBinding`. User, email, group, and binding-granted
+access are all considered before a template is included in the response.
 
 **Query Parameters:**
 - `includeHidden` (optional, boolean): When `true`, includes templates marked `hidden`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1192,7 +1192,11 @@ Returns templates the current user has access to (based on group membership).
 GET /api/debugSessions/templates/:name
 ```
 
-Returns full `DebugSessionTemplate` CRD object.
+Returns the same flattened template summary shape as the list endpoint. The
+requester must be allowed by the template itself or by at least one active
+`DebugSessionClusterBinding` that references the template; otherwise the
+endpoint returns `403 Forbidden`. Scheduling options and extra deploy variables
+that are restricted to other users or groups are omitted from the response.
 
 ### Get Template Clusters
 
@@ -1201,6 +1205,13 @@ GET /api/debugSessions/templates/:name/clusters
 ```
 
 Returns available clusters for a template with resolved constraints from cluster bindings. Used by the two-step session creation wizard to show users cluster-specific options. A matching `ClusterConfig` must have `Ready=True`; clusters with `Ready=False`, `Ready=Unknown`, or no ready condition are hidden and cannot be selected for new debug sessions. `DebugSessionClusterBinding` resources with `spec.hidden: true` are omitted from this discovery response and cannot become the default `bindingRef` here, but explicit `POST /api/debugSessions` requests may still use a hidden binding by providing `bindingRef`.
+
+The response is filtered for the authenticated requester. A template is readable
+only when the requester is allowed by `DebugSessionTemplate.spec.allowed` or by
+at least one active matching `DebugSessionClusterBinding.spec.allowed`. Cluster
+and `bindingOptions` entries are returned only for direct template or binding
+paths the requester can use at session creation time. Restricted scheduling
+options are omitted.
 
 **Response (200 OK):**
 

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -488,6 +488,12 @@ When creating a session via the UI, the template clusters API returns per-cluste
 GET /api/debugSessions/templates/:name/clusters
 ```
 
+The API filters results for the authenticated requester before returning
+binding details. A binding appears only when it is active, matches the selected
+template and cluster, and the requester matches `binding.spec.allowed`. If a
+template is visible only through bindings, direct template allowlist metadata is
+not exposed to callers who cannot use the template directly.
+
 Response includes binding information:
 
 ```json

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1264,6 +1264,13 @@ GET /api/debugSessions/templates/:name/clusters
 
 Only ready cluster configurations are offered as debug targets. A matching `ClusterConfig` must have `Ready=True`; clusters with `Ready=False`, `Ready=Unknown`, no ready condition, or a duplicate `metadata.name` in another namespace are hidden from this response and `POST /api/debugSessions` rejects new debug sessions that target them. `DebugSessionClusterBinding` objects with `spec.hidden: true` are also omitted from this UI discovery response, but callers that already know the binding name can still use it through an explicit `bindingRef` in `POST /api/debugSessions`.
 
+Template and cluster discovery is requester-specific. The API returns a
+template only when the authenticated requester can use the template directly or
+through at least one active matching `DebugSessionClusterBinding`. Cluster
+entries, binding options, scheduling options, and extra deploy variables that
+the requester cannot use at session creation time are omitted from discovery
+responses.
+
 Response includes per-cluster details:
 
 ```json

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -3618,7 +3618,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 	}
 
 	t.Run("returns clusters for template without bindings", func(t *testing.T) {
-		router, _ := setupTestRouter(t, template, clusterA, clusterB)
+		_, ctrl := setupTestRouter(t, template, clusterA, clusterB)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3654,7 +3655,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 				Reason: "ConnectionFailed",
 			},
 		}
-		router, _ := setupTestRouter(t, template, clusterA, unreadyCluster)
+		_, ctrl := setupTestRouter(t, template, clusterA, unreadyCluster)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3711,7 +3713,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 			},
 		}
 
-		router, _ := setupTestRouter(t, template, clusterA, clusterB, binding)
+		_, ctrl := setupTestRouter(t, template, clusterA, clusterB, binding)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3779,7 +3782,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 	})
 
 	t.Run("filters clusters by environment query param", func(t *testing.T) {
-		router, _ := setupTestRouter(t, template, clusterA, clusterB)
+		_, ctrl := setupTestRouter(t, template, clusterA, clusterB)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters?environment=production", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3843,7 +3847,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 			},
 		}
 
-		router, _ := setupTestRouter(t, template, clusterA, binding1, binding2)
+		_, ctrl := setupTestRouter(t, template, clusterA, binding1, binding2)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3926,7 +3931,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 			},
 		}
 
-		router, _ := setupTestRouter(t, template, clusterA, visibleBinding, hiddenBinding)
+		_, ctrl := setupTestRouter(t, template, clusterA, visibleBinding, hiddenBinding)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3953,6 +3959,86 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 
 		require.Len(t, clusterADetail.BindingOptions, 1)
 		assert.Equal(t, "binding-visible", clusterADetail.BindingOptions[0].BindingRef.Name)
+	})
+
+	t.Run("filters binding options by requester allowlist", func(t *testing.T) {
+		bindingSRE := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-sre",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{
+					Name: "test-template",
+				},
+				Clusters: []string{"cluster-a"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"sre"},
+				},
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{Name: "tenant-safe", DisplayName: "Tenant Safe"},
+						{Name: "platform-node", DisplayName: "Platform Node", AllowedGroups: []string{"platform-admins"}},
+					},
+				},
+			},
+		}
+		bindingPlatform := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-platform",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{
+					Name: "test-template",
+				},
+				Clusters: []string{"cluster-a"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"platform-admins"},
+				},
+				Constraints: &breakglassv1alpha1.DebugSessionConstraints{
+					MaxDuration: "12h",
+				},
+				Impersonation: &breakglassv1alpha1.ImpersonationConfig{
+					ServiceAccountRef: &breakglassv1alpha1.ServiceAccountReference{
+						Name:      "platform-debug",
+						Namespace: "kube-system",
+					},
+				},
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Users: []string{"platform-approver@example.com"},
+				},
+			},
+		}
+		bindingOnlyTemplate := template.DeepCopy()
+		bindingOnlyTemplate.Spec.Allowed = nil
+
+		_, ctrl := setupTestRouter(t, bindingOnlyTemplate, clusterA, bindingSRE, bindingPlatform)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
+		req.Header.Set("Accept", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NotContains(t, w.Body.String(), "binding-platform")
+		assert.NotContains(t, w.Body.String(), "platform-debug")
+		assert.NotContains(t, w.Body.String(), "platform-approver@example.com")
+		assert.NotContains(t, w.Body.String(), "platform-node")
+
+		var resp TemplateClustersResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Clusters, 1)
+		require.NotNil(t, resp.Clusters[0].BindingRef)
+		assert.Equal(t, "binding-sre", resp.Clusters[0].BindingRef.Name)
+		require.Len(t, resp.Clusters[0].BindingOptions, 1)
+		assert.Equal(t, "binding-sre", resp.Clusters[0].BindingOptions[0].BindingRef.Name)
+		require.NotNil(t, resp.Clusters[0].BindingOptions[0].SchedulingOptions)
+		require.Len(t, resp.Clusters[0].BindingOptions[0].SchedulingOptions.Options, 1)
+		assert.Equal(t, "tenant-safe", resp.Clusters[0].BindingOptions[0].SchedulingOptions.Options[0].Name)
 	})
 
 	t.Run("omits cluster available only through hidden binding", func(t *testing.T) {
@@ -3982,7 +4068,8 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 			},
 		}
 
-		router, _ := setupTestRouter(t, bindingOnlyTemplate, clusterA, hiddenBinding)
+		_, ctrl := setupTestRouter(t, bindingOnlyTemplate, clusterA, hiddenBinding)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/binding-only-template/clusters", nil)
 		req.Header.Set("Accept", "application/json")
@@ -3996,5 +4083,44 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.Empty(t, resp.Clusters)
+	})
+
+	t.Run("forbids cluster discovery when only bindings exist and requester matches none", func(t *testing.T) {
+		restrictedBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-platform",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{
+					Name: "test-template",
+				},
+				Clusters: []string{"cluster-a"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"platform-admins"},
+				},
+				Impersonation: &breakglassv1alpha1.ImpersonationConfig{
+					ServiceAccountRef: &breakglassv1alpha1.ServiceAccountReference{
+						Name:      "platform-debug",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		}
+		bindingOnlyTemplate := template.DeepCopy()
+		bindingOnlyTemplate.Spec.Allowed = nil
+
+		_, ctrl := setupTestRouter(t, bindingOnlyTemplate, clusterA, restrictedBinding)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "mallory@example.com", "mallory@example.com", []string{"tenant-users"})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
+		req.Header.Set("Accept", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.NotContains(t, w.Body.String(), "binding-platform")
+		assert.NotContains(t, w.Body.String(), "platform-debug")
 	})
 }

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -4041,6 +4041,54 @@ func TestHandleGetTemplateClusters(t *testing.T) {
 		assert.Equal(t, "tenant-safe", resp.Clusters[0].BindingOptions[0].SchedulingOptions.Options[0].Name)
 	})
 
+	t.Run("omits clusters when required binding scheduling options are unavailable", func(t *testing.T) {
+		bindingSRE := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-sre",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{
+					Name: "test-template",
+				},
+				Clusters: []string{"cluster-a"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"sre"},
+				},
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Required: true,
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{
+							Name:          "platform-node",
+							DisplayName:   "Platform Node",
+							AllowedGroups: []string{"platform-admins"},
+						},
+					},
+				},
+			},
+		}
+		bindingOnlyTemplate := template.DeepCopy()
+		bindingOnlyTemplate.Spec.Allowed = nil
+
+		_, ctrl := setupTestRouter(t, bindingOnlyTemplate, clusterA, bindingSRE)
+		router := setupAuthenticatedDebugSessionRouter(t, ctrl, "alice@example.com", "alice@example.com", []string{"sre"})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/debugSessions/templates/test-template/clusters", nil)
+		req.Header.Set("Accept", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NotContains(t, w.Body.String(), "binding-sre")
+		assert.NotContains(t, w.Body.String(), "platform-node")
+
+		var resp TemplateClustersResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Clusters)
+	})
+
 	t.Run("omits cluster available only through hidden binding", func(t *testing.T) {
 		bindingOnlyTemplate := &breakglassv1alpha1.DebugSessionTemplate{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -114,6 +114,18 @@ func (c *DebugSessionAPIController) resolveSchedulingOptions(template *breakglas
 	return response
 }
 
+func (c *DebugSessionAPIController) resolveSchedulingOptionsForRequester(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding, requester debugTemplateRequester) *SchedulingOptionsResponse {
+	var so *breakglassv1alpha1.SchedulingOptions
+
+	if binding != nil && binding.Spec.SchedulingOptions != nil {
+		so = binding.Spec.SchedulingOptions
+	} else if template.Spec.SchedulingOptions != nil {
+		so = template.Spec.SchedulingOptions
+	}
+
+	return buildSchedulingOptionsResponseForRequester(so, requester)
+}
+
 // resolveNamespaceConstraints builds API-visible namespace constraint hints.
 // Runtime validation still checks template and binding constraints separately;
 // response allow filters are only surfaced when they are safe static hints.

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -81,39 +81,6 @@ func buildConstraintsSummary(sc *breakglassv1alpha1.SchedulingConstraints) *Sche
 	return summary
 }
 
-// resolveSchedulingOptions resolves scheduling options from binding or template
-func (c *DebugSessionAPIController) resolveSchedulingOptions(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) *SchedulingOptionsResponse {
-	var so *breakglassv1alpha1.SchedulingOptions
-
-	// Binding options take precedence
-	if binding != nil && binding.Spec.SchedulingOptions != nil {
-		so = binding.Spec.SchedulingOptions
-	} else if template.Spec.SchedulingOptions != nil {
-		so = template.Spec.SchedulingOptions
-	}
-
-	if so == nil {
-		return nil
-	}
-
-	response := &SchedulingOptionsResponse{
-		Required: so.Required,
-		Options:  make([]SchedulingOptionResponse, 0, len(so.Options)),
-	}
-
-	for _, opt := range so.Options {
-		response.Options = append(response.Options, SchedulingOptionResponse{
-			Name:                  opt.Name,
-			DisplayName:           opt.DisplayName,
-			Description:           opt.Description,
-			Default:               opt.Default,
-			SchedulingConstraints: buildConstraintsSummary(opt.SchedulingConstraints),
-		})
-	}
-
-	return response
-}
-
 func (c *DebugSessionAPIController) resolveSchedulingOptionsForRequester(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding, requester debugTemplateRequester) *SchedulingOptionsResponse {
 	var so *breakglassv1alpha1.SchedulingOptions
 

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -298,11 +298,13 @@ func filterExtraDeployVariablesForRequester(vars []breakglassv1alpha1.ExtraDeplo
 			filteredOptions := make([]breakglassv1alpha1.SelectOption, 0, len(filteredVariable.Options))
 			for _, option := range filteredVariable.Options {
 				if userHasAnyExactGroup(requester.groups, option.AllowedGroups) {
+					option.AllowedGroups = nil
 					filteredOptions = append(filteredOptions, option)
 				}
 			}
 			filteredVariable.Options = filteredOptions
 		}
+		filteredVariable.AllowedGroups = nil
 		filtered = append(filtered, filteredVariable)
 	}
 
@@ -526,14 +528,14 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 		return
 	}
 
-	// Find UI-visible bindings that apply to this template. Hidden bindings can
-	// still be used through explicit API bindingRef requests, but are not offered
-	// as selectable cluster options.
-	applicableBindings := c.findVisibleBindingsForTemplate(template, bindingList.Items)
+	applicableBindings := c.findBindingsForTemplate(template, bindingList.Items)
 	if !c.canReadTemplateWithBindings(template, applicableBindings, requester) {
 		apiresponses.RespondForbidden(ctx, "access denied to this template")
 		return
 	}
+	// Hidden bindings can still authorize template access and explicit API
+	// bindingRef requests, but are not offered as selectable cluster options.
+	visibleBindings := visibleDebugSessionBindings(applicableBindings)
 
 	var clusterConfigList breakglassv1alpha1.ClusterConfigList
 	if err := c.reader().List(apiCtx, &clusterConfigList); err != nil {
@@ -546,7 +548,7 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 	clusterMap, _ := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Build the response - resolve clusters from bindings and template's allowed.clusters
-	clusterDetails := c.resolveTemplateClusters(template, applicableBindings, clusterMap, requester)
+	clusterDetails := c.resolveTemplateClusters(template, visibleBindings, clusterMap, requester)
 
 	// Apply optional query filters
 	environment := ctx.Query("environment")

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -671,11 +671,6 @@ func (c *DebugSessionAPIController) findBindingsForTemplate(template *breakglass
 	return result
 }
 
-func (c *DebugSessionAPIController) findVisibleBindingsForTemplate(template *breakglassv1alpha1.DebugSessionTemplate, bindings []breakglassv1alpha1.DebugSessionClusterBinding) []breakglassv1alpha1.DebugSessionClusterBinding {
-	applicableBindings := c.findBindingsForTemplate(template, bindings)
-	return visibleDebugSessionBindings(applicableBindings)
-}
-
 func visibleDebugSessionBindings(bindings []breakglassv1alpha1.DebugSessionClusterBinding) []breakglassv1alpha1.DebugSessionClusterBinding {
 	visibleBindings := make([]breakglassv1alpha1.DebugSessionClusterBinding, 0, len(bindings))
 	for i := range bindings {

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -390,8 +390,9 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 	// Fetch all bindings to determine which templates have available clusters
 	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
 	if err := c.reader().List(apiCtx, bindingList); err != nil {
-		reqLog.Warnw("Failed to list bindings for template cluster resolution", "error", err)
-		// Continue without binding resolution
+		reqLog.Errorw("Failed to list bindings for template cluster resolution", "error", err)
+		apiresponses.RespondInternalErrorSimple(ctx, "failed to list bindings")
+		return
 	}
 
 	requester := debugTemplateRequesterFromContext(ctx)
@@ -505,9 +506,8 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
 
-	// Fetch the template
 	template := &breakglassv1alpha1.DebugSessionTemplate{}
-	if err := c.client.Get(apiCtx, ctrlclient.ObjectKey{Name: name}, template); err != nil {
+	if err := c.reader().Get(apiCtx, ctrlclient.ObjectKey{Name: name}, template); err != nil {
 		if apierrors.IsNotFound(err) {
 			apiresponses.RespondNotFoundSimple(ctx, "template not found")
 			return
@@ -520,7 +520,7 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 	requester := debugTemplateRequesterFromContext(ctx)
 
 	var bindingList breakglassv1alpha1.DebugSessionClusterBindingList
-	if err := c.client.List(apiCtx, &bindingList); err != nil {
+	if err := c.reader().List(apiCtx, &bindingList); err != nil {
 		reqLog.Errorw("Failed to list cluster bindings", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list bindings")
 		return
@@ -536,7 +536,7 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 	}
 
 	var clusterConfigList breakglassv1alpha1.ClusterConfigList
-	if err := c.client.List(apiCtx, &clusterConfigList); err != nil {
+	if err := c.reader().List(apiCtx, &clusterConfigList); err != nil {
 		reqLog.Errorw("Failed to list cluster configs", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list clusters")
 		return
@@ -593,6 +593,9 @@ func (c *DebugSessionAPIController) countAvailableClustersForTemplate(
 		if !requester.canRequest(effectiveDebugSessionAllowed(template, binding)) {
 			continue
 		}
+		if !debugSchedulingOptionsAvailableForRequester(template, binding, requester) {
+			continue
+		}
 		bindingClusters := c.resolveClustersFromBinding(binding, clusterMap)
 		for _, clusterName := range bindingClusters {
 			if clusterMap[clusterName] != nil {
@@ -602,7 +605,10 @@ func (c *DebugSessionAPIController) countAvailableClustersForTemplate(
 	}
 
 	// Also check template's direct allowed.clusters patterns
-	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) && template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
+	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) &&
+		debugSchedulingOptionsAvailableForRequester(template, nil, requester) &&
+		template.Spec.Allowed != nil &&
+		len(template.Spec.Allowed.Clusters) > 0 {
 		resolvedClusters := resolveClusterPatterns(template.Spec.Allowed.Clusters, allClusterNames)
 		for _, clusterName := range resolvedClusters {
 			if clusterMap[clusterName] != nil {
@@ -693,6 +699,9 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 		if !requester.canRequest(effectiveDebugSessionAllowed(template, binding)) {
 			continue
 		}
+		if !debugSchedulingOptionsAvailableForRequester(template, binding, requester) {
+			continue
+		}
 		bindingClusters := c.resolveClustersFromBinding(binding, clusterMap)
 		for _, clusterName := range bindingClusters {
 			clusterBindings[clusterName] = append(clusterBindings[clusterName], binding)
@@ -720,7 +729,10 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 	}
 
 	// Then, resolve clusters from template's allowed.clusters (fallback, no binding)
-	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) && template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
+	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) &&
+		debugSchedulingOptionsAvailableForRequester(template, nil, requester) &&
+		template.Spec.Allowed != nil &&
+		len(template.Spec.Allowed.Clusters) > 0 {
 		allClusterNames := make([]string, 0, len(clusterMap))
 		for name := range clusterMap {
 			allClusterNames = append(allClusterNames, name)
@@ -744,6 +756,23 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 	}
 
 	return result
+}
+
+func debugSchedulingOptionsAvailableForRequester(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+	requester debugTemplateRequester,
+) bool {
+	var schedulingOptions *breakglassv1alpha1.SchedulingOptions
+	if binding != nil && binding.Spec.SchedulingOptions != nil {
+		schedulingOptions = binding.Spec.SchedulingOptions
+	} else if template.Spec.SchedulingOptions != nil {
+		schedulingOptions = template.Spec.SchedulingOptions
+	}
+	if schedulingOptions == nil || !schedulingOptions.Required {
+		return true
+	}
+	return len(buildSchedulingOptionsResponseForRequester(schedulingOptions, requester).Options) > 0
 }
 
 // buildClusterDetailWithBindings creates a cluster detail with all matching binding options.

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -185,6 +185,188 @@ type NotificationConfigInfo struct {
 	Enabled bool `json:"enabled"`
 }
 
+type debugTemplateRequester struct {
+	username string
+	email    string
+	groups   []string
+}
+
+func debugTemplateRequesterFromContext(ctx *gin.Context) debugTemplateRequester {
+	requester := debugTemplateRequester{}
+
+	if username, ok := ctx.Get("username"); ok {
+		if value, ok := username.(string); ok {
+			requester.username = value
+		}
+	}
+	if email, ok := ctx.Get("email"); ok {
+		if value, ok := email.(string); ok {
+			requester.email = value
+		}
+	}
+	if groups, ok := ctx.Get("groups"); ok {
+		if value, ok := groups.([]string); ok {
+			requester.groups = value
+		}
+	}
+
+	return requester
+}
+
+func (r debugTemplateRequester) canRequest(allowed *breakglassv1alpha1.DebugSessionAllowed) bool {
+	return isDebugSessionRequesterAllowed(allowed, r.username, r.email, r.groups)
+}
+
+func (r debugTemplateRequester) schedulingOptionRequester() schedulingOptionRequester {
+	return schedulingOptionRequester{
+		Username: r.username,
+		Email:    r.email,
+		Groups:   r.groups,
+	}
+}
+
+func (c *DebugSessionAPIController) canReadTemplateWithBindings(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	bindings []breakglassv1alpha1.DebugSessionClusterBinding,
+	requester debugTemplateRequester,
+) bool {
+	hasDirectClusters := template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0
+	if hasDirectClusters && requester.canRequest(effectiveDebugSessionAllowed(template, nil)) {
+		return true
+	}
+	if !hasDirectClusters && len(bindings) == 0 && requester.canRequest(effectiveDebugSessionAllowed(template, nil)) {
+		return true
+	}
+	for i := range bindings {
+		if requester.canRequest(effectiveDebugSessionAllowed(template, &bindings[i])) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildSchedulingOptionsResponseForRequester(so *breakglassv1alpha1.SchedulingOptions, requester debugTemplateRequester) *SchedulingOptionsResponse {
+	if so == nil {
+		return nil
+	}
+
+	response := &SchedulingOptionsResponse{
+		Required: so.Required,
+		Options:  make([]SchedulingOptionResponse, 0, len(so.Options)),
+	}
+	optionRequester := requester.schedulingOptionRequester()
+	for _, opt := range so.Options {
+		if !isSchedulingOptionAllowedForRequester(&opt, optionRequester) {
+			continue
+		}
+		response.Options = append(response.Options, SchedulingOptionResponse{
+			Name:                  opt.Name,
+			DisplayName:           opt.DisplayName,
+			Description:           opt.Description,
+			Default:               opt.Default,
+			SchedulingConstraints: buildConstraintsSummary(opt.SchedulingConstraints),
+		})
+	}
+
+	return response
+}
+
+func userHasAnyExactGroup(userGroups, allowedGroups []string) bool {
+	if len(allowedGroups) == 0 {
+		return true
+	}
+	for _, allowedGroup := range allowedGroups {
+		for _, userGroup := range userGroups {
+			if allowedGroup == userGroup {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func filterExtraDeployVariablesForRequester(vars []breakglassv1alpha1.ExtraDeployVariable, requester debugTemplateRequester) []breakglassv1alpha1.ExtraDeployVariable {
+	if len(vars) == 0 {
+		return nil
+	}
+
+	filtered := make([]breakglassv1alpha1.ExtraDeployVariable, 0, len(vars))
+	for _, variable := range vars {
+		if !userHasAnyExactGroup(requester.groups, variable.AllowedGroups) {
+			continue
+		}
+
+		filteredVariable := *variable.DeepCopy()
+		if len(filteredVariable.Options) > 0 {
+			filteredOptions := make([]breakglassv1alpha1.SelectOption, 0, len(filteredVariable.Options))
+			for _, option := range filteredVariable.Options {
+				if userHasAnyExactGroup(requester.groups, option.AllowedGroups) {
+					filteredOptions = append(filteredOptions, option)
+				}
+			}
+			filteredVariable.Options = filteredOptions
+		}
+		filtered = append(filtered, filteredVariable)
+	}
+
+	return filtered
+}
+
+func (c *DebugSessionAPIController) buildTemplateResponse(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	requester debugTemplateRequester,
+	allClusterNames []string,
+	availableClusterCount int,
+) DebugSessionTemplateResponse {
+	resp := DebugSessionTemplateResponse{
+		Name:                  template.Name,
+		DisplayName:           template.Spec.DisplayName,
+		Description:           template.Spec.Description,
+		Mode:                  template.Spec.Mode,
+		WorkloadType:          template.Spec.WorkloadType,
+		TargetNamespace:       template.Spec.TargetNamespace,
+		Constraints:           template.Spec.Constraints,
+		RequiresApproval:      template.Spec.Approvers != nil && (len(template.Spec.Approvers.Groups) > 0 || len(template.Spec.Approvers.Users) > 0),
+		ExtraDeployVariables:  filterExtraDeployVariablesForRequester(template.Spec.ExtraDeployVariables, requester),
+		Priority:              template.Spec.Priority,
+		Hidden:                template.Spec.Hidden,
+		Deprecated:            template.Spec.Deprecated,
+		DeprecationMessage:    template.Spec.DeprecationMessage,
+		HasAvailableClusters:  availableClusterCount > 0,
+		AvailableClusterCount: availableClusterCount,
+	}
+
+	if template.Spec.PodTemplateRef != nil {
+		resp.PodTemplateRef = template.Spec.PodTemplateRef.Name
+	}
+	if template.Spec.Allowed != nil && requester.canRequest(effectiveDebugSessionAllowed(template, nil)) {
+		if allClusterNames != nil {
+			resp.AllowedClusters = resolveClusterPatterns(template.Spec.Allowed.Clusters, allClusterNames)
+		} else {
+			resp.AllowedClusters = template.Spec.Allowed.Clusters
+		}
+		resp.AllowedGroups = template.Spec.Allowed.Groups
+	}
+	resp.SchedulingOptions = buildSchedulingOptionsResponseForRequester(template.Spec.SchedulingOptions, requester)
+
+	if template.Spec.NamespaceConstraints != nil {
+		resp.NamespaceConstraints = &NamespaceConstraintsResponse{
+			DefaultNamespace:   template.Spec.NamespaceConstraints.DefaultNamespace,
+			AllowUserNamespace: template.Spec.NamespaceConstraints.AllowUserNamespace,
+		}
+		if template.Spec.NamespaceConstraints.AllowedNamespaces != nil {
+			resp.NamespaceConstraints.AllowedPatterns = template.Spec.NamespaceConstraints.AllowedNamespaces.Patterns
+			resp.NamespaceConstraints.AllowedLabelSelectors = convertSelectorTerms(template.Spec.NamespaceConstraints.AllowedNamespaces.SelectorTerms)
+		}
+		if template.Spec.NamespaceConstraints.DeniedNamespaces != nil {
+			resp.NamespaceConstraints.DeniedPatterns = template.Spec.NamespaceConstraints.DeniedNamespaces.Patterns
+			resp.NamespaceConstraints.DeniedLabelSelectors = convertSelectorTerms(template.Spec.NamespaceConstraints.DeniedNamespaces.SelectorTerms)
+		}
+	}
+
+	return resp
+}
+
 // handleListTemplates returns available debug session templates
 // Uses the uncached apiReader if configured, for consistent reads after writes.
 func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
@@ -215,14 +397,7 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 		// Continue without binding resolution
 	}
 
-	// Get user's groups for filtering
-	userGroups, _ := ctx.Get("groups")
-	groups := []string{}
-	if userGroups != nil {
-		if g, ok := userGroups.([]string); ok {
-			groups = g
-		}
-	}
+	requester := debugTemplateRequesterFromContext(ctx)
 
 	includeHidden := ctx.Query("includeHidden") == "true"
 	includeUnavailable := ctx.Query("includeUnavailable") == "true"
@@ -233,31 +408,14 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 		if t.Spec.Hidden && !includeHidden {
 			continue
 		}
-		// Check if user has access to this template
-		if t.Spec.Allowed != nil && len(t.Spec.Allowed.Groups) > 0 {
-			hasAccess := false
-			for _, allowedGroup := range t.Spec.Allowed.Groups {
-				if allowedGroup == "*" {
-					hasAccess = true
-					break
-				}
-				for _, userGroup := range groups {
-					if matchPattern(allowedGroup, userGroup) {
-						hasAccess = true
-						break
-					}
-				}
-				if hasAccess {
-					break
-				}
-			}
-			if !hasAccess {
-				continue
-			}
+
+		applicableBindings := c.findBindingsForTemplate(&t, bindingList.Items)
+		if !c.canReadTemplateWithBindings(&t, applicableBindings, requester) {
+			continue
 		}
 
 		// Calculate available cluster count for this template
-		availableClusterCount := c.countAvailableClustersForTemplate(&t, bindingList.Items, clusterMap, allClusterNames)
+		availableClusterCount := c.countAvailableClustersForTemplate(&t, applicableBindings, clusterMap, allClusterNames, requester)
 		hasAvailableClusters := availableClusterCount > 0
 
 		// Skip templates without available clusters unless explicitly requested
@@ -269,67 +427,7 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 			continue
 		}
 
-		resp := DebugSessionTemplateResponse{
-			Name:                  t.Name,
-			DisplayName:           t.Spec.DisplayName,
-			Description:           t.Spec.Description,
-			Mode:                  t.Spec.Mode,
-			WorkloadType:          t.Spec.WorkloadType,
-			TargetNamespace:       t.Spec.TargetNamespace,
-			Constraints:           t.Spec.Constraints,
-			RequiresApproval:      t.Spec.Approvers != nil && (len(t.Spec.Approvers.Groups) > 0 || len(t.Spec.Approvers.Users) > 0),
-			ExtraDeployVariables:  t.Spec.ExtraDeployVariables,
-			Priority:              t.Spec.Priority,
-			Hidden:                t.Spec.Hidden,
-			Deprecated:            t.Spec.Deprecated,
-			DeprecationMessage:    t.Spec.DeprecationMessage,
-			HasAvailableClusters:  hasAvailableClusters,
-			AvailableClusterCount: availableClusterCount,
-		}
-
-		if t.Spec.PodTemplateRef != nil {
-			resp.PodTemplateRef = t.Spec.PodTemplateRef.Name
-		}
-		if t.Spec.Allowed != nil {
-			// Resolve cluster patterns to actual cluster names
-			resp.AllowedClusters = resolveClusterPatterns(t.Spec.Allowed.Clusters, allClusterNames)
-			resp.AllowedGroups = t.Spec.Allowed.Groups
-		}
-
-		// Include scheduling options if present
-		if t.Spec.SchedulingOptions != nil {
-			resp.SchedulingOptions = &SchedulingOptionsResponse{
-				Required: t.Spec.SchedulingOptions.Required,
-				Options:  make([]SchedulingOptionResponse, 0, len(t.Spec.SchedulingOptions.Options)),
-			}
-			for _, opt := range t.Spec.SchedulingOptions.Options {
-				resp.SchedulingOptions.Options = append(resp.SchedulingOptions.Options, SchedulingOptionResponse{
-					Name:                  opt.Name,
-					DisplayName:           opt.DisplayName,
-					Description:           opt.Description,
-					Default:               opt.Default,
-					SchedulingConstraints: buildConstraintsSummary(opt.SchedulingConstraints),
-				})
-			}
-		}
-
-		// Include namespace constraints if present
-		if t.Spec.NamespaceConstraints != nil {
-			resp.NamespaceConstraints = &NamespaceConstraintsResponse{
-				DefaultNamespace:   t.Spec.NamespaceConstraints.DefaultNamespace,
-				AllowUserNamespace: t.Spec.NamespaceConstraints.AllowUserNamespace,
-			}
-			if t.Spec.NamespaceConstraints.AllowedNamespaces != nil {
-				resp.NamespaceConstraints.AllowedPatterns = t.Spec.NamespaceConstraints.AllowedNamespaces.Patterns
-				resp.NamespaceConstraints.AllowedLabelSelectors = convertSelectorTerms(t.Spec.NamespaceConstraints.AllowedNamespaces.SelectorTerms)
-			}
-			if t.Spec.NamespaceConstraints.DeniedNamespaces != nil {
-				resp.NamespaceConstraints.DeniedPatterns = t.Spec.NamespaceConstraints.DeniedNamespaces.Patterns
-				resp.NamespaceConstraints.DeniedLabelSelectors = convertSelectorTerms(t.Spec.NamespaceConstraints.DeniedNamespaces.SelectorTerms)
-			}
-		}
-
-		templates = append(templates, resp)
+		templates = append(templates, c.buildTemplateResponse(&t, requester, allClusterNames, availableClusterCount))
 	}
 
 	sort.Slice(templates, func(i, j int) bool {
@@ -371,65 +469,21 @@ func (c *DebugSessionAPIController) handleGetTemplate(ctx *gin.Context) {
 		return
 	}
 
-	// Build response using same format as list endpoint
-	resp := DebugSessionTemplateResponse{
-		Name:                 template.Name,
-		DisplayName:          template.Spec.DisplayName,
-		Description:          template.Spec.Description,
-		Mode:                 template.Spec.Mode,
-		WorkloadType:         template.Spec.WorkloadType,
-		TargetNamespace:      template.Spec.TargetNamespace,
-		Constraints:          template.Spec.Constraints,
-		RequiresApproval:     template.Spec.Approvers != nil && (len(template.Spec.Approvers.Groups) > 0 || len(template.Spec.Approvers.Users) > 0),
-		ExtraDeployVariables: template.Spec.ExtraDeployVariables,
-		Priority:             template.Spec.Priority,
-		Hidden:               template.Spec.Hidden,
-		Deprecated:           template.Spec.Deprecated,
-		DeprecationMessage:   template.Spec.DeprecationMessage,
+	bindingList := &breakglassv1alpha1.DebugSessionClusterBindingList{}
+	if err := c.reader().List(apiCtx, bindingList); err != nil {
+		reqLog.Errorw("Failed to list bindings for template authorization", "name", name, "error", err)
+		apiresponses.RespondInternalErrorSimple(ctx, "failed to authorize template")
+		return
 	}
 
-	if template.Spec.PodTemplateRef != nil {
-		resp.PodTemplateRef = template.Spec.PodTemplateRef.Name
-	}
-	if template.Spec.Allowed != nil {
-		resp.AllowedClusters = template.Spec.Allowed.Clusters
-		resp.AllowedGroups = template.Spec.Allowed.Groups
-	}
-
-	// Include scheduling options if present
-	if template.Spec.SchedulingOptions != nil {
-		resp.SchedulingOptions = &SchedulingOptionsResponse{
-			Required: template.Spec.SchedulingOptions.Required,
-			Options:  make([]SchedulingOptionResponse, 0, len(template.Spec.SchedulingOptions.Options)),
-		}
-		for _, opt := range template.Spec.SchedulingOptions.Options {
-			resp.SchedulingOptions.Options = append(resp.SchedulingOptions.Options, SchedulingOptionResponse{
-				Name:                  opt.Name,
-				DisplayName:           opt.DisplayName,
-				Description:           opt.Description,
-				Default:               opt.Default,
-				SchedulingConstraints: buildConstraintsSummary(opt.SchedulingConstraints),
-			})
-		}
+	requester := debugTemplateRequesterFromContext(ctx)
+	applicableBindings := c.findBindingsForTemplate(template, bindingList.Items)
+	if !c.canReadTemplateWithBindings(template, applicableBindings, requester) {
+		apiresponses.RespondForbidden(ctx, "access denied to this template")
+		return
 	}
 
-	// Include namespace constraints if present
-	if template.Spec.NamespaceConstraints != nil {
-		resp.NamespaceConstraints = &NamespaceConstraintsResponse{
-			DefaultNamespace:   template.Spec.NamespaceConstraints.DefaultNamespace,
-			AllowUserNamespace: template.Spec.NamespaceConstraints.AllowUserNamespace,
-		}
-		if template.Spec.NamespaceConstraints.AllowedNamespaces != nil {
-			resp.NamespaceConstraints.AllowedPatterns = template.Spec.NamespaceConstraints.AllowedNamespaces.Patterns
-			resp.NamespaceConstraints.AllowedLabelSelectors = convertSelectorTerms(template.Spec.NamespaceConstraints.AllowedNamespaces.SelectorTerms)
-		}
-		if template.Spec.NamespaceConstraints.DeniedNamespaces != nil {
-			resp.NamespaceConstraints.DeniedPatterns = template.Spec.NamespaceConstraints.DeniedNamespaces.Patterns
-			resp.NamespaceConstraints.DeniedLabelSelectors = convertSelectorTerms(template.Spec.NamespaceConstraints.DeniedNamespaces.SelectorTerms)
-		}
-	}
-
-	ctx.JSON(http.StatusOK, resp)
+	ctx.JSON(http.StatusOK, c.buildTemplateResponse(template, requester, nil, 0))
 }
 
 // handleGetTemplateClusters returns cluster-specific details for a template
@@ -457,38 +511,7 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 		return
 	}
 
-	// Get user's groups for filtering
-	userGroups, _ := ctx.Get("groups")
-	groups := []string{}
-	if userGroups != nil {
-		if g, ok := userGroups.([]string); ok {
-			groups = g
-		}
-	}
-
-	// Check if user has access to this template
-	if template.Spec.Allowed != nil && len(template.Spec.Allowed.Groups) > 0 {
-		hasAccess := false
-		for _, allowedGroup := range template.Spec.Allowed.Groups {
-			if allowedGroup == "*" {
-				hasAccess = true
-				break
-			}
-			for _, userGroup := range groups {
-				if matchPattern(allowedGroup, userGroup) {
-					hasAccess = true
-					break
-				}
-			}
-			if hasAccess {
-				break
-			}
-		}
-		if !hasAccess {
-			apiresponses.RespondForbidden(ctx, "access denied to this template")
-			return
-		}
-	}
+	requester := debugTemplateRequesterFromContext(ctx)
 
 	// Fetch ClusterConfigs and ClusterBindings in parallel for performance
 	var clusterConfigList breakglassv1alpha1.ClusterConfigList
@@ -530,9 +553,13 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 	// still be used through explicit API bindingRef requests, but are not offered
 	// as selectable cluster options.
 	applicableBindings := c.findVisibleBindingsForTemplate(template, bindingList.Items)
+	if !c.canReadTemplateWithBindings(template, applicableBindings, requester) {
+		apiresponses.RespondForbidden(ctx, "access denied to this template")
+		return
+	}
 
 	// Build the response - resolve clusters from bindings and template's allowed.clusters
-	clusterDetails := c.resolveTemplateClusters(template, applicableBindings, clusterMap, groups)
+	clusterDetails := c.resolveTemplateClusters(template, applicableBindings, clusterMap, requester)
 
 	// Apply optional query filters
 	environment := ctx.Query("environment")
@@ -566,20 +593,19 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 // It considers both bindings and direct template.Spec.Allowed.Clusters patterns.
 func (c *DebugSessionAPIController) countAvailableClustersForTemplate(
 	template *breakglassv1alpha1.DebugSessionTemplate,
-	allBindings []breakglassv1alpha1.DebugSessionClusterBinding,
+	applicableBindings []breakglassv1alpha1.DebugSessionClusterBinding,
 	clusterMap map[string]*breakglassv1alpha1.ClusterConfig,
 	allClusterNames []string,
+	requester debugTemplateRequester,
 ) int {
 	seenClusters := make(map[string]bool)
-
-	// Count only UI-visible bindings. Hidden bindings can still be used through
-	// explicit API bindingRef requests, but should not make templates appear
-	// available in UI discovery.
-	applicableBindings := c.findVisibleBindingsForTemplate(template, allBindings)
 
 	// Collect clusters from bindings
 	for i := range applicableBindings {
 		binding := &applicableBindings[i]
+		if !requester.canRequest(effectiveDebugSessionAllowed(template, binding)) {
+			continue
+		}
 		bindingClusters := c.resolveClustersFromBinding(binding, clusterMap)
 		for _, clusterName := range bindingClusters {
 			if clusterMap[clusterName] != nil {
@@ -589,7 +615,7 @@ func (c *DebugSessionAPIController) countAvailableClustersForTemplate(
 	}
 
 	// Also check template's direct allowed.clusters patterns
-	if template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
+	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) && template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
 		resolvedClusters := resolveClusterPatterns(template.Spec.Allowed.Clusters, allClusterNames)
 		for _, clusterName := range resolvedClusters {
 			if clusterMap[clusterName] != nil {
@@ -670,13 +696,16 @@ func (c *DebugSessionAPIController) findVisibleBindingsForTemplate(template *bre
 // resolveTemplateClusters resolves all available clusters for a template.
 // When multiple bindings match the same cluster, all binding options are returned
 // so users can select which binding configuration to use.
-func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglassv1alpha1.DebugSessionTemplate, bindings []breakglassv1alpha1.DebugSessionClusterBinding, clusterMap map[string]*breakglassv1alpha1.ClusterConfig, userGroups []string) []AvailableClusterDetail {
+func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglassv1alpha1.DebugSessionTemplate, bindings []breakglassv1alpha1.DebugSessionClusterBinding, clusterMap map[string]*breakglassv1alpha1.ClusterConfig, requester debugTemplateRequester) []AvailableClusterDetail {
 	// Build a map of cluster -> all matching bindings
 	clusterBindings := make(map[string][]*breakglassv1alpha1.DebugSessionClusterBinding)
 
 	// Collect all bindings for each cluster
 	for i := range bindings {
 		binding := &bindings[i]
+		if !requester.canRequest(effectiveDebugSessionAllowed(template, binding)) {
+			continue
+		}
 		bindingClusters := c.resolveClustersFromBinding(binding, clusterMap)
 		for _, clusterName := range bindingClusters {
 			clusterBindings[clusterName] = append(clusterBindings[clusterName], binding)
@@ -699,12 +728,12 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 		}
 
 		// Build detail with all binding options
-		detail := c.buildClusterDetailWithBindings(template, matchingBindings, cc, userGroups)
+		detail := c.buildClusterDetailWithBindings(template, matchingBindings, cc, requester)
 		result = append(result, detail)
 	}
 
 	// Then, resolve clusters from template's allowed.clusters (fallback, no binding)
-	if template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
+	if requester.canRequest(effectiveDebugSessionAllowed(template, nil)) && template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
 		allClusterNames := make([]string, 0, len(clusterMap))
 		for name := range clusterMap {
 			allClusterNames = append(allClusterNames, name)
@@ -722,7 +751,7 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 			}
 
 			// No binding - use template defaults
-			detail := c.buildClusterDetailWithBindings(template, nil, cc, userGroups)
+			detail := c.buildClusterDetailWithBindings(template, nil, cc, requester)
 			result = append(result, detail)
 		}
 	}
@@ -732,7 +761,7 @@ func (c *DebugSessionAPIController) resolveTemplateClusters(template *breakglass
 
 // buildClusterDetailWithBindings creates a cluster detail with all matching binding options.
 // The first binding becomes the default (for backward compatibility with BindingRef).
-func (c *DebugSessionAPIController) buildClusterDetailWithBindings(template *breakglassv1alpha1.DebugSessionTemplate, matchingBindings []*breakglassv1alpha1.DebugSessionClusterBinding, cc *breakglassv1alpha1.ClusterConfig, userGroups []string) AvailableClusterDetail {
+func (c *DebugSessionAPIController) buildClusterDetailWithBindings(template *breakglassv1alpha1.DebugSessionTemplate, matchingBindings []*breakglassv1alpha1.DebugSessionClusterBinding, cc *breakglassv1alpha1.ClusterConfig, requester debugTemplateRequester) AvailableClusterDetail {
 	detail := AvailableClusterDetail{
 		Name:        cc.Name,
 		DisplayName: cc.Name,
@@ -747,10 +776,10 @@ func (c *DebugSessionAPIController) buildClusterDetailWithBindings(template *bre
 		// No bindings - use template defaults
 		detail.Constraints = template.Spec.Constraints
 		detail.SchedulingConstraints = c.getSchedulingConstraintsSummary(template, nil)
-		detail.SchedulingOptions = c.resolveSchedulingOptions(template, nil)
+		detail.SchedulingOptions = c.resolveSchedulingOptionsForRequester(template, nil, requester)
 		detail.NamespaceConstraints = c.resolveNamespaceConstraints(template, nil)
 		detail.Impersonation = c.resolveImpersonation(template, nil)
-		detail.Approval = c.resolveApproval(template, nil, cc, userGroups)
+		detail.Approval = c.resolveApproval(template, nil, cc, requester.groups)
 		detail.RequiredAuxResourceCategories = c.resolveRequiredAuxResourceCategories(template, nil)
 		return detail
 	}
@@ -768,11 +797,11 @@ func (c *DebugSessionAPIController) buildClusterDetailWithBindings(template *bre
 			DisplayName:                   effectiveDisplayName,
 			Constraints:                   c.mergeConstraints(template.Spec.Constraints, binding),
 			SchedulingConstraints:         c.getSchedulingConstraintsSummary(template, binding),
-			SchedulingOptions:             c.resolveSchedulingOptions(template, binding),
+			SchedulingOptions:             c.resolveSchedulingOptionsForRequester(template, binding, requester),
 			NamespaceConstraints:          c.resolveNamespaceConstraints(template, binding),
 			Impersonation:                 c.resolveImpersonation(template, binding),
 			RequiredAuxResourceCategories: c.resolveRequiredAuxResourceCategories(template, binding),
-			Approval:                      c.resolveApproval(template, binding, cc, userGroups),
+			Approval:                      c.resolveApproval(template, binding, cc, requester.groups),
 			RequestReason:                 c.resolveRequestReason(template, binding),
 			ApprovalReason:                c.resolveApprovalReason(template, binding),
 			Notification:                  c.resolveNotification(template, binding),
@@ -791,10 +820,10 @@ func (c *DebugSessionAPIController) buildClusterDetailWithBindings(template *bre
 		// Set default constraints from primary binding for backward compatibility
 		detail.Constraints = c.mergeConstraints(template.Spec.Constraints, primaryBinding)
 		detail.SchedulingConstraints = c.getSchedulingConstraintsSummary(template, primaryBinding)
-		detail.SchedulingOptions = c.resolveSchedulingOptions(template, primaryBinding)
+		detail.SchedulingOptions = c.resolveSchedulingOptionsForRequester(template, primaryBinding, requester)
 		detail.NamespaceConstraints = c.resolveNamespaceConstraints(template, primaryBinding)
 		detail.Impersonation = c.resolveImpersonation(template, primaryBinding)
-		detail.Approval = c.resolveApproval(template, primaryBinding, cc, userGroups)
+		detail.Approval = c.resolveApproval(template, primaryBinding, cc, requester.groups)
 		detail.RequiredAuxResourceCategories = c.resolveRequiredAuxResourceCategories(template, primaryBinding)
 		detail.RequestReason = c.resolveRequestReason(template, primaryBinding)
 		detail.ApprovalReason = c.resolveApprovalReason(template, primaryBinding)

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -193,10 +193,8 @@ type debugTemplateRequester struct {
 func debugTemplateRequesterFromContext(ctx *gin.Context) debugTemplateRequester {
 	requester := debugTemplateRequester{}
 
-	if username, ok := ctx.Get("username"); ok {
-		if value, ok := username.(string); ok {
-			requester.username = value
-		}
+	if username, ok := debugSessionUsernameFromContext(ctx); ok {
+		requester.username = username
 	}
 	if email, ok := ctx.Get("email"); ok {
 		if value, ok := email.(string); ok {

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -203,17 +203,8 @@ func debugTemplateRequesterFromContext(ctx *gin.Context) debugTemplateRequester 
 			requester.email = value
 		}
 	}
-	if groups, ok := ctx.Get("groups"); ok {
-		switch value := groups.(type) {
-		case []string:
-			requester.groups = value
-		case []interface{}:
-			for _, group := range value {
-				if groupName, ok := group.(string); ok {
-					requester.groups = append(requester.groups, groupName)
-				}
-			}
-		}
+	if groups, ok := ctx.Get("groups"); ok && groups != nil {
+		requester.groups = debugSessionGroupsFromContext(groups)
 	}
 
 	return requester

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"sync"
 
 	"github.com/gin-gonic/gin"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -205,8 +204,15 @@ func debugTemplateRequesterFromContext(ctx *gin.Context) debugTemplateRequester 
 		}
 	}
 	if groups, ok := ctx.Get("groups"); ok {
-		if value, ok := groups.([]string); ok {
+		switch value := groups.(type) {
+		case []string:
 			requester.groups = value
+		case []interface{}:
+			for _, group := range value {
+				if groupName, ok := group.(string); ok {
+					requester.groups = append(requester.groups, groupName)
+				}
+			}
 		}
 	}
 
@@ -413,9 +419,10 @@ func (c *DebugSessionAPIController) handleListTemplates(ctx *gin.Context) {
 		if !c.canReadTemplateWithBindings(&t, applicableBindings, requester) {
 			continue
 		}
+		visibleBindings := visibleDebugSessionBindings(applicableBindings)
 
 		// Calculate available cluster count for this template
-		availableClusterCount := c.countAvailableClustersForTemplate(&t, applicableBindings, clusterMap, allClusterNames, requester)
+		availableClusterCount := c.countAvailableClustersForTemplate(&t, visibleBindings, clusterMap, allClusterNames, requester)
 		hasAvailableClusters := availableClusterCount > 0
 
 		// Skip templates without available clusters unless explicitly requested
@@ -483,7 +490,15 @@ func (c *DebugSessionAPIController) handleGetTemplate(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, c.buildTemplateResponse(template, requester, nil, 0))
+	clusterConfigList := &breakglassv1alpha1.ClusterConfigList{}
+	if err := c.reader().List(apiCtx, clusterConfigList); err != nil {
+		reqLog.Warnw("Failed to list cluster configs for template response", "name", name, "error", err)
+	}
+	clusterMap, allClusterNames := readyDebugClusterConfigMap(clusterConfigList.Items)
+	visibleBindings := visibleDebugSessionBindings(applicableBindings)
+	availableClusterCount := c.countAvailableClustersForTemplate(template, visibleBindings, clusterMap, allClusterNames, requester)
+
+	ctx.JSON(http.StatusOK, c.buildTemplateResponse(template, requester, allClusterNames, availableClusterCount))
 }
 
 // handleGetTemplateClusters returns cluster-specific details for a template
@@ -513,41 +528,12 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 
 	requester := debugTemplateRequesterFromContext(ctx)
 
-	// Fetch ClusterConfigs and ClusterBindings in parallel for performance
-	var clusterConfigList breakglassv1alpha1.ClusterConfigList
 	var bindingList breakglassv1alpha1.DebugSessionClusterBindingList
-	var ccErr, bindErr error
-
-	// Use goroutines with sync.WaitGroup for parallel fetching
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		ccErr = c.client.List(apiCtx, &clusterConfigList)
-	}()
-
-	go func() {
-		defer wg.Done()
-		bindErr = c.client.List(apiCtx, &bindingList)
-	}()
-
-	wg.Wait()
-
-	if ccErr != nil {
-		reqLog.Errorw("Failed to list cluster configs", "error", ccErr)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to list clusters")
-		return
-	}
-
-	if bindErr != nil {
-		reqLog.Errorw("Failed to list cluster bindings", "error", bindErr)
+	if err := c.client.List(apiCtx, &bindingList); err != nil {
+		reqLog.Errorw("Failed to list cluster bindings", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list bindings")
 		return
 	}
-
-	// Build cluster name -> ready ClusterConfig map. Unready clusters are not offered as debug targets.
-	clusterMap, _ := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Find UI-visible bindings that apply to this template. Hidden bindings can
 	// still be used through explicit API bindingRef requests, but are not offered
@@ -557,6 +543,16 @@ func (c *DebugSessionAPIController) handleGetTemplateClusters(ctx *gin.Context) 
 		apiresponses.RespondForbidden(ctx, "access denied to this template")
 		return
 	}
+
+	var clusterConfigList breakglassv1alpha1.ClusterConfigList
+	if err := c.client.List(apiCtx, &clusterConfigList); err != nil {
+		reqLog.Errorw("Failed to list cluster configs", "error", err)
+		apiresponses.RespondInternalErrorSimple(ctx, "failed to list clusters")
+		return
+	}
+
+	// Build cluster name -> ready ClusterConfig map. Unready clusters are not offered as debug targets.
+	clusterMap, _ := readyDebugClusterConfigMap(clusterConfigList.Items)
 
 	// Build the response - resolve clusters from bindings and template's allowed.clusters
 	clusterDetails := c.resolveTemplateClusters(template, applicableBindings, clusterMap, requester)
@@ -678,14 +674,14 @@ func (c *DebugSessionAPIController) findBindingsForTemplate(template *breakglass
 
 func (c *DebugSessionAPIController) findVisibleBindingsForTemplate(template *breakglassv1alpha1.DebugSessionTemplate, bindings []breakglassv1alpha1.DebugSessionClusterBinding) []breakglassv1alpha1.DebugSessionClusterBinding {
 	applicableBindings := c.findBindingsForTemplate(template, bindings)
-	visibleBindings := make([]breakglassv1alpha1.DebugSessionClusterBinding, 0, len(applicableBindings))
-	for i := range applicableBindings {
-		binding := &applicableBindings[i]
+	return visibleDebugSessionBindings(applicableBindings)
+}
+
+func visibleDebugSessionBindings(bindings []breakglassv1alpha1.DebugSessionClusterBinding) []breakglassv1alpha1.DebugSessionClusterBinding {
+	visibleBindings := make([]breakglassv1alpha1.DebugSessionClusterBinding, 0, len(bindings))
+	for i := range bindings {
+		binding := &bindings[i]
 		if binding.Spec.Hidden {
-			c.log.Debugw("findVisibleBindingsForTemplate: skipping hidden binding",
-				"template", template.Name,
-				"binding", fmt.Sprintf("%s/%s", binding.Namespace, binding.Name),
-			)
 			continue
 		}
 		visibleBindings = append(visibleBindings, *binding)

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2511,6 +2511,164 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 		assert.Equal(t, 3, response.Total)
 	})
 
+	t.Run("list templates enforces allowed users and filters requester-scoped fields", func(t *testing.T) {
+		userTemplate := templates[0].DeepCopy()
+		userTemplate.Name = "user-restricted-template"
+		userTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Users: []string{"alice@example.com"},
+		}
+		userTemplate.Spec.SchedulingOptions = &breakglassv1alpha1.SchedulingOptions{
+			Options: []breakglassv1alpha1.SchedulingOption{
+				{Name: "tenant-safe", DisplayName: "Tenant Safe"},
+				{Name: "alice-only", DisplayName: "Alice Only", AllowedUsers: []string{"alice@example.com"}},
+				{Name: "platform-only", DisplayName: "Platform Only", AllowedGroups: []string{"platform-admins"}},
+			},
+		}
+		userTemplate.Spec.ExtraDeployVariables = []breakglassv1alpha1.ExtraDeployVariable{
+			{
+				Name:      "logLevel",
+				InputType: breakglassv1alpha1.InputTypeText,
+			},
+			{
+				Name:          "privilegedMode",
+				InputType:     breakglassv1alpha1.InputTypeBoolean,
+				AllowedGroups: []string{"platform-admins"},
+			},
+			{
+				Name:      "targetPool",
+				InputType: breakglassv1alpha1.InputTypeSelect,
+				Options: []breakglassv1alpha1.SelectOption{
+					{Value: "tenant"},
+					{Value: "platform", AllowedGroups: []string{"platform-admins"}},
+				},
+			},
+		}
+
+		buildRouter := func(username, email string, groups []string) *gin.Engine {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(userTemplate).
+				Build()
+
+			ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("username", username)
+				c.Set("email", email)
+				c.Set("groups", groups)
+				c.Next()
+			})
+			rg := router.Group("/api/v1/" + ctrl.BasePath())
+			err := ctrl.Register(rg)
+			require.NoError(t, err)
+			return router
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w := httptest.NewRecorder()
+		buildRouter("alice-id", "alice@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Templates []DebugSessionTemplateResponse `json:"templates"`
+			Total     int                            `json:"total"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, 1, response.Total)
+		require.Len(t, response.Templates, 1)
+		require.NotNil(t, response.Templates[0].SchedulingOptions)
+		require.Len(t, response.Templates[0].SchedulingOptions.Options, 2)
+		assert.Equal(t, []string{"tenant-safe", "alice-only"}, []string{
+			response.Templates[0].SchedulingOptions.Options[0].Name,
+			response.Templates[0].SchedulingOptions.Options[1].Name,
+		})
+		require.Len(t, response.Templates[0].ExtraDeployVariables, 2)
+		assert.Equal(t, "logLevel", response.Templates[0].ExtraDeployVariables[0].Name)
+		assert.Equal(t, "targetPool", response.Templates[0].ExtraDeployVariables[1].Name)
+		require.Len(t, response.Templates[0].ExtraDeployVariables[1].Options, 1)
+		assert.Equal(t, "tenant", response.Templates[0].ExtraDeployVariables[1].Options[0].Value)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w = httptest.NewRecorder()
+		buildRouter("bob@example.com", "bob@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 0, response.Total)
+	})
+
+	t.Run("list templates includes binding-granted templates without direct allowlist metadata", func(t *testing.T) {
+		bindingGrantedTemplate := templates[0].DeepCopy()
+		bindingGrantedTemplate.Name = "binding-granted-template"
+		bindingGrantedTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Users:    []string{"alice@example.com"},
+			Groups:   []string{"platform-admins"},
+			Clusters: []string{"prod-*"},
+		}
+		cluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-east"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionTrue,
+						Reason: "Verified",
+					},
+				},
+			},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "sre-binding", Namespace: "breakglass"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "binding-granted-template"},
+				Clusters:    []string{"prod-east"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"sre"},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(bindingGrantedTemplate, cluster, binding).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "bob@example.com")
+			c.Set("email", "bob@example.com")
+			c.Set("groups", []string{"sre"})
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response struct {
+			Templates []DebugSessionTemplateResponse `json:"templates"`
+			Total     int                            `json:"total"`
+		}
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, 1, response.Total)
+		assert.Equal(t, "binding-granted-template", response.Templates[0].Name)
+		assert.Equal(t, 1, response.Templates[0].AvailableClusterCount)
+		assert.Empty(t, response.Templates[0].AllowedClusters)
+		assert.Empty(t, response.Templates[0].AllowedGroups)
+	})
+
 	t.Run("list templates resolves cluster patterns to actual cluster names", func(t *testing.T) {
 		// Create ClusterConfigs that will be used for pattern resolution
 		clusterConfigs := []client.Object{
@@ -2929,6 +3087,59 @@ func TestDebugSessionAPIController_HandleGetTemplate(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, 404, w.Code)
+	})
+
+	t.Run("get restricted template requires requester allowlist", func(t *testing.T) {
+		restrictedTemplate := template.DeepCopy()
+		restrictedTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Users: []string{"alice@example.com"},
+		}
+		restrictedTemplate.Spec.SchedulingOptions = &breakglassv1alpha1.SchedulingOptions{
+			Options: []breakglassv1alpha1.SchedulingOption{
+				{Name: "safe"},
+				{Name: "platform", AllowedGroups: []string{"platform-admins"}},
+			},
+		}
+
+		buildRouter := func(username, email string, groups []string) *gin.Engine {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(restrictedTemplate).
+				Build()
+
+			ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("username", username)
+				c.Set("email", email)
+				c.Set("groups", groups)
+				c.Next()
+			})
+			rg := router.Group("/api/v1/" + ctrl.BasePath())
+			err := ctrl.Register(rg)
+			require.NoError(t, err)
+			return router
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates/standard-debug", nil)
+		w := httptest.NewRecorder()
+		buildRouter("bob@example.com", "bob@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates/standard-debug", nil)
+		w = httptest.NewRecorder()
+		buildRouter("alice-id", "alice@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response DebugSessionTemplateResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.NotNil(t, response.SchedulingOptions)
+		require.Len(t, response.SchedulingOptions.Options, 1)
+		assert.Equal(t, "safe", response.SchedulingOptions.Options[0].Name)
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
@@ -2469,6 +2470,34 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 		assert.Equal(t, 2, response.Total)
 	})
 
+	t.Run("list templates fails closed when bindings cannot be listed", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&templates[0]).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*breakglassv1alpha1.DebugSessionClusterBindingList); ok {
+						return fmt.Errorf("binding list unavailable")
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
 	t.Run("list templates with allowed groups filter", func(t *testing.T) {
 		// Add a template with group restriction
 		templateWithGroups := templates[0].DeepCopy()
@@ -3139,6 +3168,59 @@ func TestDebugSessionAPIController_HandleGetTemplate(t *testing.T) {
 		assert.ElementsMatch(t, []string{"prod-east", "prod-west"}, response.AllowedClusters)
 		assert.True(t, response.HasAvailableClusters)
 		assert.Equal(t, 2, response.AvailableClusterCount)
+	})
+
+	t.Run("get existing template excludes clusters when required scheduling options are unavailable", func(t *testing.T) {
+		clusterTemplate := template.DeepCopy()
+		clusterTemplate.Name = "restricted-scheduling-template"
+		clusterTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Clusters: []string{"prod-*"},
+			Groups:   []string{"*"},
+		}
+		clusterTemplate.Spec.SchedulingOptions = &breakglassv1alpha1.SchedulingOptions{
+			Required: true,
+			Options: []breakglassv1alpha1.SchedulingOption{
+				{
+					Name:          "platform-node",
+					DisplayName:   "Platform Node",
+					AllowedGroups: []string{"platform-admins"},
+				},
+			},
+		}
+		prodEast := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-east"},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(clusterTemplate, prodEast).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("groups", []string{"tenant-users"})
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates/restricted-scheduling-template", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response DebugSessionTemplateResponse
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.False(t, response.HasAvailableClusters)
+		assert.Equal(t, 0, response.AvailableClusterCount)
+		require.NotNil(t, response.SchedulingOptions)
+		assert.True(t, response.SchedulingOptions.Required)
+		assert.Empty(t, response.SchedulingOptions.Options)
 	})
 
 	t.Run("get non-existent template", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2650,6 +2650,15 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 
 		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
 		w = httptest.NewRecorder()
+		buildRouter(" alice@example.com ", "", nil).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, 1, response.Total)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w = httptest.NewRecorder()
 		buildRouter("bob@example.com", "bob@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2544,7 +2544,7 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 			},
 		}
 
-		buildRouter := func(username, email string, groups []string) *gin.Engine {
+		buildRouter := func(username, email string, groups interface{}) *gin.Engine {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(userTemplate).
@@ -2604,6 +2604,20 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 		assert.Equal(t, "targetPool", response.Templates[0].ExtraDeployVariables[1].Name)
 		require.Len(t, response.Templates[0].ExtraDeployVariables[1].Options, 1)
 		assert.Equal(t, "tenant", response.Templates[0].ExtraDeployVariables[1].Options[0].Value)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w = httptest.NewRecorder()
+		buildRouter("alice-id", "alice@example.com", []interface{}{"platform-admins"}).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, 1, response.Total)
+		require.Len(t, response.Templates[0].SchedulingOptions.Options, 3)
+		require.Len(t, response.Templates[0].ExtraDeployVariables, 3)
+		assert.Equal(t, "privilegedMode", response.Templates[0].ExtraDeployVariables[1].Name)
+		require.Len(t, response.Templates[0].ExtraDeployVariables[2].Options, 2)
+		assert.Equal(t, "platform", response.Templates[0].ExtraDeployVariables[2].Options[1].Value)
 
 		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
 		w = httptest.NewRecorder()
@@ -8003,6 +8017,49 @@ func TestDebugSessionAPIController_CreateWithExtraDeployValues(t *testing.T) {
 		assert.Contains(t, response.Name, "debug-")
 		assert.NotNil(t, response.Spec.ExtraDeployValues)
 		assert.Len(t, response.Spec.ExtraDeployValues, 5)
+	})
+
+	t.Run("create session rejects restricted extraDeployValues with empty groups", func(t *testing.T) {
+		restrictedTemplate := templateWithVariables.DeepCopy()
+		restrictedTemplate.Spec.ExtraDeployVariables = append(restrictedTemplate.Spec.ExtraDeployVariables, breakglassv1alpha1.ExtraDeployVariable{
+			Name:          "privilegedMode",
+			InputType:     breakglassv1alpha1.InputTypeBoolean,
+			AllowedGroups: []string{"platform-admins"},
+		})
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(restrictedTemplate, readyProductionCluster.DeepCopy()).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Set("groups", []string{})
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{
+			"templateRef": "template-with-vars",
+			"cluster": "production",
+			"extraDeployValues": {
+				"customName": "valid-name",
+				"privilegedMode": true
+			}
+		}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "privilegedMode")
+		assert.Contains(t, w.Body.String(), "restricted")
 	})
 
 	t.Run("create session fails with invalid boolean value", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2593,6 +2593,20 @@ func TestDebugSessionAPIController_HandleListTemplates(t *testing.T) {
 
 		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
 		w = httptest.NewRecorder()
+		buildRouter("alice-id", "alice@example.com", nil).ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.Equal(t, 1, response.Total)
+		require.Len(t, response.Templates[0].ExtraDeployVariables, 2)
+		assert.Equal(t, "logLevel", response.Templates[0].ExtraDeployVariables[0].Name)
+		assert.Equal(t, "targetPool", response.Templates[0].ExtraDeployVariables[1].Name)
+		require.Len(t, response.Templates[0].ExtraDeployVariables[1].Options, 1)
+		assert.Equal(t, "tenant", response.Templates[0].ExtraDeployVariables[1].Options[0].Value)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates?includeUnavailable=true", nil)
+		w = httptest.NewRecorder()
 		buildRouter("bob@example.com", "bob@example.com", []string{"tenant-admins"}).ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -3068,6 +3082,49 @@ func TestDebugSessionAPIController_HandleGetTemplate(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "standard-debug", response.Name)
 		assert.Equal(t, breakglassv1alpha1.DebugSessionModeWorkload, response.Mode)
+	})
+
+	t.Run("get existing template resolves direct cluster availability", func(t *testing.T) {
+		clusterTemplate := template.DeepCopy()
+		clusterTemplate.Name = "cluster-pattern-template"
+		clusterTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Clusters: []string{"prod-*"},
+		}
+		prodEast := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-east"},
+		}
+		prodWest := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-west"},
+		}
+		devEast := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "dev-east"},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(clusterTemplate, prodEast, prodWest, devEast).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions/templates/cluster-pattern-template", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response DebugSessionTemplateResponse
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "cluster-pattern-template", response.Name)
+		assert.ElementsMatch(t, []string{"prod-east", "prod-west"}, response.AllowedClusters)
+		assert.True(t, response.HasAvailableClusters)
+		assert.Equal(t, 2, response.AvailableClusterCount)
 	})
 
 	t.Run("get non-existent template", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- apply create-time requester ACL semantics to DebugSession template list/detail/cluster discovery
- filter cluster discovery to authorized direct template or binding paths only
- omit restricted scheduling options and extra deploy variables from read responses

## Evidence

Audit finding: `GET /api/debugSessions/templates`, `GET /api/debugSessions/templates/:name`, and `GET /api/debugSessions/templates/:name/clusters` disclosed templates, clusters, binding options, scheduling options, approver data, impersonation data, and extra deploy variables that the same requester could not use at `POST /api/debugSessions` time.

Duplicate check before implementation:
- `DebugSession template clusters allowed.users binding allowedGroups` -> no open PRs
- `debugSessions templates clusters ACL allowed users groups` -> no open or recent matching PRs
- `DebugSessionClusterBinding template discovery authorization` -> no open PRs

Adjacent but non-duplicate PRs:
- #851 resolves ClusterConfig namespace/duplicate lookup, not requester ACL filtering
- #824 enforces scheduling option ACLs at create time, not read-side discovery

## Validation

- `go test ./pkg/breakglass/debug -run 'TestDebugSessionAPIController_HandleListTemplates|TestDebugSessionAPIController_HandleGetTemplate|TestHandleGetTemplateClusters'`
- `go test ./pkg/breakglass/debug`
- `make test`
- `git diff --check`

No UI changed, so no UI screenshots are attached.
