### PR TITLE
docs: list idle-expired session state

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,7 +142,7 @@ The `state` parameter in list/filter operations supports filtering by session st
 - `waiting`, `waitingforscheduledtime`, `scheduled` - Sessions waiting for their scheduled start time
 - `rejected` - Rejected by approver (terminal)
 - `withdrawn` - Withdrawn by requester (terminal)
-- `expired` - Exceeded max duration (terminal)
+- `expired` - Recorded `Expired` state, or an approved session whose `status.expiresAt` has passed
 - `idleexpired` - Exceeded configured idle timeout (terminal)
 - `timeout`, `approvaltimeout` - Approval request timed out (terminal)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -92,7 +92,7 @@ The breakglass API implements a **state-first validation architecture**:
 ### State Priority Rules
 
 1. **State is ultimate authority** - A session's `state` field determines validity, not timestamps
-2. **Terminal states override timestamps** - Sessions in Rejected, Withdrawn, Expired, or ApprovalTimeout states can NEVER be valid, regardless of timestamp values
+2. **Terminal states override timestamps** - Sessions in Rejected, Withdrawn, Expired, IdleExpired, or ApprovalTimeout states can NEVER be valid, regardless of timestamp values
 3. **Timestamp preservation** - Timestamps are never cleared, only added/updated, creating a complete audit history
 
 ### Session Validity Rules
@@ -100,7 +100,7 @@ The breakglass API implements a **state-first validation architecture**:
 A session is considered valid for access ONLY if:
 
 1. **State is Approved** - Session must be in `Approved` state
-2. **Not in terminal state** - Must not be in Rejected, Withdrawn, Expired, or ApprovalTimeout
+2. **Not in terminal state** - Must not be in Rejected, Withdrawn, Expired, IdleExpired, or ApprovalTimeout
 3. **Not scheduled for future** - If `scheduledStartTime` is in the future, session is not yet valid
 4. **Not expired** - `expiresAt` timestamp must be in the future
 
@@ -109,7 +109,7 @@ A session is considered valid for access ONLY if:
 ```go
 isSessionValid(session) {
     // Terminal states override everything
-    if (session.state in [Rejected, Withdrawn, Expired, ApprovalTimeout]) {
+    if (session.state in [Rejected, Withdrawn, Expired, IdleExpired, ApprovalTimeout]) {
         return false
     }
     
@@ -140,6 +140,7 @@ The `state` parameter in list/filter operations supports filtering by session st
 - `rejected` - Rejected by approver (terminal)
 - `withdrawn` - Withdrawn by requester (terminal)
 - `expired` - Exceeded max duration (terminal)
+- `idleexpired` - Exceeded configured idle timeout (terminal)
 - `timeout` - Approval request timed out (terminal)
 
 **Note:** Filtering by state uses the session's `state` field directly. Timestamp-based validation (e.g., expiration) happens at access time via `isSessionValid()`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,15 +135,18 @@ isSessionValid(session) {
 
 The `state` parameter in list/filter operations supports filtering by session state. Valid values:
 
+- `all` - Disable state filtering
 - `pending` - Sessions awaiting approval
 - `approved` - Active sessions granting privileges
+- `active` - Currently valid sessions (`Approved` and not expired)
+- `waiting`, `waitingforscheduledtime`, `scheduled` - Sessions waiting for their scheduled start time
 - `rejected` - Rejected by approver (terminal)
 - `withdrawn` - Withdrawn by requester (terminal)
 - `expired` - Exceeded max duration (terminal)
 - `idleexpired` - Exceeded configured idle timeout (terminal)
-- `timeout` - Approval request timed out (terminal)
+- `timeout`, `approvaltimeout` - Approval request timed out (terminal)
 
-**Note:** Filtering by state uses the session's `state` field directly. Timestamp-based validation (e.g., expiration) happens at access time via `isSessionValid()`.
+**Note:** Most state tokens compare the session's recorded `status.state`. The `expired` token also matches approved sessions whose `status.expiresAt` has passed, and `active` matches only approved sessions that are currently valid according to access-time checks.
 
 ## Breakglass Session API
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -137,8 +137,8 @@ The `state` parameter in list/filter operations supports filtering by session st
 
 - `all` - Disable state filtering
 - `pending` - Sessions awaiting approval
-- `approved` - Active sessions granting privileges
-- `active` - Currently valid sessions (`Approved` and not expired)
+- `approved` - Sessions whose recorded `status.state` is `Approved`
+- `active` - Currently valid approved sessions according to scheduled-start and expiry checks
 - `waiting`, `waitingforscheduledtime`, `scheduled` - Sessions waiting for their scheduled start time
 - `rejected` - Rejected by approver (terminal)
 - `withdrawn` - Withdrawn by requester (terminal)

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -5882,8 +5882,13 @@ func TestFilterBreakglassSessions_ExhaustivePermutations(t *testing.T) {
 		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2@example.com", GrantedGroup: "g1"},
 		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateExpired, ExpiresAt: metav1.NewTime(now.Add(-time.Hour))},
 	}
+	s7 := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s7"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2@example.com", GrantedGroup: "g2"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateIdleExpired, LastActivity: &metav1.Time{Time: now.Add(-time.Hour)}},
+	}
 
-	cli := builder.WithObjects(s1, s2, s3, s4, s5, s6).Build()
+	cli := builder.WithObjects(s1, s2, s3, s4, s5, s6, s7).Build()
 	sesmanager := SessionManager{Client: cli}
 	escmanager := testEscalationLookup{Client: cli}
 	logger, _ := zap.NewDevelopment()
@@ -5917,12 +5922,13 @@ func TestFilterBreakglassSessions_ExhaustivePermutations(t *testing.T) {
 	}{
 		{"cluster_c1_mine_u1", "cluster=c1&mine=true", "u1@example.com", []string{"s1", "s5"}},
 		{"cluster_c1_user_u2_mine", "cluster=c1&user=u2@example.com&mine=true", "u2@example.com", []string{"s2"}},
-		{"user_u2_mine", "user=u2@example.com&mine=true", "u2@example.com", []string{"s2", "s4", "s6"}},
+		{"user_u2_mine", "user=u2@example.com&mine=true", "u2@example.com", []string{"s2", "s4", "s6", "s7"}},
 		{"group_g1_mine_u1", "group=g1&mine=true", "u1@example.com", []string{"s1"}},
 		{"cluster_c2_group_g2_mine_u1", "cluster=c2&group=g2&mine=true", "u1@example.com", []string{"s3"}},
 		{"state_pending_mine_u2", "state=pending&mine=true", "u2@example.com", []string{"s4"}},
 		{"state_approved_mine_u2", "state=approved&mine=true", "u2@example.com", []string{"s2"}},
 		{"cluster_c2_state_expired_mine_u2", "cluster=c2&state=expired&mine=true", "u2@example.com", []string{"s6"}},
+		{"cluster_c2_state_idleexpired_mine_u2", "cluster=c2&state=idleexpired&mine=true", "u2@example.com", []string{"s7"}},
 		{"user_u1_group_g2_mine", "user=u1@example.com&group=g2&mine=true", "u1@example.com", []string{"s3", "s5"}},
 	}
 

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -5882,10 +5882,11 @@ func TestFilterBreakglassSessions_ExhaustivePermutations(t *testing.T) {
 		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2@example.com", GrantedGroup: "g1"},
 		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateExpired, ExpiresAt: metav1.NewTime(now.Add(-time.Hour))},
 	}
+	lastActivity := metav1.NewTime(now.Add(-time.Hour))
 	s7 := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "s7"},
 		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "c2", User: "u2@example.com", GrantedGroup: "g2"},
-		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateIdleExpired, LastActivity: &metav1.Time{Time: now.Add(-time.Hour)}},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateIdleExpired, LastActivity: &lastActivity},
 	}
 
 	cli := builder.WithObjects(s1, s2, s3, s4, s5, s6, s7).Build()


### PR DESCRIPTION
## Summary
- document `IdleExpired` as a terminal BreakglassSession state in the API reference
- list `idleexpired` as a supported session `state` filter token
- add an `IdleExpired` fixture to the exhaustive session filter test

## Evidence
- `pkg/breakglass/session_controller_approval_utils.go` already accepts `state=idleexpired`
- `api/v1alpha1/breakglass_session_types.go` already defines `IdleExpired`
- the API reference omitted both the terminal state and filter token

## Validation
- `go test ./pkg/breakglass -run TestFilterBreakglassSessions_ExhaustivePermutations -count=1`
- `go test ./pkg/breakglass -count=1`
- `make lint`
- `git diff --check`

## Screenshots
- Not applicable; documentation/backend test update with no UI changes.