### PR TITLE
docs: fix debug template context casing

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/auxiliaryresource.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/auxiliaryresource.go
@@ -29,11 +29,11 @@ type AuxiliaryResourceApplyConfiguration struct {
 	Category *string `json:"category,omitempty"`
 	// templateString is a Go template that produces one or more YAML documents.
 	// Use `---` separator for multiple resources from one definition.
-	// Supports all context variables including {{ .Vars.* }} for user-provided values.
+	// Supports all context variables including {{ .vars.* }} for user-provided values.
 	// Mutually exclusive with template.
 	TemplateString *string `json:"templateString,omitempty"`
 	// template is the embedded resource template.
-	// Supports Go templating with session context variables using Sprout functions.
+	// Supports Go templating with session context variables using Sprig functions.
 	// See documentation for available variables and functions.
 	// Mutually exclusive with templateString.
 	// Deprecated: Use templateString for new templates. Removal target: v1beta1.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugpodtemplatespec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugpodtemplatespec.go
@@ -23,7 +23,7 @@ type DebugPodTemplateSpecApplyConfiguration struct {
 	// Mutually exclusive with templateString.
 	Template *DebugPodSpecApplyConfiguration `json:"template,omitempty"`
 	// templateString is an inline Go template that produces pod spec YAML.
-	// Supports Go templating with session context variables using Sprout functions.
+	// Supports Go templating with session context variables using Sprig functions.
 	// Mutually exclusive with template. Use this for dynamic pod specifications.
 	TemplateString *string `json:"templateString,omitempty"`
 }

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessiontemplatespec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/debugsessiontemplatespec.go
@@ -27,7 +27,7 @@ type DebugSessionTemplateSpecApplyConfiguration struct {
 	Mode *apiv1alpha1.DebugSessionTemplateMode `json:"mode,omitempty"`
 	// podTemplateRef references a DebugPodTemplate for the pod specification.
 	// Required when mode is "workload" or "hybrid".
-	// The referenced template can itself contain {{ .Vars.* }} placeholders.
+	// The referenced template can itself contain {{ .vars.* }} placeholders.
 	// Mutually exclusive with podTemplateString.
 	PodTemplateRef *DebugPodTemplateReferenceApplyConfiguration `json:"podTemplateRef,omitempty"`
 	// podTemplateString is an inline Go template that produces pod spec YAML.
@@ -40,7 +40,7 @@ type DebugSessionTemplateSpecApplyConfiguration struct {
 	PodOverridesTemplate *string `json:"podOverridesTemplate,omitempty"`
 	// extraDeployVariables defines user-provided variables for template rendering.
 	// These values are collected from the user at session request time
-	// and made available as {{ .Vars.<name> }} in all templates.
+	// and made available as {{ .vars.<name> }} in all templates.
 	ExtraDeployVariables []ExtraDeployVariableApplyConfiguration `json:"extraDeployVariables,omitempty"`
 	// workloadType specifies the type of workload to create (DaemonSet or Deployment).
 	// Required when mode is "workload" or "hybrid".

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/extradeployvariable.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/extradeployvariable.go
@@ -17,9 +17,9 @@ import (
 // with apply.
 //
 // ExtraDeployVariable defines a user-provided variable for template rendering.
-// Variables are available as {{ .Vars.<name> }} in all templates.
+// Variables are available as {{ .vars.<name> }} in all templates.
 type ExtraDeployVariableApplyConfiguration struct {
-	// name is the variable name, used as {{ .Vars.<name> }} in templates.
+	// name is the variable name, used as {{ .vars.<name> }} in templates.
 	// Must be a valid Go identifier (letters, digits, underscores, starting with letter).
 	Name *string `json:"name,omitempty"`
 	// displayName is the human-readable label shown in the UI.

--- a/api/v1alpha1/auxiliary_resource_types.go
+++ b/api/v1alpha1/auxiliary_resource_types.go
@@ -55,13 +55,13 @@ type AuxiliaryResource struct {
 
 	// templateString is a Go template that produces one or more YAML documents.
 	// Use `---` separator for multiple resources from one definition.
-	// Supports all context variables including {{ .Vars.* }} for user-provided values.
+	// Supports all context variables including {{ .vars.* }} for user-provided values.
 	// Mutually exclusive with template.
 	// +optional
 	TemplateString string `json:"templateString,omitempty"`
 
 	// template is the embedded resource template.
-	// Supports Go templating with session context variables using Sprout functions.
+	// Supports Go templating with session context variables using Sprig functions.
 	// See documentation for available variables and functions.
 	// Mutually exclusive with templateString.
 	// Deprecated: Use templateString for new templates. Removal target: v1beta1.
@@ -196,7 +196,7 @@ type AuxiliaryResourceContext struct {
 	Binding AuxiliaryResourceBindingContext `json:"binding"`
 
 	// Vars contains user-provided extraDeployValues.
-	// Access as {{ .Vars.variableName }} in templates.
+	// Access as {{ .vars.variableName }} in templates.
 	// +optional
 	Vars map[string]string `json:"vars,omitempty"`
 

--- a/api/v1alpha1/debug_pod_template_types.go
+++ b/api/v1alpha1/debug_pod_template_types.go
@@ -57,7 +57,7 @@ type DebugPodTemplateSpec struct {
 	Template *DebugPodSpec `json:"template,omitempty"`
 
 	// templateString is an inline Go template that produces pod spec YAML.
-	// Supports Go templating with session context variables using Sprout functions.
+	// Supports Go templating with session context variables using Sprig functions.
 	// Mutually exclusive with template. Use this for dynamic pod specifications.
 	// +optional
 	TemplateString string `json:"templateString,omitempty"`

--- a/api/v1alpha1/debug_session_template_types.go
+++ b/api/v1alpha1/debug_session_template_types.go
@@ -81,7 +81,7 @@ type DebugSessionTemplateSpec struct {
 
 	// podTemplateRef references a DebugPodTemplate for the pod specification.
 	// Required when mode is "workload" or "hybrid".
-	// The referenced template can itself contain {{ .Vars.* }} placeholders.
+	// The referenced template can itself contain {{ .vars.* }} placeholders.
 	// Mutually exclusive with podTemplateString.
 	// +optional
 	PodTemplateRef *DebugPodTemplateReference `json:"podTemplateRef,omitempty"`
@@ -100,7 +100,7 @@ type DebugSessionTemplateSpec struct {
 
 	// extraDeployVariables defines user-provided variables for template rendering.
 	// These values are collected from the user at session request time
-	// and made available as {{ .Vars.<name> }} in all templates.
+	// and made available as {{ .vars.<name> }} in all templates.
 	// +optional
 	ExtraDeployVariables []ExtraDeployVariable `json:"extraDeployVariables,omitempty"`
 

--- a/api/v1alpha1/extra_deploy_types.go
+++ b/api/v1alpha1/extra_deploy_types.go
@@ -51,9 +51,9 @@ const (
 )
 
 // ExtraDeployVariable defines a user-provided variable for template rendering.
-// Variables are available as {{ .Vars.<name> }} in all templates.
+// Variables are available as {{ .vars.<name> }} in all templates.
 type ExtraDeployVariable struct {
-	// name is the variable name, used as {{ .Vars.<name> }} in templates.
+	// name is the variable name, used as {{ .vars.<name> }} in templates.
 	// Must be a valid Go identifier (letters, digits, underscores, starting with letter).
 	// +required
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9_]*$`
@@ -202,7 +202,7 @@ type TemplateRenderContext struct {
 	Annotations map[string]string `json:"annotations"`
 
 	// Vars contains user-provided extraDeployValues.
-	// Access as {{ .Vars.variableName }}
+	// Access as {{ .vars.variableName }}
 	// +optional
 	Vars map[string]string `json:"vars,omitempty"`
 

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -952,7 +952,7 @@ func ValidateDebugSessionTemplate(template *DebugSessionTemplate) *ValidationRes
 // It builds a sample AuxiliaryResourceContext with placeholder values, executes the template,
 // and checks that the rendered output is valid YAML. Returns warnings (never errors) because
 // the sample data may not satisfy all template conditions.
-// vars provides extra deploy variable defaults to populate .Vars in the context.
+// vars provides extra deploy variable defaults to populate .vars in the context.
 func tryRenderTemplateString(templateStr string, vars map[string]string) []string {
 	if templateStr == "" || !strings.Contains(templateStr, "{{") {
 		return nil // Not a templated string, nothing to dry-run

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -2440,7 +2440,7 @@ func TestValidateAuxiliaryResources(t *testing.T) {
 		res := []AuxiliaryResource{
 			{
 				Name:           "test",
-				TemplateString: "kind: ConfigMap\nmetadata:\n  name: {{ .Session.Name }}",
+				TemplateString: "kind: ConfigMap\nmetadata:\n  name: {{ .session.name }}",
 			},
 		}
 		errs := validateAuxiliaryResources(res, fieldPath)
@@ -2804,7 +2804,7 @@ func TestValidateGoTemplateSyntax(t *testing.T) {
 		},
 		{
 			name:     "complex valid template",
-			template: "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {{ .Session.Name }}\n  labels:\n    {{- range $k, $v := .Labels }}\n    {{ $k }}: {{ $v | yamlQuote }}\n    {{- end }}",
+			template: "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {{ .session.name }}\n  labels:\n    {{- range $k, $v := .labels }}\n    {{ $k }}: {{ $v | yamlQuote }}\n    {{- end }}",
 			wantErr:  false,
 		},
 	}
@@ -2847,7 +2847,7 @@ func TestValidateAuxiliaryResources_InvalidTemplateSyntax(t *testing.T) {
 		res := []AuxiliaryResource{
 			{
 				Name:           "test",
-				TemplateString: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Session.Name }}",
+				TemplateString: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .session.name }}",
 			},
 		}
 		errs := validateAuxiliaryResources(res, fieldPath)

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugpodtemplates.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugpodtemplates.yaml
@@ -6646,7 +6646,7 @@ spec:
               templateString:
                 description: |-
                   templateString is an inline Go template that produces pod spec YAML.
-                  Supports Go templating with session context variables using Sprout functions.
+                  Supports Go templating with session context variables using Sprig functions.
                   Mutually exclusive with template. Use this for dynamic pod specifications.
                 type: string
             type: object

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
@@ -2745,7 +2745,7 @@ spec:
                         template:
                           description: |-
                             template is the embedded resource template.
-                            Supports Go templating with session context variables using Sprout functions.
+                            Supports Go templating with session context variables using Sprig functions.
                             See documentation for available variables and functions.
                             Mutually exclusive with templateString.
                             Deprecated: Use templateString for new templates. Removal target: v1beta1.
@@ -2755,7 +2755,7 @@ spec:
                           description: |-
                             templateString is a Go template that produces one or more YAML documents.
                             Use `---` separator for multiple resources from one definition.
-                            Supports all context variables including {{ .Vars.* }} for user-provided values.
+                            Supports all context variables including {{ .vars.* }} for user-provided values.
                             Mutually exclusive with template.
                           type: string
                       required:
@@ -2831,11 +2831,11 @@ spec:
                     description: |-
                       extraDeployVariables defines user-provided variables for template rendering.
                       These values are collected from the user at session request time
-                      and made available as {{ .Vars.<name> }} in all templates.
+                      and made available as {{ .vars.<name> }} in all templates.
                     items:
                       description: |-
                         ExtraDeployVariable defines a user-provided variable for template rendering.
-                        Variables are available as {{ .Vars.<name> }} in all templates.
+                        Variables are available as {{ .vars.<name> }} in all templates.
                       properties:
                         advanced:
                           description: |-
@@ -2879,7 +2879,7 @@ spec:
                           type: string
                         name:
                           description: |-
-                            name is the variable name, used as {{ .Vars.<name> }} in templates.
+                            name is the variable name, used as {{ .vars.<name> }} in templates.
                             Must be a valid Go identifier (letters, digits, underscores, starting with letter).
                           maxLength: 63
                           minLength: 1
@@ -4142,7 +4142,7 @@ spec:
                     description: |-
                       podTemplateRef references a DebugPodTemplate for the pod specification.
                       Required when mode is "workload" or "hybrid".
-                      The referenced template can itself contain {{ .Vars.* }} placeholders.
+                      The referenced template can itself contain {{ .vars.* }} placeholders.
                       Mutually exclusive with podTemplateString.
                     properties:
                       name:

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
@@ -1296,7 +1296,7 @@ spec:
                     template:
                       description: |-
                         template is the embedded resource template.
-                        Supports Go templating with session context variables using Sprout functions.
+                        Supports Go templating with session context variables using Sprig functions.
                         See documentation for available variables and functions.
                         Mutually exclusive with templateString.
                         Deprecated: Use templateString for new templates. Removal target: v1beta1.
@@ -1306,7 +1306,7 @@ spec:
                       description: |-
                         templateString is a Go template that produces one or more YAML documents.
                         Use `---` separator for multiple resources from one definition.
-                        Supports all context variables including {{ .Vars.* }} for user-provided values.
+                        Supports all context variables including {{ .vars.* }} for user-provided values.
                         Mutually exclusive with template.
                       type: string
                   required:
@@ -1382,11 +1382,11 @@ spec:
                 description: |-
                   extraDeployVariables defines user-provided variables for template rendering.
                   These values are collected from the user at session request time
-                  and made available as {{ .Vars.<name> }} in all templates.
+                  and made available as {{ .vars.<name> }} in all templates.
                 items:
                   description: |-
                     ExtraDeployVariable defines a user-provided variable for template rendering.
-                    Variables are available as {{ .Vars.<name> }} in all templates.
+                    Variables are available as {{ .vars.<name> }} in all templates.
                   properties:
                     advanced:
                       description: |-
@@ -1430,7 +1430,7 @@ spec:
                       type: string
                     name:
                       description: |-
-                        name is the variable name, used as {{ .Vars.<name> }} in templates.
+                        name is the variable name, used as {{ .vars.<name> }} in templates.
                         Must be a valid Go identifier (letters, digits, underscores, starting with letter).
                       maxLength: 63
                       minLength: 1
@@ -2687,7 +2687,7 @@ spec:
                 description: |-
                   podTemplateRef references a DebugPodTemplate for the pod specification.
                   Required when mode is "workload" or "hybrid".
-                  The referenced template can itself contain {{ .Vars.* }} placeholders.
+                  The referenced template can itself contain {{ .vars.* }} placeholders.
                   Mutually exclusive with podTemplateString.
                 properties:
                   name:

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -176,7 +176,7 @@ spec:
     {{- end }}
 ```
 
-The `templateString` supports all session context variables (`.session`, `.target`, `.vars`, etc.) using Sprout template functions. See [Template Context Variables](#template-context-variables) for the full list.
+The `templateString` supports all session context variables (`.session`, `.target`, `.vars`, etc.) using Sprig template functions. See [Template Context Variables](#template-context-variables) for the full list.
 
 > **Note:** `template` and `templateString` are mutually exclusive. The webhook will reject DebugPodTemplates with both fields set.
 
@@ -1040,12 +1040,12 @@ spec:
         apiVersion: networking.k8s.io/v1
         kind: NetworkPolicy
         metadata:
-          name: "debug-{{ .Session.Name }}-isolation"
-          namespace: "{{ .Session.Spec.TargetNamespace }}"
+          name: "debug-{{ .session.name }}-isolation"
+          namespace: "{{ .target.namespace }}"
         spec:
           podSelector:
             matchLabels:
-              breakglass.t-caas.telekom.com/session: "{{ .Session.Name }}"
+              breakglass.t-caas.telekom.com/session: "{{ .session.name }}"
           policyTypes:
             - Ingress
             - Egress
@@ -1073,14 +1073,14 @@ spec:
         apiVersion: v1
         kind: ServiceAccount
         metadata:
-          name: debug-{{ .Session.Name }}-sa
-          namespace: {{ .Target.Namespace }}
+          name: debug-{{ .session.name }}-sa
+          namespace: {{ .target.namespace }}
         ---
         apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
-          name: debug-{{ .Session.Name }}-role
-          namespace: {{ .Target.Namespace }}
+          name: debug-{{ .session.name }}-role
+          namespace: {{ .target.namespace }}
         rules:
           - apiGroups: [""]
             resources: ["pods", "pods/log"]
@@ -1089,15 +1089,15 @@ spec:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:
-          name: debug-{{ .Session.Name }}-binding
-          namespace: {{ .Target.Namespace }}
+          name: debug-{{ .session.name }}-binding
+          namespace: {{ .target.namespace }}
         subjects:
           - kind: ServiceAccount
-            name: debug-{{ .Session.Name }}-sa
-            namespace: {{ .Target.Namespace }}
+            name: debug-{{ .session.name }}-sa
+            namespace: {{ .target.namespace }}
         roleRef:
           kind: Role
-          name: debug-{{ .Session.Name }}-role
+          name: debug-{{ .session.name }}-role
           apiGroup: rbac.authorization.k8s.io
 ```
 
@@ -1132,13 +1132,13 @@ Auxiliary resource templates support Go templating with [Sprig functions](https:
 
 | Variable | Description |
 |----------|-------------|
-| `.Session.Name` | Debug session name |
-| `.Session.Namespace` | Session's namespace |
-| `.Session.Spec.Cluster` | Target cluster name |
-| `.Session.Spec.User` | Requesting user |
-| `.Session.Spec.TargetNamespace` | Target namespace for debug pods |
-| `.Session.Spec.Reason` | Session request reason |
-| `.Template.Name` | Template name |
+| `.session.name` | Debug session name |
+| `.session.namespace` | Session's namespace |
+| `.session.cluster` | Target cluster name |
+| `.session.requestedBy` | Requesting user |
+| `.target.namespace` | Target namespace for debug pods |
+| `.session.reason` | Session request reason |
+| `.template.name` | Template name |
 
 ### Lifecycle
 
@@ -1195,7 +1195,7 @@ Both pod templates and auxiliary resources support multi-document YAML for creat
 | **Readiness Tracking** | Basic (created/deleted) | Full kstatus monitoring |
 | **Categories** | Not categorized | Organized by category |
 | **Binding Requirements** | N/A | Can enforce required categories |
-| **Template Context** | `.session`, `.target`, `.vars` | `.Session`, `.Target`, `.Vars` |
+| **Template Context** | `.session`, `.target`, `.vars` | `.session`, `.target`, `.vars` |
 
 **Choose Pod Template Multi-Doc when:**
 - Resources are specific to this pod template (e.g., PVC for storage testing)

--- a/docs/extra-deploy-variables.md
+++ b/docs/extra-deploy-variables.md
@@ -35,7 +35,7 @@ Simple on/off toggle.
 
 **Usage in templates:**
 ```yaml
-{{- if eq .Vars.enableTcpdump "true" }}
+{{- if eq .vars.enableTcpdump "true" }}
 # Conditional content when enabled
 {{- end }}
 ```
@@ -58,7 +58,7 @@ Free-form text input with optional validation.
 
 **Usage in templates:**
 ```yaml
-namespace: customer-{{ .Vars.customerName | k8sName }}
+namespace: customer-{{ .vars.customerName | k8sName }}
 ```
 
 ### Number (`inputType: number`)
@@ -77,7 +77,7 @@ Numeric value with optional min/max constraints.
 
 **Usage in templates:**
 ```yaml
---iodepth={{ .Vars.ioDepth }}
+--iodepth={{ .vars.ioDepth }}
 ```
 
 ### Storage Size (`inputType: storageSize`)
@@ -96,7 +96,7 @@ Kubernetes quantity format for storage.
 
 **Usage in templates:**
 ```yaml
-sizeLimit: {{ .Vars.storageSize }}
+sizeLimit: {{ .vars.storageSize }}
 ```
 
 ### Select (`inputType: select`)
@@ -120,7 +120,7 @@ Single selection from predefined options.
 
 **Usage in templates:**
 ```yaml
-{{- if eq .Vars.networkMode "host" }}
+{{- if eq .vars.networkMode "host" }}
 hostNetwork: true
 {{- end }}
 ```
@@ -147,7 +147,7 @@ Multiple selections from predefined options.
 ```yaml
 capabilities:
   add:
-    {{- range $cap := split "," .Vars.capabilities }}
+    {{- range $cap := split "," .vars.capabilities }}
     - {{ $cap }}
     {{- end }}
 ```
@@ -217,10 +217,10 @@ The API error response includes the required groups:
 
 ```yaml
 # SAFE: User input is properly quoted
-label: {{ .Vars.customerName | yamlQuote }}
+label: {{ .vars.customerName | yamlQuote }}
 
 # UNSAFE: Could break YAML if input contains special chars
-label: {{ .Vars.customerName }}
+label: {{ .vars.customerName }}
 ```
 
 The `yamlQuote` function:
@@ -235,7 +235,7 @@ Sanitizes strings by replacing dangerous characters:
 ```yaml
 # Input: "test:value#comment"
 # Output: "test-value-comment"
-safe-label: {{ .Vars.userInput | yamlSafe }}
+safe-label: {{ .vars.userInput | yamlSafe }}
 ```
 
 ### `k8sName`
@@ -245,7 +245,7 @@ Converts strings to valid Kubernetes names:
 ```yaml
 # Input: "My Customer Name!"
 # Output: "my-customer-name"
-namespace: test-{{ .Vars.customerName | k8sName }}
+namespace: test-{{ .vars.customerName | k8sName }}
 ```
 
 ### `truncName`
@@ -254,7 +254,7 @@ Truncates strings to a maximum length:
 
 ```yaml
 # Keep within 63 char limit
-name: {{ .Session.Name | truncName 50 }}-suffix
+name: {{ .session.name | truncName 50 }}-suffix
 ```
 
 ## Complete Example
@@ -300,25 +300,25 @@ spec:
     kind: Pod
     metadata:
       labels:
-        network-mode: {{ .Vars.networkMode | yamlQuote }}
+        network-mode: {{ .vars.networkMode | yamlQuote }}
     spec:
-      {{- if eq .Vars.networkMode "host" }}
+      {{- if eq .vars.networkMode "host" }}
       hostNetwork: true
       {{- end }}
       containers:
         - name: debug
           image: nicolaka/netshoot:v0.13
           command: ["sleep", "infinity"]
-          {{- if eq .Vars.enableCapture "true" }}
+          {{- if eq .vars.enableCapture "true" }}
           volumeMounts:
             - name: captures
               mountPath: /captures
           {{- end }}
-      {{- if eq .Vars.enableCapture "true" }}
+      {{- if eq .vars.enableCapture "true" }}
       volumes:
         - name: captures
           emptyDir:
-            sizeLimit: {{ .Vars.captureSize }}
+            sizeLimit: {{ .vars.captureSize }}
       {{- end }}
 ```
 
@@ -350,14 +350,14 @@ spec:
           allowedGroups: ["platform_poweruser"]
   
   constraints:
-    maxDuration: "{{ if eq .Vars.severity \"incident\" }}8h{{ else }}2h{{ end }}"
+    maxDuration: "{{ if eq .vars.severity \"incident\" }}8h{{ else }}2h{{ end }}"
 ```
 
 ## Security Best Practices
 
 1. **Always use `yamlQuote` for user values:**
    ```yaml
-   label: {{ .Vars.userInput | yamlQuote }}
+   label: {{ .vars.userInput | yamlQuote }}
    ```
 
 2. **Use `allowedGroups` for sensitive options:**
@@ -380,7 +380,7 @@ spec:
 
 5. **Use `k8sName` for generated resource names:**
    ```yaml
-   name: test-{{ .Vars.customerName | k8sName }}
+   name: test-{{ .vars.customerName | k8sName }}
    ```
 
 ## Validation Rules


### PR DESCRIPTION
## Summary
- updates DebugSession template documentation to use the lowercase context keys exposed by runtime rendering (`.session`, `.target`, `.vars`)
- refreshes API comments, generated applyconfiguration comments, and CRD descriptions so schema docs match the renderer
- updates validation fixtures to avoid stale uppercase template examples
- corrects stale “Sprout” wording to “Sprig” where the code uses `sprig.FuncMap()`

## Evidence / Duplicate Check
- Runtime renderer converts `AuxiliaryResourceContext` through JSON before executing templates, so rendered keys are lowercase JSON names. Existing renderer tests already use `.session`, `.target`, and `.vars`.
- Live duplicate search for `debug template context Vars` returned no open or merged PR covering this docs/schema drift. Adjacent debug-template PRs (#881, #872) address UI load errors and discovery ACLs, not template context documentation.

## Screenshots
N/A - documentation and generated schema descriptions only.

## Validation
- `make generate && make manifests`
- `go test ./pkg/breakglass/debug -run 'TestRenderTemplate_SimpleTemplate|TestRenderTemplate_WithSprigFunctions|TestBuildPodRenderContext' -count=1`\n- `go test ./api/v1alpha1 -run 'TestValidateAuxiliaryResources|TestValidateGoTemplateSyntax|TestValidateTemplateStringFormat|TestValidateDebugSessionTemplateSpec_PodTemplateStringAlternative' -count=1`\n- `make lint`\n- `git diff --check`\n