### PR TITLE
fix: refresh debug binding dependency status

### DIFF
--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -377,6 +377,11 @@ status:
       message: "Binding ready"
 ```
 
+The controller refreshes this status when the binding changes and when matching
+`DebugSessionTemplate` or `ClusterConfig` resources change. Template readiness,
+cluster readiness, and selector label changes are reflected in
+`resolvedTemplates`, `resolvedClusters`, and the binding readiness conditions.
+
 ## Use Cases
 
 ### Multi-Tenant Cluster Access

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -24,10 +24,13 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -36,6 +39,11 @@ import (
 	"github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/ssa"
 	"github.com/telekom/k8s-breakglass/pkg/clusterconfiglookup"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
+)
+
+const (
+	debugBindingTemplateRefIndex = "spec.templateRef.name"
+	debugBindingClustersIndex    = "spec.clusters"
 )
 
 // DebugSessionClusterBindingReconciler watches DebugSessionClusterBinding CRs and validates
@@ -422,6 +430,126 @@ func (r *DebugSessionClusterBindingReconciler) getClusterConfigByName(ctx contex
 	return nil, clusterconfiglookup.NotFound(name)
 }
 
+func addClusterBindingRequest(requests map[types.NamespacedName]reconcile.Request, binding *breakglassv1alpha1.DebugSessionClusterBinding) {
+	if binding == nil {
+		return
+	}
+	key := types.NamespacedName{
+		Namespace: binding.Namespace,
+		Name:      binding.Name,
+	}
+	requests[key] = reconcile.Request{NamespacedName: key}
+}
+
+func requestsFromClusterBindingMap(requests map[types.NamespacedName]reconcile.Request) []reconcile.Request {
+	if len(requests) == 0 {
+		return nil
+	}
+	result := make([]reconcile.Request, 0, len(requests))
+	for _, req := range requests {
+		result = append(result, req)
+	}
+	return result
+}
+
+func (r *DebugSessionClusterBindingReconciler) bindingsForTemplate(ctx context.Context, obj client.Object) []reconcile.Request {
+	template, ok := obj.(*breakglassv1alpha1.DebugSessionTemplate)
+	if !ok || template == nil || template.Name == "" {
+		return nil
+	}
+
+	requests := make(map[types.NamespacedName]reconcile.Request)
+
+	exactBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
+	if err := r.client.List(ctx, exactBindings, client.MatchingFields{debugBindingTemplateRefIndex: template.Name}); err != nil {
+		r.logger.Warnw("Failed to list DebugSessionClusterBindings by template reference",
+			"template", template.Name,
+			"error", err)
+	} else {
+		for i := range exactBindings.Items {
+			addClusterBindingRequest(requests, &exactBindings.Items[i])
+		}
+	}
+
+	selectorBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
+	if err := r.client.List(ctx, selectorBindings); err != nil {
+		r.logger.Warnw("Failed to list DebugSessionClusterBindings for template selector mapping",
+			"template", template.Name,
+			"error", err)
+		return requestsFromClusterBindingMap(requests)
+	}
+
+	templateLabels := labels.Set(template.Labels)
+	for i := range selectorBindings.Items {
+		binding := &selectorBindings.Items[i]
+		if binding.Spec.TemplateSelector == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(binding.Spec.TemplateSelector)
+		if err != nil {
+			r.logger.Warnw("Skipping binding with invalid template selector during watch mapping",
+				"binding", binding.Name,
+				"namespace", binding.Namespace,
+				"error", err)
+			continue
+		}
+		if selector.Matches(templateLabels) {
+			addClusterBindingRequest(requests, binding)
+		}
+	}
+
+	return requestsFromClusterBindingMap(requests)
+}
+
+func (r *DebugSessionClusterBindingReconciler) bindingsForClusterConfig(ctx context.Context, obj client.Object) []reconcile.Request {
+	cluster, ok := obj.(*breakglassv1alpha1.ClusterConfig)
+	if !ok || cluster == nil || cluster.Name == "" {
+		return nil
+	}
+
+	requests := make(map[types.NamespacedName]reconcile.Request)
+
+	exactBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
+	if err := r.client.List(ctx, exactBindings, client.MatchingFields{debugBindingClustersIndex: cluster.Name}); err != nil {
+		r.logger.Warnw("Failed to list DebugSessionClusterBindings by cluster reference",
+			"cluster", cluster.Name,
+			"error", err)
+	} else {
+		for i := range exactBindings.Items {
+			addClusterBindingRequest(requests, &exactBindings.Items[i])
+		}
+	}
+
+	selectorBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
+	if err := r.client.List(ctx, selectorBindings); err != nil {
+		r.logger.Warnw("Failed to list DebugSessionClusterBindings for cluster selector mapping",
+			"cluster", cluster.Name,
+			"error", err)
+		return requestsFromClusterBindingMap(requests)
+	}
+
+	clusterLabels := labels.Set(cluster.Labels)
+	for i := range selectorBindings.Items {
+		binding := &selectorBindings.Items[i]
+		if binding.Spec.ClusterSelector == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(binding.Spec.ClusterSelector)
+		if err != nil {
+			r.logger.Warnw("Skipping binding with invalid cluster selector during watch mapping",
+				"binding", binding.Name,
+				"namespace", binding.Namespace,
+				"error", err)
+			continue
+		}
+		if selector.Matches(clusterLabels) {
+			addClusterBindingRequest(requests, binding)
+		}
+	}
+
+	return requestsFromClusterBindingMap(requests)
+}
+
 // SetupWithManager registers this reconciler with the controller-runtime manager.
 func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Predicate to filter events - reconcile on spec changes
@@ -437,8 +565,9 @@ func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&breakglassv1alpha1.DebugSessionClusterBinding{}).
-		WithEventFilter(specChangePredicate).
+		For(&breakglassv1alpha1.DebugSessionClusterBinding{}, builder.WithPredicates(specChangePredicate)).
+		Watches(&breakglassv1alpha1.DebugSessionTemplate{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForTemplate)).
+		Watches(&breakglassv1alpha1.ClusterConfig{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForClusterConfig)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -43,8 +43,11 @@ import (
 )
 
 const (
-	debugBindingTemplateRefIndex = "spec.templateRef.name"
-	debugBindingClustersIndex    = "spec.clusters"
+	debugBindingTemplateRefIndex      = "spec.templateRef.name"
+	debugBindingTemplateSelectorIndex = "spec.templateSelector"
+	debugBindingClustersIndex         = "spec.clusters"
+	debugBindingClusterSelectorIndex  = "spec.clusterSelector"
+	debugBindingSelectorPresenceValue = "true"
 )
 
 // DebugSessionClusterBindingReconciler watches DebugSessionClusterBinding CRs and validates
@@ -473,7 +476,7 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForTemplate(ctx context.C
 	}
 
 	selectorBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
-	if err := r.client.List(ctx, selectorBindings); err != nil {
+	if err := r.client.List(ctx, selectorBindings, client.MatchingFields{debugBindingTemplateSelectorIndex: debugBindingSelectorPresenceValue}); err != nil {
 		r.logger.Warnw("Failed to list DebugSessionClusterBindings for template selector mapping",
 			"template", template.Name,
 			"error", err)
@@ -526,7 +529,7 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForClusterConfig(ctx cont
 	}
 
 	selectorBindings := &breakglassv1alpha1.DebugSessionClusterBindingList{}
-	if err := r.client.List(ctx, selectorBindings); err != nil {
+	if err := r.client.List(ctx, selectorBindings, client.MatchingFields{debugBindingClusterSelectorIndex: debugBindingSelectorPresenceValue}); err != nil {
 		r.logger.Warnw("Failed to list DebugSessionClusterBindings for cluster selector mapping",
 			"cluster", cluster.Name,
 			"clusterNamespace", cluster.Namespace,

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"go.uber.org/zap"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -513,6 +514,7 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForClusterConfig(ctx cont
 	if err := r.client.List(ctx, exactBindings, client.MatchingFields{debugBindingClustersIndex: cluster.Name}); err != nil {
 		r.logger.Warnw("Failed to list DebugSessionClusterBindings by cluster reference",
 			"cluster", cluster.Name,
+			"clusterNamespace", cluster.Namespace,
 			"error", err)
 	} else {
 		for i := range exactBindings.Items {
@@ -524,6 +526,7 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForClusterConfig(ctx cont
 	if err := r.client.List(ctx, selectorBindings); err != nil {
 		r.logger.Warnw("Failed to list DebugSessionClusterBindings for cluster selector mapping",
 			"cluster", cluster.Name,
+			"clusterNamespace", cluster.Namespace,
 			"error", err)
 		return requestsFromClusterBindingMap(requests)
 	}
@@ -564,12 +567,52 @@ func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
 	}
 
+	templateDependencyPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldTemplate, okOld := e.ObjectOld.(*breakglassv1alpha1.DebugSessionTemplate)
+			newTemplate, okNew := e.ObjectNew.(*breakglassv1alpha1.DebugSessionTemplate)
+			if !okOld || !okNew || oldTemplate == nil || newTemplate == nil {
+				return true
+			}
+			return oldTemplate.Generation != newTemplate.Generation || !maps.Equal(oldTemplate.Labels, newTemplate.Labels)
+		},
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+	}
+
+	clusterConfigDependencyPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, okOld := e.ObjectOld.(*breakglassv1alpha1.ClusterConfig)
+			newCluster, okNew := e.ObjectNew.(*breakglassv1alpha1.ClusterConfig)
+			if !okOld || !okNew || oldCluster == nil || newCluster == nil {
+				return true
+			}
+			return oldCluster.Generation != newCluster.Generation ||
+				!maps.Equal(oldCluster.Labels, newCluster.Labels) ||
+				readyConditionChanged(oldCluster.Status.Conditions, newCluster.Status.Conditions)
+		},
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&breakglassv1alpha1.DebugSessionClusterBinding{}, builder.WithPredicates(specChangePredicate)).
-		Watches(&breakglassv1alpha1.DebugSessionTemplate{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForTemplate)).
-		Watches(&breakglassv1alpha1.ClusterConfig{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForClusterConfig)).
+		Watches(&breakglassv1alpha1.DebugSessionTemplate{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForTemplate), builder.WithPredicates(templateDependencyPredicate)).
+		Watches(&breakglassv1alpha1.ClusterConfig{}, handler.EnqueueRequestsFromMapFunc(r.bindingsForClusterConfig), builder.WithPredicates(clusterConfigDependencyPredicate)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
+}
+
+func readyConditionChanged(oldConditions, newConditions []metav1.Condition) bool {
+	oldReady := apimeta.FindStatusCondition(oldConditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
+	newReady := apimeta.FindStatusCondition(newConditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
+	if oldReady == nil || newReady == nil {
+		return oldReady != newReady
+	}
+	return oldReady.Status != newReady.Status ||
+		oldReady.Reason != newReady.Reason ||
+		oldReady.Message != newReady.Message ||
+		oldReady.ObservedGeneration != newReady.ObservedGeneration
 }

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -545,6 +545,9 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForClusterConfig(ctx cont
 				"error", err)
 			continue
 		}
+		if selector.Empty() {
+			continue
+		}
 		if selector.Matches(clusterLabels) {
 			addClusterBindingRequest(requests, binding)
 		}
@@ -574,7 +577,7 @@ func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager
 			if !okOld || !okNew || oldTemplate == nil || newTemplate == nil {
 				return true
 			}
-			return oldTemplate.Generation != newTemplate.Generation || !maps.Equal(oldTemplate.Labels, newTemplate.Labels)
+			return templateDependencyChanged(oldTemplate, newTemplate)
 		},
 		CreateFunc: func(e event.CreateEvent) bool { return true },
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
@@ -587,9 +590,7 @@ func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager
 			if !okOld || !okNew || oldCluster == nil || newCluster == nil {
 				return true
 			}
-			return oldCluster.Generation != newCluster.Generation ||
-				!maps.Equal(oldCluster.Labels, newCluster.Labels) ||
-				readyConditionChanged(oldCluster.Status.Conditions, newCluster.Status.Conditions)
+			return clusterConfigDependencyChanged(oldCluster, newCluster)
 		},
 		CreateFunc: func(e event.CreateEvent) bool { return true },
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
@@ -605,14 +606,31 @@ func (r *DebugSessionClusterBindingReconciler) SetupWithManager(mgr ctrl.Manager
 		Complete(r)
 }
 
+func templateDependencyChanged(oldTemplate, newTemplate *breakglassv1alpha1.DebugSessionTemplate) bool {
+	return oldTemplate.Generation != newTemplate.Generation ||
+		!maps.Equal(oldTemplate.Labels, newTemplate.Labels) ||
+		templateReadyConditionChanged(oldTemplate.Status.Conditions, newTemplate.Status.Conditions)
+}
+
+func clusterConfigDependencyChanged(oldCluster, newCluster *breakglassv1alpha1.ClusterConfig) bool {
+	return oldCluster.Generation != newCluster.Generation ||
+		!maps.Equal(oldCluster.Labels, newCluster.Labels) ||
+		readyConditionChanged(oldCluster.Status.Conditions, newCluster.Status.Conditions)
+}
+
+func templateReadyConditionChanged(oldConditions, newConditions []metav1.Condition) bool {
+	return conditionStatusChanged(oldConditions, newConditions, string(breakglassv1alpha1.DebugSessionTemplateConditionReady))
+}
+
 func readyConditionChanged(oldConditions, newConditions []metav1.Condition) bool {
-	oldReady := apimeta.FindStatusCondition(oldConditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
-	newReady := apimeta.FindStatusCondition(newConditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
+	return conditionStatusChanged(oldConditions, newConditions, string(breakglassv1alpha1.ClusterConfigConditionReady))
+}
+
+func conditionStatusChanged(oldConditions, newConditions []metav1.Condition, conditionType string) bool {
+	oldReady := apimeta.FindStatusCondition(oldConditions, conditionType)
+	newReady := apimeta.FindStatusCondition(newConditions, conditionType)
 	if oldReady == nil || newReady == nil {
 		return oldReady != newReady
 	}
-	return oldReady.Status != newReady.Status ||
-		oldReady.Reason != newReady.Reason ||
-		oldReady.Message != newReady.Message ||
-		oldReady.ObservedGeneration != newReady.ObservedGeneration
+	return oldReady.Status != newReady.Status
 }

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -44,9 +44,9 @@ import (
 
 const (
 	debugBindingTemplateRefIndex      = "spec.templateRef.name"
-	debugBindingTemplateSelectorIndex = "spec.templateSelector"
+	debugBindingTemplateSelectorIndex = "spec.templateSelector.present"
 	debugBindingClustersIndex         = "spec.clusters"
-	debugBindingClusterSelectorIndex  = "spec.clusterSelector"
+	debugBindingClusterSelectorIndex  = "spec.clusterSelector.present"
 	debugBindingSelectorPresenceValue = "true"
 )
 

--- a/pkg/config/debug_session_cluster_binding_reconciler.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler.go
@@ -494,6 +494,9 @@ func (r *DebugSessionClusterBindingReconciler) bindingsForTemplate(ctx context.C
 				"error", err)
 			continue
 		}
+		if selector.Empty() {
+			continue
+		}
 		if selector.Matches(templateLabels) {
 			addClusterBindingRequest(requests, binding)
 		}

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -746,7 +746,8 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 	r, scheme := newTestClusterBindingReconciler()
 	cluster := &breakglassv1alpha1.ClusterConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster-a",
+			Name:      "cluster-a",
+			Namespace: "tenant-a",
 			Labels: map[string]string{
 				"env": "prod",
 			},

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -42,6 +43,30 @@ func newTestClusterBindingReconciler() (*DebugSessionClusterBindingReconciler, *
 	return &DebugSessionClusterBindingReconciler{
 		logger: logger,
 	}, scheme
+}
+
+func clusterBindingRequestNames(requests []reconcile.Request) []types.NamespacedName {
+	names := make([]types.NamespacedName, 0, len(requests))
+	for _, req := range requests {
+		names = append(names, req.NamespacedName)
+	}
+	return names
+}
+
+func indexClusterBindingTemplateRef(obj client.Object) []string {
+	binding, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+	if !ok || binding == nil || binding.Spec.TemplateRef == nil || binding.Spec.TemplateRef.Name == "" {
+		return nil
+	}
+	return []string{binding.Spec.TemplateRef.Name}
+}
+
+func indexClusterBindingClusters(obj client.Object) []string {
+	binding, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+	if !ok || binding == nil || len(binding.Spec.Clusters) == 0 {
+		return nil
+	}
+	return binding.Spec.Clusters
 }
 
 func TestDebugSessionClusterBindingReconciler_Reconcile_NotFound(t *testing.T) {
@@ -631,4 +656,98 @@ func TestDebugSessionClusterBindingReconciler_ResolveClusters_DeduplicatesExplic
 	require.Len(t, resolved, 1)
 	assert.Equal(t, "shared-cluster", resolved[0].Name)
 	assert.Equal(t, "explicit", resolved[0].MatchedBy) // Explicit takes precedence
+}
+
+func TestDebugSessionClusterBindingReconciler_BindingsForTemplate(t *testing.T) {
+	r, scheme := newTestClusterBindingReconciler()
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "template-a",
+			Labels: map[string]string{
+				"tier": "standard",
+			},
+		},
+	}
+	exactBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "exact-binding", Namespace: "team-a"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "template-a"},
+		},
+	}
+	selectorBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "selector-binding", Namespace: "team-b"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			TemplateSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "standard"},
+			},
+		},
+	}
+	otherBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-binding", Namespace: "team-c"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			TemplateSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "platform"},
+			},
+		},
+	}
+
+	r.client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, exactBinding, selectorBinding, otherBinding).
+		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingTemplateRefIndex, indexClusterBindingTemplateRef).
+		Build()
+
+	requests := r.bindingsForTemplate(context.Background(), template)
+
+	assert.ElementsMatch(t, []types.NamespacedName{
+		{Namespace: "team-a", Name: "exact-binding"},
+		{Namespace: "team-b", Name: "selector-binding"},
+	}, clusterBindingRequestNames(requests))
+}
+
+func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testing.T) {
+	r, scheme := newTestClusterBindingReconciler()
+	cluster := &breakglassv1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-a",
+			Labels: map[string]string{
+				"env": "prod",
+			},
+		},
+	}
+	exactBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "exact-binding", Namespace: "team-a"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Clusters: []string{"cluster-a"},
+		},
+	}
+	selectorBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "selector-binding", Namespace: "team-b"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			ClusterSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+	otherBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-binding", Namespace: "team-c"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			ClusterSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "stage"},
+			},
+		},
+	}
+
+	r.client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, exactBinding, selectorBinding, otherBinding).
+		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingClustersIndex, indexClusterBindingClusters).
+		Build()
+
+	requests := r.bindingsForClusterConfig(context.Background(), cluster)
+
+	assert.ElementsMatch(t, []types.NamespacedName{
+		{Namespace: "team-a", Name: "exact-binding"},
+		{Namespace: "team-b", Name: "selector-binding"},
+	}, clusterBindingRequestNames(requests))
 }

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -696,10 +696,16 @@ func TestDebugSessionClusterBindingReconciler_BindingsForTemplate(t *testing.T) 
 			},
 		},
 	}
+	emptySelectorBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-selector-binding", Namespace: "team-d"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			TemplateSelector: &metav1.LabelSelector{},
+		},
+	}
 
 	r.client = fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(template, exactBinding, selectorBinding, otherBinding).
+		WithObjects(template, exactBinding, selectorBinding, otherBinding, emptySelectorBinding).
 		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingTemplateRefIndex, indexClusterBindingTemplateRef).
 		Build()
 

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -743,10 +743,16 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 			},
 		},
 	}
+	emptySelectorBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-selector-binding", Namespace: "team-d"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			ClusterSelector: &metav1.LabelSelector{},
+		},
+	}
 
 	r.client = fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(cluster, exactBinding, selectorBinding, otherBinding).
+		WithObjects(cluster, exactBinding, selectorBinding, otherBinding, emptySelectorBinding).
 		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingClustersIndex, indexClusterBindingClusters).
 		Build()
 
@@ -756,6 +762,84 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 		{Namespace: "team-a", Name: "exact-binding"},
 		{Namespace: "team-b", Name: "selector-binding"},
 	}, clusterBindingRequestNames(requests))
+}
+
+func TestDebugSessionClusterBindingReconciler_TemplateDependencyChanged(t *testing.T) {
+	readyTrue := metav1.Condition{
+		Type:               DebugSessionTemplateConditionReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "template is ready",
+		ObservedGeneration: 1,
+	}
+
+	baseTemplate := func() *breakglassv1alpha1.DebugSessionTemplate {
+		return &breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "template-a",
+				Generation: 1,
+				Labels: map[string]string{
+					"tier": "standard",
+				},
+			},
+			Status: breakglassv1alpha1.DebugSessionTemplateStatus{
+				Conditions: []metav1.Condition{readyTrue},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*breakglassv1alpha1.DebugSessionTemplate)
+		want   bool
+	}{
+		{
+			name: "unchanged template does not requeue bindings",
+			want: false,
+		},
+		{
+			name: "generation change requeues bindings",
+			mutate: func(template *breakglassv1alpha1.DebugSessionTemplate) {
+				template.Generation = 2
+			},
+			want: true,
+		},
+		{
+			name: "label change requeues selector bindings",
+			mutate: func(template *breakglassv1alpha1.DebugSessionTemplate) {
+				template.Labels = map[string]string{"tier": "privileged"}
+			},
+			want: true,
+		},
+		{
+			name: "ready status change requeues bindings",
+			mutate: func(template *breakglassv1alpha1.DebugSessionTemplate) {
+				template.Status.Conditions[0].Status = metav1.ConditionFalse
+			},
+			want: true,
+		},
+		{
+			name: "ready message change does not requeue bindings",
+			mutate: func(template *breakglassv1alpha1.DebugSessionTemplate) {
+				template.Status.Conditions[0].Message = "template is still ready"
+				template.Status.Conditions[0].Reason = "StillReady"
+				template.Status.Conditions[0].ObservedGeneration = 2
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldTemplate := baseTemplate()
+			newTemplate := oldTemplate.DeepCopy()
+			if tt.mutate != nil {
+				tt.mutate(newTemplate)
+			}
+
+			assert.Equal(t, tt.want, templateDependencyChanged(oldTemplate, newTemplate))
+		})
+	}
 }
 
 func TestDebugSessionClusterBindingReconciler_ReadyConditionChanged(t *testing.T) {
@@ -768,6 +852,10 @@ func TestDebugSessionClusterBindingReconciler_ReadyConditionChanged(t *testing.T
 	}
 	readyTrueLater := readyTrue
 	readyTrueLater.LastTransitionTime = metav1.Now()
+	readyTrueDifferentReason := readyTrue
+	readyTrueDifferentReason.Reason = "StillReady"
+	readyTrueDifferentReason.Message = "cluster is still ready"
+	readyTrueDifferentReason.ObservedGeneration = 2
 	readyFalse := readyTrue
 	readyFalse.Status = metav1.ConditionFalse
 	readyFalse.Reason = "NotReady"
@@ -775,5 +863,6 @@ func TestDebugSessionClusterBindingReconciler_ReadyConditionChanged(t *testing.T
 	assert.False(t, readyConditionChanged(nil, nil))
 	assert.True(t, readyConditionChanged(nil, []metav1.Condition{readyTrue}))
 	assert.False(t, readyConditionChanged([]metav1.Condition{readyTrue}, []metav1.Condition{readyTrueLater}))
+	assert.False(t, readyConditionChanged([]metav1.Condition{readyTrue}, []metav1.Condition{readyTrueDifferentReason}))
 	assert.True(t, readyConditionChanged([]metav1.Condition{readyTrue}, []metav1.Condition{readyFalse}))
 }

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -61,6 +61,18 @@ func indexClusterBindingTemplateRef(obj client.Object) []string {
 	return []string{binding.Spec.TemplateRef.Name}
 }
 
+func indexClusterBindingTemplateSelector(obj client.Object) []string {
+	binding, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+	if !ok || binding == nil || binding.Spec.TemplateSelector == nil {
+		return nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(binding.Spec.TemplateSelector)
+	if err != nil || selector.Empty() {
+		return nil
+	}
+	return []string{debugBindingSelectorPresenceValue}
+}
+
 func indexClusterBindingClusters(obj client.Object) []string {
 	binding, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding)
 	if !ok || binding == nil || len(binding.Spec.Clusters) == 0 {
@@ -73,6 +85,18 @@ func indexClusterBindingClusters(obj client.Object) []string {
 		}
 	}
 	return clusters
+}
+
+func indexClusterBindingClusterSelector(obj client.Object) []string {
+	binding, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+	if !ok || binding == nil || binding.Spec.ClusterSelector == nil {
+		return nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(binding.Spec.ClusterSelector)
+	if err != nil || selector.Empty() {
+		return nil
+	}
+	return []string{debugBindingSelectorPresenceValue}
 }
 
 func TestDebugSessionClusterBindingReconciler_Reconcile_NotFound(t *testing.T) {
@@ -707,6 +731,7 @@ func TestDebugSessionClusterBindingReconciler_BindingsForTemplate(t *testing.T) 
 		WithScheme(scheme).
 		WithObjects(template, exactBinding, selectorBinding, otherBinding, emptySelectorBinding).
 		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingTemplateRefIndex, indexClusterBindingTemplateRef).
+		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingTemplateSelectorIndex, indexClusterBindingTemplateSelector).
 		Build()
 
 	requests := r.bindingsForTemplate(context.Background(), template)
@@ -760,6 +785,7 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 		WithScheme(scheme).
 		WithObjects(cluster, exactBinding, selectorBinding, otherBinding, emptySelectorBinding).
 		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingClustersIndex, indexClusterBindingClusters).
+		WithIndex(&breakglassv1alpha1.DebugSessionClusterBinding{}, debugBindingClusterSelectorIndex, indexClusterBindingClusterSelector).
 		Build()
 
 	requests := r.bindingsForClusterConfig(context.Background(), cluster)

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -66,7 +66,13 @@ func indexClusterBindingClusters(obj client.Object) []string {
 	if !ok || binding == nil || len(binding.Spec.Clusters) == 0 {
 		return nil
 	}
-	return binding.Spec.Clusters
+	clusters := make([]string, 0, len(binding.Spec.Clusters))
+	for _, cluster := range binding.Spec.Clusters {
+		if cluster != "" {
+			clusters = append(clusters, cluster)
+		}
+	}
+	return clusters
 }
 
 func TestDebugSessionClusterBindingReconciler_Reconcile_NotFound(t *testing.T) {
@@ -750,4 +756,24 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 		{Namespace: "team-a", Name: "exact-binding"},
 		{Namespace: "team-b", Name: "selector-binding"},
 	}, clusterBindingRequestNames(requests))
+}
+
+func TestDebugSessionClusterBindingReconciler_ReadyConditionChanged(t *testing.T) {
+	readyTrue := metav1.Condition{
+		Type:               string(breakglassv1alpha1.ClusterConfigConditionReady),
+		Status:             metav1.ConditionTrue,
+		Reason:             "Ready",
+		Message:            "cluster is ready",
+		ObservedGeneration: 1,
+	}
+	readyTrueLater := readyTrue
+	readyTrueLater.LastTransitionTime = metav1.Now()
+	readyFalse := readyTrue
+	readyFalse.Status = metav1.ConditionFalse
+	readyFalse.Reason = "NotReady"
+
+	assert.False(t, readyConditionChanged(nil, nil))
+	assert.True(t, readyConditionChanged(nil, []metav1.Condition{readyTrue}))
+	assert.False(t, readyConditionChanged([]metav1.Condition{readyTrue}, []metav1.Condition{readyTrueLater}))
+	assert.True(t, readyConditionChanged([]metav1.Condition{readyTrue}, []metav1.Condition{readyFalse}))
 }

--- a/pkg/config/debug_session_cluster_binding_reconciler_test.go
+++ b/pkg/config/debug_session_cluster_binding_reconciler_test.go
@@ -766,7 +766,7 @@ func TestDebugSessionClusterBindingReconciler_BindingsForClusterConfig(t *testin
 
 func TestDebugSessionClusterBindingReconciler_TemplateDependencyChanged(t *testing.T) {
 	readyTrue := metav1.Condition{
-		Type:               DebugSessionTemplateConditionReady,
+		Type:               string(breakglassv1alpha1.DebugSessionTemplateConditionReady),
 		Status:             metav1.ConditionTrue,
 		Reason:             "Ready",
 		Message:            "template is ready",

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -15,7 +16,7 @@ import (
 
 // ExpectedIndexCount is the number of field indexes that should be registered.
 // Update this constant when adding or removing indexes.
-const ExpectedIndexCount = 17
+const ExpectedIndexCount = 19
 
 // registeredIndexes tracks which indexes have been successfully registered.
 // Uses sync.Map because RegisterCommonFieldIndexes may be called concurrently
@@ -209,6 +210,22 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
+	if err := register("DebugSessionClusterBinding", "spec.templateSelector", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.templateSelector", func(rawObj client.Object) []string {
+			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+			if !ok || binding == nil || binding.Spec.TemplateSelector == nil {
+				return nil
+			}
+			selector, err := metav1.LabelSelectorAsSelector(binding.Spec.TemplateSelector)
+			if err != nil || selector.Empty() {
+				return nil
+			}
+			return []string{"true"}
+		})
+	}); err != nil {
+		return err
+	}
+
 	if err := register("DebugSessionClusterBinding", "spec.clusters", func() error {
 		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.clusters", func(rawObj client.Object) []string {
 			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
@@ -222,6 +239,22 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 				}
 			}
 			return clusters
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("DebugSessionClusterBinding", "spec.clusterSelector", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.clusterSelector", func(rawObj client.Object) []string {
+			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+			if !ok || binding == nil || binding.Spec.ClusterSelector == nil {
+				return nil
+			}
+			selector, err := metav1.LabelSelectorAsSelector(binding.Spec.ClusterSelector)
+			if err != nil || selector.Empty() {
+				return nil
+			}
+			return []string{"true"}
 		})
 	}); err != nil {
 		return err

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -210,8 +210,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
-	if err := register("DebugSessionClusterBinding", "spec.templateSelector", func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.templateSelector", func(rawObj client.Object) []string {
+	if err := register("DebugSessionClusterBinding", "spec.templateSelector.present", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.templateSelector.present", func(rawObj client.Object) []string {
 			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
 			if !ok || binding == nil || binding.Spec.TemplateSelector == nil {
 				return nil
@@ -244,8 +244,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
-	if err := register("DebugSessionClusterBinding", "spec.clusterSelector", func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.clusterSelector", func(rawObj client.Object) []string {
+	if err := register("DebugSessionClusterBinding", "spec.clusterSelector.present", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.clusterSelector.present", func(rawObj client.Object) []string {
 			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
 			if !ok || binding == nil || binding.Spec.ClusterSelector == nil {
 				return nil

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -15,7 +15,7 @@ import (
 
 // ExpectedIndexCount is the number of field indexes that should be registered.
 // Update this constant when adding or removing indexes.
-const ExpectedIndexCount = 15
+const ExpectedIndexCount = 17
 
 // registeredIndexes tracks which indexes have been successfully registered.
 // Uses sync.Map because RegisterCommonFieldIndexes may be called concurrently
@@ -192,6 +192,30 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 				return []string{be.Name}
 			}
 			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("DebugSessionClusterBinding", "spec.templateRef.name", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.templateRef.name", func(rawObj client.Object) []string {
+			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+			if !ok || binding == nil || binding.Spec.TemplateRef == nil || binding.Spec.TemplateRef.Name == "" {
+				return nil
+			}
+			return []string{binding.Spec.TemplateRef.Name}
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("DebugSessionClusterBinding", "spec.clusters", func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.DebugSessionClusterBinding{}, "spec.clusters", func(rawObj client.Object) []string {
+			binding, ok := rawObj.(*breakglassv1alpha1.DebugSessionClusterBinding)
+			if !ok || binding == nil || len(binding.Spec.Clusters) == 0 {
+				return nil
+			}
+			return binding.Spec.Clusters
 		})
 	}); err != nil {
 		return err

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -215,7 +215,13 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 			if !ok || binding == nil || len(binding.Spec.Clusters) == 0 {
 				return nil
 			}
-			return binding.Spec.Clusters
+			clusters := make([]string, 0, len(binding.Spec.Clusters))
+			for _, cluster := range binding.Spec.Clusters {
+				if cluster != "" {
+					clusters = append(clusters, cluster)
+				}
+			}
+			return clusters
 		})
 	}); err != nil {
 		return err

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -142,6 +142,10 @@ func TestRegisterCommonFieldIndexes_FailureOnField(t *testing.T) {
 			failOnField: "spec.templateRef.name",
 		},
 		{
+			name:        "fail on spec.clusters",
+			failOnField: "spec.clusters",
+		},
+		{
 			name:        "fail on spec.clusterID",
 			failOnField: "spec.clusterID",
 		},
@@ -320,7 +324,7 @@ func TestIndexerFunctions_DebugSessionClusterBinding(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 			TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "template-a"},
-			Clusters:    []string{"cluster-a", "cluster-b"},
+			Clusters:    []string{"cluster-a", "", "cluster-b"},
 		},
 	}
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -84,7 +84,9 @@ func TestRegisterCommonFieldIndexes_Success(t *testing.T) {
 		"spec.allowed.group",
 		"spec.escalatedGroup",
 		"spec.templateRef.name",
+		"spec.templateSelector.present",
 		"spec.clusters",
+		"spec.clusterSelector.present",
 		"spec.clusterID",
 	}
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -83,6 +83,8 @@ func TestRegisterCommonFieldIndexes_Success(t *testing.T) {
 		"spec.allowed.cluster",
 		"spec.allowed.group",
 		"spec.escalatedGroup",
+		"spec.templateRef.name",
+		"spec.clusters",
 		"spec.clusterID",
 	}
 
@@ -134,6 +136,10 @@ func TestRegisterCommonFieldIndexes_FailureOnField(t *testing.T) {
 		{
 			name:        "fail on spec.escalatedGroup",
 			failOnField: "spec.escalatedGroup",
+		},
+		{
+			name:        "fail on spec.templateRef.name",
+			failOnField: "spec.templateRef.name",
 		},
 		{
 			name:        "fail on spec.clusterID",
@@ -294,6 +300,50 @@ func TestIndexerFunctions_DebugSession(t *testing.T) {
 		assert.ElementsMatch(t, []string{"user-a@example.com", "user-b@example.com"}, result)
 
 		empty := &breakglassv1alpha1.DebugSession{}
+		result = fn(empty)
+		assert.Nil(t, result)
+	})
+}
+
+func TestIndexerFunctions_DebugSessionClusterBinding(t *testing.T) {
+	indexer := newMockFieldIndexer()
+	logger := zaptest.NewLogger(t).Sugar()
+	ctx := context.Background()
+
+	err := RegisterCommonFieldIndexes(ctx, indexer, logger)
+	require.NoError(t, err)
+
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "debug-binding",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "template-a"},
+			Clusters:    []string{"cluster-a", "cluster-b"},
+		},
+	}
+
+	t.Run("spec.templateRef.name index", func(t *testing.T) {
+		fn := indexer.indexedFields["spec.templateRef.name"]
+		require.NotNil(t, fn)
+
+		result := fn(binding)
+		assert.Equal(t, []string{"template-a"}, result)
+
+		empty := &breakglassv1alpha1.DebugSessionClusterBinding{}
+		result = fn(empty)
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.clusters index", func(t *testing.T) {
+		fn := indexer.indexedFields["spec.clusters"]
+		require.NotNil(t, fn)
+
+		result := fn(binding)
+		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b"}, result)
+
+		empty := &breakglassv1alpha1.DebugSessionClusterBinding{}
 		result = fn(empty)
 		assert.Nil(t, result)
 	})

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -351,6 +351,36 @@ func TestIndexerFunctions_DebugSessionClusterBinding(t *testing.T) {
 		result = fn(empty)
 		assert.Nil(t, result)
 	})
+
+	t.Run("spec.templateSelector.present index", func(t *testing.T) {
+		fn := indexer.indexedFields["spec.templateSelector.present"]
+		require.NotNil(t, fn)
+
+		withSelector := binding.DeepCopy()
+		withSelector.Spec.TemplateSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "debug"}}
+		result := fn(withSelector)
+		assert.Equal(t, []string{"true"}, result)
+
+		emptySelector := binding.DeepCopy()
+		emptySelector.Spec.TemplateSelector = &metav1.LabelSelector{}
+		result = fn(emptySelector)
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.clusterSelector.present index", func(t *testing.T) {
+		fn := indexer.indexedFields["spec.clusterSelector.present"]
+		require.NotNil(t, fn)
+
+		withSelector := binding.DeepCopy()
+		withSelector.Spec.ClusterSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}
+		result := fn(withSelector)
+		assert.Equal(t, []string{"true"}, result)
+
+		emptySelector := binding.DeepCopy()
+		emptySelector.Spec.ClusterSelector = &metav1.LabelSelector{}
+		result = fn(emptySelector)
+		assert.Nil(t, result)
+	})
 }
 
 func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {


### PR DESCRIPTION
## Summary

- add reverse watches from `DebugSessionTemplate` and `ClusterConfig` updates to affected `DebugSessionClusterBinding` resources
- add exact field indexes for `spec.templateRef.name` and `spec.clusters`, with selector fallback mapping for label-selected templates/clusters
- document that binding status refreshes when matched templates or clusters change

## Evidence

`DebugSessionClusterBinding` status includes `resolvedTemplates`, `resolvedClusters`, and readiness conditions derived from referenced `DebugSessionTemplate` and `ClusterConfig` resources. Before this change, the controller only watched `DebugSessionClusterBinding` objects, so template readiness, cluster readiness, or selector-label changes could leave binding status stale until the binding itself changed.

Duplicate check before opening: live searches for `DebugSessionClusterBinding template ClusterConfig watch status stale` returned no open or recently merged PRs. Adjacent PRs #851 and #839 address different behavior: binding namespace resolution and escalation spec-update reconciliation, not dependency watches for binding status.

## Tests

- `go test ./pkg/config -run 'TestDebugSessionClusterBindingReconciler'`
- `go test ./pkg/indexer`
- `make test`
- `make lint`
- `git diff --check` (no whitespace findings; local git printed an fsmonitor-daemon notice)
