### PR TITLE
fix: guard duplicate cleanup with live reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
+- **BreakglassSession duplicate cleanup live guard**: Duplicate-session cleanup now revalidates live session state before terminating duplicates, preserving concurrent rejection, withdrawal, expiry, or activity transitions.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 - **Frontend modal dismissal**: Approval, review, and withdraw modals now keep destructive actions mounted while requests are in flight, and support Escape or modal-close dismissal only when closing is safe.
 ### Fixed

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -479,7 +479,7 @@ All session activities are logged for compliance and troubleshooting.
 - **Provide Justifications**: Include clear details for audit purposes
 - **Minimum Duration**: Request only needed time
 - **Monitor Usage**: Track session patterns and usage
-- **Clean Up**: Remove expired sessions regularly
+- **Clean Up**: Remove expired sessions regularly. Duplicate-session cleanup revalidates live session state before terminating duplicates, so concurrent rejection, withdrawal, expiry, or activity changes are preserved.
 
 ## Troubleshooting
 

--- a/pkg/breakglass/cleanup_duplicate_sessions.go
+++ b/pkg/breakglass/cleanup_duplicate_sessions.go
@@ -214,7 +214,7 @@ func getLiveDuplicateSession(
 	session breakglassv1alpha1.BreakglassSession,
 ) (breakglassv1alpha1.BreakglassSession, error) {
 	if session.Namespace == "" {
-		return mgr.GetBreakglassSessionByName(ctx, session.Name)
+		return breakglassv1alpha1.BreakglassSession{}, fmt.Errorf("get live duplicate session %q: namespace is required for live reader lookup", session.Name)
 	}
 
 	live := breakglassv1alpha1.BreakglassSession{}
@@ -252,6 +252,9 @@ func terminateDuplicateSession(
 		prepareDuplicateSessionTermination(&live, log)
 		live.Status.ObservedGeneration = live.Generation
 		if err := mgr.Client.Status().Patch(ctx, &live, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 		updated = true

--- a/pkg/breakglass/cleanup_duplicate_sessions.go
+++ b/pkg/breakglass/cleanup_duplicate_sessions.go
@@ -6,13 +6,22 @@ package breakglass
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type duplicateSessionKey struct {
+	Cluster, User, Group string
+}
 
 // sessionStatePriority returns a numeric priority for a given session state.
 // Higher values indicate higher priority when choosing which duplicate to keep.
@@ -26,6 +35,18 @@ func sessionStatePriority(state breakglassv1alpha1.BreakglassSessionState) int {
 		return 1
 	default:
 		return 0
+	}
+}
+
+func isActiveDuplicateSessionState(state breakglassv1alpha1.BreakglassSessionState) bool {
+	return sessionStatePriority(state) > 0
+}
+
+func duplicateKeyForSession(session breakglassv1alpha1.BreakglassSession) duplicateSessionKey {
+	return duplicateSessionKey{
+		Cluster: session.Spec.Cluster,
+		User:    session.Spec.User,
+		Group:   session.Spec.GrantedGroup,
 	}
 }
 
@@ -70,21 +91,19 @@ func CleanupDuplicateSessions(ctx context.Context, log *zap.SugaredLogger, mgr *
 		return // need at least 2 for a duplicate
 	}
 
-	// Group by the unique triple: cluster/user/grantedGroup
-	type tripleKey struct {
-		Cluster, User, Group string
-	}
-	groups := make(map[tripleKey][]breakglassv1alpha1.BreakglassSession)
+	// Group by the unique triple: cluster/user/grantedGroup.
+	groups := make(map[duplicateSessionKey][]breakglassv1alpha1.BreakglassSession)
 	for _, s := range allActive {
-		key := tripleKey{
-			Cluster: s.Spec.Cluster,
-			User:    s.Spec.User,
-			Group:   s.Spec.GrantedGroup,
-		}
+		key := duplicateKeyForSession(s)
 		groups[key] = append(groups[key], s)
 	}
 
 	for key, sessions := range groups {
+		if len(sessions) < 2 {
+			continue
+		}
+
+		sessions = refetchActiveDuplicateSessions(ctx, log, mgr, key, sessions)
 		if len(sessions) < 2 {
 			continue
 		}
@@ -138,71 +157,164 @@ func CleanupDuplicateSessions(ctx context.Context, log *zap.SugaredLogger, mgr *
 				"created", dup.CreationTimestamp.Time,
 			)
 
-			var (
-				targetState      breakglassv1alpha1.BreakglassSessionState
-				conditionType    breakglassv1alpha1.BreakglassSessionConditionType
-				conditionReason  string
-				conditionMessage string
-				reasonEnded      string
-			)
-
-			switch dup.Status.State {
-			case breakglassv1alpha1.SessionStatePending, breakglassv1alpha1.SessionStateWaitingForScheduledTime:
-				// Pending/Waiting sessions must be withdrawn, not expired,
-				// to satisfy the webhook state machine.
-				targetState = breakglassv1alpha1.SessionStateWithdrawn
-				conditionType = breakglassv1alpha1.SessionConditionTypeCanceled
-				conditionReason = "DuplicateSessionWithdrawn"
-				conditionMessage = "Withdrawn by cleanup routine: duplicate session for the same cluster/user/group triple."
-				reasonEnded = "withdrawn"
-			case breakglassv1alpha1.SessionStateApproved:
-				// Approved sessions can be directly expired.
-				targetState = breakglassv1alpha1.SessionStateExpired
-				conditionType = breakglassv1alpha1.SessionConditionTypeExpired
-				conditionReason = "DuplicateSessionTerminated"
-				conditionMessage = "Terminated by cleanup routine: duplicate session for the same cluster/user/group triple."
-				reasonEnded = "duplicateCleanup"
-			default:
-				// For any other state, skip to avoid invalid state transitions.
-				log.Infow("Skipping duplicate session with non-terminatable state",
-					"session", dup.Name,
-					"namespace", dup.Namespace,
-					"state", dup.Status.State,
-				)
-				continue
-			}
-
-			// Capture a single "now" for consistent terminal metadata and condition timestamps.
-			now := metav1.Now()
-
-			// Populate terminal-state timestamps that the rest of the system expects.
-			if targetState == breakglassv1alpha1.SessionStateWithdrawn {
-				if dup.Status.WithdrawnAt.IsZero() {
-					dup.Status.WithdrawnAt = now
-				}
-			}
-			if targetState == breakglassv1alpha1.SessionStateExpired {
-				dup.Status.ExpiresAt = now
-			}
-			// Set RetainedUntil so the cleanup routine can later garbage-collect the session.
-			if dup.Status.RetainedUntil.IsZero() {
-				retainFor := ParseRetainFor(dup.Spec, log)
-				dup.Status.RetainedUntil = metav1.NewTime(now.Time.Add(retainFor))
-			}
-
-			dup.Status.State = targetState
-			dup.Status.ReasonEnded = reasonEnded
-			dup.SetCondition(metav1.Condition{
-				Type:               string(conditionType),
-				Status:             metav1.ConditionTrue,
-				LastTransitionTime: now,
-				Reason:             conditionReason,
-				Message:            conditionMessage,
-			})
-
-			if err := mgr.UpdateBreakglassSessionStatus(ctx, dup); err != nil {
+			if _, err := terminateDuplicateSession(ctx, log, mgr, key, dup); err != nil {
 				log.Warnw("Failed to update duplicate session status", "session", dup.Name, "error", err)
 			}
 		}
 	}
+}
+
+func refetchActiveDuplicateSessions(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mgr *SessionManager,
+	key duplicateSessionKey,
+	sessions []breakglassv1alpha1.BreakglassSession,
+) []breakglassv1alpha1.BreakglassSession {
+	refreshed := make([]breakglassv1alpha1.BreakglassSession, 0, len(sessions))
+	seen := make(map[types.NamespacedName]struct{}, len(sessions))
+	for _, session := range sessions {
+		namespacedName := types.NamespacedName{Namespace: session.Namespace, Name: session.Name}
+		if _, ok := seen[namespacedName]; ok {
+			continue
+		}
+		seen[namespacedName] = struct{}{}
+
+		live, err := getLiveDuplicateSession(ctx, mgr, session)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.Warnw("Failed to refetch duplicate session candidate",
+					"session", session.Name,
+					"namespace", session.Namespace,
+					"error", err)
+			}
+			continue
+		}
+		if duplicateKeyForSession(live) != key {
+			log.Infow("Skipping duplicate session candidate whose key changed after refetch",
+				"session", live.Name,
+				"namespace", live.Namespace)
+			continue
+		}
+		if !isActiveDuplicateSessionState(live.Status.State) {
+			log.Infow("Skipping duplicate session candidate that is no longer active",
+				"session", live.Name,
+				"namespace", live.Namespace,
+				"state", live.Status.State)
+			continue
+		}
+		refreshed = append(refreshed, live)
+	}
+	return refreshed
+}
+
+func getLiveDuplicateSession(
+	ctx context.Context,
+	mgr *SessionManager,
+	session breakglassv1alpha1.BreakglassSession,
+) (breakglassv1alpha1.BreakglassSession, error) {
+	if session.Namespace == "" {
+		return mgr.GetBreakglassSessionByName(ctx, session.Name)
+	}
+
+	live := breakglassv1alpha1.BreakglassSession{}
+	if err := mgr.Reader().Get(ctx, types.NamespacedName{Namespace: session.Namespace, Name: session.Name}, &live); err != nil {
+		return breakglassv1alpha1.BreakglassSession{}, fmt.Errorf("get live duplicate session %s/%s: %w", session.Namespace, session.Name, err)
+	}
+	return live, nil
+}
+
+func terminateDuplicateSession(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mgr *SessionManager,
+	key duplicateSessionKey,
+	session breakglassv1alpha1.BreakglassSession,
+) (bool, error) {
+	updated := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		live, err := getLiveDuplicateSession(ctx, mgr, session)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if duplicateKeyForSession(live) != key || !isActiveDuplicateSessionState(live.Status.State) {
+			log.Infow("Skipping duplicate session that changed before status patch",
+				"session", live.Name,
+				"namespace", live.Namespace,
+				"state", live.Status.State)
+			return nil
+		}
+
+		base := live.DeepCopy()
+		prepareDuplicateSessionTermination(&live, log)
+		live.Status.ObservedGeneration = live.Generation
+		if err := mgr.Client.Status().Patch(ctx, &live, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("patch duplicate session status %s/%s: %w", session.Namespace, session.Name, err)
+	}
+	return updated, nil
+}
+
+func prepareDuplicateSessionTermination(session *breakglassv1alpha1.BreakglassSession, log *zap.SugaredLogger) {
+	var (
+		targetState      breakglassv1alpha1.BreakglassSessionState
+		conditionType    breakglassv1alpha1.BreakglassSessionConditionType
+		conditionReason  string
+		conditionMessage string
+		reasonEnded      string
+	)
+
+	switch session.Status.State {
+	case breakglassv1alpha1.SessionStatePending, breakglassv1alpha1.SessionStateWaitingForScheduledTime:
+		// Pending/Waiting sessions must be withdrawn, not expired,
+		// to satisfy the webhook state machine.
+		targetState = breakglassv1alpha1.SessionStateWithdrawn
+		conditionType = breakglassv1alpha1.SessionConditionTypeCanceled
+		conditionReason = "DuplicateSessionWithdrawn"
+		conditionMessage = "Withdrawn by cleanup routine: duplicate session for the same cluster/user/group triple."
+		reasonEnded = "withdrawn"
+	case breakglassv1alpha1.SessionStateApproved:
+		// Approved sessions can be directly expired.
+		targetState = breakglassv1alpha1.SessionStateExpired
+		conditionType = breakglassv1alpha1.SessionConditionTypeExpired
+		conditionReason = "DuplicateSessionTerminated"
+		conditionMessage = "Terminated by cleanup routine: duplicate session for the same cluster/user/group triple."
+		reasonEnded = "duplicateCleanup"
+	default:
+		return
+	}
+
+	// Capture a single "now" for consistent terminal metadata and condition timestamps.
+	now := metav1.Now()
+
+	// Populate terminal-state timestamps that the rest of the system expects.
+	if targetState == breakglassv1alpha1.SessionStateWithdrawn && session.Status.WithdrawnAt.IsZero() {
+		session.Status.WithdrawnAt = now
+	}
+	if targetState == breakglassv1alpha1.SessionStateExpired {
+		session.Status.ExpiresAt = now
+	}
+	// Set RetainedUntil so the cleanup routine can later garbage-collect the session.
+	if session.Status.RetainedUntil.IsZero() {
+		retainFor := ParseRetainFor(session.Spec, log)
+		session.Status.RetainedUntil = metav1.NewTime(now.Time.Add(retainFor))
+	}
+
+	session.Status.State = targetState
+	session.Status.ReasonEnded = reasonEnded
+	session.SetCondition(metav1.Condition{
+		Type:               string(conditionType),
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: now,
+		Reason:             conditionReason,
+		Message:            conditionMessage,
+	})
 }

--- a/pkg/breakglass/cleanup_duplicate_sessions_test.go
+++ b/pkg/breakglass/cleanup_duplicate_sessions_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap/zaptest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // stateIndexer is a field index function used by the fake client for status.state queries.
@@ -527,6 +530,65 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 		// Duplicate should NOT have been withdrawn because context was cancelled
 		assert.Equal(t, breakglassv1alpha1.SessionStatePending, got2.Status.State, "cancelled context prevents duplicate processing")
 	})
+}
+
+func TestGetLiveDuplicateSessionRequiresNamespace(t *testing.T) {
+	t.Parallel()
+
+	fc := newFakeClientWithSessions(&breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "duplicate",
+			Namespace: "breakglass",
+		},
+	})
+	mgr := NewSessionManagerWithClient(fc)
+
+	_, err := getLiveDuplicateSession(context.Background(), mgr, breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace is required")
+}
+
+func TestTerminateDuplicateSessionIgnoresStatusPatchNotFound(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctx := context.Background()
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "duplicate",
+			Namespace: "breakglass",
+		},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster: "prod",
+			User:    "developer@example.com",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(&session).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "status.state", stateIndexer).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", func(o client.Object) []string {
+			return []string{o.GetName()}
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ client.Client, subResource string, obj client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+				if subResource == "status" {
+					return apierrors.NewNotFound(schema.GroupResource{Group: breakglassv1alpha1.GroupVersion.Group, Resource: "breakglasssessions"}, obj.GetName())
+				}
+				return nil
+			},
+		}).
+		Build()
+	mgr := NewSessionManagerWithClient(fc)
+
+	updated, err := terminateDuplicateSession(ctx, logger, mgr, duplicateKeyForSession(session), session)
+
+	require.NoError(t, err)
+	assert.False(t, updated)
 }
 
 func TestSessionStatePriority(t *testing.T) {

--- a/pkg/breakglass/cleanup_duplicate_sessions_test.go
+++ b/pkg/breakglass/cleanup_duplicate_sessions_test.go
@@ -230,6 +230,101 @@ func TestCleanupDuplicateSessions(t *testing.T) {
 		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, got3.Status.State, "waiting withdrawn")
 	})
 
+	t.Run("stale duplicate already terminal in live reader is preserved", func(t *testing.T) {
+		now := time.Now()
+		keepCached := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "live-terminal-keep",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+			},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+		}
+		dupCached := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "live-terminal-dup",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
+			},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+		}
+		keepLive := keepCached.DeepCopy()
+		dupLive := dupCached.DeepCopy()
+		dupLive.Status.State = breakglassv1alpha1.SessionStateRejected
+		dupLive.Status.ReasonEnded = "rejected"
+
+		cacheClient := newFakeClientWithSessions(keepCached, dupCached)
+		readerClient := newFakeClientWithSessions(keepLive, dupLive)
+		mgr := NewSessionManagerWithClientAndReader(cacheClient, readerClient)
+
+		CleanupDuplicateSessions(ctx, logger, mgr)
+
+		var cachedDup breakglassv1alpha1.BreakglassSession
+		require.NoError(t, cacheClient.Get(ctx, client.ObjectKeyFromObject(dupCached), &cachedDup))
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, cachedDup.Status.State,
+			"stale cached duplicate must not be withdrawn after live state is terminal")
+
+		var liveDup breakglassv1alpha1.BreakglassSession
+		require.NoError(t, readerClient.Get(ctx, client.ObjectKeyFromObject(dupLive), &liveDup))
+		assert.Equal(t, breakglassv1alpha1.SessionStateRejected, liveDup.Status.State)
+		assert.Equal(t, "rejected", liveDup.Status.ReasonEnded)
+	})
+
+	t.Run("cached survivor terminal in live reader is not kept", func(t *testing.T) {
+		now := time.Now()
+		staleSurvivor := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "stale-survivor",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(now.Add(-30 * time.Minute)),
+			},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+		}
+		remainingOld := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "remaining-old",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(now.Add(-20 * time.Minute)),
+			},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+		}
+		remainingNew := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "remaining-new",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(now.Add(-5 * time.Minute)),
+			},
+			Spec:   breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c1", User: "u1", GrantedGroup: "g1"},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStatePending},
+		}
+		staleSurvivorLive := staleSurvivor.DeepCopy()
+		staleSurvivorLive.Status.State = breakglassv1alpha1.SessionStateExpired
+		staleSurvivorLive.Status.ReasonEnded = "expired"
+
+		cacheClient := newFakeClientWithSessions(staleSurvivor, remainingOld, remainingNew)
+		readerClient := newFakeClientWithSessions(staleSurvivorLive, remainingOld.DeepCopy(), remainingNew.DeepCopy())
+		mgr := NewSessionManagerWithClientAndReader(cacheClient, readerClient)
+
+		CleanupDuplicateSessions(ctx, logger, mgr)
+
+		var gotOld, gotNew breakglassv1alpha1.BreakglassSession
+		require.NoError(t, cacheClient.Get(ctx, client.ObjectKeyFromObject(remainingOld), &gotOld))
+		require.NoError(t, cacheClient.Get(ctx, client.ObjectKeyFromObject(remainingNew), &gotNew))
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, gotOld.Status.State,
+			"oldest still-active live candidate must become the recomputed survivor")
+		assert.Equal(t, breakglassv1alpha1.SessionStateWithdrawn, gotNew.Status.State,
+			"newer still-active live candidate should be withdrawn")
+
+		var liveStaleSurvivor breakglassv1alpha1.BreakglassSession
+		require.NoError(t, readerClient.Get(ctx, client.ObjectKeyFromObject(staleSurvivorLive), &liveStaleSurvivor))
+		assert.Equal(t, breakglassv1alpha1.SessionStateExpired, liveStaleSurvivor.Status.State)
+		assert.Equal(t, "expired", liveStaleSurvivor.Status.ReasonEnded)
+	})
+
 	t.Run("mixed active and terminal sessions — terminal ignored", func(t *testing.T) {
 		now := time.Now()
 		active := &breakglassv1alpha1.BreakglassSession{


### PR DESCRIPTION
## Finding

`CleanupDuplicateSessions` built duplicate groups from cache-backed state queries, chose a survivor from that snapshot, mutated cached duplicate objects, and then wrote terminal status. If a duplicate or the selected survivor had already transitioned in live state, cleanup could overwrite terminal audit state or terminate the remaining active session.

## Fix

- Refetch every duplicate candidate through the configured live reader before cleanup decisions.
- Filter candidates that no longer match the same cluster/user/group triple or are no longer active.
- Recompute the survivor from the refreshed active set.
- Patch duplicate status from the live object with optimistic locking and retry-on-conflict.
- Skip objects that become terminal or change key before the patch.

## Evidence / duplicate check

- Source evidence: `GetSessionsByState` uses the cache for indexed `status.state` queries; the old duplicate cleanup mutated those listed objects directly and delegated to `UpdateBreakglassSessionStatus`, which can also refetch by name through cache-backed paths.
- Open PR searches returned no matches for `CleanupDuplicateSessions live reader`, `duplicate cleanup stale terminal state`, or `cleanup_duplicate_sessions.go`.
- Adjacent open PRs #855, #849, #841, and #852 cover other cleanup/expiry paths, not `CleanupDuplicateSessions`.

## Local validation

- `go test ./pkg/breakglass -run 'TestCleanupDuplicateSessions' -count=1`
- `go test ./pkg/breakglass -count=1`
- `make lint`
- `git diff --check`

## Screenshots

Not applicable; this PR has no UI changes.
