### PR TITLE
Reconcile escalation generation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BreakglassEscalation generation reconciliation**: Escalation updates now reconcile on metadata generation changes and deletion-timestamp transitions, keeping `status.observedGeneration` current for Helm/Flux-driven spec updates while still ignoring status-only updates.
 - **CI: pin ORT scan image**: The ORT workflow now uses a digest-pinned `ghcr.io/oss-review-toolkit/ort:89.2.0` image instead of the moving `latest` tag, avoiding transient ORT CLI startup failures from mutable container image updates.
 - **Debug session namespace semantics**: `POST /api/debugSessions` now treats legacy body `namespace` as a deprecated alias for `targetNamespace` and rejects conflicting values. DebugSession objects are always created in the matching `ClusterConfig` namespace, and named debug-session routes honor an explicit `?namespace=` hint strictly instead of falling back to another namespace.
 - **Session drop preserves terminal audit history**: Owner `POST /api/breakglassSessions/{name}/drop` now rejects sessions that are already in a terminal state instead of rewriting Rejected, Expired, IdleExpired, Withdrawn, or ApprovalTimeout sessions to `Withdrawn`.

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -339,7 +339,8 @@ func (r *EscalationReconciler) GetCachedEscalationIDPMapping() map[string][]stri
 
 // SetupWithManager registers this reconciler with the controller-runtime manager.
 func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Predicate to filter events - only reconcile on spec changes, not status updates
+	// Predicate filters status-only updates while still reconciling spec generation
+	// changes from apply tools and deletion timestamp transitions.
 	specChangePredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldEsc, ok := e.ObjectOld.(*breakglassv1alpha1.BreakglassEscalation)

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -339,19 +339,6 @@ func (r *EscalationReconciler) GetCachedEscalationIDPMapping() map[string][]stri
 
 // SetupWithManager registers this reconciler with the controller-runtime manager.
 func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Helper function to compare two string slices
-	slicesEqual := func(a, b []string) bool {
-		if len(a) != len(b) {
-			return false
-		}
-		for i := range a {
-			if a[i] != b[i] {
-				return false
-			}
-		}
-		return true
-	}
-
 	// Predicate to filter events - only reconcile on spec changes, not status updates
 	specChangePredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -363,8 +350,7 @@ func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return true
 			}
-			return !slicesEqual(oldEsc.Spec.AllowedIdentityProviders, newEsc.Spec.AllowedIdentityProviders) ||
-				oldEsc.DeletionTimestamp != newEsc.DeletionTimestamp
+			return shouldReconcileEscalationUpdate(oldEsc, newEsc)
 		},
 		CreateFunc: func(e event.CreateEvent) bool { return true },
 		DeleteFunc: func(e event.DeleteEvent) bool { return true },
@@ -377,6 +363,13 @@ func (r *EscalationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		WithEventFilter(specChangePredicate).
 		Complete(r)
+}
+
+func shouldReconcileEscalationUpdate(oldEsc, newEsc *breakglassv1alpha1.BreakglassEscalation) bool {
+	oldDeleting := oldEsc.GetDeletionTimestamp() != nil
+	newDeleting := newEsc.GetDeletionTimestamp() != nil
+
+	return oldEsc.GetGeneration() != newEsc.GetGeneration() || oldDeleting != newDeleting
 }
 
 // validateEscalationConfig validates the escalation's configuration structure.

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -144,6 +144,68 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 		assert.True(t, onReloadCalled, "onReload callback should be called")
 	})
 
+	t.Run("valid escalation updates stale observed generation", func(t *testing.T) {
+		escalation := &breakglassv1alpha1.BreakglassEscalation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-escalation",
+				Namespace:  "default",
+				Generation: 2,
+			},
+			Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+				EscalatedGroup: "test-group",
+				MaxValidFor:    "1h",
+				Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+					Groups: []string{"allowed-group"},
+				},
+				Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+					Users: []string{"approver@example.com"},
+				},
+			},
+			Status: breakglassv1alpha1.BreakglassEscalationStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(breakglassv1alpha1.BreakglassEscalationConditionReady),
+						Status:             metav1.ConditionTrue,
+						Reason:             "ValidationSucceeded",
+						Message:            "Validation passed",
+						ObservedGeneration: 1,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(escalation).
+			WithStatusSubresource(escalation).
+			Build()
+
+		r := NewEscalationReconciler(fakeClient, logger, recorder, nil, nil, 0)
+
+		result, err := r.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		var updated breakglassv1alpha1.BreakglassEscalation
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-escalation", Namespace: "default"}, &updated)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), updated.Status.ObservedGeneration)
+
+		readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(breakglassv1alpha1.BreakglassEscalationConditionReady))
+		require.NotNil(t, readyCond)
+		assert.Equal(t, int64(2), readyCond.ObservedGeneration)
+		assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+		configCond := apimeta.FindStatusCondition(updated.Status.Conditions, string(breakglassv1alpha1.BreakglassEscalationConditionConfigValidated))
+		require.NotNil(t, configCond)
+		assert.Equal(t, int64(2), configCond.ObservedGeneration)
+		assert.Equal(t, metav1.ConditionTrue, configCond.Status)
+	})
+
 	t.Run("escalation with missing cluster ref fails validation", func(t *testing.T) {
 		escalation := &breakglassv1alpha1.BreakglassEscalation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -335,6 +397,82 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 		assert.Contains(t, cond.Message, "DenyPolicy refs not found")
 	})
+}
+
+func TestEscalationReconciler_ShouldReconcileEscalationUpdate(t *testing.T) {
+	baseTime := metav1.Now()
+
+	tests := []struct {
+		name string
+		old  *breakglassv1alpha1.BreakglassEscalation
+		new  *breakglassv1alpha1.BreakglassEscalation
+		want bool
+	}{
+		{
+			name: "status only update keeps same generation",
+			old: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: breakglassv1alpha1.BreakglassEscalationStatus{
+					ObservedGeneration: 1,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "spec update reconciles any generation change",
+			old: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					MaxValidFor: "1h",
+				},
+			},
+			new: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					MaxValidFor: "2h",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "identity provider approver update reconciles generation change",
+			old: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					AllowedIdentityProvidersForApprovers: []string{"idp-a"},
+				},
+			},
+			new: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					AllowedIdentityProvidersForApprovers: []string{"idp-b"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "deletion timestamp transition reconciles",
+			old: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			},
+			new: &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation:        1,
+					DeletionTimestamp: &baseTime,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldReconcileEscalationUpdate(tt.old, tt.new))
+		})
+	}
 }
 
 func TestEscalationReconciler_GetCachedEscalationIDPMapping(t *testing.T) {


### PR DESCRIPTION
The escalation controller predicate only reconciled updates when allowedIdentityProviders changed. Helm can update other BreakglassEscalation spec fields, which increments metadata.generation but left status.observedGeneration stale. Flux then waits forever because the CR still looks InProgress for the current generation.\n\nThis changes the predicate to reconcile any generation change while still ignoring status-only updates, and keeps deletion timestamp transitions.\n\nValidation:\n- go test ./pkg/config ./pkg/breakglass/escalation -count=1\n- git diff --check