### PR TITLE
fix: report escalation group sync conditions

### DIFF
--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -590,6 +590,26 @@ When `False`:
   message: "Referenced cluster 'missing-cluster' does not exist"
 ```
 
+#### ApprovalGroupMembersResolved Condition
+
+Tracks whether approver group members were resolved by the escalation status updater.
+This condition is separate from `Ready`: transient group-sync failures are surfaced
+for operators without changing validation/reference readiness.
+
+```yaml
+conditions:
+- type: ApprovalGroupMembersResolved
+  status: "True"
+  reason: "GroupMembersResolved"
+  message: "Resolved approver group members for 2 group(s) from 2 identity provider(s)."
+```
+
+When group synchronization fails for at least one configured approver group or IDP,
+the condition becomes `False` with `GroupSyncPartialFailure` or `GroupSyncFailed`.
+Check related `BreakglassEscalation` and `IdentityProvider` events for the specific
+failing group or provider. Escalations with no approver groups report
+`NoApproverGroupsConfigured` because no group member lookup is required.
+
 #### Condition Reasons
 
 | Reason | Status | Description |
@@ -599,7 +619,10 @@ When `False`:
 | `IdentityProviderReferenceInvalid` | False | Referenced IDP doesn't exist or is disabled |
 | `DenyPolicyReferenceInvalid` | False | Referenced deny policy doesn't exist |
 | `MailProviderValidationFailed` | False | Referenced MailProvider is missing or disabled |
-| `GroupSyncFailed` | False | Failed to sync approver groups from IDP |
+| `GroupMembersResolved` | True | Approver group members were resolved |
+| `NoApproverGroupsConfigured` | True | No approver groups require member resolution |
+| `GroupSyncPartialFailure` | False | Some approver groups or IDPs failed during group sync |
+| `GroupSyncFailed` | False | All approver group resolution failed |
 | `ValidationInProgress` | Unknown | Configuration being validated |
 
 ### Viewing Status
@@ -1111,7 +1134,7 @@ kubectl get identityprovider <name> -o yaml | grep -E '(name:|disabled:)'
 - Check if referenced IDP is disabled (`spec.disabled: true`)
 - Enable the IDP or update the escalation references
 
-#### Ready Condition: False (GroupSyncFailed)
+#### ApprovalGroupMembersResolved Condition: False (GroupSyncFailed)
 
 **Cause:** Failed to synchronize approver groups from identity provider.
 
@@ -1120,6 +1143,9 @@ kubectl get identityprovider <name> -o yaml | grep -E '(name:|disabled:)'
 ```bash
 # Check sync error details
 kubectl describe breakglassescalation <name> | grep -A 3 "GroupSyncFailed"
+
+# Check the dedicated group-sync condition
+kubectl get breakglassescalation <name> -o jsonpath='{.status.conditions[?(@.type=="ApprovalGroupMembersResolved")]}'
 
 # Check related IdentityProvider status
 kubectl describe identityprovider <idp-name>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -682,7 +682,7 @@ kubectl patch breakglassescalation <name> -p '{"spec":{"allowedIdentityProviders
 
 ### Group Sync Failing for One IDP
 
-**Symptoms:** GroupSyncStatus shows "PartialFailure" or "Failed"
+**Symptoms:** `ApprovalGroupMembersResolved` condition shows `False` with reason `GroupSyncPartialFailure` or `GroupSyncFailed`
 
 **Causes:**
 - IDP connection timeout
@@ -694,7 +694,8 @@ kubectl patch breakglassescalation <name> -p '{"spec":{"allowedIdentityProviders
 1. Check sync status and errors
 
 ```bash
-kubectl get breakglassescalation <name> -o yaml | grep -A 10 "groupSync"
+kubectl get breakglassescalation <name> -o jsonpath='{.status.conditions[?(@.type=="ApprovalGroupMembersResolved")]}'
+kubectl describe breakglassescalation <name> | grep -A 5 "GroupSync"
 ```
 
 2. Check IdentityProvider events

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Nerzal/gocloak/v13"
 	"go.uber.org/zap"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,6 +27,15 @@ import (
 const (
 	DefaultEscalationStatusUpdateInterval = 10 * time.Minute
 	DefaultClusterConfigCheckInterval     = 10 * time.Minute
+
+	groupSyncStatusSuccess        = "Success"
+	groupSyncStatusPartialFailure = "PartialFailure"
+	groupSyncStatusFailed         = "Failed"
+
+	groupSyncReasonResolved       = "GroupMembersResolved"
+	groupSyncReasonNotRequired    = "NoApproverGroupsConfigured"
+	groupSyncReasonPartialFailure = "GroupSyncPartialFailure"
+	groupSyncReasonFailed         = "GroupSyncFailed"
 )
 
 // KeycloakGroupMemberResolver uses GoCloak client to fetch group members from Keycloak admin API.
@@ -481,6 +492,12 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		groups := esc.Spec.Approvers.Groups
 		if len(groups) == 0 {
 			log.Debugw("Escalation has no approver groups; skipping", "escalation", esc.Name)
+			updated := esc.DeepCopy()
+			if updateNoApproverGroupsCondition(updated) {
+				if err := u.applyStatus(ctx, updated); err != nil {
+					log.Errorw("Failed updating escalation group sync condition", "escalation", esc.Name, "error", err)
+				}
+			}
 			continue
 		}
 		log.Debugw("Processing escalation with approver groups", "escalation", esc.Name, "groupCount", len(groups))
@@ -519,7 +536,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			// Multi-IDP mode: Use multi-IDP group sync with IDP hierarchy storage
 			log.Debugw("Using multi-IDP group sync", "escalation", esc.Name, "idps", idpsToUse)
 
-			hierarchy, _, _ := u.fetchGroupMembersFromMultipleIDPs(
+			hierarchy, syncStatus, syncErrors := u.fetchGroupMembersFromMultipleIDPs(
 				ctx,
 				&esc,
 				idpsToUse,
@@ -546,10 +563,15 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					changed = true
 				}
 			}
+			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), len(idpsToUse), len(syncErrors)) {
+				changed = true
+			}
 		} else {
 			// Legacy single-resolver mode for backward compatibility
 			log.Debugw("Using legacy single resolver mode", "escalation", esc.Name)
 
+			resolvedGroupCount := 0
+			failedGroupCount := 0
 			for _, g := range groups {
 				log.Debugw("Resolving group for escalation", "escalation", esc.Name, "group", system.RedactGroupName(g), "resolverType", fmt.Sprintf("%T", u.Resolver))
 				var norm []string
@@ -558,6 +580,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					members, err := u.Resolver.Members(ctx, g)
 					if err != nil {
 						log.Errorw("Failed resolving group members from resolver", "group", system.RedactGroupName(g), "escalation", esc.Name, "error", err, "resolverType", fmt.Sprintf("%T", u.Resolver))
+						failedGroupCount++
 						continue
 					}
 					log.Debugw("Group member resolver returned members", "group", system.RedactGroupName(g), "escalation", esc.Name, "rawMemberCount", len(members))
@@ -565,13 +588,18 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					log.Infow("Resolved approver group members (normalized)", "group", system.RedactGroupName(g), "escalation", esc.Name, "rawCount", len(members), "normalizedCount", len(norm))
 				} else {
 					log.Warnw("No group member resolver configured; skipping group resolution", "group", system.RedactGroupName(g), "escalation", esc.Name)
+					failedGroupCount++
 					continue
 				}
+				resolvedGroupCount++
 				if !equalStringSlices(norm, updated.Status.ApproverGroupMembers[g]) {
 					log.Debugw("Group members changed; marking for update", "group", system.RedactGroupName(g), "escalation", esc.Name, "oldCount", len(updated.Status.ApproverGroupMembers[g]), "newCount", len(norm))
 					updated.Status.ApproverGroupMembers[g] = norm
 					changed = true
 				}
+			}
+			if updateApprovalGroupMembersResolvedCondition(updated, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), len(groups), 1, failedGroupCount) {
+				changed = true
 			}
 		}
 
@@ -654,7 +682,7 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 		if len(groupMembers) > 0 {
 			hierarchy[""] = groupMembers
 		}
-		return hierarchy, "Success", nil
+		return hierarchy, groupSyncStatusSuccess, nil
 	}
 
 	// Multi-IDP sync: fetch from each IDP for each group
@@ -746,11 +774,11 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 	// Determine sync status
 	var syncStatus string
 	if failureCount == 0 {
-		syncStatus = "Success"
+		syncStatus = groupSyncStatusSuccess
 	} else if successCount > 0 && failureCount > 0 {
-		syncStatus = "PartialFailure"
+		syncStatus = groupSyncStatusPartialFailure
 	} else {
-		syncStatus = "Failed"
+		syncStatus = groupSyncStatusFailed
 	}
 
 	log.Infow("Multi-IDP group sync completed",
@@ -764,11 +792,90 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 	// Emit event on BreakglassEscalation if there were failures
 	if failureCount > 0 && u.EventRecorder != nil {
 		u.EventRecorder.Eventf(escalation, nil, "Warning", "GroupSyncPartialFailure", "GroupSyncPartialFailure",
-			"Multi-IDP group sync partially failed: %d IDPs succeeded, %d failed. See status.groupSyncErrors for details.",
+			"Multi-IDP group sync partially failed: %d IDPs succeeded, %d failed. Check the ApprovalGroupMembersResolved condition and related events for details.",
 			successCount, failureCount)
 	}
 
 	return hierarchy, syncStatus, syncErrors
+}
+
+func updateNoApproverGroupsCondition(escalation *breakglassv1alpha1.BreakglassEscalation) bool {
+	return setApprovalGroupMembersResolvedCondition(
+		escalation,
+		metav1.ConditionTrue,
+		groupSyncReasonNotRequired,
+		"No approver groups are configured; group member resolution is not required.",
+	)
+}
+
+func updateApprovalGroupMembersResolvedCondition(
+	escalation *breakglassv1alpha1.BreakglassEscalation,
+	syncStatus string,
+	groupCount int,
+	idpCount int,
+	errorCount int,
+) bool {
+	status := metav1.ConditionTrue
+	reason := groupSyncReasonResolved
+	message := fmt.Sprintf("Resolved approver group members for %d group(s).", groupCount)
+	if idpCount > 1 {
+		message = fmt.Sprintf("Resolved approver group members for %d group(s) from %d identity provider(s).", groupCount, idpCount)
+	}
+
+	switch syncStatus {
+	case groupSyncStatusSuccess:
+	case groupSyncStatusPartialFailure:
+		status = metav1.ConditionFalse
+		reason = groupSyncReasonPartialFailure
+		message = fmt.Sprintf("Approver group sync partially failed for %d group(s); %d error(s) recorded in related events.", groupCount, errorCount)
+	case groupSyncStatusFailed:
+		status = metav1.ConditionFalse
+		reason = groupSyncReasonFailed
+		message = fmt.Sprintf("Approver group sync failed for %d group(s); %d error(s) recorded in related events.", groupCount, errorCount)
+	default:
+		status = metav1.ConditionFalse
+		reason = groupSyncReasonFailed
+		message = fmt.Sprintf("Approver group sync returned unknown status %q for %d group(s).", syncStatus, groupCount)
+	}
+
+	return setApprovalGroupMembersResolvedCondition(escalation, status, reason, message)
+}
+
+func setApprovalGroupMembersResolvedCondition(
+	escalation *breakglassv1alpha1.BreakglassEscalation,
+	status metav1.ConditionStatus,
+	reason string,
+	message string,
+) bool {
+	condType := string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved)
+	current := apimeta.FindStatusCondition(escalation.Status.Conditions, condType)
+	if current != nil &&
+		current.Status == status &&
+		current.Reason == reason &&
+		current.Message == message &&
+		current.ObservedGeneration == escalation.Generation {
+		return false
+	}
+
+	escalation.SetCondition(metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		ObservedGeneration: escalation.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+	return true
+}
+
+func legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount int) string {
+	switch {
+	case failedGroupCount == 0:
+		return groupSyncStatusSuccess
+	case resolvedGroupCount > 0:
+		return groupSyncStatusPartialFailure
+	default:
+		return groupSyncStatusFailed
+	}
 }
 
 // createResolverForIDP creates an appropriate resolver for the given IDP config

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -509,7 +509,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 				var err error
 				markEscalationStatusObserved(updated)
 				if clearCachedMembers {
-					err = u.K8sClient.Status().Update(ctx, updated)
+					err = u.patchStatus(ctx, updated)
 				} else {
 					err = u.applyStatus(ctx, updated)
 				}
@@ -638,11 +638,17 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		}
 
 		if changed {
+			if len(updated.Status.ApproverGroupMembers) == 0 {
+				updated.Status.ApproverGroupMembers = nil
+			}
+			if len(updated.Status.IDPGroupMemberships) == 0 {
+				updated.Status.IDPGroupMemberships = nil
+			}
 			log.Infow("Updating escalation status with resolved group members", "escalation", esc.Name, "groupCount", len(groups))
 			markEscalationStatusObserved(updated)
 			var err error
 			if prunedCachedMembers {
-				err = u.K8sClient.Status().Update(ctx, updated)
+				err = u.patchStatus(ctx, updated)
 			} else {
 				err = u.applyStatus(ctx, updated)
 			}
@@ -681,6 +687,18 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 
 func (u EscalationStatusUpdater) applyStatus(ctx context.Context, escalation *breakglassv1alpha1.BreakglassEscalation) error {
 	return ssa.ApplyBreakglassEscalationStatus(ctx, u.K8sClient, escalation)
+}
+
+func (u EscalationStatusUpdater) patchStatus(ctx context.Context, escalation *breakglassv1alpha1.BreakglassEscalation) error {
+	current := &breakglassv1alpha1.BreakglassEscalation{}
+	if err := u.K8sClient.Get(ctx, client.ObjectKeyFromObject(escalation), current); err != nil {
+		return err
+	}
+
+	base := current.DeepCopy()
+	current.Status = escalation.Status
+	patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+	return u.K8sClient.Status().Patch(ctx, current, patch)
 }
 
 func markEscalationStatusObserved(escalation *breakglassv1alpha1.BreakglassEscalation) {

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -493,8 +493,26 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		if len(groups) == 0 {
 			log.Debugw("Escalation has no approver groups; skipping", "escalation", esc.Name)
 			updated := esc.DeepCopy()
-			if updateNoApproverGroupsCondition(updated) {
-				if err := u.applyStatus(ctx, updated); err != nil {
+			changed := updateNoApproverGroupsCondition(updated)
+			clearCachedMembers := false
+			if len(updated.Status.ApproverGroupMembers) > 0 {
+				updated.Status.ApproverGroupMembers = nil
+				changed = true
+				clearCachedMembers = true
+			}
+			if len(updated.Status.IDPGroupMemberships) > 0 {
+				updated.Status.IDPGroupMemberships = nil
+				changed = true
+				clearCachedMembers = true
+			}
+			if changed {
+				var err error
+				if clearCachedMembers {
+					err = u.K8sClient.Status().Update(ctx, updated)
+				} else {
+					err = u.applyStatus(ctx, updated)
+				}
+				if err != nil {
 					log.Errorw("Failed updating escalation group sync condition", "escalation", esc.Name, "error", err)
 				}
 			}
@@ -563,7 +581,14 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					changed = true
 				}
 			}
-			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), len(idpsToUse), len(syncErrors)) {
+			idpCount := len(idpsToUse)
+			if u.IDPLoader == nil {
+				idpCount = 0
+				if u.Resolver != nil {
+					idpCount = 1
+				}
+			}
+			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), idpCount, len(syncErrors)) {
 				changed = true
 			}
 		} else {
@@ -847,15 +872,15 @@ func updateApprovalGroupMembersResolvedCondition(
 	case groupSyncStatusPartialFailure:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonPartialFailure
-		message = fmt.Sprintf("Approver group sync partially failed for %d group(s); %d error(s) encountered.", groupCount, errorCount)
+		message = fmt.Sprintf("Approver group sync partially failed for %d group(s) from %d identity provider(s); %d error(s) encountered.", groupCount, idpCount, errorCount)
 	case groupSyncStatusFailed:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
-		message = fmt.Sprintf("Approver group sync failed for %d group(s); %d error(s) encountered.", groupCount, errorCount)
+		message = fmt.Sprintf("Approver group sync failed for %d group(s) from %d identity provider(s); %d error(s) encountered.", groupCount, idpCount, errorCount)
 	default:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
-		message = fmt.Sprintf("Approver group sync returned unknown status %q for %d group(s).", syncStatus, groupCount)
+		message = fmt.Sprintf("Approver group sync returned unknown status %q for %d group(s) from %d identity provider(s).", syncStatus, groupCount, idpCount)
 	}
 
 	return setApprovalGroupMembersResolvedCondition(escalation, status, reason, message)

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -661,28 +661,42 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 		log.Debugw("IDPLoader not configured; using single resolver fallback", "escalation", escalation.Name)
 		// Fallback: use legacy single resolver for backward compatibility
 		groupMembers := make(map[string][]string)
+		resolvedGroupCount := 0
+		failedGroupCount := 0
 		for _, g := range groups {
-			if u.Resolver != nil {
-				members, err := u.Resolver.Members(ctx, g)
-				if err != nil {
-					log.Errorw("Failed to resolve group members", "escalation", escalation.Name, "group", system.RedactGroupName(g), "error", err)
-					if escalation.Status.IDPGroupMemberships != nil {
-						if cachedIDP, ok := escalation.Status.IDPGroupMemberships[""]; ok {
-							if cachedMembers, ok := cachedIDP[g]; ok {
-								groupMembers[g] = cachedMembers
-							}
-						}
+			if u.Resolver == nil {
+				errorMsg := fmt.Sprintf("No group member resolver configured for group %s", system.RedactGroupName(g))
+				log.Warnw("No group member resolver configured; skipping group resolution", "escalation", escalation.Name, "group", system.RedactGroupName(g))
+				syncErrors = append(syncErrors, errorMsg)
+				failedGroupCount++
+				if cachedIDP, ok := escalation.Status.IDPGroupMemberships[""]; ok {
+					if cachedMembers, ok := cachedIDP[g]; ok {
+						groupMembers[g] = cachedMembers
 					}
-					continue
 				}
-				groupMembers[g] = normalizeMembers(members)
+				continue
 			}
+			members, err := u.Resolver.Members(ctx, g)
+			if err != nil {
+				errorMsg := fmt.Sprintf("Failed to resolve group %s: %v", system.RedactGroupName(g), err)
+				log.Errorw("Failed to resolve group members", "escalation", escalation.Name, "group", system.RedactGroupName(g), "error", err)
+				syncErrors = append(syncErrors, errorMsg)
+				failedGroupCount++
+				if cachedIDP, ok := escalation.Status.IDPGroupMemberships[""]; ok {
+					if cachedMembers, ok := cachedIDP[g]; ok {
+						groupMembers[g] = cachedMembers
+					}
+				}
+				continue
+			}
+			groupMembers[g] = normalizeMembers(members)
+			resolvedGroupCount++
 		}
 		// Store in hierarchy under empty IDP name for backward compat
 		if len(groupMembers) > 0 {
 			hierarchy[""] = groupMembers
 		}
-		return hierarchy, groupSyncStatusSuccess, nil
+		return hierarchy, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), syncErrors
 	}
 
 	// Multi-IDP sync: fetch from each IDP for each group
@@ -833,11 +847,11 @@ func updateApprovalGroupMembersResolvedCondition(
 	case groupSyncStatusPartialFailure:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonPartialFailure
-		message = fmt.Sprintf("Approver group sync partially failed for %d group(s); %d error(s) recorded in related events.", groupCount, errorCount)
+		message = fmt.Sprintf("Approver group sync partially failed for %d group(s); %d error(s) encountered.", groupCount, errorCount)
 	case groupSyncStatusFailed:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
-		message = fmt.Sprintf("Approver group sync failed for %d group(s); %d error(s) recorded in related events.", groupCount, errorCount)
+		message = fmt.Sprintf("Approver group sync failed for %d group(s); %d error(s) encountered.", groupCount, errorCount)
 	default:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -526,7 +526,8 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			updated.Status.ApproverGroupMembers = map[string][]string{}
 		}
 
-		changed := pruneUnconfiguredApproverGroupStatus(updated, groups)
+		prunedCachedMembers := pruneUnconfiguredApproverGroupStatus(updated, groups)
+		changed := prunedCachedMembers
 		if updated.Status.ApproverGroupMembers == nil {
 			updated.Status.ApproverGroupMembers = map[string][]string{}
 		}
@@ -639,7 +640,13 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		if changed {
 			log.Infow("Updating escalation status with resolved group members", "escalation", esc.Name, "groupCount", len(groups))
 			markEscalationStatusObserved(updated)
-			if err := u.applyStatus(ctx, updated); err != nil {
+			var err error
+			if prunedCachedMembers {
+				err = u.K8sClient.Status().Update(ctx, updated)
+			} else {
+				err = u.applyStatus(ctx, updated)
+			}
+			if err != nil {
 				log.Errorw("Failed updating escalation status", "escalation", esc.Name, "error", err)
 				// Emit error event
 				if u.EventRecorder != nil {

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -696,9 +696,23 @@ func (u EscalationStatusUpdater) patchStatus(ctx context.Context, escalation *br
 	}
 
 	base := current.DeepCopy()
-	current.Status = escalation.Status
+	copyEscalationGroupSyncStatus(current, escalation)
 	patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
 	return u.K8sClient.Status().Patch(ctx, current, patch)
+}
+
+func copyEscalationGroupSyncStatus(current, desired *breakglassv1alpha1.BreakglassEscalation) {
+	current.Status.ApproverGroupMembers = desired.Status.ApproverGroupMembers
+	current.Status.IDPGroupMemberships = desired.Status.IDPGroupMemberships
+	current.Status.ObservedGeneration = desired.Status.ObservedGeneration
+
+	conditionType := string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved)
+	condition := apimeta.FindStatusCondition(desired.Status.Conditions, conditionType)
+	if condition == nil {
+		apimeta.RemoveStatusCondition(&current.Status.Conditions, conditionType)
+		return
+	}
+	apimeta.SetStatusCondition(&current.Status.Conditions, *condition)
 }
 
 func markEscalationStatusObserved(escalation *breakglassv1alpha1.BreakglassEscalation) {

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -491,7 +491,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		// Collect approver groups
 		groups := esc.Spec.Approvers.Groups
 		if len(groups) == 0 {
-			log.Debugw("Escalation has no approver groups; skipping", "escalation", esc.Name)
+			log.Debugw("Escalation has no approver groups; updating group sync status", "escalation", esc.Name)
 			updated := esc.DeepCopy()
 			changed := updateNoApproverGroupsCondition(updated)
 			clearCachedMembers := false
@@ -507,6 +507,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			}
 			if changed {
 				var err error
+				markEscalationStatusObserved(updated)
 				if clearCachedMembers {
 					err = u.K8sClient.Status().Update(ctx, updated)
 				} else {
@@ -521,6 +522,11 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 		log.Debugw("Processing escalation with approver groups", "escalation", esc.Name, "groupCount", len(groups))
 
 		updated := esc.DeepCopy()
+		if updated.Status.ApproverGroupMembers == nil {
+			updated.Status.ApproverGroupMembers = map[string][]string{}
+		}
+
+		changed := pruneUnconfiguredApproverGroupStatus(updated, groups)
 		if updated.Status.ApproverGroupMembers == nil {
 			updated.Status.ApproverGroupMembers = map[string][]string{}
 		}
@@ -547,8 +553,6 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 				log.Debugw("Auto-detected multiple IDPs, using multi-IDP mode", "escalation", esc.Name, "idpCount", len(idpsToUse), "idps", idpsToUse)
 			}
 		}
-
-		changed := false
 
 		if len(idpsToUse) > 0 {
 			// Multi-IDP mode: Use multi-IDP group sync with IDP hierarchy storage
@@ -623,13 +627,18 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					changed = true
 				}
 			}
-			if updateApprovalGroupMembersResolvedCondition(updated, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), len(groups), 1, failedGroupCount) {
+			idpCount := 0
+			if u.Resolver != nil {
+				idpCount = 1
+			}
+			if updateApprovalGroupMembersResolvedCondition(updated, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), len(groups), idpCount, failedGroupCount) {
 				changed = true
 			}
 		}
 
 		if changed {
 			log.Infow("Updating escalation status with resolved group members", "escalation", esc.Name, "groupCount", len(groups))
+			markEscalationStatusObserved(updated)
 			if err := u.applyStatus(ctx, updated); err != nil {
 				log.Errorw("Failed updating escalation status", "escalation", esc.Name, "error", err)
 				// Emit error event
@@ -665,6 +674,47 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 
 func (u EscalationStatusUpdater) applyStatus(ctx context.Context, escalation *breakglassv1alpha1.BreakglassEscalation) error {
 	return ssa.ApplyBreakglassEscalationStatus(ctx, u.K8sClient, escalation)
+}
+
+func markEscalationStatusObserved(escalation *breakglassv1alpha1.BreakglassEscalation) {
+	escalation.Status.ObservedGeneration = escalation.Generation
+}
+
+func pruneUnconfiguredApproverGroupStatus(escalation *breakglassv1alpha1.BreakglassEscalation, configuredGroups []string) bool {
+	configured := make(map[string]struct{}, len(configuredGroups))
+	for _, group := range configuredGroups {
+		configured[group] = struct{}{}
+	}
+
+	changed := false
+	for group := range escalation.Status.ApproverGroupMembers {
+		if _, ok := configured[group]; !ok {
+			delete(escalation.Status.ApproverGroupMembers, group)
+			changed = true
+		}
+	}
+
+	for idp, groupMembers := range escalation.Status.IDPGroupMemberships {
+		for group := range groupMembers {
+			if _, ok := configured[group]; !ok {
+				delete(groupMembers, group)
+				changed = true
+			}
+		}
+		if len(groupMembers) == 0 {
+			delete(escalation.Status.IDPGroupMemberships, idp)
+			changed = true
+		}
+	}
+
+	if len(escalation.Status.ApproverGroupMembers) == 0 {
+		escalation.Status.ApproverGroupMembers = nil
+	}
+	if len(escalation.Status.IDPGroupMemberships) == 0 {
+		escalation.Status.IDPGroupMemberships = nil
+	}
+
+	return changed
 }
 
 // fetchGroupMembersFromMultipleIDPs fetches group members from multiple IDPs and stores in IDP hierarchy structure.
@@ -872,18 +922,25 @@ func updateApprovalGroupMembersResolvedCondition(
 	case groupSyncStatusPartialFailure:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonPartialFailure
-		message = fmt.Sprintf("Approver group sync partially failed for %d group(s) from %d identity provider(s); %d error(s) encountered.", groupCount, idpCount, errorCount)
+		message = fmt.Sprintf("Approver group sync partially failed for %d group(s)%s; %d error(s) encountered.", groupCount, identityProviderConditionContext(idpCount), errorCount)
 	case groupSyncStatusFailed:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
-		message = fmt.Sprintf("Approver group sync failed for %d group(s) from %d identity provider(s); %d error(s) encountered.", groupCount, idpCount, errorCount)
+		message = fmt.Sprintf("Approver group sync failed for %d group(s)%s; %d error(s) encountered.", groupCount, identityProviderConditionContext(idpCount), errorCount)
 	default:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
-		message = fmt.Sprintf("Approver group sync returned unknown status %q for %d group(s) from %d identity provider(s).", syncStatus, groupCount, idpCount)
+		message = fmt.Sprintf("Approver group sync returned unknown status %q for %d group(s)%s.", syncStatus, groupCount, identityProviderConditionContext(idpCount))
 	}
 
 	return setApprovalGroupMembersResolvedCondition(escalation, status, reason, message)
+}
+
+func identityProviderConditionContext(idpCount int) string {
+	if idpCount <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" from %d identity provider(s)", idpCount)
 }
 
 func setApprovalGroupMembersResolvedCondition(

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -791,8 +791,14 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 
 	// Emit event on BreakglassEscalation if there were failures
 	if failureCount > 0 && u.EventRecorder != nil {
-		u.EventRecorder.Eventf(escalation, nil, "Warning", "GroupSyncPartialFailure", "GroupSyncPartialFailure",
-			"Multi-IDP group sync partially failed: %d IDPs succeeded, %d failed. Check the ApprovalGroupMembersResolved condition and related events for details.",
+		eventReason := groupSyncReasonPartialFailure
+		eventMessage := "Multi-IDP group sync partially failed: %d IDPs succeeded, %d failed. Check the ApprovalGroupMembersResolved condition and related events for details."
+		if syncStatus == groupSyncStatusFailed {
+			eventReason = groupSyncReasonFailed
+			eventMessage = "Multi-IDP group sync failed: %d IDPs succeeded, %d failed. Check the ApprovalGroupMembersResolved condition and related events for details."
+		}
+		u.EventRecorder.Eventf(escalation, nil, "Warning", eventReason, eventReason,
+			eventMessage,
 			successCount, failureCount)
 	}
 

--- a/pkg/breakglass/escalation/escalation_status_updater_events_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_events_test.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	cfgpkg "github.com/telekom/k8s-breakglass/pkg/config"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestFetchGroupMembersFromMultipleIDPs_EventEmission_SuccessfulSync tests that events are emitted on success
@@ -88,6 +91,43 @@ func TestFetchGroupMembersFromMultipleIDPs_EventEmission_MultipleGroups(t *testi
 	t.Logf("✓ Multi-group event emission - Total groups: 2, Total members: 3 (admins: 1, approvers: 2)")
 }
 
+func TestFetchGroupMembersFromMultipleIDPs_EventReasonMatchesFullFailure(t *testing.T) {
+	log, _ := zap.NewProduction()
+	defer func() { _ = log.Sync() }()
+	slog := log.Sugar()
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		Build()
+	recorder := fakeEventRecorder{Events: make(chan string, 4)}
+
+	updater := &EscalationStatusUpdater{
+		IDPLoader:     cfgpkg.NewIdentityProviderLoader(cli),
+		EventRecorder: recorder,
+	}
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-esc-full-failure",
+			Namespace: "default",
+		},
+	}
+
+	hierarchy, status, syncErrors := updater.fetchGroupMembersFromMultipleIDPs(
+		context.Background(),
+		escalation,
+		[]string{"missing-idp-a", "missing-idp-b"},
+		[]string{"approvers"},
+		slog,
+	)
+
+	assert.Empty(t, hierarchy)
+	assert.Equal(t, groupSyncStatusFailed, status)
+	assert.Len(t, syncErrors, 2)
+	assert.Contains(t, drainRecordedEvents(recorder.Events),
+		"Warning GroupSyncFailed GroupSyncFailed Multi-IDP group sync failed: 0 IDPs succeeded, 2 failed. Check the ApprovalGroupMembersResolved condition and related events for details.")
+}
+
 // TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback tests fallback to single IDP
 func TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback(t *testing.T) {
 	log, _ := zap.NewProduction()
@@ -119,4 +159,16 @@ func TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback(t *t
 	// Fallback mode should still handle gracefully
 	assert.NotNil(t, hierarchy, "Should return valid hierarchy")
 	t.Logf("✓ Fallback mode event emission handled - Status: %s", status)
+}
+
+func drainRecordedEvents(events <-chan string) []string {
+	var drained []string
+	for {
+		select {
+		case event := <-events:
+			drained = append(drained, event)
+		default:
+			return drained
+		}
+	}
 }

--- a/pkg/breakglass/escalation/escalation_status_updater_events_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_events_test.go
@@ -2,6 +2,7 @@ package escalation
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,8 +125,11 @@ func TestFetchGroupMembersFromMultipleIDPs_EventReasonMatchesFullFailure(t *test
 	assert.Empty(t, hierarchy)
 	assert.Equal(t, groupSyncStatusFailed, status)
 	assert.Len(t, syncErrors, 2)
-	assert.Contains(t, drainRecordedEvents(recorder.Events),
-		"Warning GroupSyncFailed GroupSyncFailed Multi-IDP group sync failed: 0 IDPs succeeded, 2 failed. Check the ApprovalGroupMembersResolved condition and related events for details.")
+	assert.True(t, recordedEventContains(
+		drainRecordedEvents(recorder.Events),
+		"Warning "+groupSyncReasonFailed,
+		"Multi-IDP group sync failed: 0 IDPs succeeded, 2 failed",
+	))
 }
 
 // TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback tests fallback to single IDP
@@ -171,4 +175,20 @@ func drainRecordedEvents(events <-chan string) []string {
 			return drained
 		}
 	}
+}
+
+func recordedEventContains(events []string, parts ...string) bool {
+	for _, event := range events {
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(event, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/breakglass/escalation/escalation_status_updater_events_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_events_test.go
@@ -165,6 +165,34 @@ func TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback(t *t
 	t.Logf("✓ Fallback mode event emission handled - Status: %s", status)
 }
 
+func TestFetchGroupMembersFromMultipleIDPs_FallbackReportsMissingResolver(t *testing.T) {
+	log, _ := zap.NewProduction()
+	defer func() { _ = log.Sync() }()
+	slog := log.Sugar()
+
+	updater := &EscalationStatusUpdater{}
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-esc-missing-resolver",
+			Namespace: "default",
+		},
+	}
+
+	hierarchy, status, syncErrors := updater.fetchGroupMembersFromMultipleIDPs(
+		context.Background(),
+		escalation,
+		[]string{"configured-idp"},
+		[]string{"admins", "approvers"},
+		slog,
+	)
+
+	assert.Empty(t, hierarchy)
+	assert.Equal(t, groupSyncStatusFailed, status)
+	assert.Len(t, syncErrors, 2)
+	assert.Contains(t, syncErrors[0], "No group member resolver configured")
+}
+
 func drainRecordedEvents(events <-chan string) []string {
 	var drained []string
 	for {

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -249,7 +249,60 @@ func TestEscalationStatusUpdaterSetsApprovalGroupMembersResolvedPartialFailure(t
 	if assert.NotNil(t, condition) {
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 		assert.Equal(t, "GroupSyncPartialFailure", condition.Reason)
-		assert.Equal(t, "Approver group sync partially failed for 2 group(s); 1 error(s) encountered.", condition.Message)
+		assert.Equal(t, "Approver group sync partially failed for 2 group(s) from 1 identity provider(s); 1 error(s) encountered.", condition.Message)
+	}
+}
+
+func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		syncStatus string
+		reason     string
+		message    string
+		errorCount int
+	}{
+		{
+			name:       "partial failure",
+			syncStatus: groupSyncStatusPartialFailure,
+			reason:     groupSyncReasonPartialFailure,
+			message:    "Approver group sync partially failed for 3 group(s) from 2 identity provider(s); 1 error(s) encountered.",
+			errorCount: 1,
+		},
+		{
+			name:       "full failure",
+			syncStatus: groupSyncStatusFailed,
+			reason:     groupSyncReasonFailed,
+			message:    "Approver group sync failed for 3 group(s) from 2 identity provider(s); 2 error(s) encountered.",
+			errorCount: 2,
+		},
+		{
+			name:       "unknown status",
+			syncStatus: "Unexpected",
+			reason:     groupSyncReasonFailed,
+			message:    "Approver group sync returned unknown status \"Unexpected\" for 3 group(s) from 2 identity provider(s).",
+			errorCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			escalation := &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 7,
+				},
+			}
+
+			changed := updateApprovalGroupMembersResolvedCondition(escalation, tt.syncStatus, 3, 2, tt.errorCount)
+
+			assert.True(t, changed)
+			condition := escalation.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+			if assert.NotNil(t, condition) {
+				assert.Equal(t, metav1.ConditionFalse, condition.Status)
+				assert.Equal(t, tt.reason, condition.Reason)
+				assert.Equal(t, tt.message, condition.Message)
+				assert.Equal(t, int64(7), condition.ObservedGeneration)
+			}
+		})
 	}
 }
 
@@ -421,6 +474,14 @@ func TestEmptyApproverGroups(t *testing.T) {
 			},
 		},
 		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"admin": {"alice@example.com"},
+			},
+			IDPGroupMemberships: map[string]map[string][]string{
+				"idp-a": {
+					"admin": {"alice@example.com"},
+				},
+			},
 			Conditions: []metav1.Condition{
 				{
 					Type:    string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
@@ -450,7 +511,7 @@ func TestEmptyApproverGroups(t *testing.T) {
 	err = cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
 	assert.NoError(t, err)
 
-	// Should not have been updated (no approver groups)
+	// Stale group-member status should be cleared when no approver groups remain.
 	assert.Nil(t, updated.Status.ApproverGroupMembers)
 	assert.Nil(t, updated.Status.IDPGroupMemberships)
 	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
@@ -461,4 +522,66 @@ func TestEmptyApproverGroups(t *testing.T) {
 	}
 
 	t.Logf("✅ Test passed: Empty approver groups correctly skipped")
+}
+
+func TestExplicitIDPsWithoutLoaderReportLegacyResolverCondition(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	mockResolver := &MockGroupMemberResolverForTest{
+		memberData: map[string][]string{
+			"admin": {"alice@example.com"},
+		},
+		err: nil,
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "explicit-idps-no-loader",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"admin"},
+			},
+			AllowedIdentityProvidersForApprovers: []string{"idp-a", "idp-b"},
+		},
+	}
+
+	err := cli.Create(context.Background(), escalation)
+	assert.NoError(t, err)
+
+	updater := EscalationStatusUpdater{
+		Log:           logger.Sugar(),
+		K8sClient:     cli,
+		Resolver:      mockResolver,
+		Interval:      0,
+		EventRecorder: nil,
+		IDPLoader:     nil,
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	err = cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"alice@example.com"}, updated.Status.ApproverGroupMembers["admin"])
+
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "GroupMembersResolved", condition.Reason)
+		assert.Equal(t, "Resolved approver group members for 1 group(s).", condition.Message)
+	}
 }

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -82,6 +82,98 @@ func (c *statusUpdateTrackingSubResourceClient) Apply(ctx context.Context, obj r
 	return c.delegate.Apply(ctx, obj, opts...)
 }
 
+func TestEscalationStatusPatchPreservesUnownedConditions(t *testing.T) {
+	ctx := context.Background()
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	live := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "group-sync-status",
+			Namespace:  "default",
+			Generation: 7,
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ObservedGeneration: 1,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(breakglassv1alpha1.BreakglassEscalationConditionReady),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 7,
+					Reason:             "OtherController",
+					Message:            "ready from a different updater",
+				},
+				{
+					Type:               string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             "OldGroupSync",
+					Message:            "stale group sync status",
+				},
+			},
+		},
+	}
+	assert.NoError(t, cli.Create(ctx, live))
+
+	desired := live.DeepCopy()
+	desired.Status = breakglassv1alpha1.BreakglassEscalationStatus{
+		ObservedGeneration: 7,
+		ApproverGroupMembers: map[string][]string{
+			"admin": {"alice@example.com"},
+		},
+		IDPGroupMemberships: map[string]map[string][]string{
+			"idp-a": {
+				"admin": {"alice@example.com"},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(breakglassv1alpha1.BreakglassEscalationConditionReady),
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 7,
+				Reason:             "StaleReady",
+				Message:            "this stale condition must not be patched",
+			},
+			{
+				Type:               string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 7,
+				Reason:             "GroupMembersResolved",
+				Message:            "group members resolved",
+			},
+		},
+	}
+
+	updater := EscalationStatusUpdater{K8sClient: cli}
+	assert.NoError(t, updater.patchStatus(ctx, desired))
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	assert.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(live), updated))
+
+	assert.Equal(t, int64(7), updated.Status.ObservedGeneration)
+	assert.Equal(t, map[string][]string{
+		"admin": {"alice@example.com"},
+	}, updated.Status.ApproverGroupMembers)
+	assert.Equal(t, map[string]map[string][]string{
+		"idp-a": {
+			"admin": {"alice@example.com"},
+		},
+	}, updated.Status.IDPGroupMemberships)
+
+	ready := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionReady))
+	if assert.NotNil(t, ready) {
+		assert.Equal(t, metav1.ConditionTrue, ready.Status)
+		assert.Equal(t, "OtherController", ready.Reason)
+	}
+	groupSync := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, groupSync) {
+		assert.Equal(t, metav1.ConditionTrue, groupSync.Status)
+		assert.Equal(t, "GroupMembersResolved", groupSync.Reason)
+	}
+}
+
 // TestIDPGroupMembershipsPopulation verifies that IDPGroupMemberships are populated in multi-IDP mode
 func TestIDPGroupMembershipsPopulation(t *testing.T) {
 	logger, _ := zap.NewDevelopment()

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -2,6 +2,7 @@ package escalation
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
@@ -111,6 +112,145 @@ func TestIDPGroupMembershipsPopulation(t *testing.T) {
 	t.Logf("✅ Test passed: ApproverGroupMembers populated correctly")
 	t.Logf("   Admin group: %v", admin)
 	t.Logf("   Ops group: %v", ops)
+}
+
+func TestEscalationStatusUpdaterSetsApprovalGroupMembersResolvedOnConditionOnlyChange(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	mockResolver := &MockResolver{
+		members: map[string][]string{
+			"admin": {"alice@example.com"},
+		},
+		errors: map[string]error{},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "condition-only",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"admin"},
+			},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"admin": {"alice@example.com"},
+			},
+		},
+	}
+
+	err := cli.Create(context.Background(), escalation)
+	assert.NoError(t, err)
+	escalation.Status.ApproverGroupMembers = map[string][]string{
+		"admin": {"alice@example.com"},
+	}
+	err = cli.Status().Update(context.Background(), escalation)
+	assert.NoError(t, err)
+
+	updater := EscalationStatusUpdater{
+		Log:       logger.Sugar(),
+		K8sClient: cli,
+		Resolver:  mockResolver,
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	err = cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"alice@example.com"}, updated.Status.ApproverGroupMembers["admin"])
+
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "GroupMembersResolved", condition.Reason)
+		assert.Equal(t, "Resolved approver group members for 1 group(s).", condition.Message)
+	}
+}
+
+func TestEscalationStatusUpdaterSetsApprovalGroupMembersResolvedPartialFailure(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	mockResolver := &MockResolver{
+		members: map[string][]string{
+			"admin": {"alice@example.com"},
+		},
+		errors: map[string]error{
+			"ops": errors.New("group lookup failed"),
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "partial-group-sync",
+			Namespace: "default",
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"admin", "ops"},
+			},
+		},
+	}
+
+	err := cli.Create(context.Background(), escalation)
+	assert.NoError(t, err)
+	escalation.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
+			Status:  metav1.ConditionFalse,
+			Reason:  "GroupSyncFailed",
+			Message: "stale group sync failure",
+		},
+	}
+	err = cli.Status().Update(context.Background(), escalation)
+	assert.NoError(t, err)
+
+	updater := EscalationStatusUpdater{
+		Log:       logger.Sugar(),
+		K8sClient: cli,
+		Resolver:  mockResolver,
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	err = cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"alice@example.com"}, updated.Status.ApproverGroupMembers["admin"])
+	assert.Empty(t, updated.Status.ApproverGroupMembers["ops"])
+
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, "GroupSyncPartialFailure", condition.Reason)
+		assert.Equal(t, "Approver group sync partially failed for 2 group(s); 1 error(s) recorded in related events.", condition.Message)
+	}
 }
 
 // TestIDPGroupMembershipsNotPopulatedInLegacyMode verifies that IDPGroupMemberships stays empty in legacy mode
@@ -280,6 +420,16 @@ func TestEmptyApproverGroups(t *testing.T) {
 				Groups: []string{}, // Empty - should be skipped
 			},
 		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:    string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved),
+					Status:  metav1.ConditionFalse,
+					Reason:  "GroupSyncFailed",
+					Message: "stale group sync failure",
+				},
+			},
+		},
 	}
 
 	err := cli.Create(context.Background(), escalation)
@@ -303,6 +453,12 @@ func TestEmptyApproverGroups(t *testing.T) {
 	// Should not have been updated (no approver groups)
 	assert.Nil(t, updated.Status.ApproverGroupMembers)
 	assert.Nil(t, updated.Status.IDPGroupMemberships)
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "NoApproverGroupsConfigured", condition.Reason)
+		assert.Equal(t, "No approver groups are configured; group member resolution is not required.", condition.Message)
+	}
 
 	t.Logf("✅ Test passed: Empty approver groups correctly skipped")
 }

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -697,8 +697,8 @@ func TestEscalationStatusUpdaterPrunesRemovedApproverGroupsWithStatusUpdate(t *t
 	err = baseClient.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 1, trackingClient.statusWriter.updates)
-	assert.Zero(t, trackingClient.statusWriter.patches)
+	assert.Zero(t, trackingClient.statusWriter.updates)
+	assert.Equal(t, 1, trackingClient.statusWriter.patches)
 	assert.Equal(t, map[string][]string{
 		"admin": {"alice@example.com"},
 	}, updated.Status.ApproverGroupMembers)
@@ -708,6 +708,75 @@ func TestEscalationStatusUpdaterPrunesRemovedApproverGroupsWithStatusUpdate(t *t
 		},
 	}, updated.Status.IDPGroupMemberships)
 	assert.Equal(t, int64(4), updated.Status.ObservedGeneration)
+}
+
+func TestEscalationStatusUpdaterDoesNotPersistEmptyApproverGroupMembersAfterFullPrune(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	baseClient := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+	trackingClient := newStatusUpdateTrackingClient(baseClient)
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "fully-pruned-approver-groups",
+			Namespace:  "default",
+			Generation: 5,
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"admin"},
+			},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ObservedGeneration: 1,
+			ApproverGroupMembers: map[string][]string{
+				"removed": {"stale@example.com"},
+			},
+			IDPGroupMemberships: map[string]map[string][]string{
+				"idp-a": {
+					"removed": {"stale@example.com"},
+				},
+			},
+		},
+	}
+
+	err := baseClient.Create(context.Background(), escalation)
+	assert.NoError(t, err)
+
+	updater := EscalationStatusUpdater{
+		Log:       logger.Sugar(),
+		K8sClient: trackingClient,
+		Resolver: &MockGroupMemberResolverForTest{
+			err: errors.New("resolver unavailable"),
+		},
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	err = baseClient.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
+	assert.NoError(t, err)
+
+	assert.Zero(t, trackingClient.statusWriter.updates)
+	assert.Equal(t, 1, trackingClient.statusWriter.patches)
+	assert.Nil(t, updated.Status.ApproverGroupMembers)
+	assert.Nil(t, updated.Status.IDPGroupMemberships)
+	assert.Equal(t, int64(5), updated.Status.ObservedGeneration)
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, "GroupSyncFailed", condition.Reason)
+	}
 }
 
 func TestExplicitIDPsWithoutLoaderReportLegacyResolverCondition(t *testing.T) {

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -27,6 +28,58 @@ func (m *MockGroupMemberResolverForTest) Members(ctx context.Context, group stri
 		return nil, m.err
 	}
 	return m.memberData[group], nil
+}
+
+type statusUpdateTrackingClient struct {
+	client.Client
+	statusWriter *statusUpdateTrackingSubResourceClient
+}
+
+func newStatusUpdateTrackingClient(delegate client.Client) *statusUpdateTrackingClient {
+	return &statusUpdateTrackingClient{
+		Client:       delegate,
+		statusWriter: &statusUpdateTrackingSubResourceClient{delegate: delegate.SubResource("status")},
+	}
+}
+
+func (c *statusUpdateTrackingClient) Status() client.StatusWriter {
+	return c.statusWriter
+}
+
+func (c *statusUpdateTrackingClient) SubResource(subResource string) client.SubResourceClient {
+	if subResource == "status" {
+		return c.statusWriter
+	}
+	return c.Client.SubResource(subResource)
+}
+
+type statusUpdateTrackingSubResourceClient struct {
+	delegate client.SubResourceClient
+	updates  int
+	patches  int
+}
+
+func (c *statusUpdateTrackingSubResourceClient) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	return c.delegate.Get(ctx, obj, subResource, opts...)
+}
+
+func (c *statusUpdateTrackingSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	return c.delegate.Create(ctx, obj, subResource, opts...)
+}
+
+func (c *statusUpdateTrackingSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	c.updates++
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func (c *statusUpdateTrackingSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	c.patches++
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *statusUpdateTrackingSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	c.patches++
+	return c.delegate.Apply(ctx, obj, opts...)
 }
 
 // TestIDPGroupMembershipsPopulation verifies that IDPGroupMemberships are populated in multi-IDP mode
@@ -578,6 +631,83 @@ func TestPruneUnconfiguredApproverGroupStatus(t *testing.T) {
 			"admin": {"alice@example.com"},
 		},
 	}, escalation.Status.IDPGroupMemberships)
+}
+
+func TestEscalationStatusUpdaterPrunesRemovedApproverGroupsWithStatusUpdate(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	baseClient := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+	trackingClient := newStatusUpdateTrackingClient(baseClient)
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "removed-approver-group",
+			Namespace:  "default",
+			Generation: 4,
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"admin"},
+			},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ObservedGeneration: 1,
+			ApproverGroupMembers: map[string][]string{
+				"admin":   {"alice@example.com"},
+				"removed": {"stale@example.com"},
+			},
+			IDPGroupMemberships: map[string]map[string][]string{
+				"idp-a": {
+					"admin":   {"alice@example.com"},
+					"removed": {"stale@example.com"},
+				},
+				"idp-b": {
+					"removed": {"other-stale@example.com"},
+				},
+			},
+		},
+	}
+
+	err := baseClient.Create(context.Background(), escalation)
+	assert.NoError(t, err)
+
+	updater := EscalationStatusUpdater{
+		Log:       logger.Sugar(),
+		K8sClient: trackingClient,
+		Resolver: &MockGroupMemberResolverForTest{
+			memberData: map[string][]string{
+				"admin": {"alice@example.com"},
+			},
+		},
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	err = baseClient.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, trackingClient.statusWriter.updates)
+	assert.Zero(t, trackingClient.statusWriter.patches)
+	assert.Equal(t, map[string][]string{
+		"admin": {"alice@example.com"},
+	}, updated.Status.ApproverGroupMembers)
+	assert.Equal(t, map[string]map[string][]string{
+		"idp-a": {
+			"admin": {"alice@example.com"},
+		},
+	}, updated.Status.IDPGroupMemberships)
+	assert.Equal(t, int64(4), updated.Status.ObservedGeneration)
 }
 
 func TestExplicitIDPsWithoutLoaderReportLegacyResolverCondition(t *testing.T) {

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -257,6 +257,7 @@ func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures
 	tests := []struct {
 		name       string
 		syncStatus string
+		idpCount   int
 		reason     string
 		message    string
 		errorCount int
@@ -264,6 +265,7 @@ func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures
 		{
 			name:       "partial failure",
 			syncStatus: groupSyncStatusPartialFailure,
+			idpCount:   2,
 			reason:     groupSyncReasonPartialFailure,
 			message:    "Approver group sync partially failed for 3 group(s) from 2 identity provider(s); 1 error(s) encountered.",
 			errorCount: 1,
@@ -271,6 +273,7 @@ func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures
 		{
 			name:       "full failure",
 			syncStatus: groupSyncStatusFailed,
+			idpCount:   2,
 			reason:     groupSyncReasonFailed,
 			message:    "Approver group sync failed for 3 group(s) from 2 identity provider(s); 2 error(s) encountered.",
 			errorCount: 2,
@@ -278,8 +281,25 @@ func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures
 		{
 			name:       "unknown status",
 			syncStatus: "Unexpected",
+			idpCount:   2,
 			reason:     groupSyncReasonFailed,
 			message:    "Approver group sync returned unknown status \"Unexpected\" for 3 group(s) from 2 identity provider(s).",
+			errorCount: 0,
+		},
+		{
+			name:       "full failure without resolver context",
+			syncStatus: groupSyncStatusFailed,
+			idpCount:   0,
+			reason:     groupSyncReasonFailed,
+			message:    "Approver group sync failed for 3 group(s); 3 error(s) encountered.",
+			errorCount: 3,
+		},
+		{
+			name:       "unknown status without resolver context",
+			syncStatus: "Unexpected",
+			idpCount:   0,
+			reason:     groupSyncReasonFailed,
+			message:    "Approver group sync returned unknown status \"Unexpected\" for 3 group(s).",
 			errorCount: 0,
 		},
 	}
@@ -292,7 +312,7 @@ func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures
 				},
 			}
 
-			changed := updateApprovalGroupMembersResolvedCondition(escalation, tt.syncStatus, 3, 2, tt.errorCount)
+			changed := updateApprovalGroupMembersResolvedCondition(escalation, tt.syncStatus, 3, tt.idpCount, tt.errorCount)
 
 			assert.True(t, changed)
 			condition := escalation.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
@@ -461,8 +481,9 @@ func TestEmptyApproverGroups(t *testing.T) {
 
 	escalation := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "no-approvers",
-			Namespace: "default",
+			Name:       "no-approvers",
+			Namespace:  "default",
+			Generation: 3,
 		},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
 			EscalatedGroup: "admin-group",
@@ -474,6 +495,7 @@ func TestEmptyApproverGroups(t *testing.T) {
 			},
 		},
 		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ObservedGeneration: 1,
 			ApproverGroupMembers: map[string][]string{
 				"admin": {"alice@example.com"},
 			},
@@ -514,14 +536,48 @@ func TestEmptyApproverGroups(t *testing.T) {
 	// Stale group-member status should be cleared when no approver groups remain.
 	assert.Nil(t, updated.Status.ApproverGroupMembers)
 	assert.Nil(t, updated.Status.IDPGroupMemberships)
+	assert.Equal(t, int64(3), updated.Status.ObservedGeneration)
 	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
 	if assert.NotNil(t, condition) {
 		assert.Equal(t, metav1.ConditionTrue, condition.Status)
 		assert.Equal(t, "NoApproverGroupsConfigured", condition.Reason)
 		assert.Equal(t, "No approver groups are configured; group member resolution is not required.", condition.Message)
+		assert.Equal(t, int64(3), condition.ObservedGeneration)
 	}
 
 	t.Logf("✅ Test passed: Empty approver groups correctly skipped")
+}
+
+func TestPruneUnconfiguredApproverGroupStatus(t *testing.T) {
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"admin":   {"alice@example.com"},
+				"removed": {"stale@example.com"},
+			},
+			IDPGroupMemberships: map[string]map[string][]string{
+				"idp-a": {
+					"admin":   {"alice@example.com"},
+					"removed": {"stale@example.com"},
+				},
+				"idp-b": {
+					"removed": {"other-stale@example.com"},
+				},
+			},
+		},
+	}
+
+	changed := pruneUnconfiguredApproverGroupStatus(escalation, []string{"admin"})
+
+	assert.True(t, changed)
+	assert.Equal(t, map[string][]string{
+		"admin": {"alice@example.com"},
+	}, escalation.Status.ApproverGroupMembers)
+	assert.Equal(t, map[string]map[string][]string{
+		"idp-a": {
+			"admin": {"alice@example.com"},
+		},
+	}, escalation.Status.IDPGroupMemberships)
 }
 
 func TestExplicitIDPsWithoutLoaderReportLegacyResolverCondition(t *testing.T) {

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -249,7 +249,7 @@ func TestEscalationStatusUpdaterSetsApprovalGroupMembersResolvedPartialFailure(t
 	if assert.NotNil(t, condition) {
 		assert.Equal(t, metav1.ConditionFalse, condition.Status)
 		assert.Equal(t, "GroupSyncPartialFailure", condition.Reason)
-		assert.Equal(t, "Approver group sync partially failed for 2 group(s); 1 error(s) recorded in related events.", condition.Message)
+		assert.Equal(t, "Approver group sync partially failed for 2 group(s); 1 error(s) encountered.", condition.Message)
 	}
 }
 

--- a/pkg/breakglass/escalation/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_test.go
@@ -180,9 +180,10 @@ func TestFetchGroupMembersFromMultipleIDPs_NilResolver(t *testing.T) {
 	hierarchy, status, syncErrors := updater.fetchGroupMembersFromMultipleIDPs(
 		ctx, escalation, []string{}, []string{"admin-group"}, slog)
 
-	assert.Equal(t, "Success", status)
-	assert.Len(t, syncErrors, 0)
+	assert.Equal(t, groupSyncStatusFailed, status)
+	assert.Len(t, syncErrors, 1)
 	assert.NotNil(t, hierarchy)
+	assert.Empty(t, hierarchy)
 }
 
 // TestNormalizeMembers_Deduplication tests member normalization removes duplicates


### PR DESCRIPTION
## Summary
- maintain the `ApprovalGroupMembersResolved` condition from the escalation status updater for successful, non-required, partially failed, and failed approver group sync
- persist condition-only updates even when cached approver members are unchanged
- replace stale docs that described group sync as a `Ready=False` reason or `GroupSyncStatus` field

## Evidence
The status updater already computed group-sync outcomes, but discarded them and only applied status when member maps changed. That left the declared `ApprovalGroupMembersResolved` condition missing or stale while docs referenced a non-existent `GroupSyncStatus`/`status.groupSyncErrors` surface.

Duplicate check before implementation: open PR search for `ApprovalGroupMembersResolved`, `GroupSyncFailed`, and `EscalationStatusUpdater group sync condition` returned no matches. Adjacent PRs #877 and #879 cover escalation validation/reconcile triggers, not group-sync status maintenance.

## Tests
- `go test ./pkg/breakglass/escalation -run 'TestEscalationStatusUpdaterSetsApprovalGroupMembersResolved|TestEmptyApproverGroups|TestIDPGroupMembershipsPopulation|TestFetchGroupMembersFromMultipleIDPs' -count=1`
- `go test ./pkg/breakglass/escalation -count=1`
- `make lint`
- `make test`
- `git diff --check`
