### PR TITLE
fix: tighten breakglass admission validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **BreakglassEscalation admission validation**: Escalation duration fields now reject non-positive or malformed values consistently, `idleTimeout` and `approvalTimeout` are checked against the effective `maxValidFor`, and invalid cluster glob patterns are rejected before they can affect session admission.
 - **BreakglassSession approver IDP enforcement**: Approval and rejection requests now enforce `BreakglassEscalation.spec.allowedIdentityProvidersForApprovers`, denying approvers whose authenticated IdentityProvider is missing or not allowed.
 - **Frontend debug logging hardening**: Production builds no longer enable verbose debug logging from URL or localStorage flags, group and claim refresh diagnostics log only counts and claim keys instead of sensitive group memberships or full profile claims, and stale OIDC refresh tokens are removed from browser session state before silent renew.
 - **BreakglassSession approval safety**: Classic session approval now rejects pending sessions whose approval timeout has already elapsed, scopes approval authorization to the `BreakglassEscalation` that owns the session when an owner reference is present, and checks approval/rejection authorization before body validation or state-specific errors so unrelated callers cannot infer session details.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationallowed.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationallowed.go
@@ -19,7 +19,7 @@ type BreakglassEscalationAllowedApplyConfiguration struct {
 	// clusters is a list of clusters this escalation can be used for.
 	// Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
 	// Use "*" to match all clusters (global escalation).
-	// Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
+	// Admission validates glob syntax with path.Match. Runtime matching for stored escalations uses filepath.Match semantics on the controller OS.
 	Clusters []string `json:"clusters,omitempty"`
 	// groups is a list of groups this escalation can be used by.
 	// Supports exact string matching. Globbing (wildcards) and regex patterns are not yet supported.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationallowed.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationallowed.go
@@ -19,7 +19,7 @@ type BreakglassEscalationAllowedApplyConfiguration struct {
 	// clusters is a list of clusters this escalation can be used for.
 	// Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
 	// Use "*" to match all clusters (global escalation).
-	// Glob patterns follow filepath.Match semantics: * matches any sequence of characters, ? matches single character.
+	// Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
 	Clusters []string `json:"clusters,omitempty"`
 	// groups is a list of groups this escalation can be used by.
 	// Supports exact string matching. Globbing (wildcards) and regex patterns are not yet supported.

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglassescalationspec.go
@@ -24,7 +24,7 @@ type BreakglassEscalationSpecApplyConfiguration struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which sessions
 	// for this escalation are automatically expired with state IdleExpired.
 	// If not set, idle timeout is not enforced for sessions created from this escalation.
-	// Must be at least 1m and must not exceed maxValidFor when both are set.
+	// Must be at least 1m and must not exceed maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
 	IdleTimeout *string `json:"idleTimeout,omitempty"`
 	// retainFor is the amount of time to wait before removing a session for this escalation after it expired
 	RetainFor *string `json:"retainFor,omitempty"`

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/breakglasssessionspec.go
@@ -28,7 +28,7 @@ type BreakglassSessionSpecApplyConfiguration struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which the session
 	// is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
 	// Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-	// Must be at least 1m and must be less than or equal to maxValidFor when both are set.
+	// Must be at least 1m and must be less than or equal to maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
 	IdleTimeout *string `json:"idleTimeout,omitempty"`
 	// retainFor is the amount of time to wait before removing the session object after it was expired.
 	RetainFor *string `json:"retainFor,omitempty"`

--- a/api/v1alpha1/breakglass_escalation_types.go
+++ b/api/v1alpha1/breakglass_escalation_types.go
@@ -295,7 +295,7 @@ type BreakglassEscalationAllowed struct {
 	// clusters is a list of clusters this escalation can be used for.
 	// Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
 	// Use "*" to match all clusters (global escalation).
-	// Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
+	// Admission validates glob syntax with path.Match. Runtime matching for stored escalations uses filepath.Match semantics on the controller OS.
 	// +kubebuilder:validation:MaxItems=50
 	Clusters []string `json:"clusters,omitempty"`
 	// groups is a list of groups this escalation can be used by.

--- a/api/v1alpha1/breakglass_escalation_types.go
+++ b/api/v1alpha1/breakglass_escalation_types.go
@@ -68,7 +68,7 @@ type BreakglassEscalationSpec struct {
 
 	// maxValidFor is the maximum amount of time a session for this escalation will be active for after it is approved.
 	// +default="1h"
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	MaxValidFor string `json:"maxValidFor,omitempty"`
 
 	// idleTimeout is the duration of inactivity (no authorization requests) after which sessions
@@ -76,19 +76,19 @@ type BreakglassEscalationSpec struct {
 	// If not set, idle timeout is not enforced for sessions created from this escalation.
 	// Must be at least 1m and must not exceed maxValidFor when both are set.
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`
 
 	// retainFor is the amount of time to wait before removing a session for this escalation after it expired
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	RetainFor string `json:"retainFor,omitempty"`
 
 	// approvalTimeout is the maximum amount of time allowed for an approver to approve a session for this escalation.
 	// If this duration elapses without approval, the session expires and transitions to ApprovalTimeout state.
 	// +default="1h"
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	ApprovalTimeout string `json:"approvalTimeout,omitempty"`
 
 	// clusterConfigRefs lists ClusterConfig object names this escalation applies to (alternative to allowed.clusters).
@@ -451,6 +451,7 @@ func validateBreakglassEscalationAdditionalLists(spec *BreakglassEscalationSpec,
 	clusterConfigRefsPath := specPath.Child("clusterConfigRefs")
 	allErrs = append(allErrs, validateStringListEntriesNotEmpty(spec.ClusterConfigRefs, clusterConfigRefsPath)...)
 	allErrs = append(allErrs, validateStringListNoDuplicates(spec.ClusterConfigRefs, clusterConfigRefsPath)...)
+	allErrs = append(allErrs, validateClusterGlobPatterns(spec.ClusterConfigRefs, clusterConfigRefsPath)...)
 
 	denyPolicyRefsPath := specPath.Child("denyPolicyRefs")
 	allErrs = append(allErrs, validateStringListEntriesNotEmpty(spec.DenyPolicyRefs, denyPolicyRefsPath)...)

--- a/api/v1alpha1/breakglass_escalation_types.go
+++ b/api/v1alpha1/breakglass_escalation_types.go
@@ -74,7 +74,7 @@ type BreakglassEscalationSpec struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which sessions
 	// for this escalation are automatically expired with state IdleExpired.
 	// If not set, idle timeout is not enforced for sessions created from this escalation.
-	// Must be at least 1m and must not exceed maxValidFor when both are set.
+	// Must be at least 1m and must not exceed maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
 	// +optional
 	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`
@@ -295,7 +295,7 @@ type BreakglassEscalationAllowed struct {
 	// clusters is a list of clusters this escalation can be used for.
 	// Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
 	// Use "*" to match all clusters (global escalation).
-	// Glob patterns follow filepath.Match semantics: * matches any sequence of characters, ? matches single character.
+	// Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
 	// +kubebuilder:validation:MaxItems=50
 	Clusters []string `json:"clusters,omitempty"`
 	// groups is a list of groups this escalation can be used by.

--- a/api/v1alpha1/breakglass_escalation_types_test.go
+++ b/api/v1alpha1/breakglass_escalation_types_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -405,6 +406,46 @@ func TestBreakglassEscalationValidateCreate_EmptyClusterConfigRefsEntry(t *testi
 	_, err := esc.ValidateCreate(context.Background(), esc)
 	if err == nil {
 		t.Fatal("expected error when clusterConfigRefs has empty entry")
+	}
+}
+
+func TestBreakglassEscalationValidateCreate_InvalidAllowedClusterGlob(t *testing.T) {
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "ops",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"prod-["},
+			},
+			Approvers: BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+		},
+	}
+
+	_, err := esc.ValidateCreate(context.Background(), esc)
+	if err == nil {
+		t.Fatal("expected error when allowed.clusters has invalid glob")
+	}
+	if !strings.Contains(err.Error(), "invalid cluster glob pattern") {
+		t.Fatalf("expected invalid cluster glob pattern error, got %v", err)
+	}
+}
+
+func TestBreakglassEscalationValidateCreate_InvalidClusterConfigRefGlob(t *testing.T) {
+	esc := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup:    "ops",
+			ClusterConfigRefs: []string{"prod-["},
+			Approvers:         BreakglassEscalationApprovers{Users: []string{"approver@example.com"}},
+		},
+	}
+
+	_, err := esc.ValidateCreate(context.Background(), esc)
+	if err == nil {
+		t.Fatal("expected error when clusterConfigRefs has invalid glob")
+	}
+	if !strings.Contains(err.Error(), "invalid cluster glob pattern") {
+		t.Fatalf("expected invalid cluster glob pattern error, got %v", err)
 	}
 }
 

--- a/api/v1alpha1/breakglass_session_types.go
+++ b/api/v1alpha1/breakglass_session_types.go
@@ -80,7 +80,7 @@ type BreakglassSessionSpec struct {
 
 	// maxValidFor is the maximum amount of time the session will be active for after it is approved.
 	// +default="1h"
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	MaxValidFor string `json:"maxValidFor,omitempty"`
 
 	// idleTimeout is the duration of inactivity (no authorization requests) after which the session
@@ -88,12 +88,12 @@ type BreakglassSessionSpec struct {
 	// Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
 	// Must be at least 1m and must be less than or equal to maxValidFor when both are set.
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`
 
 	// retainFor is the amount of time to wait before removing the session object after it was expired.
 	// +default="720h"
-	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|ms|s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	RetainFor string `json:"retainFor,omitempty"`
 
 	// clusterConfigRef references the ClusterConfig object associated with this session (if different from spec.cluster parsing result).

--- a/api/v1alpha1/breakglass_session_types.go
+++ b/api/v1alpha1/breakglass_session_types.go
@@ -86,7 +86,7 @@ type BreakglassSessionSpec struct {
 	// idleTimeout is the duration of inactivity (no authorization requests) after which the session
 	// is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
 	// Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-	// Must be at least 1m and must be less than or equal to maxValidFor when both are set.
+	// Must be at least 1m and must be less than or equal to maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
 	// +optional
 	// +kubebuilder:validation:Pattern="^([0-9]+d([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+)$"
 	IdleTimeout string `json:"idleTimeout,omitempty"`

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -244,31 +244,28 @@ func ValidateBreakglassSession(session *BreakglassSession) *ValidationResult {
 		result.Errors = append(result.Errors, field.Required(specPath.Child("grantedGroup"), "grantedGroup is required"))
 	}
 
-	// Validate durations
-	if session.Spec.MaxValidFor != "" {
-		result.Errors = append(result.Errors, validateDurationFormat(session.Spec.MaxValidFor, specPath.Child("maxValidFor"))...)
+	maxValidForDuration, maxValidForErr := parsePositiveDurationField(session.Spec.MaxValidFor, "maxValidFor", specPath.Child("maxValidFor"))
+	if maxValidForErr != nil {
+		result.Errors = append(result.Errors, maxValidForErr)
+	}
+	effectiveMaxValidFor, effectiveMaxValidForLabel := effectiveMaxValidForDuration(session.Spec.MaxValidFor, maxValidForDuration)
+
+	if _, retainForErr := parsePositiveDurationField(session.Spec.RetainFor, "retainFor", specPath.Child("retainFor")); retainForErr != nil {
+		result.Errors = append(result.Errors, retainForErr)
 	}
 
-	if session.Spec.RetainFor != "" {
-		result.Errors = append(result.Errors, validateDurationFormat(session.Spec.RetainFor, specPath.Child("retainFor"))...)
-	}
-
+	// Validate idleTimeout if set
 	if session.Spec.IdleTimeout != "" {
-		idleTimeout, err := ParseDuration(session.Spec.IdleTimeout)
-		if err != nil {
-			result.Errors = append(result.Errors, field.Invalid(specPath.Child("idleTimeout"), session.Spec.IdleTimeout, fmt.Sprintf("invalid duration: %v", err)))
-		} else if idleTimeout <= 0 {
-			result.Errors = append(result.Errors, field.Invalid(specPath.Child("idleTimeout"), session.Spec.IdleTimeout, "idleTimeout must be positive"))
+		idleTimeout, idleTimeoutErr := parsePositiveDurationField(session.Spec.IdleTimeout, "idleTimeout", specPath.Child("idleTimeout"))
+		if idleTimeoutErr != nil {
+			result.Errors = append(result.Errors, idleTimeoutErr)
 		} else if idleTimeout < time.Minute {
 			// Minimum 1 minute to avoid premature expiry from the 30s activity flush buffer.
 			// Activity is flushed to status every ~30s; shorter idle timeouts would race with the buffer.
 			result.Errors = append(result.Errors, field.Invalid(specPath.Child("idleTimeout"), session.Spec.IdleTimeout, "idleTimeout must be at least 1m"))
-		} else if session.Spec.MaxValidFor != "" {
-			maxValid, mvErr := ParseDuration(session.Spec.MaxValidFor)
-			if mvErr == nil && idleTimeout > maxValid {
-				result.Errors = append(result.Errors, field.Invalid(specPath.Child("idleTimeout"), session.Spec.IdleTimeout,
-					fmt.Sprintf("idleTimeout (%s) must not exceed maxValidFor (%s)", session.Spec.IdleTimeout, session.Spec.MaxValidFor)))
-			}
+		} else if maxValidForErr == nil && idleTimeout > effectiveMaxValidFor {
+			result.Errors = append(result.Errors, field.Invalid(specPath.Child("idleTimeout"), session.Spec.IdleTimeout,
+				fmt.Sprintf("idleTimeout (%s) must not exceed maxValidFor (%s)", session.Spec.IdleTimeout, effectiveMaxValidForLabel)))
 		}
 	}
 

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -132,6 +132,7 @@ func ValidateBreakglassEscalation(escalation *BreakglassEscalation) *ValidationR
 	for i, cluster := range escalation.Spec.Allowed.Clusters {
 		result.Errors = append(result.Errors, validateIdentifierFormat(cluster, allowedClustersPath.Index(i))...)
 	}
+	result.Errors = append(result.Errors, validateClusterGlobPatterns(escalation.Spec.Allowed.Clusters, allowedClustersPath)...)
 
 	// Validate approvers
 	approverGroupsPath := specPath.Child("approvers").Child("groups")

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"path/filepath"
-
 	"context"
 	"errors"
 	"fmt"

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -29,6 +29,10 @@ var dayPattern = regexp.MustCompile(`^(\d+)d(.*)$`)
 // integer overflow when converting to time.Duration (int64 nanoseconds).
 const maxDurationDays = 365
 
+// defaultBreakglassMaxValidFor mirrors the +default markers on
+// BreakglassEscalationSpec.MaxValidFor and BreakglassSessionSpec.MaxValidFor.
+// Test coverage pins those markers to this value so admission validation cannot
+// drift from Kubernetes defaulting silently.
 const defaultBreakglassMaxValidFor = "1h"
 
 // ParseDuration parses a duration string with extended support for day units.

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -503,32 +503,59 @@ func effectiveMaxValidForDuration(raw string, parsed time.Duration) (time.Durati
 	if raw != "" {
 		return parsed, raw
 	}
-	return time.Hour, "default " + defaultBreakglassMaxValidFor
+	defaultDuration, err := ParseDuration(defaultBreakglassMaxValidFor)
+	if err != nil {
+		// This is a compile-time constant; keep the fallback defensive.
+		return time.Hour, "default " + defaultBreakglassMaxValidFor
+	}
+	return defaultDuration, "default " + defaultBreakglassMaxValidFor
 }
 
-func clusterMatchesValidationPattern(cluster string, pattern string) bool {
+func clusterMatchesValidationPattern(cluster string, pattern string) (bool, error) {
 	if pattern == cluster {
-		return true
+		return true, nil
 	}
 	matched, err := filepath.Match(pattern, cluster)
-	return err == nil && matched
+	if err != nil {
+		return false, fmt.Errorf("invalid cluster glob pattern %q: %w", pattern, err)
+	}
+	return matched, nil
 }
 
-func escalationMatchesSessionClusterForValidation(escalation *BreakglassEscalation, cluster string) bool {
+func invalidEscalationClusterPatternError(path *field.Path, escalationName string, fieldName string, pattern string, err error) *field.Error {
+	return field.Forbidden(
+		path,
+		fmt.Sprintf("matching escalation %q has invalid %s pattern %q: %v", escalationName, fieldName, pattern, err),
+	)
+}
+
+func escalationMatchesSessionClusterForValidation(escalation *BreakglassEscalation, cluster string, path *field.Path) (bool, field.ErrorList) {
 	if escalation == nil {
-		return false
+		return false, nil
 	}
 	for _, allowedCluster := range escalation.Spec.Allowed.Clusters {
-		if clusterMatchesValidationPattern(cluster, allowedCluster) {
-			return true
+		matched, err := clusterMatchesValidationPattern(cluster, allowedCluster)
+		if err != nil {
+			return false, field.ErrorList{
+				invalidEscalationClusterPatternError(path, escalation.Name, "allowed.clusters", allowedCluster, err),
+			}
+		}
+		if matched {
+			return true, nil
 		}
 	}
 	for _, clusterConfigRef := range escalation.Spec.ClusterConfigRefs {
-		if clusterMatchesValidationPattern(cluster, clusterConfigRef) {
-			return true
+		matched, err := clusterMatchesValidationPattern(cluster, clusterConfigRef)
+		if err != nil {
+			return false, field.ErrorList{
+				invalidEscalationClusterPatternError(path, escalation.Name, "clusterConfigRefs", clusterConfigRef, err),
+			}
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // the session is allowed by the associated escalation rule.
@@ -588,7 +615,11 @@ func validateSessionIdentityProviderAuthorization(
 			continue
 		}
 
-		if escalationMatchesSessionClusterForValidation(esc, sessionCluster) {
+		clusterMatches, clusterMatchErrs := escalationMatchesSessionClusterForValidation(esc, sessionCluster, path)
+		if len(clusterMatchErrs) > 0 {
+			return clusterMatchErrs
+		}
+		if clusterMatches {
 			relevantEscalations = append(relevantEscalations, esc)
 		}
 	}

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -29,6 +30,8 @@ var dayPattern = regexp.MustCompile(`^(\d+)d(.*)$`)
 // maxDurationDays is the upper bound for day values in ParseDuration to prevent
 // integer overflow when converting to time.Duration (int64 nanoseconds).
 const maxDurationDays = 365
+
+const defaultBreakglassMaxValidFor = "1h"
 
 // ParseDuration parses a duration string with extended support for day units.
 // Go's time.ParseDuration only supports up to hours (h), but this function
@@ -433,63 +436,99 @@ func validateIdentityProviderFields(
 func validateTimeoutRelationships(spec *BreakglassEscalationSpec, specPath *field.Path) field.ErrorList {
 	var errs field.ErrorList
 
-	// Get durations - these have defaults ("1h") in the spec comments
 	maxValidFor := spec.MaxValidFor
 	approvalTimeout := spec.ApprovalTimeout
 
-	// Helper to parse and validate duration string (supports day units like "7d", "90d")
-	parseDuration := func(durationStr string, fieldName string, path *field.Path) (time.Duration, *field.Error) {
-		if durationStr == "" {
-			return 0, nil // Not set, return zero
-		}
-
-		duration, err := ParseDuration(durationStr)
-		if err != nil {
-			return 0, field.Invalid(path, durationStr, fmt.Sprintf("invalid duration format: %v", err))
-		}
-
-		if duration <= 0 {
-			return 0, field.Invalid(path, durationStr, fieldName+" must be greater than 0")
-		}
-
-		return duration, nil
-	}
-
 	// Parse and validate maxValidFor
-	maxValidForDuration, maxValidForErr := parseDuration(maxValidFor, "maxValidFor", specPath.Child("maxValidFor"))
+	maxValidForDuration, maxValidForErr := parsePositiveDurationField(maxValidFor, "maxValidFor", specPath.Child("maxValidFor"))
 	if maxValidForErr != nil {
 		errs = append(errs, maxValidForErr)
-		return errs // Can't compare if maxValidFor is invalid
 	}
+	effectiveMaxValidFor, effectiveMaxValidForLabel := effectiveMaxValidForDuration(maxValidFor, maxValidForDuration)
 
 	// Parse and validate approvalTimeout
-	approvalTimeoutDuration, approvalTimeoutErr := parseDuration(approvalTimeout, "approvalTimeout", specPath.Child("approvalTimeout"))
+	approvalTimeoutDuration, approvalTimeoutErr := parsePositiveDurationField(approvalTimeout, "approvalTimeout", specPath.Child("approvalTimeout"))
 	if approvalTimeoutErr != nil {
 		errs = append(errs, approvalTimeoutErr)
-	} else if approvalTimeout != "" && approvalTimeoutDuration > maxValidForDuration {
+	} else if approvalTimeout != "" && maxValidForErr == nil && approvalTimeoutDuration > effectiveMaxValidFor {
 		errs = append(errs, field.Invalid(
 			specPath.Child("approvalTimeout"),
 			approvalTimeout,
-			fmt.Sprintf("approvalTimeout (%v) must be less than or equal to maxValidFor (%v)", approvalTimeout, maxValidFor),
+			fmt.Sprintf("approvalTimeout (%s) must be less than or equal to maxValidFor (%s)", approvalTimeout, effectiveMaxValidForLabel),
 		))
+	}
+
+	// Parse and validate retainFor
+	retainFor := spec.RetainFor
+	if _, retainForErr := parsePositiveDurationField(retainFor, "retainFor", specPath.Child("retainFor")); retainForErr != nil {
+		errs = append(errs, retainForErr)
 	}
 
 	// Parse and validate idleTimeout
 	idleTimeout := spec.IdleTimeout
-	idleTimeoutDuration, idleTimeoutErr := parseDuration(idleTimeout, "idleTimeout", specPath.Child("idleTimeout"))
+	idleTimeoutDuration, idleTimeoutErr := parsePositiveDurationField(idleTimeout, "idleTimeout", specPath.Child("idleTimeout"))
 	if idleTimeoutErr != nil {
 		errs = append(errs, idleTimeoutErr)
 	} else if idleTimeout != "" {
 		if idleTimeoutDuration < time.Minute {
 			errs = append(errs, field.Invalid(specPath.Child("idleTimeout"), idleTimeout,
 				"idleTimeout must be at least 1m"))
-		} else if maxValidForDuration > 0 && idleTimeoutDuration > maxValidForDuration {
+		} else if maxValidForErr == nil && idleTimeoutDuration > effectiveMaxValidFor {
 			errs = append(errs, field.Invalid(specPath.Child("idleTimeout"), idleTimeout,
-				fmt.Sprintf("idleTimeout (%s) must not exceed maxValidFor (%s)", idleTimeout, maxValidFor)))
+				fmt.Sprintf("idleTimeout (%s) must not exceed maxValidFor (%s)", idleTimeout, effectiveMaxValidForLabel)))
 		}
 	}
 
 	return errs
+}
+
+func parsePositiveDurationField(durationStr string, fieldName string, path *field.Path) (time.Duration, *field.Error) {
+	if durationStr == "" {
+		return 0, nil
+	}
+
+	duration, err := ParseDuration(durationStr)
+	if err != nil {
+		return 0, field.Invalid(path, durationStr, fmt.Sprintf("invalid duration format: %v", err))
+	}
+
+	if duration <= 0 {
+		return 0, field.Invalid(path, durationStr, fieldName+" must be positive")
+	}
+
+	return duration, nil
+}
+
+func effectiveMaxValidForDuration(raw string, parsed time.Duration) (time.Duration, string) {
+	if raw != "" {
+		return parsed, raw
+	}
+	return time.Hour, "default " + defaultBreakglassMaxValidFor
+}
+
+func clusterMatchesValidationPattern(cluster string, pattern string) bool {
+	if pattern == cluster {
+		return true
+	}
+	matched, err := filepath.Match(pattern, cluster)
+	return err == nil && matched
+}
+
+func escalationMatchesSessionClusterForValidation(escalation *BreakglassEscalation, cluster string) bool {
+	if escalation == nil {
+		return false
+	}
+	for _, allowedCluster := range escalation.Spec.Allowed.Clusters {
+		if clusterMatchesValidationPattern(cluster, allowedCluster) {
+			return true
+		}
+	}
+	for _, clusterConfigRef := range escalation.Spec.ClusterConfigRefs {
+		if clusterMatchesValidationPattern(cluster, clusterConfigRef) {
+			return true
+		}
+	}
+	return false
 }
 
 // the session is allowed by the associated escalation rule.
@@ -549,24 +588,7 @@ func validateSessionIdentityProviderAuthorization(
 			continue
 		}
 
-		// Check if escalation's clusters include this session's cluster
-		clusterMatches := false
-		for _, allowedCluster := range esc.Spec.Allowed.Clusters {
-			if matched, _ := filepath.Match(allowedCluster, sessionCluster); matched || allowedCluster == sessionCluster {
-				clusterMatches = true
-				break
-			}
-		}
-		if !clusterMatches {
-			for _, ref := range esc.Spec.ClusterConfigRefs {
-				if matched, _ := filepath.Match(ref, sessionCluster); matched || ref == sessionCluster {
-					clusterMatches = true
-					break
-				}
-			}
-		}
-
-		if clusterMatches {
+		if escalationMatchesSessionClusterForValidation(esc, sessionCluster) {
 			relevantEscalations = append(relevantEscalations, esc)
 		}
 	}

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -532,8 +532,8 @@ func validateClusterGlobPatterns(patterns []string, fieldPath *field.Path) field
 }
 
 func clusterMatchesValidationPattern(cluster string, pattern string) bool {
-	if pattern == cluster {
-		return true
+	if !strings.ContainsAny(pattern, "*?[") {
+		return pattern == cluster
 	}
 	matched, err := path.Match(pattern, cluster)
 	if err != nil {

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -430,9 +430,10 @@ func validateIdentityProviderFields(
 	return errs
 }
 
-// validateTimeoutRelationships ensures that timeout values have proper relationships:
-// - approvalTimeout must be less than or equal to maxValidFor (if both are set)
-// - All timeout values must be positive durations
+// validateTimeoutRelationships ensures timeout values use valid durations and relationships:
+// - approvalTimeout and idleTimeout must not exceed the effective maxValidFor
+// - idleTimeout must be at least one minute
+// - maxValidFor, approvalTimeout, retainFor, and idleTimeout must be positive when set
 func validateTimeoutRelationships(spec *BreakglassEscalationSpec, specPath *field.Path) field.ErrorList {
 	var errs field.ErrorList
 
@@ -511,51 +512,55 @@ func effectiveMaxValidForDuration(raw string, parsed time.Duration) (time.Durati
 	return defaultDuration, "default " + defaultBreakglassMaxValidFor
 }
 
-func clusterMatchesValidationPattern(cluster string, pattern string) (bool, error) {
+func validateClusterGlobPatterns(patterns []string, fieldPath *field.Path) field.ErrorList {
+	if len(patterns) == 0 || fieldPath == nil {
+		return nil
+	}
+
+	var errs field.ErrorList
+	for i, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if _, err := path.Match(pattern, ""); err != nil {
+			errs = append(errs, field.Invalid(
+				fieldPath.Index(i),
+				pattern,
+				fmt.Sprintf("invalid cluster glob pattern: %v", err),
+			))
+		}
+	}
+	return errs
+}
+
+func clusterMatchesValidationPattern(cluster string, pattern string) bool {
 	if pattern == cluster {
-		return true, nil
+		return true
 	}
-	matched, err := filepath.Match(pattern, cluster)
+	matched, err := path.Match(pattern, cluster)
 	if err != nil {
-		return false, fmt.Errorf("invalid cluster glob pattern %q: %w", pattern, err)
+		// Existing malformed escalations should not make new BreakglassSession
+		// admission fail. BreakglassEscalation admission rejects invalid globs.
+		return false
 	}
-	return matched, nil
+	return matched
 }
 
-func invalidEscalationClusterPatternError(path *field.Path, escalationName string, fieldName string, pattern string, err error) *field.Error {
-	return field.Forbidden(
-		path,
-		fmt.Sprintf("matching escalation %q has invalid %s pattern %q: %v", escalationName, fieldName, pattern, err),
-	)
-}
-
-func escalationMatchesSessionClusterForValidation(escalation *BreakglassEscalation, cluster string, path *field.Path) (bool, field.ErrorList) {
+func escalationMatchesSessionClusterForValidation(escalation *BreakglassEscalation, cluster string) bool {
 	if escalation == nil {
-		return false, nil
+		return false
 	}
 	for _, allowedCluster := range escalation.Spec.Allowed.Clusters {
-		matched, err := clusterMatchesValidationPattern(cluster, allowedCluster)
-		if err != nil {
-			return false, field.ErrorList{
-				invalidEscalationClusterPatternError(path, escalation.Name, "allowed.clusters", allowedCluster, err),
-			}
-		}
-		if matched {
-			return true, nil
+		if clusterMatchesValidationPattern(cluster, allowedCluster) {
+			return true
 		}
 	}
 	for _, clusterConfigRef := range escalation.Spec.ClusterConfigRefs {
-		matched, err := clusterMatchesValidationPattern(cluster, clusterConfigRef)
-		if err != nil {
-			return false, field.ErrorList{
-				invalidEscalationClusterPatternError(path, escalation.Name, "clusterConfigRefs", clusterConfigRef, err),
-			}
-		}
-		if matched {
-			return true, nil
+		if clusterMatchesValidationPattern(cluster, clusterConfigRef) {
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 // the session is allowed by the associated escalation rule.
@@ -615,11 +620,7 @@ func validateSessionIdentityProviderAuthorization(
 			continue
 		}
 
-		clusterMatches, clusterMatchErrs := escalationMatchesSessionClusterForValidation(esc, sessionCluster, path)
-		if len(clusterMatchErrs) > 0 {
-			return clusterMatchErrs
-		}
-		if clusterMatches {
+		if escalationMatchesSessionClusterForValidation(esc, sessionCluster) {
 			relevantEscalations = append(relevantEscalations, esc)
 		}
 	}

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -803,11 +803,7 @@ func TestValidateSessionIdentityProviderAuthorization_InvalidAllowedClusterGlob(
 		"corporate-idp",
 		field.NewPath("spec").Child("identityProviderName"),
 	)
-	assert.NotNil(t, errs, "invalid glob on a matching escalation should fail closed")
-	errText := errs.ToAggregate().Error()
-	assert.Contains(t, errText, `matching escalation "esc-invalid-cluster-glob"`)
-	assert.Contains(t, errText, "invalid allowed.clusters pattern")
-	assert.Contains(t, errText, "prod-[")
+	assert.Nil(t, errs, "invalid stored glob should be ignored during session authorization matching")
 }
 
 func TestValidateSessionIdentityProviderAuthorization_MatchesClusterConfigRef(t *testing.T) {
@@ -891,11 +887,7 @@ func TestValidateSessionIdentityProviderAuthorization_InvalidClusterConfigRefGlo
 		"corporate-idp",
 		field.NewPath("spec").Child("identityProviderName"),
 	)
-	assert.NotNil(t, errs, "invalid clusterConfigRefs glob should fail closed")
-	errText := errs.ToAggregate().Error()
-	assert.Contains(t, errText, `matching escalation "esc-invalid-clusterconfig-glob"`)
-	assert.Contains(t, errText, "invalid clusterConfigRefs pattern")
-	assert.Contains(t, errText, "prod-[")
+	assert.Nil(t, errs, "invalid stored clusterConfigRefs glob should be ignored during session authorization matching")
 }
 
 func TestValidateSessionIdentityProviderAuthorization_DifferentGroup(t *testing.T) {
@@ -2486,6 +2478,8 @@ func TestParseDuration_StandardDurations(t *testing.T) {
 		{"30m", 30 * time.Minute},
 		{"1h30m", 90 * time.Minute},
 		{"2h30m", 150 * time.Minute},
+		{"1.5h", 90 * time.Minute},
+		{"0.5m", 30 * time.Second},
 		{"10s", 10 * time.Second},
 		{"500ms", 500 * time.Millisecond},
 		{"1h15m30s", time.Hour + 15*time.Minute + 30*time.Second},
@@ -2531,6 +2525,7 @@ func TestParseDuration_MixedDayHours(t *testing.T) {
 		{"1d12h", 36 * time.Hour},
 		{"2d6h", 54 * time.Hour},
 		{"1d1h", 25 * time.Hour},
+		{"1d1.5h", 25*time.Hour + 30*time.Minute},
 		{"7d12h30m", 7*24*time.Hour + 12*time.Hour + 30*time.Minute},
 	}
 

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +45,20 @@ func TestEffectiveMaxValidForDurationUsesDefaultString(t *testing.T) {
 	duration, label = effectiveMaxValidForDuration("30m", explicitDuration)
 	assert.Equal(t, explicitDuration, duration)
 	assert.Equal(t, "30m", label)
+}
+
+func TestDefaultBreakglassMaxValidForMatchesKubebuilderMarkers(t *testing.T) {
+	defaultMarker := fmt.Sprintf("// +default=%q", defaultBreakglassMaxValidFor)
+
+	for _, file := range []string{"breakglass_escalation_types.go", "breakglass_session_types.go"} {
+		t.Run(file, func(t *testing.T) {
+			content, err := os.ReadFile(file)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Contains(t, string(content), defaultMarker)
+		})
+	}
 }
 
 // TestValidateSessionIdentityProviderAuthorization_EmptyIDPName tests backward compatibility

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -32,6 +32,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestEffectiveMaxValidForDurationUsesDefaultString(t *testing.T) {
+	expectedDefault, err := ParseDuration(defaultBreakglassMaxValidFor)
+	assert.NoError(t, err)
+
+	duration, label := effectiveMaxValidForDuration("", 0)
+	assert.Equal(t, expectedDefault, duration)
+	assert.Equal(t, "default "+defaultBreakglassMaxValidFor, label)
+
+	explicitDuration := 30 * time.Minute
+	duration, label = effectiveMaxValidForDuration("30m", explicitDuration)
+	assert.Equal(t, explicitDuration, duration)
+	assert.Equal(t, "30m", label)
+}
+
 // TestValidateSessionIdentityProviderAuthorization_EmptyIDPName tests backward compatibility
 // when session has no IDP name (single-IDP or manual creation mode)
 func TestValidateSessionIdentityProviderAuthorization_EmptyIDPName(t *testing.T) {
@@ -755,6 +769,47 @@ func TestValidateSessionIdentityProviderAuthorization_MatchesAllowedClusterGlob(
 	assert.NotNil(t, errs, "glob-matched escalation should enforce allowed IDPs")
 }
 
+func TestValidateSessionIdentityProviderAuthorization_InvalidAllowedClusterGlob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+
+	escalation := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-invalid-cluster-glob", Namespace: "default"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "cluster-admin",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"prod-["},
+			},
+			Approvers:                BreakglassEscalationApprovers{Users: []string{"approver@test.com"}},
+			AllowedIdentityProviders: []string{"corporate-idp"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(escalation).Build()
+
+	oldClient := webhookClient
+	oldCache := webhookCache
+	defer func() {
+		webhookClient = oldClient
+		webhookCache = oldCache
+	}()
+	webhookClient = fakeClient
+	webhookCache = nil
+
+	errs := validateSessionIdentityProviderAuthorization(
+		context.Background(),
+		"prod-eu",
+		"cluster-admin",
+		"corporate-idp",
+		field.NewPath("spec").Child("identityProviderName"),
+	)
+	assert.NotNil(t, errs, "invalid glob on a matching escalation should fail closed")
+	errText := errs.ToAggregate().Error()
+	assert.Contains(t, errText, `matching escalation "esc-invalid-cluster-glob"`)
+	assert.Contains(t, errText, "invalid allowed.clusters pattern")
+	assert.Contains(t, errText, "prod-[")
+}
+
 func TestValidateSessionIdentityProviderAuthorization_MatchesClusterConfigRef(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = AddToScheme(scheme)
@@ -799,6 +854,48 @@ func TestValidateSessionIdentityProviderAuthorization_MatchesClusterConfigRef(t 
 		field.NewPath("spec").Child("identityProviderName"),
 	)
 	assert.NotNil(t, errs, "clusterConfigRefs glob should match and reject disallowed IDP")
+}
+
+func TestValidateSessionIdentityProviderAuthorization_InvalidClusterConfigRefGlob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+
+	escalation := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-invalid-clusterconfig-glob", Namespace: "default"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "cluster-admin",
+			ClusterConfigRefs: []string{
+				"prod-[",
+			},
+			Allowed:                  BreakglassEscalationAllowed{},
+			Approvers:                BreakglassEscalationApprovers{Users: []string{"approver@test.com"}},
+			AllowedIdentityProviders: []string{"corporate-idp"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(escalation).Build()
+
+	oldClient := webhookClient
+	oldCache := webhookCache
+	defer func() {
+		webhookClient = oldClient
+		webhookCache = oldCache
+	}()
+	webhookClient = fakeClient
+	webhookCache = nil
+
+	errs := validateSessionIdentityProviderAuthorization(
+		context.Background(),
+		"prod-eu",
+		"cluster-admin",
+		"corporate-idp",
+		field.NewPath("spec").Child("identityProviderName"),
+	)
+	assert.NotNil(t, errs, "invalid clusterConfigRefs glob should fail closed")
+	errText := errs.ToAggregate().Error()
+	assert.Contains(t, errText, `matching escalation "esc-invalid-clusterconfig-glob"`)
+	assert.Contains(t, errText, "invalid clusterConfigRefs pattern")
+	assert.Contains(t, errText, "prod-[")
 }
 
 func TestValidateSessionIdentityProviderAuthorization_DifferentGroup(t *testing.T) {

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -732,6 +732,58 @@ func TestValidateSessionIdentityProviderAuthorization_WithMatchingEscalation(t *
 	assert.NotNil(t, errs, "should reject non-matching IDP")
 }
 
+func TestClusterMatchesValidationPattern(t *testing.T) {
+	cases := []struct {
+		name    string
+		cluster string
+		pattern string
+		want    bool
+	}{
+		{
+			name:    "exact non-glob match",
+			cluster: "prod-eu",
+			pattern: "prod-eu",
+			want:    true,
+		},
+		{
+			name:    "exact non-glob mismatch",
+			cluster: "prod-eu",
+			pattern: "prod-us",
+			want:    false,
+		},
+		{
+			name:    "glob match",
+			cluster: "prod-eu",
+			pattern: "prod-*",
+			want:    true,
+		},
+		{
+			name:    "glob mismatch",
+			cluster: "dev-eu",
+			pattern: "prod-*",
+			want:    false,
+		},
+		{
+			name:    "malformed glob does not exact match",
+			cluster: "prod-[",
+			pattern: "prod-[",
+			want:    false,
+		},
+		{
+			name:    "malformed glob does not match other cluster",
+			cluster: "prod-eu",
+			pattern: "prod-[",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clusterMatchesValidationPattern(tc.cluster, tc.pattern))
+		})
+	}
+}
+
 func TestValidateSessionIdentityProviderAuthorization_MatchesAllowedClusterGlob(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = AddToScheme(scheme)

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -435,6 +435,23 @@ func TestValidateTimeoutRelationships_ApprovalTimeoutTooLarge(t *testing.T) {
 	assert.NotNil(t, errs, "approvalTimeout > maxValidFor should fail")
 }
 
+func TestValidateTimeoutRelationships_ApprovalTimeoutUsesDefaultMaxValidFor(t *testing.T) {
+	spec := &BreakglassEscalationSpec{
+		ApprovalTimeout: "30m",
+	}
+	errs := validateTimeoutRelationships(spec, field.NewPath("spec"))
+	assert.Nil(t, errs, "approvalTimeout <= default maxValidFor should pass")
+}
+
+func TestValidateTimeoutRelationships_ApprovalTimeoutExceedsDefaultMaxValidFor(t *testing.T) {
+	spec := &BreakglassEscalationSpec{
+		ApprovalTimeout: "2h",
+	}
+	errs := validateTimeoutRelationships(spec, field.NewPath("spec"))
+	assert.NotNil(t, errs, "approvalTimeout > default maxValidFor should fail")
+	assert.Contains(t, errs.ToAggregate().Error(), "default 1h")
+}
+
 func TestValidateTimeoutRelationships_InvalidMaxValidFor(t *testing.T) {
 	spec := &BreakglassEscalationSpec{
 		MaxValidFor: "invalid",
@@ -495,12 +512,35 @@ func TestValidateTimeoutRelationships_IdleTimeoutExceedsMaxValidFor(t *testing.T
 	assert.NotNil(t, errs, "idleTimeout > maxValidFor should fail")
 }
 
+func TestValidateTimeoutRelationships_IdleTimeoutExceedsDefaultMaxValidFor(t *testing.T) {
+	spec := &BreakglassEscalationSpec{
+		IdleTimeout: "2h",
+	}
+	errs := validateTimeoutRelationships(spec, field.NewPath("spec"))
+	assert.NotNil(t, errs, "idleTimeout > default maxValidFor should fail")
+	assert.Contains(t, errs.ToAggregate().Error(), "default 1h")
+}
+
 func TestValidateTimeoutRelationships_IdleTimeoutInvalidFormat(t *testing.T) {
 	spec := &BreakglassEscalationSpec{
 		IdleTimeout: "garbage",
 	}
 	errs := validateTimeoutRelationships(spec, field.NewPath("spec"))
 	assert.NotNil(t, errs, "invalid idleTimeout format should fail")
+}
+
+func TestValidateTimeoutRelationships_RetainForInvalid(t *testing.T) {
+	testCases := []string{"garbage", "0s", "-1h"}
+	for _, retainFor := range testCases {
+		t.Run(retainFor, func(t *testing.T) {
+			spec := &BreakglassEscalationSpec{
+				RetainFor: retainFor,
+			}
+			errs := validateTimeoutRelationships(spec, field.NewPath("spec"))
+			assert.NotNil(t, errs, "invalid retainFor should fail")
+			assert.Contains(t, errs.ToAggregate().Error(), "retainFor")
+		})
+	}
 }
 
 // TestEnsureClusterWideUniqueName tests cluster-wide name uniqueness validation
@@ -676,6 +716,89 @@ func TestValidateSessionIdentityProviderAuthorization_WithMatchingEscalation(t *
 		field.NewPath("spec").Child("identityProviderName"),
 	)
 	assert.NotNil(t, errs, "should reject non-matching IDP")
+}
+
+func TestValidateSessionIdentityProviderAuthorization_MatchesAllowedClusterGlob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+
+	escalation := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-glob", Namespace: "default"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup: "cluster-admin",
+			Allowed: BreakglassEscalationAllowed{
+				Clusters: []string{"prod-*"},
+			},
+			Approvers:                BreakglassEscalationApprovers{Users: []string{"approver@test.com"}},
+			AllowedIdentityProviders: []string{"corporate-idp"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(escalation).Build()
+
+	oldClient := webhookClient
+	oldCache := webhookCache
+	defer func() {
+		webhookClient = oldClient
+		webhookCache = oldCache
+	}()
+	webhookClient = fakeClient
+	webhookCache = nil
+
+	errs := validateSessionIdentityProviderAuthorization(
+		context.Background(),
+		"prod-eu",
+		"cluster-admin",
+		"unauthorized-idp",
+		field.NewPath("spec").Child("identityProviderName"),
+	)
+	assert.NotNil(t, errs, "glob-matched escalation should enforce allowed IDPs")
+}
+
+func TestValidateSessionIdentityProviderAuthorization_MatchesClusterConfigRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+
+	escalation := &BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-clusterconfig", Namespace: "default"},
+		Spec: BreakglassEscalationSpec{
+			EscalatedGroup:                       "cluster-admin",
+			ClusterConfigRefs:                    []string{"prod-*"},
+			Allowed:                              BreakglassEscalationAllowed{},
+			Approvers:                            BreakglassEscalationApprovers{Users: []string{"approver@test.com"}},
+			AllowedIdentityProvidersForRequests:  []string{"requester-idp"},
+			AllowedIdentityProvidersForApprovers: []string{"approver-idp"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(escalation).Build()
+
+	oldClient := webhookClient
+	oldCache := webhookCache
+	defer func() {
+		webhookClient = oldClient
+		webhookCache = oldCache
+	}()
+	webhookClient = fakeClient
+	webhookCache = nil
+
+	errs := validateSessionIdentityProviderAuthorization(
+		context.Background(),
+		"prod-eu",
+		"cluster-admin",
+		"requester-idp",
+		field.NewPath("spec").Child("identityProviderName"),
+	)
+	assert.Nil(t, errs, "clusterConfigRefs glob should match and allow requester IDP")
+
+	errs = validateSessionIdentityProviderAuthorization(
+		context.Background(),
+		"prod-eu",
+		"cluster-admin",
+		"unauthorized-idp",
+		field.NewPath("spec").Child("identityProviderName"),
+	)
+	assert.NotNil(t, errs, "clusterConfigRefs glob should match and reject disallowed IDP")
 }
 
 func TestValidateSessionIdentityProviderAuthorization_DifferentGroup(t *testing.T) {

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -234,11 +234,35 @@ func TestValidateBreakglassEscalation(t *testing.T) {
 		assert.Contains(t, result.ErrorMessage(), "must not exceed maxValidFor")
 	})
 
+	t.Run("escalation idleTimeout exceeds default maxValidFor", func(t *testing.T) {
+		e := validEscalation()
+		e.Spec.IdleTimeout = "2h"
+		result := ValidateBreakglassEscalation(e)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "default 1h")
+	})
+
 	t.Run("escalation idleTimeout exactly at minimum floor", func(t *testing.T) {
 		e := validEscalation()
 		e.Spec.IdleTimeout = "1m"
 		result := ValidateBreakglassEscalation(e)
 		assert.True(t, result.IsValid(), "expected valid, got errors: %s", result.ErrorMessage())
+	})
+
+	t.Run("escalation retainFor invalid", func(t *testing.T) {
+		e := validEscalation()
+		e.Spec.RetainFor = "garbage"
+		result := ValidateBreakglassEscalation(e)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "retainFor")
+	})
+
+	t.Run("escalation retainFor must be positive", func(t *testing.T) {
+		e := validEscalation()
+		e.Spec.RetainFor = "0s"
+		result := ValidateBreakglassEscalation(e)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "retainFor")
 	})
 }
 
@@ -359,6 +383,14 @@ func TestValidateBreakglassSession(t *testing.T) {
 		assert.Contains(t, result.ErrorMessage(), "maxValidFor")
 	})
 
+	t.Run("idleTimeout exceeds default maxValidFor", func(t *testing.T) {
+		s := validSession()
+		s.Spec.IdleTimeout = "2h"
+		result := ValidateBreakglassSession(s)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "default 1h")
+	})
+
 	t.Run("idleTimeout within maxValidFor", func(t *testing.T) {
 		s := validSession()
 		s.Spec.IdleTimeout = "30m"
@@ -370,6 +402,7 @@ func TestValidateBreakglassSession(t *testing.T) {
 	t.Run("idleTimeout with day unit", func(t *testing.T) {
 		s := validSession()
 		s.Spec.IdleTimeout = "1d"
+		s.Spec.MaxValidFor = "2d"
 		result := ValidateBreakglassSession(s)
 		assert.True(t, result.IsValid())
 	})
@@ -402,6 +435,38 @@ func TestValidateBreakglassSession(t *testing.T) {
 		result := ValidateBreakglassSession(s)
 		assert.False(t, result.IsValid())
 		assert.Contains(t, result.ErrorMessage(), "positive")
+	})
+
+	t.Run("invalid maxValidFor format", func(t *testing.T) {
+		s := validSession()
+		s.Spec.MaxValidFor = "not-a-duration"
+		result := ValidateBreakglassSession(s)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "maxValidFor")
+	})
+
+	t.Run("maxValidFor must be positive", func(t *testing.T) {
+		s := validSession()
+		s.Spec.MaxValidFor = "0s"
+		result := ValidateBreakglassSession(s)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "maxValidFor")
+	})
+
+	t.Run("invalid retainFor format", func(t *testing.T) {
+		s := validSession()
+		s.Spec.RetainFor = "not-a-duration"
+		result := ValidateBreakglassSession(s)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "retainFor")
+	})
+
+	t.Run("retainFor must be positive", func(t *testing.T) {
+		s := validSession()
+		s.Spec.RetainFor = "-1h"
+		result := ValidateBreakglassSession(s)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "retainFor")
 	})
 }
 

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -399,6 +399,15 @@ func TestValidateBreakglassSession(t *testing.T) {
 		assert.True(t, result.IsValid())
 	})
 
+	t.Run("decimal durations", func(t *testing.T) {
+		s := validSession()
+		s.Spec.MaxValidFor = "1.5h"
+		s.Spec.IdleTimeout = "0.5h"
+		s.Spec.RetainFor = "1.5h"
+		result := ValidateBreakglassSession(s)
+		assert.True(t, result.IsValid(), result.ErrorMessage())
+	})
+
 	t.Run("idleTimeout with day unit", func(t *testing.T) {
 		s := validSession()
 		s.Spec.IdleTimeout = "1d"

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
@@ -144,7 +144,7 @@ spec:
                 description: |-
                   approvalTimeout is the maximum amount of time allowed for an approver to approve a session for this escalation.
                   If this duration elapses without approval, the session expires and transitions to ApprovalTimeout state.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               approvers:
                 description: approvers specifies who is allowed to approve this escalation.
@@ -209,7 +209,7 @@ spec:
                   for this escalation are automatically expired with state IdleExpired.
                   If not set, idle timeout is not enforced for sessions created from this escalation.
                   Must be at least 1m and must not exceed maxValidFor when both are set.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               mailProvider:
                 description: |-
@@ -222,7 +222,7 @@ spec:
                 default: 1h
                 description: maxValidFor is the maximum amount of time a session for
                   this escalation will be active for after it is approved.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               notificationExclusions:
                 description: |-
@@ -388,7 +388,7 @@ spec:
               retainFor:
                 description: retainFor is the amount of time to wait before removing
                   a session for this escalation after it expired
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               sessionLimitsOverride:
                 description: |-

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
@@ -67,7 +67,7 @@ spec:
                       clusters is a list of clusters this escalation can be used for.
                       Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
                       Use "*" to match all clusters (global escalation).
-                      Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
+                      Admission validates glob syntax with path.Match. Runtime matching for stored escalations uses filepath.Match semantics on the controller OS.
                     items:
                       type: string
                     maxItems: 50

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglassescalations.yaml
@@ -67,7 +67,7 @@ spec:
                       clusters is a list of clusters this escalation can be used for.
                       Supports exact string matching and glob patterns (e.g., "prod-*", "*-staging", "*").
                       Use "*" to match all clusters (global escalation).
-                      Glob patterns follow filepath.Match semantics: * matches any sequence of characters, ? matches single character.
+                      Glob patterns follow path.Match semantics: * matches any sequence of characters, ? matches single character.
                     items:
                       type: string
                     maxItems: 50
@@ -208,7 +208,7 @@ spec:
                   idleTimeout is the duration of inactivity (no authorization requests) after which sessions
                   for this escalation are automatically expired with state IdleExpired.
                   If not set, idle timeout is not enforced for sessions created from this escalation.
-                  Must be at least 1m and must not exceed maxValidFor when both are set.
+                  Must be at least 1m and must not exceed maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
                 pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               mailProvider:

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
@@ -137,13 +137,13 @@ spec:
                   is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
                   Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
                   Must be at least 1m and must be less than or equal to maxValidFor when both are set.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               maxValidFor:
                 default: 1h
                 description: maxValidFor is the maximum amount of time the session
                   will be active for after it is approved.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               requestReason:
                 description: |-
@@ -169,7 +169,7 @@ spec:
                 default: 720h
                 description: retainFor is the amount of time to wait before removing
                   the session object after it was expired.
-                pattern: ^([0-9]+(ns|us|ms|s|m|h|d))+$
+                pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               scheduledStartTime:
                 description: |-

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
@@ -136,7 +136,7 @@ spec:
                   idleTimeout is the duration of inactivity (no authorization requests) after which the session
                   is automatically expired with state IdleExpired. If not set, idle timeout is not enforced.
                   Parsed by ParseDuration; supports day units (e.g., "15m", "1h", "1d").
-                  Must be at least 1m and must be less than or equal to maxValidFor when both are set.
+                  Must be at least 1m and must be less than or equal to maxValidFor; when maxValidFor is omitted, admission validates against the default 1h.
                 pattern: ^([0-9]+d([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))*|([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+)$
                 type: string
               maxValidFor:

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -1001,7 +1001,7 @@ The controller matches requested clusters against `spec.allowed.clusters` and `s
 
 #### Glob Pattern Matching
 
-Both `allowed.clusters` and `clusterConfigRefs` support **glob patterns** for flexible cluster matching. This uses Go's `filepath.Match` syntax:
+Both `allowed.clusters` and `clusterConfigRefs` support **glob patterns** for flexible cluster matching. This uses Go's `path.Match` syntax:
 
 | Pattern | Matches |
 |---------|---------|

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -1001,7 +1001,7 @@ The controller matches requested clusters against `spec.allowed.clusters` and `s
 
 #### Glob Pattern Matching
 
-Both `allowed.clusters` and `clusterConfigRefs` support **glob patterns** for flexible cluster matching. This uses Go's `path.Match` syntax:
+Both `allowed.clusters` and `clusterConfigRefs` support **glob patterns** for flexible cluster matching. Admission validates patterns with Go's `path.Match` syntax; existing runtime matching for stored `BreakglassEscalation` objects uses Go's `filepath.Match` semantics for cluster names.
 
 | Pattern | Matches |
 |---------|---------|

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -100,10 +100,11 @@ SelfSubjectReview.
 
 ### maxValidFor
 
-Maximum time a session will remain active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365.
+Maximum time a session will remain active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
 
 ```yaml
-maxValidFor: "2h"    # 2 hours (default: 1h)
+maxValidFor: "1h"    # 1 hour (default)
+maxValidFor: "2h"    # 2 hours
 maxValidFor: "30m"   # 30 minutes
 maxValidFor: "4h"    # 4 hours
 maxValidFor: "1d12h" # 1 day and 12 hours
@@ -128,7 +129,7 @@ idleTimeout: "30m"   # Expire after 30 minutes of inactivity
 
 **Effective granularity**: Idle checks run every ~5 minutes (the cleanup interval), so a 1-minute idle timeout may not trigger until up to 5 minutes after the true idle point.
 
-**Relationship to maxValidFor**: `idleTimeout` must not exceed `maxValidFor` (if both are set).
+**Relationship to maxValidFor**: `idleTimeout` must not exceed `maxValidFor`. If `maxValidFor` is omitted, admission validates against the default `1h`.
 
 ### retainFor
 
@@ -138,6 +139,8 @@ How long to retain expired/revoked sessions before deletion:
 retainFor: "720h"    # Keep for 30 days (default: 720h)
 retainFor: "168h"    # Keep for 7 days
 ```
+
+The value must be a positive duration.
 
 ### approvalTimeout
 
@@ -150,6 +153,8 @@ approvalTimeout: "30m"   # Timeout after 30 minutes
 ```
 
 If not set, a default timeout of `1h` is applied. To change this behavior, explicitly set `approvalTimeout` to the desired duration.
+
+`approvalTimeout` must be a positive duration and must not exceed `maxValidFor`. If `maxValidFor` is omitted, admission validates it against the default `1h`.
 
 **Example:** Require quick approvals for emergency escalations:
 
@@ -479,6 +484,9 @@ allowedIdentityProvidersForApprovers:
   resolved member list is authoritative for that group.
 - Approval endpoints deny requests when an approver allowlist is configured but
   the authenticated caller's IDP is missing or not listed.
+- Session admission applies requester IDP restrictions to matching escalations
+  found through exact or glob matches in both `allowed.clusters` and
+  `clusterConfigRefs`.
 
 #### Example: Restrict to Corporate OIDC only
 

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -100,12 +100,13 @@ SelfSubjectReview.
 
 ### maxValidFor
 
-Maximum time a session will remain active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
+Maximum time a session will remain active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Decimal sub-day units such as `1.5h` are accepted; day values must be whole numbers, must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
 
 ```yaml
 maxValidFor: "1h"    # 1 hour (default)
 maxValidFor: "2h"    # 2 hours
 maxValidFor: "30m"   # 30 minutes
+maxValidFor: "1.5h"  # 1 hour and 30 minutes
 maxValidFor: "4h"    # 4 hours
 maxValidFor: "1d12h" # 1 day and 12 hours
 ```
@@ -1009,6 +1010,10 @@ Both `allowed.clusters` and `clusterConfigRefs` support **glob patterns** for fl
 | `*-staging` | Clusters ending with `-staging` |
 | `cluster-?` | Clusters like `cluster-1`, `cluster-2` (single character) |
 | `[abc]-cluster` | `a-cluster`, `b-cluster`, or `c-cluster` |
+
+Malformed glob patterns, for example an unclosed character class like `prod-[`,
+are rejected by `BreakglassEscalation` admission. Existing malformed patterns are
+ignored during session matching rather than failing unrelated session admission.
 
 **Example: Regional cluster access**
 

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -170,7 +170,7 @@ grantedGroup: "view-only"         # Read-only access
 
 #### maxValidFor
 
-Maximum time the session will be active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365.
+Maximum time the session will be active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
 
 ```yaml
 maxValidFor: "1h"   # 1 hour (default)
@@ -180,7 +180,7 @@ maxValidFor: "30m"  # 30 minutes
 
 #### idleTimeout
 
-Maximum duration a session can remain idle (no authorized webhook requests) before being automatically expired to the `IdleExpired` state. If not set, the session remains active for its full `maxValidFor` window. Parsed via the project's `ParseDuration` (supports day units like `"1d12h"`). Must be at least `1m` and must not exceed `maxValidFor`.
+Maximum duration a session can remain idle (no authorized webhook requests) before being automatically expired to the `IdleExpired` state. If not set, the session remains active for its full `maxValidFor` window. Parsed via the project's `ParseDuration` (supports day units like `"1d12h"`). Must be at least `1m` and must not exceed `maxValidFor`; when `maxValidFor` is omitted, admission validates against the default `1h`.
 
 Copied automatically from the matched `BreakglassEscalation` at approval time.
 
@@ -197,6 +197,8 @@ Time to wait before removing the session object after it expires:
 retainFor: "720h"  # 720 hours / 30 days (default)
 retainFor: "168h"  # 168 hours / 7 days
 ```
+
+The value must be a positive duration.
 
 #### clusterConfigRef
 

--- a/docs/breakglass-session.md
+++ b/docs/breakglass-session.md
@@ -170,12 +170,13 @@ grantedGroup: "view-only"         # Read-only access
 
 #### maxValidFor
 
-Maximum time the session will be active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Day values must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
+Maximum time the session will be active after approval. Supports Go `time.ParseDuration` syntax with an additional day unit (`d`). Decimal sub-day units such as `1.5h` are accepted; day values must be whole numbers, must not exceed 365, and the duration must be positive. If omitted, admission and runtime behavior use the default `1h`.
 
 ```yaml
 maxValidFor: "1h"   # 1 hour (default)
 maxValidFor: "2h"   # 2 hours
 maxValidFor: "30m"  # 30 minutes
+maxValidFor: "1.5h" # 1 hour and 30 minutes
 ```
 
 #### idleTimeout


### PR DESCRIPTION
## Summary
- validate `BreakglassSession.spec.maxValidFor` and `spec.retainFor` as positive durations
- validate `BreakglassEscalation.spec.retainFor` as a positive duration
- compare escalation `approvalTimeout` and `idleTimeout`, and session `idleTimeout`, against the default `maxValidFor` of `1h` when `maxValidFor` is omitted
- enforce session requester IDP restrictions for matching escalations found through exact/glob `allowed.clusters` and `clusterConfigRefs`
- update docs and changelog for the admission behavior

## Evidence
Audit found three admission gaps on `origin/main`:
- `approvalTimeout` was compared to a zero duration when `maxValidFor` was omitted, rejecting valid values below the default `1h` and not reporting the default comparison clearly.
- malformed or non-positive `retainFor` and session `maxValidFor` values were accepted by shared admission validation.
- session IDP authorization only exact-matched `allowed.clusters`, so restricted escalations using glob cluster targets or `clusterConfigRefs` were missed.

Duplicate check before opening:
- `gh search prs --repo telekom/k8s-breakglass --state open 'approvalTimeout default maxValidFor retainFor validation'` => no matches
- `gh search prs --repo telekom/k8s-breakglass --state open 'validateSessionIdentityProviderAuthorization clusterConfigRefs glob'` => no matches
- `gh search prs --repo telekom/k8s-breakglass --state open 'BreakglassSession retainFor maxValidFor admission validation'` => no matches

## Validation
- `go test ./api/v1alpha1 -run 'TestValidateTimeoutRelationships|TestValidateBreakglassSession|TestValidateBreakglassEscalation|TestValidateSessionIdentityProviderAuthorization' -count=1`
- `go test ./api/v1alpha1 -count=1`
- `make lint`
- `git diff --check`

## Screenshots
N/A: no UI files changed.
