### PR TITLE
fix: reject invalid session state filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
+- **BreakglassSession state filters**: `GET /api/breakglassSessions` now returns `400 Bad Request` for unknown non-empty `state` filter tokens.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 - **Frontend modal dismissal**: Approval, review, and withdraw modals now keep destructive actions mounted while requests are in flight, and support Escape or modal-close dismissal only when closing is safe.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -170,7 +170,7 @@ Authorization: Bearer <token>
 | `approver` | boolean | Sessions user can approve (default: `true`) |
 | `approvedByMe` | boolean | Sessions the user has already approved |
 | `activeOnly` | boolean | Only return currently running sessions that are in `Approved` state and granting access; pending approval and scheduled-wait sessions are excluded |
-| `state` | string | Accepts a single value, comma-separated list, or repeated parameter. Supported tokens: `all`, `pending`, `approved`, `active`, `waiting`, `waitingforscheduledtime`, `scheduled`, `rejected`, `withdrawn`, `expired`, `idleexpired`, `timeout`, `approvaltimeout`. The `active` token matches only currently running `Approved` sessions. |
+| `state` | string | Accepts a single value, comma-separated list, or repeated parameter. Supported tokens: `all`, `pending`, `approved`, `active`, `waiting`, `waitingforscheduledtime`, `scheduled`, `rejected`, `withdrawn`, `expired`, `idleexpired`, `timeout`, `approvaltimeout`. The `active` token matches only currently running `Approved` sessions. Unknown non-empty tokens return `400 Bad Request`. |
 | `token` | string | Validate approval-link metadata for a session name. This mode returns metadata for one session instead of the normal session list. |
 
 **Response:** Array of `BreakglassSession` resources filtered by query parameters:

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -999,12 +999,20 @@ func validateStateFilterTokens(tokens []string) []string {
 	if len(tokens) == 0 {
 		return nil
 	}
-	invalid := make([]string, 0)
+	invalidSet := make(map[string]struct{})
 	for _, token := range tokens {
 		if _, supported := sessionStateFilterPredicates[token]; !supported {
-			invalid = append(invalid, token)
+			invalidSet[token] = struct{}{}
 		}
 	}
+	if len(invalidSet) == 0 {
+		return nil
+	}
+	invalid := make([]string, 0, len(invalidSet))
+	for token := range invalidSet {
+		invalid = append(invalid, token)
+	}
+	sort.Strings(invalid)
 	return invalid
 }
 

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -903,6 +904,57 @@ func dropK8sInternalFieldsSessionList(list []breakglassv1alpha1.BreakglassSessio
 
 type sessionStatePredicate func(breakglassv1alpha1.BreakglassSession) bool
 
+var sessionStateFilterPredicates = map[string]sessionStatePredicate{
+	"all": nil,
+	"pending": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStatePending
+	},
+	"approved": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateApproved
+	},
+	"active": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return IsSessionAccessActive(session)
+	},
+	"waiting": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateWaitingForScheduledTime
+	},
+	"waitingforscheduledtime": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateWaitingForScheduledTime
+	},
+	"scheduled": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateWaitingForScheduledTime
+	},
+	"rejected": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return IsSessionRejected(session)
+	},
+	"withdrawn": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return IsSessionWithdrawn(session)
+	},
+	"expired": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return IsSessionExpired(session)
+	},
+	"idleexpired": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateIdleExpired
+	},
+	"timeout": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateTimeout
+	},
+	"approvaltimeout": func(session breakglassv1alpha1.BreakglassSession) bool {
+		return session.Status.State == breakglassv1alpha1.SessionStateTimeout
+	},
+}
+
+var supportedSessionStateFilterTokens = sortedSessionStateFilterTokens()
+
+func sortedSessionStateFilterTokens() []string {
+	tokens := make([]string, 0, len(sessionStateFilterPredicates))
+	for token := range sessionStateFilterPredicates {
+		tokens = append(tokens, token)
+	}
+	sort.Strings(tokens)
+	return tokens
+}
+
 func ParseBoolQuery(value string, defaultVal bool) bool {
 	if value == "" {
 		return defaultVal
@@ -943,54 +995,33 @@ func normalizeStateToken(value string) string {
 	return replacer.Replace(trimmed)
 }
 
+func validateStateFilterTokens(tokens []string) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
+	invalid := make([]string, 0)
+	for _, token := range tokens {
+		if _, supported := sessionStateFilterPredicates[token]; !supported {
+			invalid = append(invalid, token)
+		}
+	}
+	return invalid
+}
+
 func buildStateFilterPredicates(tokens []string) []sessionStatePredicate {
 	if len(tokens) == 0 {
 		return nil
 	}
 	predicates := make([]sessionStatePredicate, 0, len(tokens))
 	for _, token := range tokens {
-		switch token {
-		case "all":
-			return nil
-		case "pending":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return session.Status.State == breakglassv1alpha1.SessionStatePending
-			})
-		case "approved":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return session.Status.State == breakglassv1alpha1.SessionStateApproved
-			})
-		case "rejected":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return IsSessionRejected(session)
-			})
-		case "withdrawn":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return IsSessionWithdrawn(session)
-			})
-		case "expired":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return IsSessionExpired(session)
-			})
-		case "timeout", "approvaltimeout":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return session.Status.State == breakglassv1alpha1.SessionStateTimeout
-			})
-		case "active":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return IsSessionAccessActive(session)
-			})
-		case "waitingforscheduledtime", "waiting", "scheduled":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return session.Status.State == breakglassv1alpha1.SessionStateWaitingForScheduledTime
-			})
-		case "idleexpired":
-			predicates = append(predicates, func(session breakglassv1alpha1.BreakglassSession) bool {
-				return session.Status.State == breakglassv1alpha1.SessionStateIdleExpired
-			})
-		default:
+		predicate, supported := sessionStateFilterPredicates[token]
+		if !supported {
 			continue
 		}
+		if predicate == nil {
+			return nil
+		}
+		predicates = append(predicates, predicate)
 	}
 	return predicates
 }

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -673,6 +673,27 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 		return
 	}
 
+	// Ownership and state filters are request-local, so validate them before
+	// listing sessions from Kubernetes.
+	includeMine := ParseBoolQuery(c.Query("mine"), false)
+	includeApprover := ParseBoolQuery(c.Query("approver"), true)
+	includeApprovedByMe := ParseBoolQuery(c.Query("approvedByMe"), false)
+	activeOnly := ParseBoolQuery(c.Query("activeOnly"), false)
+	stateFilters := normalizeStateFilters(c)
+	if invalidFilters := validateStateFilterTokens(stateFilters); len(invalidFilters) > 0 {
+		apiresponses.RespondBadRequestWithDetails(
+			c,
+			"invalid state filter",
+			fmt.Sprintf(
+				"unsupported state filter value(s): %s. Supported values: %s",
+				strings.Join(invalidFilters, ", "),
+				strings.Join(supportedSessionStateFilterTokens, ", "),
+			),
+		)
+		return
+	}
+	statePredicates := buildStateFilterPredicates(stateFilters)
+
 	var sessions []breakglassv1alpha1.BreakglassSession
 	var err error
 	if clusterQ != "" || userQ != "" || groupQ != "" {
@@ -698,14 +719,6 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 		apiresponses.RespondInternalError(c, "list sessions", err, reqLog)
 		return
 	}
-
-	// Ownership filters
-	includeMine := ParseBoolQuery(c.Query("mine"), false)
-	includeApprover := ParseBoolQuery(c.Query("approver"), true)
-	includeApprovedByMe := ParseBoolQuery(c.Query("approvedByMe"), false)
-	activeOnly := ParseBoolQuery(c.Query("activeOnly"), false)
-	stateFilters := normalizeStateFilters(c)
-	statePredicates := buildStateFilterPredicates(stateFilters)
 
 	var userEmail string
 	if includeMine || includeApprovedByMe {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -4917,9 +4917,19 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&apiErr))
 		assert.Equal(t, "BAD_REQUEST", apiErr.Code)
 		assert.Equal(t, "invalid state filter", apiErr.Error)
-		assert.Contains(t, apiErr.Details, invalidToken)
-		assert.Equal(t, 1, strings.Count(apiErr.Details, invalidToken))
-		assert.Contains(t, apiErr.Details, "Supported values:")
+		invalidList, ok := strings.CutPrefix(apiErr.Details, "unsupported state filter value(s): ")
+		require.True(t, ok, "unexpected details format: %q", apiErr.Details)
+		invalidList, supportedValues, ok := strings.Cut(invalidList, ". Supported values:")
+		require.True(t, ok, "details should include supported values: %q", apiErr.Details)
+		assert.NotEmpty(t, supportedValues)
+		invalidTokens := strings.Split(invalidList, ", ")
+		matches := 0
+		for _, token := range invalidTokens {
+			if token == invalidToken {
+				matches++
+			}
+		}
+		assert.Equal(t, 1, matches)
 	}
 
 	assertInvalidState(t, "/breakglassSessions?state=not-a-state&mine=true", "notastate")

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -4901,6 +4901,9 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		res := w.Result()
+		defer func() {
+			assert.NoError(t, res.Body.Close())
+		}()
 		if res.StatusCode != http.StatusBadRequest {
 			t.Fatalf("expected 400 Bad Request, got %d", res.StatusCode)
 		}

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -4893,6 +4893,32 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 
 	assertStates(t, "/breakglassSessions?state=pending&state=approved&mine=true", []string{"multi-pending", "multi-approved"})
 	assertStates(t, "/breakglassSessions?state=pending,approved&mine=true", []string{"multi-pending", "multi-approved"})
+	assertStates(t, "/breakglassSessions?state=all&mine=true", []string{"multi-pending", "multi-approved", "multi-rejected"})
+
+	assertInvalidState := func(t *testing.T, query string, invalidToken string) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, query, nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+		res := w.Result()
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 Bad Request, got %d", res.StatusCode)
+		}
+		var apiErr struct {
+			Code    string `json:"code"`
+			Error   string `json:"error"`
+			Details string `json:"details"`
+		}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&apiErr))
+		assert.Equal(t, "BAD_REQUEST", apiErr.Code)
+		assert.Equal(t, "invalid state filter", apiErr.Error)
+		assert.Contains(t, apiErr.Details, invalidToken)
+		assert.Contains(t, apiErr.Details, "Supported values:")
+	}
+
+	assertInvalidState(t, "/breakglassSessions?state=not-a-state&mine=true", "notastate")
+	assertInvalidState(t, "/breakglassSessions?state=pending,not-a-state&mine=true", "notastate")
+	assertInvalidState(t, "/breakglassSessions?state=not-a-state&state=still-not-a-state&mine=true", "stillnotastate")
 }
 
 func TestFilterBreakglassSessionsApprovedByMe(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -4867,7 +4867,8 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 
 	assertStates := func(t *testing.T, query string, want []string) {
 		t.Helper()
-		req, _ := http.NewRequest(http.MethodGet, query, nil)
+		req, err := http.NewRequest(http.MethodGet, query, nil)
+		require.NoError(t, err)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		res := w.Result()
@@ -4897,7 +4898,8 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 
 	assertInvalidState := func(t *testing.T, query string, invalidToken string) {
 		t.Helper()
-		req, _ := http.NewRequest(http.MethodGet, query, nil)
+		req, err := http.NewRequest(http.MethodGet, query, nil)
+		require.NoError(t, err)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
 		res := w.Result()
@@ -4916,12 +4918,14 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 		assert.Equal(t, "BAD_REQUEST", apiErr.Code)
 		assert.Equal(t, "invalid state filter", apiErr.Error)
 		assert.Contains(t, apiErr.Details, invalidToken)
+		assert.Equal(t, 1, strings.Count(apiErr.Details, invalidToken))
 		assert.Contains(t, apiErr.Details, "Supported values:")
 	}
 
 	assertInvalidState(t, "/breakglassSessions?state=not-a-state&mine=true", "notastate")
 	assertInvalidState(t, "/breakglassSessions?state=pending,not-a-state&mine=true", "notastate")
 	assertInvalidState(t, "/breakglassSessions?state=not-a-state&state=still-not-a-state&mine=true", "stillnotastate")
+	assertInvalidState(t, "/breakglassSessions?state=duplicate-invalid&state=duplicate-invalid&mine=true", "duplicateinvalid")
 }
 
 func TestFilterBreakglassSessionsApprovedByMe(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject unknown non-empty `state` query tokens on `GET /api/breakglassSessions` with `400 BAD_REQUEST`
- keep repeated, comma-separated, and `state=all` behavior for supported filters
- document the bad-request behavior and add a changelog entry

## Evidence
Before this change, `normalizeStateFilters` normalized arbitrary tokens and `buildStateFilterPredicates` dropped unknown tokens. A request such as `GET /api/breakglassSessions?state=not-a-state&mine=true` could therefore behave like no state filter was applied and return broader authorized results than the caller expected.

Duplicate check before opening: live open PR searches for `invalid state filter`, `normalizeStateFilters`, `buildStateFilterPredicates`, and `state=not-a-state` found no duplicate. Adjacent PRs #892, #882, and #886 cover idle-expired docs or expiry operations, not invalid filter rejection.

## Tests
- `go test ./pkg/breakglass -run 'TestFilterBreakglassSessionsByMultipleStates|TestFilterBreakglassSessionsByState' -count=1`\n- `go test ./pkg/breakglass -count=1`\n- `make lint`\n- `git diff --check`