### PR TITLE
fix: refetch idle sessions through live reader

### DIFF
--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -290,7 +290,7 @@ status:
   lastActivity: "2024-01-15T10:45:00Z"
 ```
 
-Used as the primary baseline for idle timeout calculation. Sessions without `lastActivity` are skipped by the idle-timeout controller to avoid false positives.
+Used as the primary baseline for idle timeout calculation. Sessions without `lastActivity` are skipped by the idle-timeout controller to avoid false positives. Before writing `IdleExpired`, cleanup refetches the live namespaced session and revalidates both state and `lastActivity` so a stale cache snapshot cannot overwrite a newer terminal state or recent activity update.
 
 #### activityCount
 

--- a/pkg/breakglass/expire_idle_sessions.go
+++ b/pkg/breakglass/expire_idle_sessions.go
@@ -25,6 +25,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/mail"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // maxStatusUpdateRetries is the maximum number of status update attempts
@@ -93,46 +94,19 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 			continue
 		}
 
+		fresh, refreshedIdle, ok, err := wc.prepareIdleExpiredSession(ctx, ses, idleTimeout)
+		if err != nil || !ok {
+			continue
+		}
+		ses = fresh
+		idleSince = refreshedIdle
+		baseline = ses.Status.LastActivity.Time
+
 		wc.log.Infow("Expiring session due to idle timeout",
 			"session", ses.Name,
 			"idleTimeout", ses.Spec.IdleTimeout,
 			"idleSince", idleSince.Round(time.Second),
 			"lastActivity", baseline)
-
-		// Prepare status transition
-		ses.Status.State = breakglassv1alpha1.SessionStateIdleExpired
-		ses.SetCondition(newIdleCondition(idleSince, ses.Spec.IdleTimeout))
-		ses.Status.ReasonEnded = "idleTimeout"
-		retainFor := ParseRetainFor(ses.Spec, wc.log)
-		ses.Status.RetainedUntil = metav1.NewTime(time.Now().UTC().Add(retainFor))
-
-		// Ensure we have correct metadata for the API update.
-		// Re-validate idle condition after refetch to avoid TOCTOU race where
-		// activity was recorded between our initial check and this point.
-		if stored, gerr := wc.sessionManager.GetBreakglassSessionByName(ctx, ses.Name); gerr == nil {
-			ses.Namespace = stored.Namespace
-			ses.ResourceVersion = stored.ResourceVersion
-			// If the session was already transitioned to a terminal state by another
-			// controller replica, skip idle expiry to avoid overwriting the reason.
-			if stored.Status.State != breakglassv1alpha1.SessionStateApproved {
-				wc.log.Infow("Session already transitioned after refetch; skipping idle expiry",
-					"session", ses.Name, "currentState", stored.Status.State)
-				continue
-			}
-			// Re-validate: if the stored session's lastActivity is more recent, it may no longer be idle
-			if stored.Status.LastActivity != nil && !stored.Status.LastActivity.IsZero() {
-				refreshedIdle := time.Since(stored.Status.LastActivity.Time)
-				if refreshedIdle < idleTimeout {
-					wc.log.Infow("Session no longer idle after refetch; skipping expiry",
-						"session", ses.Name,
-						"refreshedIdleSince", refreshedIdle.Round(time.Second))
-					continue
-				}
-			}
-		} else {
-			wc.log.Debugw("could not refetch session before idle status update; will attempt update anyway",
-				"session", ses.Name, "error", gerr)
-		}
 
 		// Persist the status change with retry on conflict (following ExpireApprovedSessions pattern)
 		var lastErr error
@@ -149,23 +123,12 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 				wc.log.Warnw("failed to update idle-expired session status (will retry)",
 					"session", ses.Name, "attempt", attempt+1, "error", err)
 
-				if updated, gerr := wc.sessionManager.GetBreakglassSessionByName(ctx, ses.Name); gerr == nil {
-					// If the session was already transitioned to a terminal state by another process,
-					// do not overwrite it — just stop retrying.
-					if updated.Status.State != breakglassv1alpha1.SessionStateApproved {
-						wc.log.Infow("Session already transitioned by another process; skipping idle expiry",
-							"session", ses.Name, "currentState", updated.Status.State)
-						lastErr = nil
-						break
-					}
-					updated.Status.State = ses.Status.State
-					updated.Status.Conditions = ses.Status.Conditions
-					updated.Status.ReasonEnded = ses.Status.ReasonEnded
-					updated.Status.RetainedUntil = ses.Status.RetainedUntil
+				if updated, _, ok, err := wc.prepareIdleExpiredSession(ctx, ses, idleTimeout); err != nil {
+					break
+				} else if ok {
 					ses = updated
 				} else {
-					wc.log.Errorw("failed to refetch session after failed idle status update",
-						"session", ses.Name, "error", gerr)
+					lastErr = nil
 					break
 				}
 				// Brief context-aware delay before retry to allow the API server
@@ -185,6 +148,67 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 			wc.sendSessionIdleExpiredEmail(ses)
 		}
 	}
+}
+
+func (wc *BreakglassSessionController) prepareIdleExpiredSession(
+	ctx context.Context,
+	session breakglassv1alpha1.BreakglassSession,
+	idleTimeout time.Duration,
+) (breakglassv1alpha1.BreakglassSession, time.Duration, bool, error) {
+	refreshed, err := wc.getFreshIdleSession(ctx, session)
+	if err != nil {
+		wc.log.Warnw("could not refetch session before idle status update; skipping idle expiry",
+			"session", session.Name,
+			"namespace", session.Namespace,
+			"error", err)
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, err
+	}
+
+	if refreshed.Status.State != breakglassv1alpha1.SessionStateApproved {
+		wc.log.Infow("Session already transitioned after refetch; skipping idle expiry",
+			"session", session.Name,
+			"currentState", refreshed.Status.State)
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
+	}
+
+	if refreshed.Status.LastActivity == nil || refreshed.Status.LastActivity.IsZero() {
+		wc.log.Infow("Session no longer has activity after refetch; skipping idle expiry",
+			"session", session.Name)
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
+	}
+
+	refreshedIdle := time.Since(refreshed.Status.LastActivity.Time)
+	if refreshedIdle < idleTimeout {
+		wc.log.Infow("Session no longer idle after refetch; skipping expiry",
+			"session", session.Name,
+			"refreshedIdleSince", refreshedIdle.Round(time.Second))
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
+	}
+
+	refreshed.Status.State = breakglassv1alpha1.SessionStateIdleExpired
+	refreshed.SetCondition(newIdleCondition(refreshedIdle, refreshed.Spec.IdleTimeout))
+	refreshed.Status.ReasonEnded = "idleTimeout"
+	retainFor := ParseRetainFor(refreshed.Spec, wc.log)
+	refreshed.Status.RetainedUntil = metav1.NewTime(time.Now().UTC().Add(retainFor))
+	return refreshed, refreshedIdle, true, nil
+}
+
+func (wc *BreakglassSessionController) getFreshIdleSession(
+	ctx context.Context,
+	session breakglassv1alpha1.BreakglassSession,
+) (breakglassv1alpha1.BreakglassSession, error) {
+	if session.Namespace == "" {
+		return wc.sessionManager.GetBreakglassSessionByName(ctx, session.Name)
+	}
+
+	refreshed := breakglassv1alpha1.BreakglassSession{}
+	if err := wc.sessionManager.Reader().Get(ctx, types.NamespacedName{
+		Namespace: session.Namespace,
+		Name:      session.Name,
+	}, &refreshed); err != nil {
+		return breakglassv1alpha1.BreakglassSession{}, fmt.Errorf("get live breakglass session %s/%s: %w", session.Namespace, session.Name, err)
+	}
+	return refreshed, nil
 }
 
 // sendSessionIdleExpiredEmail sends a notification when a session is expired due to idle timeout.

--- a/pkg/breakglass/expire_idle_sessions.go
+++ b/pkg/breakglass/expire_idle_sessions.go
@@ -124,6 +124,7 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 					"session", ses.Name, "attempt", attempt+1, "error", err)
 
 				if updated, _, ok, err := wc.prepareIdleExpiredSession(ctx, ses); err != nil {
+					lastErr = fmt.Errorf("prepare idle-expired session after status update attempt %d failed: %w", attempt+1, err)
 					break
 				} else if ok {
 					ses = updated

--- a/pkg/breakglass/expire_idle_sessions.go
+++ b/pkg/breakglass/expire_idle_sessions.go
@@ -94,7 +94,7 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 			continue
 		}
 
-		fresh, refreshedIdle, ok, err := wc.prepareIdleExpiredSession(ctx, ses, idleTimeout)
+		fresh, refreshedIdle, ok, err := wc.prepareIdleExpiredSession(ctx, ses)
 		if err != nil || !ok {
 			continue
 		}
@@ -123,7 +123,7 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 				wc.log.Warnw("failed to update idle-expired session status (will retry)",
 					"session", ses.Name, "attempt", attempt+1, "error", err)
 
-				if updated, _, ok, err := wc.prepareIdleExpiredSession(ctx, ses, idleTimeout); err != nil {
+				if updated, _, ok, err := wc.prepareIdleExpiredSession(ctx, ses); err != nil {
 					break
 				} else if ok {
 					ses = updated
@@ -153,7 +153,6 @@ func (wc *BreakglassSessionController) ExpireIdleSessions(ctx context.Context) {
 func (wc *BreakglassSessionController) prepareIdleExpiredSession(
 	ctx context.Context,
 	session breakglassv1alpha1.BreakglassSession,
-	idleTimeout time.Duration,
 ) (breakglassv1alpha1.BreakglassSession, time.Duration, bool, error) {
 	refreshed, err := wc.getFreshIdleSession(ctx, session)
 	if err != nil {
@@ -177,11 +176,27 @@ func (wc *BreakglassSessionController) prepareIdleExpiredSession(
 		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
 	}
 
+	if refreshed.Spec.IdleTimeout == "" {
+		wc.log.Infow("Session no longer has idle timeout after refetch; skipping idle expiry",
+			"session", session.Name)
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
+	}
+
+	refreshedIdleTimeout, err := breakglassv1alpha1.ParseDuration(refreshed.Spec.IdleTimeout)
+	if err != nil {
+		wc.log.Warnw("invalid idleTimeout on refetched session, skipping idle expiry",
+			"session", session.Name,
+			"idleTimeout", refreshed.Spec.IdleTimeout,
+			"error", err)
+		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
+	}
+
 	refreshedIdle := time.Since(refreshed.Status.LastActivity.Time)
-	if refreshedIdle < idleTimeout {
+	if refreshedIdle < refreshedIdleTimeout {
 		wc.log.Infow("Session no longer idle after refetch; skipping expiry",
 			"session", session.Name,
-			"refreshedIdleSince", refreshedIdle.Round(time.Second))
+			"refreshedIdleSince", refreshedIdle.Round(time.Second),
+			"idleTimeout", refreshed.Spec.IdleTimeout)
 		return breakglassv1alpha1.BreakglassSession{}, 0, false, nil
 	}
 
@@ -198,7 +213,7 @@ func (wc *BreakglassSessionController) getFreshIdleSession(
 	session breakglassv1alpha1.BreakglassSession,
 ) (breakglassv1alpha1.BreakglassSession, error) {
 	if session.Namespace == "" {
-		return wc.sessionManager.GetBreakglassSessionByName(ctx, session.Name)
+		return breakglassv1alpha1.BreakglassSession{}, fmt.Errorf("refusing idle session refetch without namespace for %q", session.Name)
 	}
 
 	refreshed := breakglassv1alpha1.BreakglassSession{}

--- a/pkg/breakglass/expire_idle_sessions_test.go
+++ b/pkg/breakglass/expire_idle_sessions_test.go
@@ -409,6 +409,107 @@ func TestExpireIdleSessions_UsesReaderBeforeStatusUpdate(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("fails closed when listed session has no namespace", func(t *testing.T) {
+		staleCached := breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "missing-namespace-idle-session"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "production",
+				User:         "user@example.com",
+				GrantedGroup: "admin",
+				IdleTimeout:  "10m",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:        breakglassv1alpha1.SessionStateApproved,
+				LastActivity: &staleActivity,
+			},
+		}
+		manager := NewSessionManagerWithClientAndReader(newIdleTestClient(scheme), newIdleTestClient(scheme))
+		ctrl := &BreakglassSessionController{log: logger, sessionManager: manager}
+
+		_, _, ok, err := ctrl.prepareIdleExpiredSession(context.Background(), staleCached)
+
+		require.Error(t, err)
+		assert.False(t, ok)
+		assert.Contains(t, err.Error(), "without namespace")
+	})
+}
+
+func TestExpireIdleSessions_ReevaluatesLiveIdleTimeout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := breakglassv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	logger := zaptest.NewLogger(t).Sugar()
+	staleActivity := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+
+	t.Run("skips when live idle timeout is extended", func(t *testing.T) {
+		staleCached := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "live-timeout-session", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "production",
+				User:         "user@example.com",
+				GrantedGroup: "admin",
+				IdleTimeout:  "10m",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:        breakglassv1alpha1.SessionStateApproved,
+				LastActivity: &staleActivity,
+			},
+		}
+		live := staleCached.DeepCopy()
+		live.Spec.IdleTimeout = "30m"
+
+		cacheClient := newIdleTestClient(scheme, staleCached)
+		readerClient := newIdleTestClient(scheme, live)
+		manager := NewSessionManagerWithClientAndReader(cacheClient, readerClient)
+		ctrl := &BreakglassSessionController{log: logger, sessionManager: manager}
+
+		ctrl.ExpireIdleSessions(context.Background())
+
+		var cachedAfter breakglassv1alpha1.BreakglassSession
+		require.NoError(t, cacheClient.Get(context.Background(), client.ObjectKeyFromObject(staleCached), &cachedAfter))
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, cachedAfter.Status.State)
+	})
+
+	t.Run("uses live idle timeout in expired condition", func(t *testing.T) {
+		staleCached := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "live-condition-session", Namespace: "default"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "production",
+				User:         "user@example.com",
+				GrantedGroup: "admin",
+				IdleTimeout:  "10m",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:        breakglassv1alpha1.SessionStateApproved,
+				LastActivity: &staleActivity,
+			},
+		}
+		live := staleCached.DeepCopy()
+		live.Spec.IdleTimeout = "15m"
+
+		cacheClient := newIdleTestClient(scheme, staleCached)
+		readerClient := newIdleTestClient(scheme, live)
+		manager := NewSessionManagerWithClientAndReader(cacheClient, readerClient)
+		ctrl := &BreakglassSessionController{log: logger, sessionManager: manager}
+
+		ctrl.ExpireIdleSessions(context.Background())
+
+		var cachedAfter breakglassv1alpha1.BreakglassSession
+		require.NoError(t, cacheClient.Get(context.Background(), client.ObjectKeyFromObject(staleCached), &cachedAfter))
+		assert.Equal(t, breakglassv1alpha1.SessionStateIdleExpired, cachedAfter.Status.State)
+
+		var idleCondition *metav1.Condition
+		for i := range cachedAfter.Status.Conditions {
+			if cachedAfter.Status.Conditions[i].Type == string(breakglassv1alpha1.SessionConditionTypeIdle) {
+				idleCondition = &cachedAfter.Status.Conditions[i]
+				break
+			}
+		}
+		require.NotNil(t, idleCondition)
+		assert.Contains(t, idleCondition.Message, "idle timeout: 15m")
+	})
 }
 
 func TestExpireIdleSessions_SendsEmail(t *testing.T) {

--- a/pkg/breakglass/expire_idle_sessions_test.go
+++ b/pkg/breakglass/expire_idle_sessions_test.go
@@ -341,6 +341,76 @@ func TestExpireIdleSessions(t *testing.T) {
 	})
 }
 
+func TestExpireIdleSessions_UsesReaderBeforeStatusUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := breakglassv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	logger := zaptest.NewLogger(t).Sugar()
+	staleActivity := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+	recentActivity := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+
+	tests := []struct {
+		name       string
+		liveStatus breakglassv1alpha1.BreakglassSessionStatus
+	}{
+		{
+			name: "skips when live session is already terminal",
+			liveStatus: breakglassv1alpha1.BreakglassSessionStatus{
+				State:        breakglassv1alpha1.SessionStateExpired,
+				LastActivity: &staleActivity,
+				ReasonEnded:  "dropped",
+			},
+		},
+		{
+			name: "skips when live session has recent activity",
+			liveStatus: breakglassv1alpha1.BreakglassSessionStatus{
+				State:        breakglassv1alpha1.SessionStateApproved,
+				LastActivity: &recentActivity,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			staleCached := &breakglassv1alpha1.BreakglassSession{
+				ObjectMeta: metav1.ObjectMeta{Name: "stale-idle-session", Namespace: "default"},
+				Spec: breakglassv1alpha1.BreakglassSessionSpec{
+					Cluster:      "production",
+					User:         "user@example.com",
+					GrantedGroup: "admin",
+					IdleTimeout:  "10m",
+				},
+				Status: breakglassv1alpha1.BreakglassSessionStatus{
+					State:        breakglassv1alpha1.SessionStateApproved,
+					LastActivity: &staleActivity,
+				},
+			}
+			live := staleCached.DeepCopy()
+			live.Status = tt.liveStatus
+
+			cacheClient := newIdleTestClient(scheme, staleCached)
+			readerClient := newIdleTestClient(scheme, live)
+			manager := NewSessionManagerWithClientAndReader(cacheClient, readerClient)
+			ctrl := &BreakglassSessionController{log: logger, sessionManager: manager}
+
+			ctrl.ExpireIdleSessions(context.Background())
+
+			var cachedAfter breakglassv1alpha1.BreakglassSession
+			require.NoError(t, cacheClient.Get(context.Background(), client.ObjectKeyFromObject(staleCached), &cachedAfter))
+			assert.Equal(t, breakglassv1alpha1.SessionStateApproved, cachedAfter.Status.State,
+				"stale cache snapshot must not be patched to IdleExpired")
+
+			var liveAfter breakglassv1alpha1.BreakglassSession
+			require.NoError(t, readerClient.Get(context.Background(), client.ObjectKeyFromObject(live), &liveAfter))
+			assert.Equal(t, tt.liveStatus.State, liveAfter.Status.State)
+			if tt.liveStatus.ReasonEnded != "" {
+				assert.Equal(t, tt.liveStatus.ReasonEnded, liveAfter.Status.ReasonEnded)
+			}
+		})
+	}
+}
+
 func TestExpireIdleSessions_SendsEmail(t *testing.T) {
 	// TestExpireIdleSessions_SendsEmail
 	//

--- a/pkg/breakglass/expire_idle_sessions_test.go
+++ b/pkg/breakglass/expire_idle_sessions_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/config"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -975,6 +977,69 @@ func TestExpireIdleSessions_AllRetriesExhausted(t *testing.T) {
 	require.NoError(t, gerr)
 	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, got.Status.State,
 		"Session should remain Approved when all status update retries are exhausted")
+}
+
+func TestExpireIdleSessions_ReportsRevalidationErrorAfterStatusUpdateFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := breakglassv1alpha1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core).Sugar()
+
+	past := metav1.NewTime(time.Now().UTC().Add(-20 * time.Minute))
+	ses := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "revalidation-error-session", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "production",
+			User:         "user@example.com",
+			GrantedGroup: "admin",
+			IdleTimeout:  "10m",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:        breakglassv1alpha1.SessionStateApproved,
+			LastActivity: &past,
+		},
+	}
+
+	statusUpdateFailed := false
+	var retryRevalidationFailures int
+	var patchCallCount int
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ses).
+		WithStatusSubresource(ses).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", idleTestMetadataNameIndexer).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if statusUpdateFailed && key.Namespace == ses.Namespace && key.Name == ses.Name {
+					retryRevalidationFailures++
+					return fmt.Errorf("api reader unavailable")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+			SubResourcePatch: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+				patchCallCount++
+				statusUpdateFailed = true
+				return fmt.Errorf("transient status update")
+			},
+		}).
+		Build()
+
+	manager := &SessionManager{Client: fakeClient}
+	ctrl := &BreakglassSessionController{log: logger, sessionManager: manager}
+
+	ctrl.ExpireIdleSessions(context.Background())
+
+	require.Equal(t, 1, retryRevalidationFailures, "expected retry revalidation to fail once")
+	require.Equal(t, 1, patchCallCount, "retry loop should stop after revalidation fails")
+
+	entries := logs.FilterMessage("failed to update idle-expired session after retries").All()
+	require.Len(t, entries, 1)
+	loggedErr := fmt.Sprint(entries[0].ContextMap()["error"])
+	assert.Contains(t, loggedErr, "prepare idle-expired session after status update attempt 1 failed")
+	assert.Contains(t, loggedErr, "api reader unavailable")
+	assert.NotContains(t, loggedErr, "transient status update")
 }
 
 func TestExpireIdleSessions_ConcurrentTransitionDuringRetry(t *testing.T) {


### PR DESCRIPTION
## Finding

`ExpireIdleSessions` lists approved sessions from the cache and then refetches by name with `GetBreakglassSessionByName` before writing `IdleExpired`. That refetch can still use the cache-backed client, even when `SessionManager` was constructed with an APIReader/live reader. A stale cache snapshot can therefore overwrite a newer terminal state or miss recent `lastActivity` before the first status patch.

## Fix

- Refetch the namespaced `BreakglassSession` through `SessionManager.Reader()` before preparing an idle-expired status update.
- Revalidate the live state and `lastActivity` before the first write and before retrying after a failed status patch.
- Fail closed when the live read fails instead of writing a stale cached object.
- Document the live revalidation behavior.

## Evidence / duplicate check

- Source evidence: `GetSessionsByState` intentionally uses the cache for indexed `status.state` lookups, while `GetBreakglassSessionByName` can also read from the cache-backed client instead of the configured live reader.
- Duplicate search before opening returned no open PR matches for `idle expiry APIReader stale cache`, `ExpireIdleSessions GetBreakglassSessionByName Reader`, or `lastActivity stale cache IdleExpired`.
- #855 covers approved/pending time expiry stale-state writes; it does not change `ExpireIdleSessions` live-reader behavior.

## Local validation

- `go test ./pkg/breakglass -run 'TestExpireIdleSessions' -count=1`
- `go test ./pkg/breakglass -count=1`
- `make lint`
- `git diff --check`

## Screenshots

Not applicable; this PR has no UI changes.
