### PR TITLE
docs: document idle timeout minimum

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationspec.go
@@ -24,7 +24,7 @@ type BreakglassEscalationSpecApplyConfiguration struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which sessions
 	// for this escalation are automatically expired with state IdleExpired.
 	// If not set, idle timeout is not enforced for sessions created from this escalation.
-	// Must not exceed maxValidFor when both are set.
+	// Must be at least 1m and must not exceed maxValidFor when both are set.
 	IdleTimeout *string `json:"idleTimeout,omitempty"`
 	// retainFor is the amount of time to wait before removing a session for this escalation after it expired
 	RetainFor *string `json:"retainFor,omitempty"`

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionspec.go
@@ -28,7 +28,7 @@ type BreakglassSessionSpecApplyConfiguration struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which the session
 	// is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
 	// Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-	// Must be less than or equal to maxValidFor when both are set.
+	// Must be at least 1m and must be less than or equal to maxValidFor when both are set.
 	IdleTimeout *string `json:"idleTimeout,omitempty"`
 	// retainFor is the amount of time to wait before removing the session object after it was expired.
 	RetainFor *string `json:"retainFor,omitempty"`

--- a/api/v1alpha1/breakglass_escalation_types.go
+++ b/api/v1alpha1/breakglass_escalation_types.go
@@ -74,7 +74,7 @@ type BreakglassEscalationSpec struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which sessions
 	// for this escalation are automatically expired with state IdleExpired.
 	// If not set, idle timeout is not enforced for sessions created from this escalation.
-	// Must not exceed maxValidFor when both are set.
+	// Must be at least 1m and must not exceed maxValidFor when both are set.
 	// +optional
 	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`

--- a/api/v1alpha1/breakglass_session_types.go
+++ b/api/v1alpha1/breakglass_session_types.go
@@ -86,7 +86,7 @@ type BreakglassSessionSpec struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which the session
 	// is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
 	// Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-	// Must be less than or equal to maxValidFor when both are set.
+	// Must be at least 1m and must be less than or equal to maxValidFor when both are set.
 	// +optional
 	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
@@ -208,7 +208,7 @@ spec:
                   idleTimeout is the duration of inactivity (no authorization requests) after which sessions
                   for this escalation are automatically expired with state IdleExpired.
                   If not set, idle timeout is not enforced for sessions created from this escalation.
-                  Must not exceed maxValidFor when both are set.
+                  Must be at least 1m and must not exceed maxValidFor when both are set.
                 pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
                 type: string
               mailProvider:

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
@@ -136,7 +136,7 @@ spec:
                   idleTimeout is the duration of inactivity (no authorization requests) after which the session
                   is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
                   Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-                  Must be less than or equal to maxValidFor when both are set.
+                  Must be at least 1m and must be less than or equal to maxValidFor when both are set.
                 pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
                 type: string
               maxValidFor:

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -179,7 +179,7 @@ maxValidFor: "30m"  # 30 minutes
 
 #### idleTimeout
 
-Maximum duration a session can remain idle (no authorized webhook requests) before being automatically expired to the `IdleExpired` state. If not set, the session remains active for its full `maxValidFor` window. Parsed via the project's `ParseDuration` (supports day units like `"1d12h"`). Must not exceed `maxValidFor`.
+Maximum duration a session can remain idle (no authorized webhook requests) before being automatically expired to the `IdleExpired` state. If not set, the session remains active for its full `maxValidFor` window. Parsed via the project's `ParseDuration` (supports day units like `"1d12h"`). Must be at least `1m` and must not exceed `maxValidFor`.
 
 Copied automatically from the matched `BreakglassEscalation` at approval time.
 

--- a/docs/design/idle-timeout.md
+++ b/docs/design/idle-timeout.md
@@ -177,6 +177,7 @@ Add `IdleExpired` to the status tag mapping and session state options in the fro
 ### 6.1 Admission Webhook
 
 - Validate `idleTimeout` is parseable via `v1alpha1.ParseDuration` if set.
+- Validate `idleTimeout` is at least `1m` when set.
 - Validate `idleTimeout` ≤ `maxValidFor` (idle timeout should not exceed session lifetime).
 
 ### 6.2 Unit Tests


### PR DESCRIPTION
## Summary

- Document the enforced `idleTimeout >= 1m` validation floor in `BreakglassEscalation` and `BreakglassSession` API comments.
- Regenerate applyconfiguration comments and CRD descriptions from the updated API comments.
- Align `docs/breakglass-session.md` and `docs/design/idle-timeout.md` with the existing validation behavior.
- Add a changelog entry for the documentation/schema-description correction.

## Evidence

Existing validation already rejects sub-minute idle timeouts for both resources:

- `api/v1alpha1/validation_test.go` has `idleTimeout below minimum floor` cases for `BreakglassEscalation` and `BreakglassSession` asserting `at least 1m`.
- `docs/breakglass-escalation.md` already documented the 1 minute minimum, but `docs/breakglass-session.md`, API comments, and generated CRD descriptions only mentioned the `maxValidFor` upper bound.

## Duplicate check

Searched before opening:

- `gh search prs --repo telekom/k8s-breakglass "idleTimeout minimum" --state open`
- `gh search prs --repo telekom/k8s-breakglass "idleTimeout 1m" --state open`
- `gh search prs --repo telekom/k8s-breakglass "idleTimeout minimum" --merged`
- `gh search prs --repo telekom/k8s-breakglass "idleTimeout" --state open`

Only open hit was #855, which covers stale expiry controller behavior and does not update this docs/schema-description drift.

## Screenshots

N/A. This PR has no UI changes.

## Validation

- `make generate && make manifests`
- `go test ./api/v1alpha1 -run 'TestValidateBreakglass(Escalation|Session)|TestValidateTimeoutRelationships_IdleTimeout' -count=1`
- `make lint`
- `git diff --check`
