### PR TITLE
Wire DebugSession reconciler audit and mail services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
+- **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 ### Fixed
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -690,7 +690,8 @@ func startBackgroundRoutines(ctx context.Context, wg *sync.WaitGroup, errCh chan
 	go func() {
 		defer wg.Done()
 		if err := reconciler.Setup(ctx, deps.reconcilerMgr, deps.idpLoader, deps.server,
-			deps.ccProvider, deps.auditService, deps.mailService, deps.escalationManager, deps.cliConfig.EnableControllers, log); err != nil {
+			deps.ccProvider, deps.auditService, deps.mailService, deps.cfg.Frontend,
+			deps.cliConfig.DisableEmail, deps.escalationManager, deps.cliConfig.EnableControllers, log); err != nil {
 			errCh <- fmt.Errorf("reconciler manager failed: %w", err)
 		}
 	}()

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1530,6 +1530,12 @@ audit:
         memory: 64Mi
 ```
 
+The DebugSession reconciler emits lifecycle audit events through configured
+`AuditConfig` sinks for approval timeouts, session failures, pod failures,
+container restarts, and auxiliary resource deploy/cleanup operations. Failure
+notifications to the requester use the configured `MailProvider` and honor
+`--disable-email`.
+
 ## API Endpoints
 
 Debug sessions can be managed via the REST API:

--- a/pkg/breakglass/debug/auxiliary_resource_manager.go
+++ b/pkg/breakglass/debug/auxiliary_resource_manager.go
@@ -43,6 +43,7 @@ type AuxiliaryResourceManager struct {
 	log              *zap.SugaredLogger
 	client           client.Client
 	auditManager     *audit.Manager
+	auditProvider    func() *audit.Manager
 	readinessChecker *utils.ReadinessChecker
 }
 
@@ -58,6 +59,19 @@ func NewAuxiliaryResourceManager(log *zap.SugaredLogger, cli client.Client) *Aux
 // SetAuditManager sets the audit manager for emitting audit events.
 func (m *AuxiliaryResourceManager) SetAuditManager(am *audit.Manager) {
 	m.auditManager = am
+	m.auditProvider = nil
+}
+
+// SetAuditManagerProvider sets a reload-aware audit manager provider.
+func (m *AuxiliaryResourceManager) SetAuditManagerProvider(provider func() *audit.Manager) {
+	m.auditProvider = provider
+}
+
+func (m *AuxiliaryResourceManager) currentAuditManager() *audit.Manager {
+	if m.auditProvider != nil {
+		return m.auditProvider()
+	}
+	return m.auditManager
 }
 
 // DeployAuxiliaryResources deploys all enabled auxiliary resources for a session.
@@ -609,8 +623,8 @@ func (m *AuxiliaryResourceManager) deployResource(
 			"namespace", obj.GetNamespace())
 
 		// Emit audit event
-		if m.auditManager != nil {
-			m.auditManager.DebugSessionResourceDeployed(
+		if auditManager := m.currentAuditManager(); auditManager != nil {
+			auditManager.DebugSessionResourceDeployed(
 				ctx,
 				session.Name,
 				session.Namespace,
@@ -719,8 +733,8 @@ func (m *AuxiliaryResourceManager) deleteResource(
 		"namespace", status.Namespace)
 
 	// Emit audit event for resource cleanup
-	if m.auditManager != nil {
-		m.auditManager.DebugSessionResourceCleanup(
+	if auditManager := m.currentAuditManager(); auditManager != nil {
+		auditManager.DebugSessionResourceCleanup(
 			ctx,
 			session.Name,
 			session.Namespace,

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -61,6 +61,7 @@ type DebugSessionController struct {
 	log          *zap.SugaredLogger
 	client       ctrlclient.Client
 	ccProvider   *cluster.ClientProvider
+	auditService *audit.Service
 	auditManager *audit.Manager
 	mailService  breakglass.MailEnqueuer
 	auxiliaryMgr *AuxiliaryResourceManager
@@ -82,6 +83,19 @@ func NewDebugSessionController(log *zap.SugaredLogger, client ctrlclient.Client,
 // WithAuditManager sets the audit manager for the controller
 func (c *DebugSessionController) WithAuditManager(am *audit.Manager) *DebugSessionController {
 	c.auditManager = am
+	c.auditService = nil
+	if c.auxiliaryMgr != nil {
+		c.auxiliaryMgr.SetAuditManager(am)
+	}
+	return c
+}
+
+// WithAuditService sets the reloadable audit service for the controller.
+func (c *DebugSessionController) WithAuditService(auditService *audit.Service) *DebugSessionController {
+	c.auditService = auditService
+	if c.auxiliaryMgr != nil {
+		c.auxiliaryMgr.SetAuditManagerProvider(c.currentAuditManager)
+	}
 	return c
 }
 
@@ -92,6 +106,13 @@ func (c *DebugSessionController) WithMailService(mailService breakglass.MailEnqu
 	c.baseURL = baseURL
 	c.disableEmail = disableEmail
 	return c
+}
+
+func (c *DebugSessionController) currentAuditManager() *audit.Manager {
+	if c.auditService != nil {
+		return c.auditService.Manager()
+	}
+	return c.auditManager
 }
 
 // SetupWithManager sets up the controller with the Manager
@@ -263,8 +284,10 @@ func (c *DebugSessionController) handlePendingApproval(ctx context.Context, ds *
 			"debugSession", ds.Name, "namespace", ds.Namespace,
 			"reason", reason)
 
-		if c.shouldEmitAudit(ds) && c.auditManager != nil {
-			c.auditManager.DebugSessionApprovalTimeout(ctx, ds.Name, ds.Namespace, ds.Spec.Cluster)
+		if c.shouldEmitAudit(ds) {
+			if auditManager := c.currentAuditManager(); auditManager != nil {
+				auditManager.DebugSessionApprovalTimeout(ctx, ds.Name, ds.Namespace, ds.Spec.Cluster)
+			}
 		}
 
 		ds.Status.State = breakglassv1alpha1.DebugSessionStateFailed
@@ -467,19 +490,21 @@ func (c *DebugSessionController) failSession(ctx context.Context, ds *breakglass
 	)
 
 	// Emit audit event if audit is enabled for this session
-	if c.shouldEmitAudit(ds) && c.auditManager != nil {
-		c.auditManager.DebugSessionFailed(ctx, ds.Name, ds.Namespace, ds.Spec.Cluster, reason, map[string]interface{}{
-			"template":       ds.Spec.TemplateRef,
-			"requested_by":   ds.Spec.RequestedBy,
-			"previous_state": string(ds.Status.State),
-		})
-		// Send to webhook destinations if configured
-		c.sendToWebhookDestinations(ctx, ds, "DebugSessionFailed", map[string]interface{}{
-			"session":   ds.Name,
-			"namespace": ds.Namespace,
-			"cluster":   ds.Spec.Cluster,
-			"reason":    reason,
-		})
+	if c.shouldEmitAudit(ds) {
+		if auditManager := c.currentAuditManager(); auditManager != nil {
+			auditManager.DebugSessionFailed(ctx, ds.Name, ds.Namespace, ds.Spec.Cluster, reason, map[string]interface{}{
+				"template":       ds.Spec.TemplateRef,
+				"requested_by":   ds.Spec.RequestedBy,
+				"previous_state": string(ds.Status.State),
+			})
+			// Send to webhook destinations if configured
+			c.sendToWebhookDestinations(ctx, ds, "DebugSessionFailed", map[string]interface{}{
+				"session":   ds.Name,
+				"namespace": ds.Namespace,
+				"cluster":   ds.Spec.Cluster,
+				"reason":    reason,
+			})
+		}
 	}
 
 	ds.Status.State = breakglassv1alpha1.DebugSessionStateFailed

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -576,7 +576,9 @@ func isSafeDebugSessionFailureRecipient(recipient string) bool {
 	if recipient == "" || !strings.Contains(recipient, "@") {
 		return false
 	}
-	return strings.IndexFunc(recipient, unicode.IsControl) == -1
+	return strings.IndexFunc(recipient, func(r rune) bool {
+		return unicode.IsControl(r) || unicode.IsSpace(r) || strings.ContainsRune(",;<>", r)
+	}) == -1
 }
 
 // shouldEmitAudit checks if audit events should be emitted for this session

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/audit"
@@ -526,12 +527,12 @@ func (c *DebugSessionController) sendDebugSessionFailedEmail(ds *breakglassv1alp
 		return
 	}
 
-	requesterEmail := ds.Spec.RequestedByEmail
+	requesterEmail := strings.TrimSpace(ds.Spec.RequestedByEmail)
 	if requesterEmail == "" {
-		requesterEmail = ds.Spec.RequestedBy
+		requesterEmail = strings.TrimSpace(ds.Spec.RequestedBy)
 	}
-	if !strings.Contains(requesterEmail, "@") {
-		c.log.Warnw("Skipping debug session failed email - no valid email address", "session", ds.Name, "recipient", requesterEmail)
+	if !isSafeDebugSessionFailureRecipient(requesterEmail) {
+		c.log.Warnw("Skipping debug session failed email - no valid email address", "session", ds.Name)
 		return
 	}
 	recipients := []string{requesterEmail}
@@ -569,6 +570,13 @@ func (c *DebugSessionController) sendDebugSessionFailedEmail(ds *breakglassv1alp
 	} else {
 		c.log.Infow("Debug session failed email queued", "session", ds.Name, "requester", ds.Spec.RequestedBy)
 	}
+}
+
+func isSafeDebugSessionFailureRecipient(recipient string) bool {
+	if recipient == "" || !strings.Contains(recipient, "@") {
+		return false
+	}
+	return strings.IndexFunc(recipient, unicode.IsControl) == -1
 }
 
 // shouldEmitAudit checks if audit events should be emitted for this session

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -525,11 +525,20 @@ func (c *DebugSessionController) sendDebugSessionFailedEmail(ds *breakglassv1alp
 		return
 	}
 
-	recipients := []string{ds.Spec.RequestedBy}
+	requesterEmail := ds.Spec.RequestedByEmail
+	if requesterEmail == "" {
+		requesterEmail = ds.Spec.RequestedBy
+	}
+	recipients := []string{requesterEmail}
+
+	requesterName := ds.Spec.RequestedByDisplayName
+	if requesterName == "" {
+		requesterName = ds.Spec.RequestedBy
+	}
 
 	params := mail.DebugSessionFailedMailParams{
-		RequesterName:  ds.Spec.RequestedBy,
-		RequesterEmail: ds.Spec.RequestedBy,
+		RequesterName:  requesterName,
+		RequesterEmail: requesterEmail,
 		SessionID:      ds.Name,
 		Cluster:        ds.Spec.Cluster,
 		TemplateName:   ds.Spec.TemplateRef,

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -539,6 +539,9 @@ func (c *DebugSessionController) sendDebugSessionFailedEmail(ds *breakglassv1alp
 	requesterName := ds.Spec.RequestedByDisplayName
 	if requesterName == "" {
 		requesterName = ds.Spec.RequestedBy
+		if strings.EqualFold(requesterName, requesterEmail) {
+			requesterName = ""
+		}
 	}
 
 	params := mail.DebugSessionFailedMailParams{

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -528,6 +529,10 @@ func (c *DebugSessionController) sendDebugSessionFailedEmail(ds *breakglassv1alp
 	requesterEmail := ds.Spec.RequestedByEmail
 	if requesterEmail == "" {
 		requesterEmail = ds.Spec.RequestedBy
+	}
+	if !strings.Contains(requesterEmail, "@") {
+		c.log.Warnw("Skipping debug session failed email - no valid email address", "session", ds.Name, "recipient", requesterEmail)
+		return
 	}
 	recipients := []string{requesterEmail}
 

--- a/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_lifecycle.go
@@ -199,14 +199,16 @@ func (c *DebugSessionController) monitorPodHealth(ctx context.Context, ds *break
 			"node", pod.Spec.NodeName,
 		)
 
-		if c.shouldEmitAudit(ds) && c.auditManager != nil {
-			c.auditManager.DebugSessionPodFailed(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, reason, message)
-			c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodFailed", map[string]interface{}{
-				"pod":       pod.Name,
-				"namespace": pod.Namespace,
-				"reason":    reason,
-				"message":   message,
-			})
+		if c.shouldEmitAudit(ds) {
+			if auditManager := c.currentAuditManager(); auditManager != nil {
+				auditManager.DebugSessionPodFailed(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, reason, message)
+				c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodFailed", map[string]interface{}{
+					"pod":       pod.Name,
+					"namespace": pod.Namespace,
+					"reason":    reason,
+					"message":   message,
+				})
+			}
 		}
 		metrics.DebugSessionPodFailures.WithLabelValues(ds.Spec.Cluster, ds.Name, reason).Inc()
 	}
@@ -231,15 +233,17 @@ func (c *DebugSessionController) monitorPodHealth(ctx context.Context, ds *break
 				"lastTerminationReason", lastTerminationReason,
 			)
 
-			if c.shouldEmitAudit(ds) && c.auditManager != nil {
-				c.auditManager.DebugSessionPodRestarted(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, cs.RestartCount, lastTerminationReason)
-				c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodRestarted", map[string]interface{}{
-					"pod":                   pod.Name,
-					"namespace":             pod.Namespace,
-					"container":             cs.Name,
-					"restartCount":          cs.RestartCount,
-					"lastTerminationReason": lastTerminationReason,
-				})
+			if c.shouldEmitAudit(ds) {
+				if auditManager := c.currentAuditManager(); auditManager != nil {
+					auditManager.DebugSessionPodRestarted(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, cs.RestartCount, lastTerminationReason)
+					c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodRestarted", map[string]interface{}{
+						"pod":                   pod.Name,
+						"namespace":             pod.Namespace,
+						"container":             cs.Name,
+						"restartCount":          cs.RestartCount,
+						"lastTerminationReason": lastTerminationReason,
+					})
+				}
 			}
 			metrics.DebugSessionPodRestarts.WithLabelValues(ds.Spec.Cluster, ds.Name).Inc()
 		}
@@ -263,15 +267,17 @@ func (c *DebugSessionController) monitorPodHealth(ctx context.Context, ds *break
 					"waitingMessage", waitingMessage,
 				)
 
-				if c.shouldEmitAudit(ds) && c.auditManager != nil {
-					c.auditManager.DebugSessionPodFailed(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, waitingReason, waitingMessage)
-					c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodFailed", map[string]interface{}{
-						"pod":       pod.Name,
-						"namespace": pod.Namespace,
-						"container": cs.Name,
-						"reason":    waitingReason,
-						"message":   waitingMessage,
-					})
+				if c.shouldEmitAudit(ds) {
+					if auditManager := c.currentAuditManager(); auditManager != nil {
+						auditManager.DebugSessionPodFailed(ctx, ds.Name, ds.Namespace, pod.Name, pod.Namespace, waitingReason, waitingMessage)
+						c.sendToWebhookDestinations(ctx, ds, "DebugSessionPodFailed", map[string]interface{}{
+							"pod":       pod.Name,
+							"namespace": pod.Namespace,
+							"container": cs.Name,
+							"reason":    waitingReason,
+							"message":   waitingMessage,
+						})
+					}
 				}
 				metrics.DebugSessionPodFailures.WithLabelValues(ds.Spec.Cluster, ds.Name, waitingReason).Inc()
 			}

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -93,3 +93,15 @@ func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
 	assert.Contains(t, messages[0].Body, "Requester Display")
 	assert.NotContains(t, messages[0].Body, "requester-id")
 }
+
+func TestDebugSessionController_SendDebugSessionFailedEmailSkipsNonEmailRequester(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	mockMail := NewMockMailEnqueuer(true)
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
+
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "opaque-subject")
+	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
+
+	assert.Empty(t, mockMail.GetMessages())
+}

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -94,6 +94,34 @@ func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
 	assert.NotContains(t, messages[0].Body, "requester-id")
 }
 
+func TestDebugSessionController_SendDebugSessionFailedEmailTrimsRequesterEmail(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	mockMail := NewMockMailEnqueuer(true)
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
+
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester-id")
+	session.Spec.RequestedByEmail = "  requester@example.com  "
+	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
+}
+
+func TestDebugSessionController_SendDebugSessionFailedEmailSkipsControlCharacterRecipient(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	mockMail := NewMockMailEnqueuer(true)
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
+
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester-id")
+	session.Spec.RequestedByEmail = "requester@example.com\r\nbcc: attacker@example.com"
+	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
+
+	assert.Empty(t, mockMail.GetMessages())
+}
+
 func TestDebugSessionController_SendDebugSessionFailedEmailLegacyRequesterEmail(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	mockMail := NewMockMailEnqueuer(true)

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -1,0 +1,75 @@
+package debug
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/audit"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDebugSessionController_WithAuditServiceUsesReloadedManager(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	auditService := audit.NewService(fakeClient, zap.NewNop(), "breakglass")
+	t.Cleanup(func() {
+		require.NoError(t, auditService.Close())
+	})
+
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithAuditService(auditService)
+
+	require.Nil(t, controller.currentAuditManager(), "audit manager should be nil before AuditConfig reload")
+	require.Nil(t, controller.auxiliaryMgr.currentAuditManager(), "auxiliary resources should share the same empty audit state")
+
+	require.NoError(t, auditService.ReloadMultiple(context.Background(), []*breakglassv1alpha1.AuditConfig{{
+		ObjectMeta: metav1.ObjectMeta{Name: "debug-audit"},
+		Spec: breakglassv1alpha1.AuditConfigSpec{
+			Enabled: true,
+			Sinks: []breakglassv1alpha1.AuditSinkConfig{{
+				Name: "log",
+				Type: breakglassv1alpha1.AuditSinkTypeLog,
+				Log:  &breakglassv1alpha1.LogSinkSpec{Level: "info"},
+			}},
+		},
+	}}))
+
+	manager := controller.currentAuditManager()
+	require.NotNil(t, manager, "controller should resolve the manager created by AuditConfig reload")
+	assert.Same(t, manager, controller.auxiliaryMgr.currentAuditManager(), "auxiliary manager should resolve the same current audit manager")
+}
+
+func TestDebugSessionController_WithAuditManagerConfiguresAuxiliaryManager(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	auditManager := audit.NewManager(audit.NewLogSink(zap.NewNop()), audit.DefaultManagerConfig(), zap.NewNop())
+	t.Cleanup(func() {
+		require.NoError(t, auditManager.Close())
+	})
+
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithAuditManager(auditManager)
+
+	assert.Same(t, auditManager, controller.currentAuditManager())
+	assert.Same(t, auditManager, controller.auxiliaryMgr.currentAuditManager())
+}
+
+func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	mockMail := NewMockMailEnqueuer(true)
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
+
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester@example.com")
+	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, "debug-failed", messages[0].SessionID)
+	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
+	assert.Contains(t, messages[0].Subject, "Debug Session Failed: debug-failed")
+	assert.Contains(t, messages[0].Body, "https://breakglass.example.com/debug-sessions")
+}

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -94,6 +94,22 @@ func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
 	assert.NotContains(t, messages[0].Body, "requester-id")
 }
 
+func TestDebugSessionController_SendDebugSessionFailedEmailLegacyRequesterEmail(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+	mockMail := NewMockMailEnqueuer(true)
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
+		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
+
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester@example.com")
+	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
+
+	messages := mockMail.GetMessages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
+	assert.Contains(t, messages[0].Body, "requester@example.com")
+	assert.NotContains(t, messages[0].Body, "requester@example.com<br>")
+}
+
 func TestDebugSessionController_SendDebugSessionFailedEmailSkipsNonEmailRequester(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	mockMail := NewMockMailEnqueuer(true)

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -122,6 +122,25 @@ func TestDebugSessionController_SendDebugSessionFailedEmailSkipsControlCharacter
 	assert.Empty(t, mockMail.GetMessages())
 }
 
+func TestIsSafeDebugSessionFailureRecipientRejectsUnsafeRecipientLists(t *testing.T) {
+	tests := []struct {
+		name      string
+		recipient string
+	}{
+		{name: "space separated", recipient: "requester@example.com attacker@example.com"},
+		{name: "tab separated", recipient: "requester@example.com\tattacker@example.com"},
+		{name: "comma separated", recipient: "requester@example.com,attacker@example.com"},
+		{name: "semicolon separated", recipient: "requester@example.com;attacker@example.com"},
+		{name: "display name wrapper", recipient: "Requester <requester@example.com>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, isSafeDebugSessionFailureRecipient(tt.recipient))
+		})
+	}
+}
+
 func TestDebugSessionController_SendDebugSessionFailedEmailLegacyRequesterEmail(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
 	mockMail := NewMockMailEnqueuer(true)

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package debug
 
 import (

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -79,7 +79,9 @@ func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
 	controller := NewDebugSessionController(zap.NewNop().Sugar(), fakeClient, nil).
 		WithMailService(mockMail, "Test Breakglass", "https://breakglass.example.com", false)
 
-	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester@example.com")
+	session := newTestDebugSession("debug-failed", "node-shell", "prod", "requester-id")
+	session.Spec.RequestedByEmail = "requester@example.com"
+	session.Spec.RequestedByDisplayName = "Requester Display"
 	controller.sendDebugSessionFailedEmail(session, "debug pod failed")
 
 	messages := mockMail.GetMessages()
@@ -88,4 +90,6 @@ func TestDebugSessionController_SendDebugSessionFailedEmail(t *testing.T) {
 	assert.Equal(t, []string{"requester@example.com"}, messages[0].Recipients)
 	assert.Contains(t, messages[0].Subject, "Debug Session Failed: debug-failed")
 	assert.Contains(t, messages[0].Body, "https://breakglass.example.com/debug-sessions")
+	assert.Contains(t, messages[0].Body, "Requester Display")
+	assert.NotContains(t, messages[0].Body, "requester-id")
 }

--- a/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_wiring_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestDebugSessionController_WithAuditServiceUsesReloadedManager(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
-	auditService := audit.NewService(fakeClient, zap.NewNop(), "breakglass")
+	auditService := audit.NewService(fakeClient, nil, zap.NewNop(), "breakglass")
 	t.Cleanup(func() {
 		require.NoError(t, auditService.Close())
 	})

--- a/pkg/mail/templates/debug_session_failed.html
+++ b/pkg/mail/templates/debug_session_failed.html
@@ -201,6 +201,15 @@
         <span class="detail-label">Session ID:</span>
         <span class="detail-value">{{.SessionID}}</span>
       </div>
+      {{if or .RequesterName .RequesterEmail}}
+      <div class="detail-row">
+        <span class="detail-label">Requester:</span>
+        <span class="detail-value">
+          {{if .RequesterName}}{{.RequesterName}}{{end}}
+          {{if .RequesterEmail}}<br><span style="color: #666;">{{.RequesterEmail}}</span>{{end}}
+        </span>
+      </div>
+      {{end}}
       <div class="detail-row">
         <span class="detail-label">Cluster:</span>
         <span class="detail-value">{{.Cluster}}</span>

--- a/pkg/mail/templates/debug_session_failed.html
+++ b/pkg/mail/templates/debug_session_failed.html
@@ -206,7 +206,7 @@
         <span class="detail-label">Requester:</span>
         <span class="detail-value">
           {{if .RequesterName}}{{.RequesterName}}{{end}}
-          {{if .RequesterEmail}}<br><span style="color: #666;">{{.RequesterEmail}}</span>{{end}}
+          {{if .RequesterEmail}}{{if .RequesterName}}<br>{{end}}<span style="color: #666;">{{.RequesterEmail}}</span>{{end}}
         </span>
       </div>
       {{end}}

--- a/pkg/mail/templates_test.go
+++ b/pkg/mail/templates_test.go
@@ -915,6 +915,8 @@ func TestRenderDebugSessionFailed(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
+	assert.Contains(t, result, "John Doe")
+	assert.Contains(t, result, "john.doe@example.com")
 	assert.Contains(t, result, "debug-session-fail")
 	assert.Contains(t, result, "quota exceeded")
 	assert.Contains(t, result, "prod-cluster-01")

--- a/pkg/mail/templates_test.go
+++ b/pkg/mail/templates_test.go
@@ -937,4 +937,6 @@ func TestRenderDebugSessionFailedMinimalParams(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
 	assert.Contains(t, result, "session-min")
+	assert.NotContains(t, result, "<br><span style=\"color: #666;\">user@example.com</span>")
+	assert.Contains(t, result, "<span style=\"color: #666;\">user@example.com</span>")
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -142,6 +142,8 @@ func Setup(
 	ccProvider *cluster.ClientProvider,
 	auditService *audit.Service,
 	mailService *mail.Service,
+	frontendConfig config.Frontend,
+	disableEmail bool,
 	escalationManager *escalation.EscalationManager,
 	enableControllers bool,
 	log *zap.SugaredLogger,
@@ -312,7 +314,9 @@ func Setup(
 
 		// Register DebugSession Reconciler with controller-runtime manager
 		log.Debugw("Setting up DebugSession reconciler")
-		debugSessionReconciler := debug.NewDebugSessionController(log, mgr.GetClient(), ccProvider)
+		debugSessionReconciler := debug.NewDebugSessionController(log, mgr.GetClient(), ccProvider).
+			WithAuditService(auditService).
+			WithMailService(mailService, frontendConfig.BrandingName, frontendConfig.BaseURL, disableEmail)
 		if err := debugSessionReconciler.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("failed to setup DebugSession reconciler with manager: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Wire the controller-runtime `DebugSession` reconciler to the reloadable `AuditConfig` service.
- Wire the same reconciler to the configured `MailProvider` settings for requester failure notifications.
- Resolve audit managers lazily so sessions created before `AuditConfig` reloads still emit later reconciler-side audit events.
- Pass the audit manager provider through the auxiliary resource manager for deploy/cleanup audit events.

## Evidence

The audit found that `pkg/reconciler/reconciler.go` received `auditService` and `mailService` but constructed `debug.NewDebugSessionController(...)` without `.WithAuditService(...)` or `.WithMailService(...)`. The reconciler then nil-gated approval-timeout, failure, pod-health, and auxiliary-resource audit paths, causing production events and failure emails to silently no-op.

Duplicate check: no open PR matched `DebugSession audit mail reconciler` before opening this one.

## UI Screenshots

Not applicable. This PR changes backend controller wiring, tests, docs, and changelog only; no UI files changed.

## Validation

- `go test ./pkg/breakglass/debug -run 'TestDebugSessionController_(WithAuditServiceUsesReloadedManager|WithAuditManagerConfiguresAuxiliaryManager|SendDebugSessionFailedEmail)$|TestSetAuditManager' -count=1 -timeout=180s`
- `go test ./pkg/reconciler -count=1 -timeout=180s`
- `go test ./pkg/breakglass/debug -count=1 -timeout=240s`
- `make test`
- `make lint`
- `git -c core.fsmonitor=false diff --check`
