### PR TITLE
fix: refresh escalation dependency validation

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -30,7 +30,7 @@ jobs:
   e2e-smoke:
     name: E2E Bootstrap Smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -198,7 +198,7 @@ mailProvider: "prod-mail-provider"
 
 If omitted, Breakglass uses the cluster-level mail provider, and if that is unset, the default MailProvider. This allows sensitive escalations to route via hardened SMTP relays while everything else uses the default.
 
-> **Runtime validation:** The webhook no longer blocks missing MailProviders. The Escalation controller re-checks the reference after admission and flips the `MailProviderValid` condition (and emits a warning event) if the provider is missing or disabled. Create/enable the provider to restore the condition to `True` and re-enable notifications.
+> **Runtime validation:** The webhook no longer blocks missing MailProviders. The Escalation controller re-checks the reference after admission and flips the `MailProviderValid` condition (and emits a warning event) if the provider is missing or disabled. The controller watches referenced MailProvider changes and deletions, so creating or enabling the provider refreshes the condition and re-enables notifications.
 
 ### notificationExclusions
 
@@ -465,6 +465,8 @@ allowedIdentityProvidersForApprovers:
 - Cannot be mixed with legacy `allowedIdentityProviders` field
 - All referenced IdentityProviders must exist
 
+> **Runtime validation:** The Escalation controller watches referenced IdentityProvider changes and deletions and refreshes the `IDPRefsValid` condition when a provider is created, disabled, enabled, or removed.
+
 **Behavior:**
 
 - If `allowedIdentityProvidersForRequests` is empty, all IDPs can request (default)
@@ -661,7 +663,7 @@ clusterConfigRefs: ["*"]         # ALL clusters (global escalation)
 
 **Glob patterns**: Supports `*` (any characters), `?` (single character), and `[abc]` (character class). See [Glob Pattern Matching](#glob-pattern-matching) for details.
 
-> **Runtime validation:** The admission webhook intentionally accepts escalations even if the referenced `ClusterConfig` objects are missing. The Escalation controller re-validates these references and updates the `ClusterRefsValid` condition (and emits warning events) whenever a reference cannot be resolved.
+> **Runtime validation:** The admission webhook intentionally accepts escalations even if the referenced `ClusterConfig` objects are missing. The Escalation controller re-validates exact and glob references, watches matching `ClusterConfig` changes and deletions, and updates the `ClusterRefsValid` condition (and emits warning events) whenever a reference cannot be resolved.
 
 The Escalation API defaults `activeOnly=true`. With a concrete or glob `cluster`
 filter, escalations are hidden when every matching registered `ClusterConfig`
@@ -678,7 +680,7 @@ Default deny policies attached to any session created via this escalation:
 denyPolicyRefs: ["deny-production-secrets", "deny-destructive-actions"]
 ```
 
-> **Runtime validation:** Missing or misconfigured `DenyPolicy` references do not block creation. Instead, the Escalation controller surfaces problems through the `DenyPolicyRefsValid` condition and warning events so operators can react without being prevented from applying manifests.
+> **Runtime validation:** Missing or misconfigured `DenyPolicy` references do not block creation. Instead, the Escalation controller watches referenced DenyPolicy changes and deletions, then surfaces problems through the `DenyPolicyRefsValid` condition and warning events so operators can react without being prevented from applying manifests.
 
 ### podSecurityOverrides
 

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -198,7 +198,7 @@ mailProvider: "prod-mail-provider"
 
 If omitted, Breakglass uses the cluster-level mail provider, and if that is unset, the default MailProvider. This allows sensitive escalations to route via hardened SMTP relays while everything else uses the default.
 
-> **Runtime validation:** The webhook no longer blocks missing MailProviders. The Escalation controller re-checks the reference after admission and flips the `MailProviderValid` condition (and emits a warning event) if the provider is missing or disabled. The controller watches referenced MailProvider changes and deletions, so creating or enabling the provider refreshes the condition and re-enables notifications.
+> **Runtime validation:** The webhook no longer blocks missing MailProviders. The Escalation controller re-checks the reference after admission and flips the `MailProviderValid` condition (and emits a warning event) if the provider is missing or disabled. The controller watches referenced MailProvider create/delete events and update events that change `metadata.generation` or `metadata.deletionTimestamp`; status-only updates are ignored. Creating or enabling the provider refreshes the condition and re-enables notifications.
 
 ### notificationExclusions
 
@@ -465,7 +465,7 @@ allowedIdentityProvidersForApprovers:
 - Cannot be mixed with legacy `allowedIdentityProviders` field
 - All referenced IdentityProviders must exist
 
-> **Runtime validation:** The Escalation controller watches referenced IdentityProvider changes and deletions and refreshes the `IDPRefsValid` condition when a provider is created, disabled, enabled, or removed.
+> **Runtime validation:** The Escalation controller watches referenced IdentityProvider create/delete events and update events that change `metadata.generation` or `metadata.deletionTimestamp`; status-only updates are ignored. It refreshes the `IDPRefsValid` condition when a provider is created, disabled, enabled, or removed.
 
 **Behavior:**
 
@@ -663,7 +663,7 @@ clusterConfigRefs: ["*"]         # ALL clusters (global escalation)
 
 **Glob patterns**: Supports `*` (any characters), `?` (single character), and `[abc]` (character class). See [Glob Pattern Matching](#glob-pattern-matching) for details.
 
-> **Runtime validation:** The admission webhook intentionally accepts escalations even if the referenced `ClusterConfig` objects are missing. The Escalation controller re-validates exact and glob references, watches matching `ClusterConfig` changes and deletions, and updates the `ClusterRefsValid` condition (and emits warning events) whenever a reference cannot be resolved.
+> **Runtime validation:** The admission webhook intentionally accepts escalations even if the referenced `ClusterConfig` objects are missing. The Escalation controller re-validates exact and glob references, watches matching `ClusterConfig` create/delete events and update events that change `metadata.generation` or `metadata.deletionTimestamp`, and updates the `ClusterRefsValid` condition (and emits warning events) whenever a reference cannot be resolved. Status-only updates do not refresh the condition.
 
 The Escalation API defaults `activeOnly=true`. With a concrete or glob `cluster`
 filter, escalations are hidden when every matching registered `ClusterConfig`
@@ -680,7 +680,7 @@ Default deny policies attached to any session created via this escalation:
 denyPolicyRefs: ["deny-production-secrets", "deny-destructive-actions"]
 ```
 
-> **Runtime validation:** Missing or misconfigured `DenyPolicy` references do not block creation. Instead, the Escalation controller watches referenced DenyPolicy changes and deletions, then surfaces problems through the `DenyPolicyRefsValid` condition and warning events so operators can react without being prevented from applying manifests.
+> **Runtime validation:** Missing or misconfigured `DenyPolicy` references do not block creation. Instead, the Escalation controller watches referenced DenyPolicy create/delete events and update events that change `metadata.generation` or `metadata.deletionTimestamp`, then surfaces problems through the `DenyPolicyRefsValid` condition and warning events so operators can react without being prevented from applying manifests. Status-only updates are ignored.
 
 ### podSecurityOverrides
 

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -24,6 +24,7 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/ssa"
+	"github.com/telekom/k8s-breakglass/pkg/indexer"
 )
 
 // EscalationReconciler watches BreakglassEscalation CRs and validates their configuration.
@@ -445,9 +446,28 @@ func (r *EscalationReconciler) escalationsForClusterConfig(ctx context.Context, 
 		listOpts = append(listOpts, client.InNamespace(namespace))
 	}
 
-	return r.escalationRequestsMatching(ctx, listOpts, "ClusterConfig", clusterName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
-		return clusterRefListMatchesName(esc.Spec.ClusterConfigRefs, clusterName)
-	})
+	exactRequests := r.escalationRequestsMatching(
+		ctx,
+		appendListOptions(listOpts, client.MatchingFields{indexer.BreakglassEscalationClusterConfigRefField: clusterName}),
+		"ClusterConfig",
+		clusterName,
+		func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+			return clusterRefListMatchesName(esc.Spec.ClusterConfigRefs, clusterName)
+		},
+	)
+	patternRequests := r.escalationRequestsMatching(
+		ctx,
+		appendListOptions(listOpts, client.MatchingFields{
+			indexer.BreakglassEscalationClusterConfigRefPatternField: indexer.BreakglassEscalationGlobPatternIndexValue,
+		}),
+		"ClusterConfig",
+		clusterName,
+		func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+			return clusterRefListMatchesName(esc.Spec.ClusterConfigRefs, clusterName)
+		},
+	)
+
+	return deduplicateRequests(append(exactRequests, patternRequests...))
 }
 
 func (r *EscalationReconciler) escalationsForIdentityProvider(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -456,7 +476,9 @@ func (r *EscalationReconciler) escalationsForIdentityProvider(ctx context.Contex
 		return nil
 	}
 
-	return r.escalationRequestsMatching(ctx, nil, "IdentityProvider", idpName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+	return r.escalationRequestsMatching(ctx, []client.ListOption{
+		client.MatchingFields{indexer.BreakglassEscalationIdentityProviderField: idpName},
+	}, "IdentityProvider", idpName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 		return containsTrimmedString(esc.Spec.AllowedIdentityProviders, idpName) ||
 			containsTrimmedString(esc.Spec.AllowedIdentityProvidersForRequests, idpName) ||
 			containsTrimmedString(esc.Spec.AllowedIdentityProvidersForApprovers, idpName)
@@ -469,7 +491,9 @@ func (r *EscalationReconciler) escalationsForDenyPolicy(ctx context.Context, obj
 		return nil
 	}
 
-	return r.escalationRequestsMatching(ctx, nil, "DenyPolicy", policyName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+	return r.escalationRequestsMatching(ctx, []client.ListOption{
+		client.MatchingFields{indexer.BreakglassEscalationDenyPolicyRefField: policyName},
+	}, "DenyPolicy", policyName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 		return containsTrimmedString(esc.Spec.DenyPolicyRefs, policyName)
 	})
 }
@@ -480,7 +504,9 @@ func (r *EscalationReconciler) escalationsForMailProvider(ctx context.Context, o
 		return nil
 	}
 
-	return r.escalationRequestsMatching(ctx, nil, "MailProvider", providerName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+	return r.escalationRequestsMatching(ctx, []client.ListOption{
+		client.MatchingFields{indexer.BreakglassEscalationMailProviderField: providerName},
+	}, "MailProvider", providerName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 		return strings.TrimSpace(esc.Spec.MailProvider) == providerName
 	})
 }
@@ -494,6 +520,9 @@ func (r *EscalationReconciler) escalationRequestsMatching(
 ) []reconcile.Request {
 	var list breakglassv1alpha1.BreakglassEscalationList
 	if err := r.client.List(ctx, &list, listOpts...); err != nil {
+		if isFieldIndexUnavailable(err) {
+			return r.escalationRequestsMatching(ctx, withoutMatchingFields(listOpts), dependencyKind, dependencyName, matches)
+		}
 		if r.logger != nil {
 			r.logger.Warnw("Failed to list BreakglassEscalations for dependency change",
 				"dependencyKind", dependencyKind,
@@ -521,6 +550,58 @@ func (r *EscalationReconciler) escalationRequestsMatching(
 		return requests[i].Namespace < requests[j].Namespace
 	})
 	return requests
+}
+
+func appendListOptions(base []client.ListOption, extra ...client.ListOption) []client.ListOption {
+	out := make([]client.ListOption, 0, len(base)+len(extra))
+	out = append(out, base...)
+	out = append(out, extra...)
+	return out
+}
+
+func withoutMatchingFields(opts []client.ListOption) []client.ListOption {
+	filtered := make([]client.ListOption, 0, len(opts))
+	for _, opt := range opts {
+		if _, ok := opt.(client.MatchingFields); ok {
+			continue
+		}
+		filtered = append(filtered, opt)
+	}
+	return filtered
+}
+
+func isFieldIndexUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "field index") ||
+		strings.Contains(msg, "no indexer") ||
+		strings.Contains(msg, "no index with name") ||
+		strings.Contains(msg, "field label not supported") ||
+		strings.Contains(msg, "Index with name")
+}
+
+func deduplicateRequests(requests []reconcile.Request) []reconcile.Request {
+	if len(requests) < 2 {
+		return requests
+	}
+	seen := make(map[client.ObjectKey]struct{}, len(requests))
+	out := make([]reconcile.Request, 0, len(requests))
+	for _, req := range requests {
+		if _, ok := seen[req.NamespacedName]; ok {
+			continue
+		}
+		seen[req.NamespacedName] = struct{}{}
+		out = append(out, req)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace == out[j].Namespace {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Namespace < out[j].Namespace
+	})
+	return out
 }
 
 func containsTrimmedString(values []string, needle string) bool {
@@ -582,6 +663,9 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 		}
 
 		if strings.ContainsAny(name, "*?[") {
+			if err := validateClusterRefPattern(name); err != nil {
+				return fmt.Errorf("invalid ClusterConfigRefs glob pattern %q: %w", name, err)
+			}
 			matched, err := r.clusterConfigRefHasMatch(ctx, esc.Namespace, name)
 			if err != nil {
 				return err
@@ -609,6 +693,11 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 	}
 
 	return nil
+}
+
+func validateClusterRefPattern(pattern string) error {
+	_, err := filepath.Match(pattern, "")
+	return err
 }
 
 func (r *EscalationReconciler) clusterConfigRefHasMatch(ctx context.Context, namespace, pattern string) (bool, error) {

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,9 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -349,12 +353,33 @@ func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
 	}
 
+	dependencyPredicate := dependencyChangePredicate()
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&breakglassv1alpha1.BreakglassEscalation{}).
+		For(&breakglassv1alpha1.BreakglassEscalation{}, builder.WithPredicates(specChangePredicate)).
+		Watches(
+			&breakglassv1alpha1.ClusterConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.escalationsForClusterConfig),
+			builder.WithPredicates(dependencyPredicate),
+		).
+		Watches(
+			&breakglassv1alpha1.IdentityProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.escalationsForIdentityProvider),
+			builder.WithPredicates(dependencyPredicate),
+		).
+		Watches(
+			&breakglassv1alpha1.DenyPolicy{},
+			handler.EnqueueRequestsFromMapFunc(r.escalationsForDenyPolicy),
+			builder.WithPredicates(dependencyPredicate),
+		).
+		Watches(
+			&breakglassv1alpha1.MailProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.escalationsForMailProvider),
+			builder.WithPredicates(dependencyPredicate),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1, // Process one escalation at a time
 		}).
-		WithEventFilter(specChangePredicate).
 		Complete(r)
 }
 
@@ -382,6 +407,150 @@ func shouldReconcileEscalationUpdate(oldObj, newObj client.Object) bool {
 	default:
 		return !oldDeletionTimestamp.Equal(newDeletionTimestamp)
 	}
+}
+
+func dependencyChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true
+			}
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+			oldDeleting := e.ObjectOld.GetDeletionTimestamp()
+			newDeleting := e.ObjectNew.GetDeletionTimestamp()
+			switch {
+			case oldDeleting == nil && newDeleting == nil:
+				return false
+			case oldDeleting == nil || newDeleting == nil:
+				return true
+			default:
+				return !oldDeleting.Equal(newDeleting)
+			}
+		},
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+	}
+}
+
+func (r *EscalationReconciler) escalationsForClusterConfig(ctx context.Context, obj client.Object) []reconcile.Request {
+	clusterName := strings.TrimSpace(obj.GetName())
+	if clusterName == "" {
+		return nil
+	}
+
+	var listOpts []client.ListOption
+	if namespace := obj.GetNamespace(); namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+
+	return r.escalationRequestsMatching(ctx, listOpts, "ClusterConfig", clusterName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+		return clusterRefListMatchesName(esc.Spec.ClusterConfigRefs, clusterName)
+	})
+}
+
+func (r *EscalationReconciler) escalationsForIdentityProvider(ctx context.Context, obj client.Object) []reconcile.Request {
+	idpName := strings.TrimSpace(obj.GetName())
+	if idpName == "" {
+		return nil
+	}
+
+	return r.escalationRequestsMatching(ctx, nil, "IdentityProvider", idpName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+		return containsTrimmedString(esc.Spec.AllowedIdentityProviders, idpName) ||
+			containsTrimmedString(esc.Spec.AllowedIdentityProvidersForRequests, idpName) ||
+			containsTrimmedString(esc.Spec.AllowedIdentityProvidersForApprovers, idpName)
+	})
+}
+
+func (r *EscalationReconciler) escalationsForDenyPolicy(ctx context.Context, obj client.Object) []reconcile.Request {
+	policyName := strings.TrimSpace(obj.GetName())
+	if policyName == "" {
+		return nil
+	}
+
+	return r.escalationRequestsMatching(ctx, nil, "DenyPolicy", policyName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+		return containsTrimmedString(esc.Spec.DenyPolicyRefs, policyName)
+	})
+}
+
+func (r *EscalationReconciler) escalationsForMailProvider(ctx context.Context, obj client.Object) []reconcile.Request {
+	providerName := strings.TrimSpace(obj.GetName())
+	if providerName == "" {
+		return nil
+	}
+
+	return r.escalationRequestsMatching(ctx, nil, "MailProvider", providerName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
+		return strings.TrimSpace(esc.Spec.MailProvider) == providerName
+	})
+}
+
+func (r *EscalationReconciler) escalationRequestsMatching(
+	ctx context.Context,
+	listOpts []client.ListOption,
+	dependencyKind string,
+	dependencyName string,
+	matches func(*breakglassv1alpha1.BreakglassEscalation) bool,
+) []reconcile.Request {
+	var list breakglassv1alpha1.BreakglassEscalationList
+	if err := r.client.List(ctx, &list, listOpts...); err != nil {
+		if r.logger != nil {
+			r.logger.Warnw("Failed to list BreakglassEscalations for dependency change",
+				"dependencyKind", dependencyKind,
+				"dependencyName", dependencyName,
+				"error", err)
+		}
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		esc := &list.Items[i]
+		if !matches(esc) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(esc),
+		})
+	}
+
+	sort.Slice(requests, func(i, j int) bool {
+		if requests[i].Namespace == requests[j].Namespace {
+			return requests[i].Name < requests[j].Name
+		}
+		return requests[i].Namespace < requests[j].Namespace
+	})
+	return requests
+}
+
+func containsTrimmedString(values []string, needle string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func clusterRefListMatchesName(refs []string, clusterName string) bool {
+	for _, ref := range refs {
+		if clusterRefMatchesName(ref, clusterName) {
+			return true
+		}
+	}
+	return false
+}
+
+func clusterRefMatchesName(ref string, clusterName string) bool {
+	pattern := strings.TrimSpace(ref)
+	if pattern == "" {
+		return false
+	}
+	if pattern == clusterName {
+		return true
+	}
+	matched, err := filepath.Match(pattern, clusterName)
+	return err == nil && matched
 }
 
 // validateEscalationConfig validates the escalation's configuration structure.
@@ -412,6 +581,18 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 			continue
 		}
 
+		if strings.ContainsAny(name, "*?[") {
+			matched, err := r.clusterConfigRefHasMatch(ctx, esc.Namespace, name)
+			if err != nil {
+				return err
+			}
+			if matched {
+				continue
+			}
+			missing = append(missing, fmt.Sprintf("%s/%s", esc.Namespace, name))
+			continue
+		}
+
 		clusterKey := client.ObjectKey{Namespace: esc.Namespace, Name: name}
 		cluster := &breakglassv1alpha1.ClusterConfig{}
 		if err := r.client.Get(ctx, clusterKey, cluster); err != nil {
@@ -428,6 +609,21 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 	}
 
 	return nil
+}
+
+func (r *EscalationReconciler) clusterConfigRefHasMatch(ctx context.Context, namespace, pattern string) (bool, error) {
+	var clusters breakglassv1alpha1.ClusterConfigList
+	if err := r.client.List(ctx, &clusters, client.InNamespace(namespace)); err != nil {
+		return false, fmt.Errorf("failed to list ClusterConfigs in namespace %q for pattern %q: %w", namespace, pattern, err)
+	}
+
+	for i := range clusters.Items {
+		if clusterRefMatchesName(pattern, clusters.Items[i].Name) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // validateIDPRefs validates that all referenced IDPs exist

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -448,7 +448,7 @@ func (r *EscalationReconciler) escalationsForClusterConfig(ctx context.Context, 
 
 	exactRequests := r.escalationRequestsMatching(
 		ctx,
-		appendListOptions(listOpts, client.MatchingFields{indexer.BreakglassEscalationClusterConfigRefField: clusterName}),
+		appendListOptions(listOpts, client.MatchingFields{indexer.BreakglassEscalationClusterConfigRefsField: clusterName}),
 		"ClusterConfig",
 		clusterName,
 		func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
@@ -458,7 +458,7 @@ func (r *EscalationReconciler) escalationsForClusterConfig(ctx context.Context, 
 	patternRequests := r.escalationRequestsMatching(
 		ctx,
 		appendListOptions(listOpts, client.MatchingFields{
-			indexer.BreakglassEscalationClusterConfigRefPatternField: indexer.BreakglassEscalationGlobPatternIndexValue,
+			indexer.BreakglassEscalationClusterConfigRefsPatternField: indexer.BreakglassEscalationGlobPatternIndexValue,
 		}),
 		"ClusterConfig",
 		clusterName,
@@ -477,7 +477,7 @@ func (r *EscalationReconciler) escalationsForIdentityProvider(ctx context.Contex
 	}
 
 	return r.escalationRequestsMatching(ctx, []client.ListOption{
-		client.MatchingFields{indexer.BreakglassEscalationIdentityProviderField: idpName},
+		client.MatchingFields{indexer.BreakglassEscalationAllowedIdentityProvidersField: idpName},
 	}, "IdentityProvider", idpName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 		return containsTrimmedString(esc.Spec.AllowedIdentityProviders, idpName) ||
 			containsTrimmedString(esc.Spec.AllowedIdentityProvidersForRequests, idpName) ||
@@ -492,7 +492,7 @@ func (r *EscalationReconciler) escalationsForDenyPolicy(ctx context.Context, obj
 	}
 
 	return r.escalationRequestsMatching(ctx, []client.ListOption{
-		client.MatchingFields{indexer.BreakglassEscalationDenyPolicyRefField: policyName},
+		client.MatchingFields{indexer.BreakglassEscalationDenyPolicyRefsField: policyName},
 	}, "DenyPolicy", policyName, func(esc *breakglassv1alpha1.BreakglassEscalation) bool {
 		return containsTrimmedString(esc.Spec.DenyPolicyRefs, policyName)
 	})
@@ -656,6 +656,7 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 	}
 
 	var missing []string
+	var clusterConfigs *breakglassv1alpha1.ClusterConfigList
 	for _, clusterName := range esc.Spec.ClusterConfigRefs {
 		name := strings.TrimSpace(clusterName)
 		if name == "" || name == "*" {
@@ -666,11 +667,13 @@ func (r *EscalationReconciler) validateClusterRef(ctx context.Context, esc *brea
 			if err := validateClusterRefPattern(name); err != nil {
 				return fmt.Errorf("invalid ClusterConfigRefs glob pattern %q: %w", name, err)
 			}
-			matched, err := r.clusterConfigRefHasMatch(ctx, esc.Namespace, name)
-			if err != nil {
-				return err
+			if clusterConfigs == nil {
+				clusterConfigs = &breakglassv1alpha1.ClusterConfigList{}
+				if err := r.client.List(ctx, clusterConfigs, client.InNamespace(esc.Namespace)); err != nil {
+					return fmt.Errorf("failed to list ClusterConfigs in namespace %q for ClusterConfigRefs patterns: %w", esc.Namespace, err)
+				}
 			}
-			if matched {
+			if clusterConfigRefHasMatch(clusterConfigs.Items, name) {
 				continue
 			}
 			missing = append(missing, fmt.Sprintf("%s/%s", esc.Namespace, name))
@@ -700,19 +703,14 @@ func validateClusterRefPattern(pattern string) error {
 	return err
 }
 
-func (r *EscalationReconciler) clusterConfigRefHasMatch(ctx context.Context, namespace, pattern string) (bool, error) {
-	var clusters breakglassv1alpha1.ClusterConfigList
-	if err := r.client.List(ctx, &clusters, client.InNamespace(namespace)); err != nil {
-		return false, fmt.Errorf("failed to list ClusterConfigs in namespace %q for pattern %q: %w", namespace, pattern, err)
-	}
-
-	for i := range clusters.Items {
-		if clusterRefMatchesName(pattern, clusters.Items[i].Name) {
-			return true, nil
+func clusterConfigRefHasMatch(clusters []breakglassv1alpha1.ClusterConfig, pattern string) bool {
+	for i := range clusters {
+		if clusterRefMatchesName(pattern, clusters[i].Name) {
+			return true
 		}
 	}
 
-	return false, nil
+	return false
 }
 
 // validateIDPRefs validates that all referenced IDPs exist

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -521,7 +521,10 @@ func (r *EscalationReconciler) escalationRequestsMatching(
 	var list breakglassv1alpha1.BreakglassEscalationList
 	if err := r.client.List(ctx, &list, listOpts...); err != nil {
 		if isFieldIndexUnavailable(err) {
-			return r.escalationRequestsMatching(ctx, withoutMatchingFields(listOpts), dependencyKind, dependencyName, matches)
+			fallbackOpts := withoutMatchingFields(listOpts)
+			if len(fallbackOpts) < len(listOpts) {
+				return r.escalationRequestsMatching(ctx, fallbackOpts, dependencyKind, dependencyName, matches)
+			}
 		}
 		if r.logger != nil {
 			r.logger.Warnw("Failed to list BreakglassEscalations for dependency change",

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -543,12 +543,6 @@ func (r *EscalationReconciler) escalationRequestsMatching(
 		})
 	}
 
-	sort.Slice(requests, func(i, j int) bool {
-		if requests[i].Namespace == requests[j].Namespace {
-			return requests[i].Name < requests[j].Name
-		}
-		return requests[i].Namespace < requests[j].Namespace
-	})
 	return requests
 }
 

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -287,6 +288,56 @@ func TestEscalationReconciler_DependencyMapFunctions(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "prod-mail"},
 		})),
 	)
+}
+
+func TestIsFieldIndexUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "controller runtime field index",
+			err:  errors.New("field index spec.mailProvider does not exist"),
+			want: true,
+		},
+		{
+			name: "fake client no indexer",
+			err:  errors.New("List on GroupVersionKind with no indexer configured"),
+			want: true,
+		},
+		{
+			name: "missing index name",
+			err:  errors.New("no index with name spec.clusterConfigRefs"),
+			want: true,
+		},
+		{
+			name: "field label unsupported",
+			err:  errors.New("field label not supported: spec.allowedIdentityProviders"),
+			want: true,
+		},
+		{
+			name: "uppercase index wording",
+			err:  errors.New("Index with name spec.denyPolicyRefs does not exist"),
+			want: true,
+		},
+		{
+			name: "unrelated list error",
+			err:  errors.New("permission denied listing BreakglassEscalations"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isFieldIndexUnavailable(tt.err))
+		})
+	}
 }
 
 func requestKeys(requests []reconcile.Request) []string {

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -173,6 +175,125 @@ func TestShouldReconcileEscalationUpdate(t *testing.T) {
 			&breakglassv1alpha1.ClusterConfig{},
 		))
 	})
+}
+
+func TestEscalationDependencyChangePredicate(t *testing.T) {
+	pred := dependencyChangePredicate()
+
+	assert.True(t, pred.Create(event.CreateEvent{Object: &breakglassv1alpha1.MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail"},
+	}}))
+	assert.True(t, pred.Delete(event.DeleteEvent{Object: &breakglassv1alpha1.MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail"},
+	}}))
+
+	oldProvider := &breakglassv1alpha1.MailProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mail", Generation: 1},
+	}
+	sameProvider := oldProvider.DeepCopy()
+	sameProvider.ResourceVersion = "2"
+
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldProvider, ObjectNew: sameProvider}))
+
+	newGeneration := oldProvider.DeepCopy()
+	newGeneration.Generation = 2
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldProvider, ObjectNew: newGeneration}))
+
+	deletingProvider := oldProvider.DeepCopy()
+	deletingAt := metav1.Now()
+	deletingProvider.DeletionTimestamp = &deletingAt
+	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldProvider, ObjectNew: deletingProvider}))
+}
+
+func TestEscalationReconciler_DependencyMapFunctions(t *testing.T) {
+	scheme := newTestEscalationReconcilerScheme()
+	logger := zap.NewNop().Sugar()
+
+	escalation := func(name, namespace string, spec breakglassv1alpha1.BreakglassEscalationSpec) *breakglassv1alpha1.BreakglassEscalation {
+		return &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       spec,
+		}
+	}
+
+	clusterExact := escalation("cluster-exact", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		ClusterConfigRefs: []string{"prod-a"},
+	})
+	clusterGlob := escalation("cluster-glob", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		ClusterConfigRefs: []string{"prod-*"},
+	})
+	clusterWildcard := escalation("cluster-wildcard", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		ClusterConfigRefs: []string{"*"},
+	})
+	clusterOtherNamespace := escalation("cluster-other-namespace", "team-b", breakglassv1alpha1.BreakglassEscalationSpec{
+		ClusterConfigRefs: []string{"prod-a"},
+	})
+	idpLegacy := escalation("idp-legacy", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		AllowedIdentityProviders: []string{"corp-idp"},
+	})
+	idpRequester := escalation("idp-requester", "team-b", breakglassv1alpha1.BreakglassEscalationSpec{
+		AllowedIdentityProvidersForRequests: []string{"corp-idp"},
+	})
+	idpApprover := escalation("idp-approver", "team-b", breakglassv1alpha1.BreakglassEscalationSpec{
+		AllowedIdentityProvidersForApprovers: []string{"corp-idp"},
+	})
+	denyPolicy := escalation("deny-policy", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		DenyPolicyRefs: []string{"prod-deny"},
+	})
+	mailProvider := escalation("mail-provider", "team-a", breakglassv1alpha1.BreakglassEscalationSpec{
+		MailProvider: "prod-mail",
+	})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			clusterExact,
+			clusterGlob,
+			clusterWildcard,
+			clusterOtherNamespace,
+			idpLegacy,
+			idpRequester,
+			idpApprover,
+			denyPolicy,
+			mailProvider,
+		).
+		Build()
+	r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+	ctx := context.Background()
+
+	assert.Equal(t,
+		[]string{"team-a/cluster-exact", "team-a/cluster-glob", "team-a/cluster-wildcard"},
+		requestKeys(r.escalationsForClusterConfig(ctx, &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-a", Namespace: "team-a"},
+		})),
+	)
+	assert.Equal(t,
+		[]string{"team-a/idp-legacy", "team-b/idp-approver", "team-b/idp-requester"},
+		requestKeys(r.escalationsForIdentityProvider(ctx, &breakglassv1alpha1.IdentityProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: "corp-idp"},
+		})),
+	)
+	assert.Equal(t,
+		[]string{"team-a/deny-policy"},
+		requestKeys(r.escalationsForDenyPolicy(ctx, &breakglassv1alpha1.DenyPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-deny"},
+		})),
+	)
+	assert.Equal(t,
+		[]string{"team-a/mail-provider"},
+		requestKeys(r.escalationsForMailProvider(ctx, &breakglassv1alpha1.MailProvider{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-mail"},
+		})),
+	)
+}
+
+func requestKeys(requests []reconcile.Request) []string {
+	keys := make([]string, 0, len(requests))
+	for _, req := range requests {
+		keys = append(keys, req.NamespacedName.String())
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func TestEscalationReconciler_Reconcile(t *testing.T) {
@@ -705,6 +826,53 @@ func TestEscalationReconciler_ValidateClusterRef(t *testing.T) {
 
 		err := r.validateClusterRef(context.Background(), esc)
 		require.NoError(t, err)
+	})
+
+	t.Run("glob cluster ref passes when matching ClusterConfig exists", func(t *testing.T) {
+		cluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-eu", Namespace: "default"},
+			Spec:       breakglassv1alpha1.ClusterConfigSpec{},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			Build()
+		r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+
+		esc := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				ClusterConfigRefs: []string{"prod-*"},
+			},
+		}
+
+		err := r.validateClusterRef(context.Background(), esc)
+		require.NoError(t, err)
+	})
+
+	t.Run("glob cluster ref fails when no matching ClusterConfig exists", func(t *testing.T) {
+		cluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "staging-eu", Namespace: "default"},
+			Spec:       breakglassv1alpha1.ClusterConfigSpec{},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			Build()
+		r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+
+		esc := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				ClusterConfigRefs: []string{"prod-*"},
+			},
+		}
+
+		err := r.validateClusterRef(context.Background(), esc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ClusterConfigRefs not found: default/prod-*")
 	})
 }
 

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -874,6 +874,22 @@ func TestEscalationReconciler_ValidateClusterRef(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ClusterConfigRefs not found: default/prod-*")
 	})
+
+	t.Run("invalid glob cluster ref reports syntax error", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+
+		esc := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				ClusterConfigRefs: []string{"prod-["},
+			},
+		}
+
+		err := r.validateClusterRef(context.Background(), esc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid ClusterConfigRefs glob pattern")
+	})
 }
 
 func TestEscalationReconciler_ValidateIDPRefs(t *testing.T) {

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -16,7 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -849,6 +851,39 @@ func TestEscalationReconciler_ValidateClusterRef(t *testing.T) {
 
 		err := r.validateClusterRef(context.Background(), esc)
 		require.NoError(t, err)
+	})
+
+	t.Run("multiple glob cluster refs share one ClusterConfig list", func(t *testing.T) {
+		cluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-eu", Namespace: "default"},
+			Spec:       breakglassv1alpha1.ClusterConfigSpec{},
+		}
+		var clusterConfigListCalls int
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*breakglassv1alpha1.ClusterConfigList); ok {
+						clusterConfigListCalls++
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}).
+			Build()
+		r := NewEscalationReconciler(fakeClient, logger, nil, nil, nil, 0)
+
+		esc := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				ClusterConfigRefs: []string{"prod-*", "prod-e*"},
+			},
+		}
+
+		err := r.validateClusterRef(context.Background(), esc)
+		require.NoError(t, err)
+		assert.Equal(t, 1, clusterConfigListCalls)
 	})
 
 	t.Run("glob cluster ref fails when no matching ClusterConfig exists", func(t *testing.T) {

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -17,7 +17,7 @@ import (
 
 // ExpectedIndexCount is the number of field indexes that should be registered.
 // Update this constant when adding or removing indexes.
-const ExpectedIndexCount = 24
+const ExpectedIndexCount = 25
 
 const (
 	BreakglassEscalationClusterConfigRefsField        = "spec.clusterConfigRefs"

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -16,7 +17,16 @@ import (
 
 // ExpectedIndexCount is the number of field indexes that should be registered.
 // Update this constant when adding or removing indexes.
-const ExpectedIndexCount = 20
+const ExpectedIndexCount = 24
+
+const (
+	BreakglassEscalationClusterConfigRefField        = "spec.clusterConfigRef"
+	BreakglassEscalationClusterConfigRefPatternField = "spec.clusterConfigRefPattern"
+	BreakglassEscalationIdentityProviderField        = "spec.identityProvider"
+	BreakglassEscalationDenyPolicyRefField           = "spec.denyPolicyRef"
+	BreakglassEscalationMailProviderField            = "spec.mailProvider"
+	BreakglassEscalationGlobPatternIndexValue        = "__has_glob_pattern__"
+)
 
 // registeredIndexes tracks which indexes have been successfully registered.
 // Uses sync.Map because RegisterCommonFieldIndexes may be called concurrently
@@ -176,6 +186,82 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
+	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefField, func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			return uniqueTrimmedIndexValues(be.Spec.ClusterConfigRefs)
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefPatternField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefPatternField, func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			for _, ref := range be.Spec.ClusterConfigRefs {
+				if strings.ContainsAny(strings.TrimSpace(ref), "*?[") {
+					return []string{BreakglassEscalationGlobPatternIndexValue}
+				}
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("BreakglassEscalation", BreakglassEscalationIdentityProviderField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationIdentityProviderField, func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			values := make([]string, 0,
+				len(be.Spec.AllowedIdentityProviders)+
+					len(be.Spec.AllowedIdentityProvidersForRequests)+
+					len(be.Spec.AllowedIdentityProvidersForApprovers))
+			values = append(values, be.Spec.AllowedIdentityProviders...)
+			values = append(values, be.Spec.AllowedIdentityProvidersForRequests...)
+			values = append(values, be.Spec.AllowedIdentityProvidersForApprovers...)
+			return uniqueTrimmedIndexValues(values)
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("BreakglassEscalation", BreakglassEscalationDenyPolicyRefField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationDenyPolicyRefField, func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			return uniqueTrimmedIndexValues(be.Spec.DenyPolicyRefs)
+		})
+	}); err != nil {
+		return err
+	}
+
+	if err := register("BreakglassEscalation", BreakglassEscalationMailProviderField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationMailProviderField, func(rawObj client.Object) []string {
+			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			name := strings.TrimSpace(be.Spec.MailProvider)
+			if name == "" {
+				return nil
+			}
+			return []string{name}
+		})
+	}); err != nil {
+		return err
+	}
+
 	if err := register("BreakglassEscalation", "spec.allowed.group", func() error {
 		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, "spec.allowed.group", func(rawObj client.Object) []string {
 			if be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation); ok && be != nil {
@@ -304,6 +390,29 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 	return nil
+}
+
+func uniqueTrimmedIndexValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // AssertIndexesRegistered checks that the expected number of field indexes have been registered.

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -20,12 +20,12 @@ import (
 const ExpectedIndexCount = 24
 
 const (
-	BreakglassEscalationClusterConfigRefField        = "spec.clusterConfigRef"
-	BreakglassEscalationClusterConfigRefPatternField = "spec.clusterConfigRefPattern"
-	BreakglassEscalationIdentityProviderField        = "spec.identityProvider"
-	BreakglassEscalationDenyPolicyRefField           = "spec.denyPolicyRef"
-	BreakglassEscalationMailProviderField            = "spec.mailProvider"
-	BreakglassEscalationGlobPatternIndexValue        = "__has_glob_pattern__"
+	BreakglassEscalationClusterConfigRefsField        = "spec.clusterConfigRefs"
+	BreakglassEscalationClusterConfigRefsPatternField = "spec.clusterConfigRefs.pattern"
+	BreakglassEscalationAllowedIdentityProvidersField = "spec.allowedIdentityProviders.all"
+	BreakglassEscalationDenyPolicyRefsField           = "spec.denyPolicyRefs"
+	BreakglassEscalationMailProviderField             = "spec.mailProvider"
+	BreakglassEscalationGlobPatternIndexValue         = "__has_glob_pattern__"
 )
 
 // registeredIndexes tracks which indexes have been successfully registered.
@@ -180,14 +180,14 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 			out := make([]string, 0, len(be.Spec.Allowed.Clusters)+len(be.Spec.ClusterConfigRefs))
 			out = append(out, be.Spec.Allowed.Clusters...)
 			out = append(out, be.Spec.ClusterConfigRefs...)
-			return out
+			return uniqueTrimmedIndexValues(out)
 		})
 	}); err != nil {
 		return err
 	}
 
-	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefField, func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefField, func(rawObj client.Object) []string {
+	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefsField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefsField, func(rawObj client.Object) []string {
 			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
 			if !ok || be == nil {
 				return nil
@@ -198,8 +198,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
-	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefPatternField, func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefPatternField, func(rawObj client.Object) []string {
+	if err := register("BreakglassEscalation", BreakglassEscalationClusterConfigRefsPatternField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationClusterConfigRefsPatternField, func(rawObj client.Object) []string {
 			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
 			if !ok || be == nil {
 				return nil
@@ -215,8 +215,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
-	if err := register("BreakglassEscalation", BreakglassEscalationIdentityProviderField, func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationIdentityProviderField, func(rawObj client.Object) []string {
+	if err := register("BreakglassEscalation", BreakglassEscalationAllowedIdentityProvidersField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationAllowedIdentityProvidersField, func(rawObj client.Object) []string {
 			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
 			if !ok || be == nil {
 				return nil
@@ -234,8 +234,8 @@ func RegisterCommonFieldIndexes(ctx context.Context, idx client.FieldIndexer, lo
 		return err
 	}
 
-	if err := register("BreakglassEscalation", BreakglassEscalationDenyPolicyRefField, func() error {
-		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationDenyPolicyRefField, func(rawObj client.Object) []string {
+	if err := register("BreakglassEscalation", BreakglassEscalationDenyPolicyRefsField, func() error {
+		return idx.IndexField(ctx, &breakglassv1alpha1.BreakglassEscalation{}, BreakglassEscalationDenyPolicyRefsField, func(rawObj client.Object) []string {
 			be, ok := rawObj.(*breakglassv1alpha1.BreakglassEscalation)
 			if !ok || be == nil {
 				return nil

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -82,6 +82,11 @@ func TestRegisterCommonFieldIndexes_Success(t *testing.T) {
 		"status.state",
 		"status.participants.user",
 		"spec.allowed.cluster",
+		BreakglassEscalationClusterConfigRefField,
+		BreakglassEscalationClusterConfigRefPatternField,
+		BreakglassEscalationIdentityProviderField,
+		BreakglassEscalationDenyPolicyRefField,
+		BreakglassEscalationMailProviderField,
 		"spec.allowed.group",
 		"spec.escalatedGroup",
 		"spec.templateRef.name",
@@ -423,7 +428,12 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 				Clusters: []string{"cluster-a", "cluster-b"},
 				Groups:   []string{"developers@example.com", "ops@example.com"},
 			},
-			ClusterConfigRefs: []string{"cluster-c"},
+			ClusterConfigRefs:                    []string{"cluster-c", "cluster-*", "cluster-c", " "},
+			DenyPolicyRefs:                       []string{"deny-prod", "deny-prod", " "},
+			AllowedIdentityProviders:             []string{"corp-idp", "corp-idp"},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+			MailProvider:                         "prod-mail",
 		},
 	}
 
@@ -432,11 +442,68 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
-		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b", "cluster-c"}, result)
+		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b", "cluster-c", "cluster-*", "cluster-c", " "}, result)
 
 		// Test with nil escalation
 		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
 		assert.Empty(t, result)
+	})
+
+	t.Run("spec.clusterConfigRef index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefField]
+		require.NotNil(t, fn)
+
+		result := fn(escalation)
+		assert.ElementsMatch(t, []string{"cluster-c", "cluster-*"}, result)
+
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.clusterConfigRefPattern index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefPatternField]
+		require.NotNil(t, fn)
+
+		result := fn(escalation)
+		assert.Equal(t, []string{BreakglassEscalationGlobPatternIndexValue}, result)
+
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{ClusterConfigRefs: []string{"cluster-c"}},
+		})
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.identityProvider index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationIdentityProviderField]
+		require.NotNil(t, fn)
+
+		result := fn(escalation)
+		assert.ElementsMatch(t, []string{"corp-idp", "requester-idp", "approver-idp"}, result)
+
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.denyPolicyRef index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationDenyPolicyRefField]
+		require.NotNil(t, fn)
+
+		result := fn(escalation)
+		assert.Equal(t, []string{"deny-prod"}, result)
+
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("spec.mailProvider index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationMailProviderField]
+		require.NotNil(t, fn)
+
+		result := fn(escalation)
+		assert.Equal(t, []string{"prod-mail"}, result)
+
+		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
+		assert.Nil(t, result)
 	})
 
 	t.Run("spec.allowed.group index", func(t *testing.T) {
@@ -662,6 +729,7 @@ func TestIsIndexRegistered(t *testing.T) {
 	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.cluster"))
 	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.clusterConfigRef"))
 	assert.True(t, IsIndexRegistered("BreakglassEscalation", "spec.allowed.cluster"))
+	assert.True(t, IsIndexRegistered("BreakglassEscalation", BreakglassEscalationIdentityProviderField))
 	assert.True(t, IsIndexRegistered("ClusterConfig", "metadata.name"))
 	assert.False(t, IsIndexRegistered("NonExistent", "field"))
 }

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -82,10 +82,10 @@ func TestRegisterCommonFieldIndexes_Success(t *testing.T) {
 		"status.state",
 		"status.participants.user",
 		"spec.allowed.cluster",
-		BreakglassEscalationClusterConfigRefField,
-		BreakglassEscalationClusterConfigRefPatternField,
-		BreakglassEscalationIdentityProviderField,
-		BreakglassEscalationDenyPolicyRefField,
+		BreakglassEscalationClusterConfigRefsField,
+		BreakglassEscalationClusterConfigRefsPatternField,
+		BreakglassEscalationAllowedIdentityProvidersField,
+		BreakglassEscalationDenyPolicyRefsField,
 		BreakglassEscalationMailProviderField,
 		"spec.allowed.group",
 		"spec.escalatedGroup",
@@ -442,15 +442,15 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
-		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b", "cluster-c", "cluster-*", "cluster-c", " "}, result)
+		assert.ElementsMatch(t, []string{"cluster-a", "cluster-b", "cluster-c", "cluster-*"}, result)
 
 		// Test with nil escalation
 		result = fn(&breakglassv1alpha1.BreakglassEscalation{})
 		assert.Empty(t, result)
 	})
 
-	t.Run("spec.clusterConfigRef index", func(t *testing.T) {
-		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefField]
+	t.Run("spec.clusterConfigRefs index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefsField]
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
@@ -460,8 +460,8 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
-	t.Run("spec.clusterConfigRefPattern index", func(t *testing.T) {
-		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefPatternField]
+	t.Run("spec.clusterConfigRefs pattern index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationClusterConfigRefsPatternField]
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
@@ -473,8 +473,8 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
-	t.Run("spec.identityProvider index", func(t *testing.T) {
-		fn := indexer.indexedFields[BreakglassEscalationIdentityProviderField]
+	t.Run("spec.allowedIdentityProviders aggregate index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationAllowedIdentityProvidersField]
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
@@ -484,8 +484,8 @@ func TestIndexerFunctions_BreakglassEscalation(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
-	t.Run("spec.denyPolicyRef index", func(t *testing.T) {
-		fn := indexer.indexedFields[BreakglassEscalationDenyPolicyRefField]
+	t.Run("spec.denyPolicyRefs index", func(t *testing.T) {
+		fn := indexer.indexedFields[BreakglassEscalationDenyPolicyRefsField]
 		require.NotNil(t, fn)
 
 		result := fn(escalation)
@@ -729,7 +729,7 @@ func TestIsIndexRegistered(t *testing.T) {
 	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.cluster"))
 	assert.True(t, IsIndexRegistered("BreakglassSession", "spec.clusterConfigRef"))
 	assert.True(t, IsIndexRegistered("BreakglassEscalation", "spec.allowed.cluster"))
-	assert.True(t, IsIndexRegistered("BreakglassEscalation", BreakglassEscalationIdentityProviderField))
+	assert.True(t, IsIndexRegistered("BreakglassEscalation", BreakglassEscalationAllowedIdentityProvidersField))
 	assert.True(t, IsIndexRegistered("ClusterConfig", "metadata.name"))
 	assert.False(t, IsIndexRegistered("NonExistent", "field"))
 }


### PR DESCRIPTION
## Summary
- add dependency watches so referenced ClusterConfig, IdentityProvider, DenyPolicy, and MailProvider changes requeue matching BreakglassEscalations
- validate clusterConfigRefs glob patterns against matching ClusterConfig objects instead of treating glob refs as literal names
- document the runtime refresh behavior and add an Unreleased changelog entry

## Evidence
The EscalationReconciler previously watched only BreakglassEscalation objects. Conditions such as ClusterRefsValid, IDPRefsValid, DenyPolicyRefsValid, and MailProviderValid could stay stale until a periodic resync or direct escalation change after a referenced resource was created, deleted, disabled, or enabled. The same validation path also treated clusterConfigRefs like `prod-*` as exact ClusterConfig names even though the API/docs support glob matching.

## Duplicate check
- `gh pr list --state open --search "EscalationReconciler ClusterConfigRefs dependency watches"` returned no open PRs
- `gh pr list --state open --search "clusterConfigRefs glob validation"` returned no open PRs
- recent merged PRs #808-#838 did not cover escalation dependency watches or clusterConfigRefs glob validation

## Validation
- `go test ./pkg/config -run 'TestEscalation'`\n- `go test ./pkg/config`\n- `make lint`\n- `git diff --check`\n- `make test`\n\n## Screenshots\nNot applicable: this PR changes backend controller behavior plus docs/changelog only; no UI files or visible UI states changed.