### PR TITLE
fix: harden debug scheduling constraints

### DIFF
--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -796,6 +796,8 @@ schedulingConstraints:
     node-role.kubernetes.io/master: "*"
 ```
 
+Exact `deniedNodes` entries and `deniedNodeLabels` are rendered into hard node affinity requirements on created debug workloads. Glob-style `deniedNodes` entries are retained in the resolved session constraints for policy visibility, but Kubernetes node affinity cannot enforce glob patterns directly; prefer stable labels in `deniedNodeLabels` for hard node-pool exclusion.
+
 ### Scheduling Options
 
 Scheduling options allow administrators to offer users a choice of predefined scheduling configurations. This reduces the need for multiple templates for different node pools:
@@ -840,6 +842,8 @@ The controller refreshes `status.allowedPods` dynamically as debug pods start, s
 3. Base `schedulingConstraints` from template (mandatory for all options)
 4. Selected option's `schedulingConstraints` (additive)
 5. User's `nodeSelector` (if allowed by template)
+
+Selected options and cluster bindings may add stricter constraints but cannot replace mandatory ones. If a binding or option sets a different value for an existing mandatory `nodeSelector` key, or tries to narrow a `deniedNodeLabels` key to a different exact value, the request is rejected instead of silently weakening the base constraint. Required node affinity is combined with Kubernetes-correct AND semantics across selector terms.
 
 ## Namespace Constraints
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -843,7 +843,7 @@ The controller refreshes `status.allowedPods` dynamically as debug pods start, s
 4. Selected option's `schedulingConstraints` (additive)
 5. User's `nodeSelector` (if allowed by template)
 
-Selected options and cluster bindings may add stricter constraints but cannot replace mandatory ones. If a binding or option sets a different value for an existing mandatory `nodeSelector` key, or tries to narrow a `deniedNodeLabels` key to a different exact value, the request is rejected instead of silently weakening the base constraint. Required node affinity is combined with Kubernetes-correct AND semantics across selector terms.
+Selected options and cluster bindings may add stricter constraints but cannot replace mandatory ones. If a binding or option sets a different value for an existing mandatory `nodeSelector` key, the request is rejected instead of silently weakening the base constraint. `deniedNodeLabels` are additive: a wildcard `*` value denies every value for that key and dominates narrower exact-value entries, while conflicting exact values for the same key are rejected. Required node affinity is combined with Kubernetes-correct AND semantics across selector terms.
 
 ## Namespace Constraints
 

--- a/pkg/breakglass/debug/debug_session_api_constraints.go
+++ b/pkg/breakglass/debug/debug_session_api_constraints.go
@@ -7,7 +7,10 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+const maxRequiredNodeSelectorTerms = 128
 
 type schedulingOptionRequester struct {
 	Username string
@@ -367,6 +370,9 @@ func (c *DebugSessionAPIController) resolveSchedulingConstraints(
 		}
 		baseConstraints = mergedBase
 	}
+	if err := validateSchedulingConstraints(baseConstraints, "base schedulingConstraints"); err != nil {
+		return nil, "", err
+	}
 
 	// Resolve effective scheduling options: binding takes precedence over template
 	var effectiveOpts *breakglassv1alpha1.SchedulingOptions
@@ -465,6 +471,12 @@ func isSchedulingOptionAllowedForRequester(opt *breakglassv1alpha1.SchedulingOpt
 // mergeSchedulingConstraints merges base constraints with option constraints.
 // Option constraints are additive and must not weaken base constraints.
 func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConstraints) (*breakglassv1alpha1.SchedulingConstraints, error) {
+	if err := validateSchedulingConstraints(base, "base schedulingConstraints"); err != nil {
+		return nil, err
+	}
+	if err := validateSchedulingConstraints(option, "option schedulingConstraints"); err != nil {
+		return nil, err
+	}
 	if base == nil && option == nil {
 		return nil, nil
 	}
@@ -527,7 +539,11 @@ func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConst
 
 	// For node affinity, option's required affinity is ANDed with base.
 	if option.RequiredNodeAffinity != nil {
-		merged.RequiredNodeAffinity = andNodeSelectors(merged.RequiredNodeAffinity, option.RequiredNodeAffinity)
+		combined, err := andNodeSelectors(merged.RequiredNodeAffinity, option.RequiredNodeAffinity)
+		if err != nil {
+			return nil, fmt.Errorf("requiredNodeAffinity: %w", err)
+		}
+		merged.RequiredNodeAffinity = combined
 	}
 
 	// Preferred affinities are additive
@@ -550,21 +566,82 @@ func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConst
 	return merged, nil
 }
 
-func andNodeSelectors(left, right *corev1.NodeSelector) *corev1.NodeSelector {
+func validateSchedulingConstraints(constraints *breakglassv1alpha1.SchedulingConstraints, context string) error {
+	if constraints == nil {
+		return nil
+	}
+	if constraints.RequiredNodeAffinity != nil && len(constraints.RequiredNodeAffinity.NodeSelectorTerms) > maxRequiredNodeSelectorTerms {
+		return fmt.Errorf("%s requiredNodeAffinity has %d nodeSelectorTerms, maximum is %d",
+			context, len(constraints.RequiredNodeAffinity.NodeSelectorTerms), maxRequiredNodeSelectorTerms)
+	}
+	if err := validateDeniedNodeLabels(constraints.DeniedNodeLabels, context); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDeniedNodeLabels(deniedNodeLabels map[string]string, context string) error {
+	if len(deniedNodeLabels) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(deniedNodeLabels))
+	for key := range deniedNodeLabels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+			return fmt.Errorf("%s deniedNodeLabels key %q is invalid: %s", context, key, strings.Join(errs, "; "))
+		}
+		value := deniedNodeLabels[key]
+		if value == "*" {
+			continue
+		}
+		if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+			return fmt.Errorf("%s deniedNodeLabels[%q] value %q is invalid: %s", context, key, value, strings.Join(errs, "; "))
+		}
+	}
+	return nil
+}
+
+func andNodeSelectors(left, right *corev1.NodeSelector) (*corev1.NodeSelector, error) {
 	if left == nil {
 		if right == nil {
-			return nil
+			return nil, nil
 		}
-		return right.DeepCopy()
+		return right.DeepCopy(), nil
 	}
 	if right == nil {
-		return left.DeepCopy()
+		return left.DeepCopy(), nil
 	}
 	if len(left.NodeSelectorTerms) == 0 {
-		return right.DeepCopy()
+		return right.DeepCopy(), nil
 	}
 	if len(right.NodeSelectorTerms) == 0 {
-		return left.DeepCopy()
+		return left.DeepCopy(), nil
+	}
+	if nodeSelectorTermProductExceedsLimit(len(left.NodeSelectorTerms), len(right.NodeSelectorTerms), maxRequiredNodeSelectorTerms) {
+		return nil, fmt.Errorf("combining %d and %d nodeSelectorTerms would exceed maximum of %d resulting terms",
+			len(left.NodeSelectorTerms), len(right.NodeSelectorTerms), maxRequiredNodeSelectorTerms)
+	}
+
+	if len(left.NodeSelectorTerms) == 1 {
+		out := &corev1.NodeSelector{
+			NodeSelectorTerms: make([]corev1.NodeSelectorTerm, 0, len(right.NodeSelectorTerms)),
+		}
+		for _, rightTerm := range right.NodeSelectorTerms {
+			out.NodeSelectorTerms = append(out.NodeSelectorTerms, andNodeSelectorTerms(left.NodeSelectorTerms[0], rightTerm))
+		}
+		return out, nil
+	}
+	if len(right.NodeSelectorTerms) == 1 {
+		out := &corev1.NodeSelector{
+			NodeSelectorTerms: make([]corev1.NodeSelectorTerm, 0, len(left.NodeSelectorTerms)),
+		}
+		for _, leftTerm := range left.NodeSelectorTerms {
+			out.NodeSelectorTerms = append(out.NodeSelectorTerms, andNodeSelectorTerms(leftTerm, right.NodeSelectorTerms[0]))
+		}
+		return out, nil
 	}
 
 	out := &corev1.NodeSelector{
@@ -572,15 +649,26 @@ func andNodeSelectors(left, right *corev1.NodeSelector) *corev1.NodeSelector {
 	}
 	for _, leftTerm := range left.NodeSelectorTerms {
 		for _, rightTerm := range right.NodeSelectorTerms {
-			term := corev1.NodeSelectorTerm{}
-			term.MatchExpressions = append(term.MatchExpressions, leftTerm.MatchExpressions...)
-			term.MatchExpressions = append(term.MatchExpressions, rightTerm.MatchExpressions...)
-			term.MatchFields = append(term.MatchFields, leftTerm.MatchFields...)
-			term.MatchFields = append(term.MatchFields, rightTerm.MatchFields...)
-			out.NodeSelectorTerms = append(out.NodeSelectorTerms, term)
+			out.NodeSelectorTerms = append(out.NodeSelectorTerms, andNodeSelectorTerms(leftTerm, rightTerm))
 		}
 	}
-	return out
+	return out, nil
+}
+
+func nodeSelectorTermProductExceedsLimit(leftTerms, rightTerms, limit int) bool {
+	if leftTerms == 0 || rightTerms == 0 {
+		return false
+	}
+	return leftTerms > limit/rightTerms
+}
+
+func andNodeSelectorTerms(leftTerm, rightTerm corev1.NodeSelectorTerm) corev1.NodeSelectorTerm {
+	term := corev1.NodeSelectorTerm{}
+	term.MatchExpressions = append(term.MatchExpressions, leftTerm.MatchExpressions...)
+	term.MatchExpressions = append(term.MatchExpressions, rightTerm.MatchExpressions...)
+	term.MatchFields = append(term.MatchFields, leftTerm.MatchFields...)
+	term.MatchFields = append(term.MatchFields, rightTerm.MatchFields...)
+	return term
 }
 
 // resolveClusterPatterns expands cluster patterns (e.g., "*", "prod-*") to actual cluster names.

--- a/pkg/breakglass/debug/debug_session_api_constraints.go
+++ b/pkg/breakglass/debug/debug_session_api_constraints.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type schedulingOptionRequester struct {
@@ -360,7 +361,11 @@ func (c *DebugSessionAPIController) resolveSchedulingConstraints(
 	// base constraints (which are documented as mandatory additions on top of the template).
 	baseConstraints := template.Spec.SchedulingConstraints
 	if binding != nil && binding.Spec.SchedulingConstraints != nil {
-		baseConstraints = mergeSchedulingConstraints(baseConstraints, binding.Spec.SchedulingConstraints)
+		mergedBase, err := mergeSchedulingConstraints(baseConstraints, binding.Spec.SchedulingConstraints)
+		if err != nil {
+			return nil, "", fmt.Errorf("binding scheduling constraints conflict with template constraints: %w", err)
+		}
+		baseConstraints = mergedBase
 	}
 
 	// Resolve effective scheduling options: binding takes precedence over template
@@ -424,7 +429,10 @@ func (c *DebugSessionAPIController) resolveSchedulingConstraints(
 	}
 
 	// Merge base constraints with option's constraints
-	merged := mergeSchedulingConstraints(baseConstraints, selectedOpt.SchedulingConstraints)
+	merged, err := mergeSchedulingConstraints(baseConstraints, selectedOpt.SchedulingConstraints)
+	if err != nil {
+		return nil, "", fmt.Errorf("scheduling option %q conflicts with mandatory constraints: %w", selectedOption, err)
+	}
 
 	return merged, selectedOption, nil
 }
@@ -455,26 +463,30 @@ func isSchedulingOptionAllowedForRequester(opt *breakglassv1alpha1.SchedulingOpt
 }
 
 // mergeSchedulingConstraints merges base constraints with option constraints.
-// Option constraints override base constraints for conflicting keys.
-func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConstraints) *breakglassv1alpha1.SchedulingConstraints {
+// Option constraints are additive and must not weaken base constraints.
+func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConstraints) (*breakglassv1alpha1.SchedulingConstraints, error) {
 	if base == nil && option == nil {
-		return nil
+		return nil, nil
 	}
 	if base == nil {
-		return option.DeepCopy()
+		return option.DeepCopy(), nil
 	}
 	if option == nil {
-		return base.DeepCopy()
+		return base.DeepCopy(), nil
 	}
 
 	merged := base.DeepCopy()
 
-	// Merge nodeSelector (option overrides base on conflict)
+	// Merge nodeSelector additively. Conflicting values cannot be represented
+	// without weakening the mandatory selector, so reject the selected option.
 	if len(option.NodeSelector) > 0 {
 		if merged.NodeSelector == nil {
 			merged.NodeSelector = make(map[string]string)
 		}
 		for k, v := range option.NodeSelector {
+			if existing, ok := merged.NodeSelector[k]; ok && existing != v {
+				return nil, fmt.Errorf("nodeSelector %q requires both %q and %q", k, existing, v)
+			}
 			merged.NodeSelector[k] = v
 		}
 	}
@@ -484,12 +496,26 @@ func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConst
 		merged.DeniedNodes = append(merged.DeniedNodes, option.DeniedNodes...)
 	}
 
-	// Merge deniedNodeLabels (option overrides base on conflict)
+	// Merge deniedNodeLabels additively. "*" denies all values for the key and
+	// therefore dominates exact-value denies for the same key.
 	if len(option.DeniedNodeLabels) > 0 {
 		if merged.DeniedNodeLabels == nil {
 			merged.DeniedNodeLabels = make(map[string]string)
 		}
 		for k, v := range option.DeniedNodeLabels {
+			if existing, ok := merged.DeniedNodeLabels[k]; ok {
+				switch {
+				case existing == v:
+					continue
+				case existing == "*":
+					continue
+				case v == "*":
+					merged.DeniedNodeLabels[k] = v
+					continue
+				default:
+					return nil, fmt.Errorf("deniedNodeLabels %q cannot add both %q and %q", k, existing, v)
+				}
+			}
 			merged.DeniedNodeLabels[k] = v
 		}
 	}
@@ -499,17 +525,9 @@ func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConst
 		merged.Tolerations = append(merged.Tolerations, option.Tolerations...)
 	}
 
-	// For node affinity, option's required affinity is ANDed with base
+	// For node affinity, option's required affinity is ANDed with base.
 	if option.RequiredNodeAffinity != nil {
-		if merged.RequiredNodeAffinity == nil {
-			merged.RequiredNodeAffinity = option.RequiredNodeAffinity.DeepCopy()
-		} else {
-			// AND the node selector terms
-			merged.RequiredNodeAffinity.NodeSelectorTerms = append(
-				merged.RequiredNodeAffinity.NodeSelectorTerms,
-				option.RequiredNodeAffinity.NodeSelectorTerms...,
-			)
-		}
+		merged.RequiredNodeAffinity = andNodeSelectors(merged.RequiredNodeAffinity, option.RequiredNodeAffinity)
 	}
 
 	// Preferred affinities are additive
@@ -525,7 +543,44 @@ func mergeSchedulingConstraints(base, option *breakglassv1alpha1.SchedulingConst
 		merged.PreferredPodAntiAffinity = append(merged.PreferredPodAntiAffinity, option.PreferredPodAntiAffinity...)
 	}
 
-	return merged
+	if len(option.TopologySpreadConstraints) > 0 {
+		merged.TopologySpreadConstraints = append(merged.TopologySpreadConstraints, option.TopologySpreadConstraints...)
+	}
+
+	return merged, nil
+}
+
+func andNodeSelectors(left, right *corev1.NodeSelector) *corev1.NodeSelector {
+	if left == nil {
+		if right == nil {
+			return nil
+		}
+		return right.DeepCopy()
+	}
+	if right == nil {
+		return left.DeepCopy()
+	}
+	if len(left.NodeSelectorTerms) == 0 {
+		return right.DeepCopy()
+	}
+	if len(right.NodeSelectorTerms) == 0 {
+		return left.DeepCopy()
+	}
+
+	out := &corev1.NodeSelector{
+		NodeSelectorTerms: make([]corev1.NodeSelectorTerm, 0, len(left.NodeSelectorTerms)*len(right.NodeSelectorTerms)),
+	}
+	for _, leftTerm := range left.NodeSelectorTerms {
+		for _, rightTerm := range right.NodeSelectorTerms {
+			term := corev1.NodeSelectorTerm{}
+			term.MatchExpressions = append(term.MatchExpressions, leftTerm.MatchExpressions...)
+			term.MatchExpressions = append(term.MatchExpressions, rightTerm.MatchExpressions...)
+			term.MatchFields = append(term.MatchFields, leftTerm.MatchFields...)
+			term.MatchFields = append(term.MatchFields, rightTerm.MatchFields...)
+			out.NodeSelectorTerms = append(out.NodeSelectorTerms, term)
+		}
+	}
+	return out
 }
 
 // resolveClusterPatterns expands cluster patterns (e.g., "*", "prod-*") to actual cluster names.

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -3291,6 +3291,33 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		}
 	})
 
+	t.Run("topology spread constraints are additive", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+			}},
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				MaxSkew:           2,
+				TopologyKey:       "topology.kubernetes.io/zone",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+			}},
+		}
+
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.TopologySpreadConstraints, 2)
+		assert.Equal(t, "kubernetes.io/hostname", result.TopologySpreadConstraints[0].TopologyKey)
+		assert.Equal(t, "topology.kubernetes.io/zone", result.TopologySpreadConstraints[1].TopologyKey)
+
+		result.TopologySpreadConstraints[0].TopologyKey = "mutated"
+		assert.Equal(t, "kubernetes.io/hostname", base.TopologySpreadConstraints[0].TopologyKey)
+	})
+
 	t.Run("denied node label wildcard cannot be weakened by exact value", func(t *testing.T) {
 		base := &breakglassv1alpha1.SchedulingConstraints{
 			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "*"},

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -3195,6 +3195,20 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 // ============================================================================
 
 func TestMergeSchedulingConstraints(t *testing.T) {
+	nodeSelectorWithTerms := func(count int, key string) *corev1.NodeSelector {
+		terms := make([]corev1.NodeSelectorTerm, 0, count)
+		for i := 0; i < count; i++ {
+			terms = append(terms, corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key:      key,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{fmt.Sprintf("value-%d", i)},
+				}},
+			})
+		}
+		return &corev1.NodeSelector{NodeSelectorTerms: terms}
+	}
+
 	t.Run("nil base and option returns nil", func(t *testing.T) {
 		result, err := mergeSchedulingConstraints(nil, nil)
 		require.NoError(t, err)
@@ -3291,6 +3305,38 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		}
 	})
 
+	t.Run("required node affinity permits single-term fast path up to limit", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: nodeSelectorWithTerms(1, "pool"),
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: nodeSelectorWithTerms(maxRequiredNodeSelectorTerms, "zone"),
+		}
+
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.RequiredNodeAffinity)
+		require.Len(t, result.RequiredNodeAffinity.NodeSelectorTerms, maxRequiredNodeSelectorTerms)
+		for _, term := range result.RequiredNodeAffinity.NodeSelectorTerms {
+			assert.Len(t, term.MatchExpressions, 2)
+		}
+	})
+
+	t.Run("required node affinity rejects oversized cross product", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: nodeSelectorWithTerms(13, "pool"),
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: nodeSelectorWithTerms(10, "zone"),
+		}
+
+		result, err := mergeSchedulingConstraints(base, option)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "would exceed maximum")
+	})
+
 	t.Run("topology spread constraints are additive", func(t *testing.T) {
 		base := &breakglassv1alpha1.SchedulingConstraints{
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
@@ -3330,6 +3376,29 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, "*", result.DeniedNodeLabels["node-role.kubernetes.io/control-plane"])
+	})
+
+	t.Run("invalid denied node label key is rejected", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"invalid/key/too/many": "true"},
+		}
+
+		result, err := mergeSchedulingConstraints(base, nil)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "deniedNodeLabels key")
+	})
+
+	t.Run("invalid denied node label value is rejected", func(t *testing.T) {
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/debug": "bad/value"},
+		}
+
+		result, err := mergeSchedulingConstraints(nil, option)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "deniedNodeLabels")
+		assert.Contains(t, err.Error(), "value")
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -3140,6 +3141,53 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 		// Option overlay
 		assert.Equal(t, "nvidia", resolved.NodeSelector["accelerator"])
 	})
+
+	t.Run("rejects option that conflicts with mandatory node selector", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				SchedulingConstraints: &breakglassv1alpha1.SchedulingConstraints{
+					NodeSelector: map[string]string{"node-pool": "restricted"},
+				},
+				SchedulingOptions: &breakglassv1alpha1.SchedulingOptions{
+					Options: []breakglassv1alpha1.SchedulingOption{
+						{
+							Name: "general",
+							SchedulingConstraints: &breakglassv1alpha1.SchedulingConstraints{
+								NodeSelector: map[string]string{"node-pool": "general"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "general", nil, requester)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicts with mandatory constraints")
+		assert.Contains(t, err.Error(), "nodeSelector")
+	})
+
+	t.Run("rejects binding that conflicts with template mandatory node selector", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				SchedulingConstraints: &breakglassv1alpha1.SchedulingConstraints{
+					NodeSelector: map[string]string{"node-pool": "restricted"},
+				},
+			},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				SchedulingConstraints: &breakglassv1alpha1.SchedulingConstraints{
+					NodeSelector: map[string]string{"node-pool": "general"},
+				},
+			},
+		}
+
+		_, _, err := ctrl.resolveSchedulingConstraints(template, "", binding, requester)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "binding scheduling constraints conflict")
+		assert.Contains(t, err.Error(), "nodeSelector")
+	})
 }
 
 // ============================================================================
@@ -3148,7 +3196,8 @@ func TestResolveSchedulingConstraints(t *testing.T) {
 
 func TestMergeSchedulingConstraints(t *testing.T) {
 	t.Run("nil base and option returns nil", func(t *testing.T) {
-		result := mergeSchedulingConstraints(nil, nil)
+		result, err := mergeSchedulingConstraints(nil, nil)
+		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
@@ -3156,7 +3205,8 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		option := &breakglassv1alpha1.SchedulingConstraints{
 			NodeSelector: map[string]string{"key": "value"},
 		}
-		result := mergeSchedulingConstraints(nil, option)
+		result, err := mergeSchedulingConstraints(nil, option)
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, "value", result.NodeSelector["key"])
 		// Ensure it's a copy
@@ -3168,23 +3218,38 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		base := &breakglassv1alpha1.SchedulingConstraints{
 			NodeSelector: map[string]string{"key": "value"},
 		}
-		result := mergeSchedulingConstraints(base, nil)
+		result, err := mergeSchedulingConstraints(base, nil)
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, "value", result.NodeSelector["key"])
 	})
 
-	t.Run("option overrides base for conflicts", func(t *testing.T) {
+	t.Run("option adds node selector keys without replacing mandatory keys", func(t *testing.T) {
 		base := &breakglassv1alpha1.SchedulingConstraints{
 			NodeSelector: map[string]string{"shared": "base-value", "base-only": "base"},
 		}
 		option := &breakglassv1alpha1.SchedulingConstraints{
-			NodeSelector: map[string]string{"shared": "option-value", "option-only": "option"},
+			NodeSelector: map[string]string{"shared": "base-value", "option-only": "option"},
 		}
-		result := mergeSchedulingConstraints(base, option)
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
 		require.NotNil(t, result)
-		assert.Equal(t, "option-value", result.NodeSelector["shared"])
+		assert.Equal(t, "base-value", result.NodeSelector["shared"])
 		assert.Equal(t, "base", result.NodeSelector["base-only"])
 		assert.Equal(t, "option", result.NodeSelector["option-only"])
+	})
+
+	t.Run("option cannot replace mandatory node selector value", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			NodeSelector: map[string]string{"shared": "base-value"},
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			NodeSelector: map[string]string{"shared": "option-value"},
+		}
+		result, err := mergeSchedulingConstraints(base, option)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "nodeSelector")
 	})
 
 	t.Run("denied nodes are additive", func(t *testing.T) {
@@ -3194,11 +3259,50 @@ func TestMergeSchedulingConstraints(t *testing.T) {
 		option := &breakglassv1alpha1.SchedulingConstraints{
 			DeniedNodes: []string{"node-c"},
 		}
-		result := mergeSchedulingConstraints(base, option)
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Len(t, result.DeniedNodes, 3)
 		assert.Contains(t, result.DeniedNodes, "node-a")
 		assert.Contains(t, result.DeniedNodes, "node-c")
+	})
+
+	t.Run("required node affinity is ANDed by cross product", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"debug"}}}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"ops"}}}},
+			}},
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			RequiredNodeAffinity: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"}}}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"b"}}}},
+			}},
+		}
+
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.RequiredNodeAffinity)
+		require.Len(t, result.RequiredNodeAffinity.NodeSelectorTerms, 4)
+		for _, term := range result.RequiredNodeAffinity.NodeSelectorTerms {
+			assert.Len(t, term.MatchExpressions, 2)
+		}
+	})
+
+	t.Run("denied node label wildcard cannot be weakened by exact value", func(t *testing.T) {
+		base := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "*"},
+		}
+		option := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "false"},
+		}
+
+		result, err := mergeSchedulingConstraints(base, option)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "*", result.DeniedNodeLabels["node-role.kubernetes.io/control-plane"])
 	})
 }
 

--- a/pkg/breakglass/debug/debug_session_reconciler_rendering.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_rendering.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -558,6 +559,7 @@ func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstrain
 			exactNodes = append(exactNodes, node)
 		}
 		if len(exactNodes) > 0 {
+			sort.Strings(exactNodes)
 			term.MatchFields = append(term.MatchFields, corev1.NodeSelectorRequirement{
 				Key:      "metadata.name",
 				Operator: corev1.NodeSelectorOpNotIn,
@@ -566,7 +568,13 @@ func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstrain
 		}
 	}
 
-	for key, value := range constraints.DeniedNodeLabels {
+	deniedLabelKeys := make([]string, 0, len(constraints.DeniedNodeLabels))
+	for key := range constraints.DeniedNodeLabels {
+		deniedLabelKeys = append(deniedLabelKeys, key)
+	}
+	sort.Strings(deniedLabelKeys)
+	for _, key := range deniedLabelKeys {
+		value := constraints.DeniedNodeLabels[key]
 		requirement := corev1.NodeSelectorRequirement{
 			Key: key,
 		}

--- a/pkg/breakglass/debug/debug_session_reconciler_rendering.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_rendering.go
@@ -449,9 +449,12 @@ func (c *DebugSessionController) buildPodDisruptionBudget(ds *breakglassv1alpha1
 
 // applySchedulingConstraints applies SchedulingConstraints to a PodSpec.
 // This merges the constraints with any existing scheduling configuration.
-func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec, constraints *breakglassv1alpha1.SchedulingConstraints) {
+func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec, constraints *breakglassv1alpha1.SchedulingConstraints) error {
 	if constraints == nil {
-		return
+		return nil
+	}
+	if err := validateSchedulingConstraints(constraints, "schedulingConstraints"); err != nil {
+		return err
 	}
 
 	// Apply node selector (merge, constraints take precedence)
@@ -483,10 +486,14 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 			if spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
 				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = constraints.RequiredNodeAffinity.DeepCopy()
 			} else {
-				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = andNodeSelectors(
+				combined, err := andNodeSelectors(
 					spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 					constraints.RequiredNodeAffinity,
 				)
+				if err != nil {
+					return fmt.Errorf("requiredNodeAffinity: %w", err)
+				}
+				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = combined
 			}
 		}
 
@@ -528,7 +535,10 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 	}
 
 	if len(constraints.DeniedNodes) > 0 || len(constraints.DeniedNodeLabels) > 0 {
-		deniedSelector := buildDeniedNodeSelector(constraints)
+		deniedSelector, err := buildDeniedNodeSelector(constraints)
+		if err != nil {
+			return err
+		}
 		if deniedSelector != nil {
 			if spec.Affinity == nil {
 				spec.Affinity = &corev1.Affinity{}
@@ -536,17 +546,25 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 			if spec.Affinity.NodeAffinity == nil {
 				spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			}
-			spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = andNodeSelectors(
+			combined, err := andNodeSelectors(
 				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 				deniedSelector,
 			)
+			if err != nil {
+				return fmt.Errorf("deniedNodeLabels: %w", err)
+			}
+			spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = combined
 		}
 	}
+	return nil
 }
 
-func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstraints) *corev1.NodeSelector {
+func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstraints) (*corev1.NodeSelector, error) {
 	if constraints == nil || (len(constraints.DeniedNodes) == 0 && len(constraints.DeniedNodeLabels) == 0) {
-		return nil
+		return nil, nil
+	}
+	if err := validateDeniedNodeLabels(constraints.DeniedNodeLabels, "schedulingConstraints"); err != nil {
+		return nil, err
 	}
 
 	term := corev1.NodeSelectorTerm{}
@@ -588,9 +606,9 @@ func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstrain
 	}
 
 	if len(term.MatchFields) == 0 && len(term.MatchExpressions) == 0 {
-		return nil
+		return nil, nil
 	}
-	return &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{term}}
+	return &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{term}}, nil
 }
 
 // convertDebugPodSpec converts our DebugPodSpecInner to corev1.PodSpec

--- a/pkg/breakglass/debug/debug_session_reconciler_rendering.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_rendering.go
@@ -551,7 +551,7 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 				deniedSelector,
 			)
 			if err != nil {
-				return fmt.Errorf("deniedNodeLabels: %w", err)
+				return fmt.Errorf("merge denied node scheduling selector: %w", err)
 			}
 			spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = combined
 		}

--- a/pkg/breakglass/debug/debug_session_reconciler_rendering.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_rendering.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"fmt"
+	"strings"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -481,10 +482,9 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 			if spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
 				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = constraints.RequiredNodeAffinity.DeepCopy()
 			} else {
-				// AND the node selector terms
-				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-					spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-					constraints.RequiredNodeAffinity.NodeSelectorTerms...,
+				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = andNodeSelectors(
+					spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+					constraints.RequiredNodeAffinity,
 				)
 			}
 		}
@@ -526,16 +526,63 @@ func (c *DebugSessionController) applySchedulingConstraints(spec *corev1.PodSpec
 		spec.TopologySpreadConstraints = append(spec.TopologySpreadConstraints, constraints.TopologySpreadConstraints...)
 	}
 
-	// Note: deniedNodes and deniedNodeLabels are advisory constraints
-	// They should be enforced via admission webhooks or node anti-affinity rules
-	// Here we convert them to node anti-affinity expressions
 	if len(constraints.DeniedNodes) > 0 || len(constraints.DeniedNodeLabels) > 0 {
-		c.log.Debugw("Denied nodes/labels configured",
-			"deniedNodes", constraints.DeniedNodes,
-			"deniedNodeLabels", constraints.DeniedNodeLabels)
-		// These are enforced at the admission webhook level for hard blocks
-		// For soft enforcement, we could add them as preferredNodeAffinity with negative weight
+		deniedSelector := buildDeniedNodeSelector(constraints)
+		if deniedSelector != nil {
+			if spec.Affinity == nil {
+				spec.Affinity = &corev1.Affinity{}
+			}
+			if spec.Affinity.NodeAffinity == nil {
+				spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+			}
+			spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = andNodeSelectors(
+				spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+				deniedSelector,
+			)
+		}
 	}
+}
+
+func buildDeniedNodeSelector(constraints *breakglassv1alpha1.SchedulingConstraints) *corev1.NodeSelector {
+	if constraints == nil || (len(constraints.DeniedNodes) == 0 && len(constraints.DeniedNodeLabels) == 0) {
+		return nil
+	}
+
+	term := corev1.NodeSelectorTerm{}
+	if len(constraints.DeniedNodes) > 0 {
+		exactNodes := make([]string, 0, len(constraints.DeniedNodes))
+		for _, node := range constraints.DeniedNodes {
+			if strings.ContainsAny(node, "*?[") {
+				continue
+			}
+			exactNodes = append(exactNodes, node)
+		}
+		if len(exactNodes) > 0 {
+			term.MatchFields = append(term.MatchFields, corev1.NodeSelectorRequirement{
+				Key:      "metadata.name",
+				Operator: corev1.NodeSelectorOpNotIn,
+				Values:   exactNodes,
+			})
+		}
+	}
+
+	for key, value := range constraints.DeniedNodeLabels {
+		requirement := corev1.NodeSelectorRequirement{
+			Key: key,
+		}
+		if value == "*" {
+			requirement.Operator = corev1.NodeSelectorOpDoesNotExist
+		} else {
+			requirement.Operator = corev1.NodeSelectorOpNotIn
+			requirement.Values = []string{value}
+		}
+		term.MatchExpressions = append(term.MatchExpressions, requirement)
+	}
+
+	if len(term.MatchFields) == 0 && len(term.MatchExpressions) == 0 {
+		return nil
+	}
+	return &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{term}}
 }
 
 // convertDebugPodSpec converts our DebugPodSpecInner to corev1.PodSpec

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -3529,8 +3530,11 @@ func TestApplySchedulingConstraints(t *testing.T) {
 	t.Run("enforces denied exact nodes and labels as required node affinity", func(t *testing.T) {
 		spec := &corev1.PodSpec{}
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
-			DeniedNodes:      []string{"bad-node-1", "bad-node-2"},
-			DeniedNodeLabels: map[string]string{"tainted": "true"},
+			DeniedNodes: []string{"bad-node-2", "bad-node-1"},
+			DeniedNodeLabels: map[string]string{
+				"tainted":                               "true",
+				"node-role.kubernetes.io/control-plane": "*",
+			},
 		}
 		ctrl.applySchedulingConstraints(spec, constraints)
 		require.NotNil(t, spec.Affinity)
@@ -3542,11 +3546,20 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		require.Len(t, term.MatchFields, 1)
 		assert.Equal(t, "metadata.name", term.MatchFields[0].Key)
 		assert.Equal(t, corev1.NodeSelectorOpNotIn, term.MatchFields[0].Operator)
-		assert.ElementsMatch(t, []string{"bad-node-1", "bad-node-2"}, term.MatchFields[0].Values)
-		require.Len(t, term.MatchExpressions, 1)
-		assert.Equal(t, "tainted", term.MatchExpressions[0].Key)
-		assert.Equal(t, corev1.NodeSelectorOpNotIn, term.MatchExpressions[0].Operator)
-		assert.Equal(t, []string{"true"}, term.MatchExpressions[0].Values)
+		assert.Equal(t, []string{"bad-node-1", "bad-node-2"}, term.MatchFields[0].Values)
+		require.Len(t, term.MatchExpressions, 2)
+		assert.Equal(t, "node-role.kubernetes.io/control-plane", term.MatchExpressions[0].Key)
+		assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, term.MatchExpressions[0].Operator)
+		assert.Empty(t, term.MatchExpressions[0].Values)
+		assert.Equal(t, "tainted", term.MatchExpressions[1].Key)
+		assert.Equal(t, corev1.NodeSelectorOpNotIn, term.MatchExpressions[1].Operator)
+		assert.Equal(t, []string{"true"}, term.MatchExpressions[1].Values)
+
+		selector, err := labels.Parse("tainted notin (true)")
+		require.NoError(t, err)
+		assert.True(t, selector.Matches(labels.Set{}), "Kubernetes NotIn permits nodes without the label key")
+		assert.True(t, selector.Matches(labels.Set{"tainted": "false"}))
+		assert.False(t, selector.Matches(labels.Set{"tainted": "true"}))
 	})
 
 	t.Run("enforces denied wildcard labels as label absence", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -3302,7 +3302,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		spec := &corev1.PodSpec{
 			NodeSelector: map[string]string{"existing": "selector"},
 		}
-		ctrl.applySchedulingConstraints(spec, nil)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, nil))
 		assert.Equal(t, map[string]string{"existing": "selector"}, spec.NodeSelector)
 	})
 
@@ -3314,7 +3314,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				"zone":      "us-east-1a",
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Equal(t, map[string]string{
 			"node-pool": "debug",
 			"zone":      "us-east-1a",
@@ -3328,7 +3328,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
 			NodeSelector: map[string]string{"constraint": "value"},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Equal(t, map[string]string{
 			"existing":   "value",
 			"constraint": "value",
@@ -3342,7 +3342,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
 			NodeSelector: map[string]string{"key": "new-value"},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Equal(t, map[string]string{"key": "new-value"}, spec.NodeSelector)
 	})
 
@@ -3357,7 +3357,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				{Key: "new", Value: "value", Effect: corev1.TaintEffectNoSchedule},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Len(t, spec.Tolerations, 2)
 		assert.Equal(t, "existing", spec.Tolerations[0].Key)
 		assert.Equal(t, "new", spec.Tolerations[1].Key)
@@ -3376,7 +3376,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		require.NotNil(t, spec.Affinity)
 		require.NotNil(t, spec.Affinity.NodeAffinity)
 		require.NotNil(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
@@ -3410,7 +3410,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		// Kubernetes ORs node selector terms, so AND requires combining both
 		// expressions into the same resulting term.
 		require.Len(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, 1)
@@ -3431,7 +3431,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		require.NotNil(t, spec.Affinity)
 		require.NotNil(t, spec.Affinity.NodeAffinity)
 		assert.Len(t, spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
@@ -3450,7 +3450,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		require.NotNil(t, spec.Affinity)
 		require.NotNil(t, spec.Affinity.PodAntiAffinity)
 		assert.Len(t, spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, 1)
@@ -3473,7 +3473,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		require.NotNil(t, spec.Affinity)
 		require.NotNil(t, spec.Affinity.PodAntiAffinity)
 		assert.Len(t, spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
@@ -3513,7 +3513,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 			DeniedNodes:      []string{"node-1"},
 			DeniedNodeLabels: map[string]string{"exclude": "true"},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 
 		// Verify all constraints applied
 		assert.Equal(t, map[string]string{"pool": "debug"}, spec.NodeSelector)
@@ -3536,7 +3536,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				"node-role.kubernetes.io/control-plane": "*",
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		require.NotNil(t, spec.Affinity)
 		require.NotNil(t, spec.Affinity.NodeAffinity)
 		required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
@@ -3567,7 +3567,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
 			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "*"},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 		require.NotNil(t, required)
 		require.Len(t, required.NodeSelectorTerms, 1)
@@ -3583,7 +3583,32 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
 			DeniedNodes: []string{"control-plane-*"},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
+		assert.Nil(t, spec.Affinity)
+	})
+
+	t.Run("rejects invalid denied node label key before rendering", func(t *testing.T) {
+		spec := &corev1.PodSpec{}
+		constraints := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"invalid/key/too/many": "true"},
+		}
+
+		err := ctrl.applySchedulingConstraints(spec, constraints)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deniedNodeLabels key")
+		assert.Nil(t, spec.Affinity)
+	})
+
+	t.Run("rejects invalid denied node label value before rendering", func(t *testing.T) {
+		spec := &corev1.PodSpec{}
+		constraints := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/debug": "bad/value"},
+		}
+
+		err := ctrl.applySchedulingConstraints(spec, constraints)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deniedNodeLabels")
+		assert.Contains(t, err.Error(), "value")
 		assert.Nil(t, spec.Affinity)
 	})
 
@@ -3601,7 +3626,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Len(t, spec.TopologySpreadConstraints, 1)
 		assert.Equal(t, int32(1), spec.TopologySpreadConstraints[0].MaxSkew)
 		assert.Equal(t, "topology.kubernetes.io/zone", spec.TopologySpreadConstraints[0].TopologyKey)
@@ -3627,7 +3652,7 @@ func TestApplySchedulingConstraints(t *testing.T) {
 				},
 			},
 		}
-		ctrl.applySchedulingConstraints(spec, constraints)
+		require.NoError(t, ctrl.applySchedulingConstraints(spec, constraints))
 		assert.Len(t, spec.TopologySpreadConstraints, 2)
 		assert.Equal(t, "kubernetes.io/hostname", spec.TopologySpreadConstraints[0].TopologyKey)
 		assert.Equal(t, "topology.kubernetes.io/zone", spec.TopologySpreadConstraints[1].TopologyKey)

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -3410,8 +3410,10 @@ func TestApplySchedulingConstraints(t *testing.T) {
 			},
 		}
 		ctrl.applySchedulingConstraints(spec, constraints)
-		// Both terms should be present (AND logic via multiple terms)
-		assert.Len(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, 2)
+		// Kubernetes ORs node selector terms, so AND requires combining both
+		// expressions into the same resulting term.
+		require.Len(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, 1)
+		assert.Len(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, 2)
 	})
 
 	t.Run("applies preferred node affinity", func(t *testing.T) {
@@ -3524,16 +3526,52 @@ func TestApplySchedulingConstraints(t *testing.T) {
 		assert.Len(t, spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
 	})
 
-	t.Run("handles denied nodes logging", func(t *testing.T) {
-		// This test ensures the code path for denied nodes is covered
+	t.Run("enforces denied exact nodes and labels as required node affinity", func(t *testing.T) {
 		spec := &corev1.PodSpec{}
 		constraints := &breakglassv1alpha1.SchedulingConstraints{
 			DeniedNodes:      []string{"bad-node-1", "bad-node-2"},
 			DeniedNodeLabels: map[string]string{"tainted": "true"},
 		}
-		// Should not panic, just log
 		ctrl.applySchedulingConstraints(spec, constraints)
-		// No assertions needed - just verifying no panic
+		require.NotNil(t, spec.Affinity)
+		require.NotNil(t, spec.Affinity.NodeAffinity)
+		required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		require.NotNil(t, required)
+		require.Len(t, required.NodeSelectorTerms, 1)
+		term := required.NodeSelectorTerms[0]
+		require.Len(t, term.MatchFields, 1)
+		assert.Equal(t, "metadata.name", term.MatchFields[0].Key)
+		assert.Equal(t, corev1.NodeSelectorOpNotIn, term.MatchFields[0].Operator)
+		assert.ElementsMatch(t, []string{"bad-node-1", "bad-node-2"}, term.MatchFields[0].Values)
+		require.Len(t, term.MatchExpressions, 1)
+		assert.Equal(t, "tainted", term.MatchExpressions[0].Key)
+		assert.Equal(t, corev1.NodeSelectorOpNotIn, term.MatchExpressions[0].Operator)
+		assert.Equal(t, []string{"true"}, term.MatchExpressions[0].Values)
+	})
+
+	t.Run("enforces denied wildcard labels as label absence", func(t *testing.T) {
+		spec := &corev1.PodSpec{}
+		constraints := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodeLabels: map[string]string{"node-role.kubernetes.io/control-plane": "*"},
+		}
+		ctrl.applySchedulingConstraints(spec, constraints)
+		required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		require.NotNil(t, required)
+		require.Len(t, required.NodeSelectorTerms, 1)
+		term := required.NodeSelectorTerms[0]
+		require.Len(t, term.MatchExpressions, 1)
+		assert.Equal(t, "node-role.kubernetes.io/control-plane", term.MatchExpressions[0].Key)
+		assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, term.MatchExpressions[0].Operator)
+		assert.Empty(t, term.MatchExpressions[0].Values)
+	})
+
+	t.Run("ignores denied node glob patterns that cannot be rendered as hard affinity", func(t *testing.T) {
+		spec := &corev1.PodSpec{}
+		constraints := &breakglassv1alpha1.SchedulingConstraints{
+			DeniedNodes: []string{"control-plane-*"},
+		}
+		ctrl.applySchedulingConstraints(spec, constraints)
+		assert.Nil(t, spec.Affinity)
 	})
 
 	t.Run("applies topology spread constraints", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -650,10 +650,14 @@ func (c *DebugSessionController) buildPodSpec(ds *breakglassv1alpha1.DebugSessio
 	// Apply resolved scheduling constraints from session
 	// These are computed at session creation time and take precedence
 	if ds.Spec.ResolvedSchedulingConstraints != nil {
-		c.applySchedulingConstraints(spec, ds.Spec.ResolvedSchedulingConstraints)
+		if err := c.applySchedulingConstraints(spec, ds.Spec.ResolvedSchedulingConstraints); err != nil {
+			return nil, fmt.Errorf("apply resolved scheduling constraints: %w", err)
+		}
 	} else if template.Spec.SchedulingConstraints != nil {
 		// Fallback to template constraints if session doesn't have resolved constraints
-		c.applySchedulingConstraints(spec, template.Spec.SchedulingConstraints)
+		if err := c.applySchedulingConstraints(spec, template.Spec.SchedulingConstraints); err != nil {
+			return nil, fmt.Errorf("apply template scheduling constraints: %w", err)
+		}
 	}
 
 	if template.Spec.ResourceQuota != nil {


### PR DESCRIPTION
## Summary
- reject DebugSession cluster bindings or selected scheduling options that try to replace mandatory `nodeSelector` values
- merge required node affinity with Kubernetes-correct AND semantics instead of appending OR terms
- render exact denied node names and denied node labels into hard node affinity on created debug workloads
- document the exact enforcement boundary for `deniedNodes` glob patterns

## Finding Evidence
A DebugSession scheduling option or cluster binding could previously replace base mandatory scheduling selectors because `mergeSchedulingConstraints` overwrote conflicting `nodeSelector` and `deniedNodeLabels` entries. Required node affinity was appended as additional `NodeSelectorTerms`, but Kubernetes ORs those terms, so the resulting workload could satisfy only the option/binding term instead of both the mandatory base term and the selected option term. `deniedNodes` and `deniedNodeLabels` were only logged during rendering and did not constrain the workload.

Affected files:
- `pkg/breakglass/debug/debug_session_api_constraints.go`
- `pkg/breakglass/debug/debug_session_reconciler_rendering.go`

## Duplicate Check
Open PR searches before implementation found no existing PR covering this specific scheduling-constraint merge or denied-node enforcement issue:
- `DebugSession scheduling constraints nodeSelector deniedNodes`
- `debug scheduling option nodeSelector`
- `deniedNodeLabels DebugSession`

Related open DebugSession PRs cover namespace constraints, binding ACLs, lifecycle expiry, and pod operations, but not scheduling constraint composition.

## Validation
- `go test ./pkg/breakglass/debug -run 'TestResolveSchedulingConstraints|TestMergeSchedulingConstraints|TestApplySchedulingConstraints' -count=1`
- `go test ./pkg/breakglass/debug -count=1`
- `make lint`
- `git diff --check`

## Screenshots
Not applicable: this PR changes backend scheduling validation/rendering and documentation only; no UI changed.
