### PR TITLE
fix: guard release chart app versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,6 +575,11 @@ jobs:
           if [ "${REMOTE_CHART_LOOKUP_STATUS}" -eq 0 ]; then
             REMOTE_CHART_METADATA="${REMOTE_CHART_LOOKUP_OUTPUT}"
             REMOTE_APP_VERSION="$(printf '%s\n' "${REMOTE_CHART_METADATA}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
+            if [ -z "${REMOTE_APP_VERSION}" ]; then
+              echo "::error::Failed to determine remote escalation-config:${CHART_VERSION} appVersion from GHCR metadata." >&2
+              printf '%s\n' "${REMOTE_CHART_METADATA}" >&2
+              exit 1
+            fi
             if [ "${REMOTE_APP_VERSION}" = "${CHART_APP_VERSION}" ]; then
               echo "Chart escalation-config:${CHART_VERSION} already present in GHCR with appVersion ${REMOTE_APP_VERSION}; skipping push."
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,7 +584,7 @@ jobs:
             exit 1
           fi
 
-          if printf '%s\n' "${REMOTE_CHART_LOOKUP_OUTPUT}" | grep -Eiq '(not found|not exist|no such|manifest unknown|404)'; then
+          if printf '%s\n' "${REMOTE_CHART_LOOKUP_OUTPUT}" | grep -Eiq '(^Error: .*(not found|manifest unknown)|(^|[[:space:]])manifest unknown([[:space:][:punct:]]|$))'; then
             echo "Chart escalation-config:${CHART_VERSION} is not present in GHCR; publishing new package."
           else
             echo "::error::Failed to inspect existing escalation-config:${CHART_VERSION} chart in GHCR before publishing." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,8 +550,10 @@ jobs:
           set -euo pipefail
 
           CHART_PACKAGE="$(ls chart-dist/escalation-config-*.tgz | head -n1)"
-          CHART_VERSION="$(helm show chart "${CHART_PACKAGE}" | awk '/^version:/ {print $2}')"
-          CHART_APP_VERSION="$(helm show chart "${CHART_PACKAGE}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
+          RELEASE_TAG="${{ github.ref_name }}"
+          CHART_METADATA="$(helm show chart "${CHART_PACKAGE}")"
+          CHART_VERSION="$(printf '%s\n' "${CHART_METADATA}" | awk '/^version:/ {print $2}')"
+          CHART_APP_VERSION="$(printf '%s\n' "${CHART_METADATA}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
 
           if [ -z "${CHART_VERSION}" ]; then
             echo "Failed to determine chart version from ${CHART_PACKAGE}" >&2
@@ -559,6 +561,10 @@ jobs:
           fi
           if [ -z "${CHART_APP_VERSION}" ]; then
             echo "Failed to determine chart appVersion from ${CHART_PACKAGE}" >&2
+            exit 1
+          fi
+          if [ "${CHART_APP_VERSION}" != "${RELEASE_TAG}" ]; then
+            echo "::error::Packaged escalation-config:${CHART_VERSION} appVersion ${CHART_APP_VERSION} does not match release tag ${RELEASE_TAG}." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,18 +551,45 @@ jobs:
 
           CHART_PACKAGE="$(ls chart-dist/escalation-config-*.tgz | head -n1)"
           CHART_VERSION="$(helm show chart "${CHART_PACKAGE}" | awk '/^version:/ {print $2}')"
+          CHART_APP_VERSION="$(helm show chart "${CHART_PACKAGE}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
 
           if [ -z "${CHART_VERSION}" ]; then
             echo "Failed to determine chart version from ${CHART_PACKAGE}" >&2
             exit 1
           fi
+          if [ -z "${CHART_APP_VERSION}" ]; then
+            echo "Failed to determine chart appVersion from ${CHART_PACKAGE}" >&2
+            exit 1
+          fi
 
-          echo "Preparing to publish escalation-config:${CHART_VERSION} to ${CHART_REPO}"
+          echo "Preparing to publish escalation-config:${CHART_VERSION} appVersion ${CHART_APP_VERSION} to ${CHART_REPO}"
 
-          # Idempotent behavior for reruns: skip if this chart version already exists.
-          if helm show chart "${CHART_REPO}/escalation-config" --version "${CHART_VERSION}" >/dev/null 2>&1; then
-            echo "Chart escalation-config:${CHART_VERSION} already present in GHCR; skipping push."
-            exit 0
+          # Idempotent behavior for reruns: skip only if this exact chart version
+          # already exists for the same release tag. A different appVersion under
+          # the same chart version would leave GHCR serving a stale release.
+          set +e
+          REMOTE_CHART_LOOKUP_OUTPUT="$(helm show chart "${CHART_REPO}/escalation-config" --version "${CHART_VERSION}" 2>&1)"
+          REMOTE_CHART_LOOKUP_STATUS=$?
+          set -e
+
+          if [ "${REMOTE_CHART_LOOKUP_STATUS}" -eq 0 ]; then
+            REMOTE_CHART_METADATA="${REMOTE_CHART_LOOKUP_OUTPUT}"
+            REMOTE_APP_VERSION="$(printf '%s\n' "${REMOTE_CHART_METADATA}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
+            if [ "${REMOTE_APP_VERSION}" = "${CHART_APP_VERSION}" ]; then
+              echo "Chart escalation-config:${CHART_VERSION} already present in GHCR with appVersion ${REMOTE_APP_VERSION}; skipping push."
+              exit 0
+            fi
+
+            echo "::error::Chart escalation-config:${CHART_VERSION} already exists in GHCR with appVersion ${REMOTE_APP_VERSION:-<unknown>}, but this release packages appVersion ${CHART_APP_VERSION}. Bump charts/escalation-config/Chart.yaml version before releasing."
+            exit 1
+          fi
+
+          if printf '%s\n' "${REMOTE_CHART_LOOKUP_OUTPUT}" | grep -Eiq '(not found|not exist|no such|manifest unknown|404)'; then
+            echo "Chart escalation-config:${CHART_VERSION} is not present in GHCR; publishing new package."
+          else
+            echo "::error::Failed to inspect existing escalation-config:${CHART_VERSION} chart in GHCR before publishing." >&2
+            printf '%s\n' "${REMOTE_CHART_LOOKUP_OUTPUT}" >&2
+            exit "${REMOTE_CHART_LOOKUP_STATUS}"
           fi
 
           helm push "${CHART_PACKAGE}" "${CHART_REPO}"

--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -44,7 +44,10 @@ helm install my-escalation \
 ```
 
 `<chart-version>` is the chart `version` from `charts/escalation-config/Chart.yaml`.
-It is versioned independently from the container image tag.
+It is versioned independently from the container image tag. Each released chart
+package must use a chart version that has not already been published for a
+different release tag. Release reruns may reuse the same chart version only when
+the packaged `appVersion` matches the already-published OCI chart.
 
 ## Configuration
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -86,7 +86,7 @@ Consumers should be able to:
    helm show chart oci://ghcr.io/telekom/k8s-breakglass/charts/escalation-config \
       --version <chart-version>
    ```
-  Confirm the returned `version` is the expected chart version and `appVersion` is the release tag.
+  - Confirm the returned `version` is the expected chart version and `appVersion` is the release tag.
 - Verify SBOM attestation:
   ```bash
   cosign verify-attestation ghcr.io/telekom/k8s-breakglass@<digest> \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -40,6 +40,7 @@ This document defines the release requirements for k8s-breakglass. It is intende
    - `charts/escalation-config` is packaged during release preparation.
    - The packaged chart is pushed to GHCR as a Helm OCI artifact at `oci://ghcr.io/telekom/k8s-breakglass/charts/escalation-config`.
    - The chart `.tgz` is attached to the GitHub Release assets.
+   - Every release tag that changes the packaged chart `appVersion` must use a unique chart `version` in `charts/escalation-config/Chart.yaml`. Release reruns may skip an already-published chart only when the remote chart `appVersion` matches the release tag.
 
 ## Multi-Architecture Builds
 
@@ -63,6 +64,7 @@ Release images are built as multi-arch manifests supporting both `linux/amd64` a
 - Verify CI success on the release commit.
 - Ensure the changelog is up to date.
 - Use `vX.Y.Z` tags for stable releases and `vX.Y.Z-rc.1` style tags for prereleases. Do not use SemVer build metadata in release tags.
+- Bump `charts/escalation-config/Chart.yaml` `version` before cutting a release whose chart `appVersion` has not already been published under that chart version.
 - Generate artifacts via the release workflow.
 - Verify chart publication in GHCR (`oci://ghcr.io/telekom/k8s-breakglass/charts/escalation-config`).
 - Publish checksums and update release notes.
@@ -84,6 +86,7 @@ Consumers should be able to:
    helm show chart oci://ghcr.io/telekom/k8s-breakglass/charts/escalation-config \
       --version <chart-version>
    ```
+  Confirm the returned `version` is the expected chart version and `appVersion` is the release tag.
 - Verify SBOM attestation:
   ```bash
   cosign verify-attestation ghcr.io/telekom/k8s-breakglass@<digest> \

--- a/hack/verify-release-provenance.sh
+++ b/hack/verify-release-provenance.sh
@@ -43,8 +43,10 @@ deny_pattern 'DIGEST="\$\{RAW_MANIFEST_DIGEST\}"' \
   "release provenance must not sign or attest a computed raw-manifest digest"
 deny_pattern 'github\.run_started_at' \
   "github.run_started_at is not a valid GitHub Actions context property"
-deny_pattern 'helm show chart .*([[:space:]]2>[[:space:]]*/dev/null|>[[:space:]]*/dev/null[[:space:]]+2>&1)' \
+deny_pattern 'helm show chart .*([[:space:]]*2>[[:space:]]*/dev/null|>[[:space:]]*/dev/null[[:space:]]*2>&1)' \
   "Helm chart publishing must not suppress remote chart lookup errors"
+deny_pattern 'CHART_(VERSION|APP_VERSION)="\$\(helm show chart' \
+  "release workflow must capture packaged Helm chart metadata once before extracting fields"
 deny_pattern 'grep -Eiq .*no such' \
   "Helm chart missing classifier must not treat DNS/network no-such-host errors as chart-not-present"
 deny_pattern 'already present in GHCR; skipping push' \
@@ -60,6 +62,10 @@ require_pattern 'subject-digest: \$\{\{ steps\.inspect\.outputs\.digest \}\}' \
   "release provenance attestation must use the inspected registry digest output"
 require_pattern 'CHART_APP_VERSION=' \
   "release workflow must read the packaged Helm chart appVersion"
+require_pattern 'CHART_METADATA="\$\(helm show chart "\$\{CHART_PACKAGE\}"\)"' \
+  "release workflow must capture packaged Helm chart metadata once"
+require_pattern '\[ "\$\{CHART_APP_VERSION\}" != "\$\{RELEASE_TAG\}" \]' \
+  "release workflow must fail when packaged Helm chart appVersion does not match the release tag"
 require_pattern 'REMOTE_APP_VERSION=' \
   "release workflow must read the remote Helm chart appVersion before skipping an existing chart version"
 require_pattern 'Failed to determine remote escalation-config:\$\{CHART_VERSION\} appVersion from GHCR metadata' \

--- a/hack/verify-release-provenance.sh
+++ b/hack/verify-release-provenance.sh
@@ -43,8 +43,10 @@ deny_pattern 'DIGEST="\$\{RAW_MANIFEST_DIGEST\}"' \
   "release provenance must not sign or attest a computed raw-manifest digest"
 deny_pattern 'github\.run_started_at' \
   "github.run_started_at is not a valid GitHub Actions context property"
-deny_pattern 'helm show chart .*[[:space:]]2>/dev/null' \
+deny_pattern 'helm show chart .*([[:space:]]2>[[:space:]]*/dev/null|>[[:space:]]*/dev/null[[:space:]]+2>&1)' \
   "Helm chart publishing must not suppress remote chart lookup errors"
+deny_pattern 'grep -Eiq .*no such' \
+  "Helm chart missing classifier must not treat DNS/network no-such-host errors as chart-not-present"
 deny_pattern 'already present in GHCR; skipping push' \
   "Helm chart publishing must not skip existing chart versions without checking appVersion"
 
@@ -64,6 +66,8 @@ require_pattern 'REMOTE_CHART_LOOKUP_STATUS=' \
   "release workflow must preserve the remote chart lookup exit status"
 require_pattern 'Failed to inspect existing escalation-config' \
   "release workflow must fail real remote chart lookup errors before publishing"
+require_pattern 'grep -Eiq.*manifest unknown' \
+  "release workflow must classify Helm/GHCR missing-chart errors without broad network-error matches"
 require_pattern '\[ "\$\{REMOTE_APP_VERSION\}" = "\$\{CHART_APP_VERSION\}" \]' \
   "release workflow must skip chart publication only when remote and packaged appVersion match"
 require_pattern 'Bump charts/escalation-config/Chart.yaml version before releasing' \

--- a/hack/verify-release-provenance.sh
+++ b/hack/verify-release-provenance.sh
@@ -43,6 +43,10 @@ deny_pattern 'DIGEST="\$\{RAW_MANIFEST_DIGEST\}"' \
   "release provenance must not sign or attest a computed raw-manifest digest"
 deny_pattern 'github\.run_started_at' \
   "github.run_started_at is not a valid GitHub Actions context property"
+deny_pattern 'helm show chart .*[[:space:]]2>/dev/null' \
+  "Helm chart publishing must not suppress remote chart lookup errors"
+deny_pattern 'already present in GHCR; skipping push' \
+  "Helm chart publishing must not skip existing chart versions without checking appVersion"
 
 require_pattern 'docker buildx imagetools inspect "\$\{IMG\}"' \
   "release workflow must inspect the pushed image through the registry"
@@ -52,6 +56,18 @@ require_pattern 'Could not determine registry digest' \
   "release workflow must fail when the registry digest cannot be determined"
 require_pattern 'subject-digest: \$\{\{ steps\.inspect\.outputs\.digest \}\}' \
   "release provenance attestation must use the inspected registry digest output"
+require_pattern 'CHART_APP_VERSION=' \
+  "release workflow must read the packaged Helm chart appVersion"
+require_pattern 'REMOTE_APP_VERSION=' \
+  "release workflow must read the remote Helm chart appVersion before skipping an existing chart version"
+require_pattern 'REMOTE_CHART_LOOKUP_STATUS=' \
+  "release workflow must preserve the remote chart lookup exit status"
+require_pattern 'Failed to inspect existing escalation-config' \
+  "release workflow must fail real remote chart lookup errors before publishing"
+require_pattern '\[ "\$\{REMOTE_APP_VERSION\}" = "\$\{CHART_APP_VERSION\}" \]' \
+  "release workflow must skip chart publication only when remote and packaged appVersion match"
+require_pattern 'Bump charts/escalation-config/Chart.yaml version before releasing' \
+  "release workflow must fail clearly when a chart version already exists with a different appVersion"
 
 if [ "${failures}" -ne 0 ]; then
   exit 1

--- a/hack/verify-release-provenance.sh
+++ b/hack/verify-release-provenance.sh
@@ -62,6 +62,8 @@ require_pattern 'CHART_APP_VERSION=' \
   "release workflow must read the packaged Helm chart appVersion"
 require_pattern 'REMOTE_APP_VERSION=' \
   "release workflow must read the remote Helm chart appVersion before skipping an existing chart version"
+require_pattern 'Failed to determine remote escalation-config:\$\{CHART_VERSION\} appVersion from GHCR metadata' \
+  "release workflow must fail clearly when remote chart metadata lacks appVersion"
 require_pattern 'REMOTE_CHART_LOOKUP_STATUS=' \
   "release workflow must preserve the remote chart lookup exit status"
 require_pattern 'Failed to inspect existing escalation-config' \


### PR DESCRIPTION
## Summary
- bump `charts/escalation-config` chart version to `0.3.1` for the next release
- make release chart publishing skip only when the remote GHCR chart version has the same `appVersion` as the package being released
- fail with a clear chart-version bump error when a chart version already exists with a different `appVersion`
- extend the release workflow guard and document the chart version/appVersion rule

## Evidence
The release workflow stamped each release tag into the packaged chart `appVersion` but kept `version: 0.3.0`. The publish step skipped whenever `escalation-config:0.3.0` already existed in GHCR, so later releases could attach a correct `.tgz` asset while GHCR still served the first published `0.3.0` chart.

Duplicate check before opening: live open PR search for `release chart`, `Chart.yaml`, `Helm OCI`, `GHCR`, and `appVersion` found no PR touching `.github/workflows/release.yml`, `charts/escalation-config/Chart.yaml`, `docs/release-process.md`, or the chart README.

## Tests
- `make verify-release-provenance`
- `helm lint charts/escalation-config`
- `helm template test-release charts/escalation-config --debug`
- `git diff --check`