### PR TITLE
fix: guard DebugSession expiration status writes

### DIFF
--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1425,6 +1425,8 @@ constraints for that session. Renewals extend the current expiration time, but
 the renewed expiration cannot move past `status.startsAt + maxDuration`.
 Only the requester or an active `owner`/`participant` status entry can renew a
 session; `viewer` entries and participants with `leftAt` set cannot renew.
+Expiration-related status updates use optimistic locking, so a stale reconciler
+or cleanup pass cannot overwrite a newer renewal or participant update.
 
 ## Terminal Sharing
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1425,9 +1425,9 @@ constraints for that session. Renewals extend the current expiration time, but
 the renewed expiration cannot move past `status.startsAt + maxDuration`.
 Only the requester or an active `owner`/`participant` status entry can renew a
 session; `viewer` entries and participants with `leftAt` set cannot renew.
-The active-session expiry, expiring-soon message, and cleanup timeout writers
-use optimistic locking, so stale reconciler or cleanup passes cannot overwrite a
-newer renewal or participant update.
+The active-session expiry, approval-timeout, expiring-soon message, cleanup
+timeout, and cleanup expiry writers use optimistic locking, so stale reconciler
+or cleanup passes cannot overwrite a newer renewal or participant update.
 
 ## Terminal Sharing
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1425,8 +1425,9 @@ constraints for that session. Renewals extend the current expiration time, but
 the renewed expiration cannot move past `status.startsAt + maxDuration`.
 Only the requester or an active `owner`/`participant` status entry can renew a
 session; `viewer` entries and participants with `leftAt` set cannot renew.
-Expiration-related status updates use optimistic locking, so a stale reconciler
-or cleanup pass cannot overwrite a newer renewal or participant update.
+The active-session expiry, expiring-soon message, and cleanup timeout writers
+use optimistic locking, so stale reconciler or cleanup passes cannot overwrite a
+newer renewal or participant update.
 
 ## Terminal Sharing
 

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -345,10 +345,10 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 						"expiresAt", ds.Status.ExpiresAt,
 					)...)
 
-				ds.Status.State = breakglassv1alpha1.DebugSessionStateExpired
-				ds.Status.Message = "Session expired (cleanup routine)"
-
-				if err := ApplyDebugSessionStatus(ctx, routine.Manager, &ds); err != nil {
+				if err := PatchDebugSessionStatusWithOptimisticLock(ctx, routine.Manager, &ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+					status.State = breakglassv1alpha1.DebugSessionStateExpired
+					status.Message = "Session expired (cleanup routine)"
+				}); err != nil {
 					routine.Log.Errorw("error updating expired debug session status",
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue
@@ -382,10 +382,10 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 						"approvalTimeout", DebugSessionApprovalTimeout.String(),
 					)...)
 
-				ds.Status.State = breakglassv1alpha1.DebugSessionStateFailed
-				ds.Status.Message = fmt.Sprintf("Approval timed out after %s", DebugSessionApprovalTimeout)
-
-				if err := ApplyDebugSessionStatus(ctx, routine.Manager, &ds); err != nil {
+				if err := PatchDebugSessionStatusWithOptimisticLock(ctx, routine.Manager, &ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+					status.State = breakglassv1alpha1.DebugSessionStateFailed
+					status.Message = fmt.Sprintf("Approval timed out after %s", DebugSessionApprovalTimeout)
+				}); err != nil {
 					routine.Log.Errorw("error updating timed-out debug session status",
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -349,6 +350,11 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 					status.State = breakglassv1alpha1.DebugSessionStateExpired
 					status.Message = "Session expired (cleanup routine)"
 				}); err != nil {
+					if apierrors.IsConflict(err) {
+						routine.Log.Debugw("skipping expired debug session status update after concurrent change",
+							append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
+						continue
+					}
 					routine.Log.Errorw("error updating expired debug session status",
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue
@@ -386,6 +392,11 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 					status.State = breakglassv1alpha1.DebugSessionStateFailed
 					status.Message = fmt.Sprintf("Approval timed out after %s", DebugSessionApprovalTimeout)
 				}); err != nil {
+					if apierrors.IsConflict(err) {
+						routine.Log.Debugw("skipping approval-timeout debug session status update after concurrent change",
+							append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
+						continue
+					}
 					routine.Log.Errorw("error updating timed-out debug session status",
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -337,15 +337,6 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 		// Check if active session has expired
 		if ds.Status.State == breakglassv1alpha1.DebugSessionStateActive {
 			if ds.Status.ExpiresAt != nil && now.After(ds.Status.ExpiresAt.Time) {
-				routine.Log.Infow("Debug session expired, marking as Expired",
-					append(system.NamespacedFields(ds.Name, ds.Namespace),
-						"cluster", ds.Spec.Cluster,
-						"template", ds.Spec.TemplateRef,
-						"requestedBy", ds.Spec.RequestedBy,
-						"startsAt", ds.Status.StartsAt,
-						"expiresAt", ds.Status.ExpiresAt,
-					)...)
-
 				if err := PatchDebugSessionStatusWithOptimisticLock(ctx, routine.Manager, &ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
 					status.State = breakglassv1alpha1.DebugSessionStateExpired
 					status.Message = "Session expired (cleanup routine)"
@@ -359,6 +350,14 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue
 				}
+				routine.Log.Infow("Debug session expired, marking as Expired",
+					append(system.NamespacedFields(ds.Name, ds.Namespace),
+						"cluster", ds.Spec.Cluster,
+						"template", ds.Spec.TemplateRef,
+						"requestedBy", ds.Spec.RequestedBy,
+						"startsAt", ds.Status.StartsAt,
+						"expiresAt", ds.Status.ExpiresAt,
+					)...)
 
 				// Emit audit event for expired debug session
 				if routine.AuditService != nil {
@@ -379,15 +378,6 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 		if ds.Status.State == breakglassv1alpha1.DebugSessionStatePendingApproval {
 			// If approval times out, mark as failed
 			if ds.Status.Approval != nil && ds.CreationTimestamp.Add(DebugSessionApprovalTimeout).Before(now) {
-				routine.Log.Infow("Debug session approval timed out, marking as Failed",
-					append(system.NamespacedFields(ds.Name, ds.Namespace),
-						"cluster", ds.Spec.Cluster,
-						"template", ds.Spec.TemplateRef,
-						"requestedBy", ds.Spec.RequestedBy,
-						"createdAt", ds.CreationTimestamp,
-						"approvalTimeout", DebugSessionApprovalTimeout.String(),
-					)...)
-
 				if err := PatchDebugSessionStatusWithOptimisticLock(ctx, routine.Manager, &ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
 					status.State = breakglassv1alpha1.DebugSessionStateFailed
 					status.Message = fmt.Sprintf("Approval timed out after %s", DebugSessionApprovalTimeout)
@@ -401,6 +391,14 @@ func (routine CleanupRoutine) cleanupExpiredDebugSessions(ctx context.Context) {
 						append(system.NamespacedFields(ds.Name, ds.Namespace), "error", err)...)
 					continue
 				}
+				routine.Log.Infow("Debug session approval timed out, marking as Failed",
+					append(system.NamespacedFields(ds.Name, ds.Namespace),
+						"cluster", ds.Spec.Cluster,
+						"template", ds.Spec.TemplateRef,
+						"requestedBy", ds.Spec.RequestedBy,
+						"createdAt", ds.CreationTimestamp,
+						"approvalTimeout", DebugSessionApprovalTimeout.String(),
+					)...)
 
 				// Emit audit event for approval timeout
 				if routine.AuditService != nil {

--- a/pkg/breakglass/cleanup_task_test.go
+++ b/pkg/breakglass/cleanup_task_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestCleanupRoutine_markCleanupExpiredSession(t *testing.T) {
@@ -662,6 +663,61 @@ func TestCleanupRoutine_cleanupExpiredDebugSessions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, breakglassv1alpha1.DebugSessionStateExpired, updated.Status.State)
 		assert.Contains(t, updated.Status.Message, "expired")
+	})
+
+	t.Run("stale active expiration list does not overwrite renewed session", func(t *testing.T) {
+		pastTime := metav1.NewTime(time.Now().Add(-1 * time.Hour).Truncate(time.Second))
+		renewedTime := metav1.NewTime(time.Now().Add(time.Hour).Truncate(time.Second))
+
+		staleListItem := &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "active-renewed-from-stale-list",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster: "test-cluster",
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State:        breakglassv1alpha1.DebugSessionStateActive,
+				ExpiresAt:    &pastTime,
+				RenewalCount: 0,
+			},
+		}
+		liveSession := staleListItem.DeepCopy()
+		liveSession.ResourceVersion = "2"
+		liveSession.Status.ExpiresAt = &renewedTime
+		liveSession.Status.RenewalCount = 1
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(liveSession).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if debugSessions, ok := list.(*breakglassv1alpha1.DebugSessionList); ok {
+						debugSessions.Items = []breakglassv1alpha1.DebugSession{*staleListItem}
+						return nil
+					}
+					return cl.List(ctx, list, opts...)
+				},
+			}).
+			Build()
+
+		manager := &SessionManager{Client: fakeClient}
+		routine := CleanupRoutine{Log: logger, Manager: manager}
+
+		routine.cleanupExpiredDebugSessions(context.Background())
+
+		var updated breakglassv1alpha1.DebugSession
+		err := fakeClient.Get(context.Background(), client.ObjectKey{Name: liveSession.Name, Namespace: liveSession.Namespace}, &updated)
+		assert.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, updated.Status.State)
+		require.NotNil(t, updated.Status.ExpiresAt)
+		assert.True(t, updated.Status.ExpiresAt.Equal(&renewedTime),
+			"expiresAt mismatch: got %s, want %s", updated.Status.ExpiresAt.Time, renewedTime.Time)
+		assert.Equal(t, int32(1), updated.Status.RenewalCount)
+		assert.Empty(t, updated.Status.Message)
 	})
 
 	t.Run("terminated session within retention period", func(t *testing.T) {

--- a/pkg/breakglass/cleanup_task_test.go
+++ b/pkg/breakglass/cleanup_task_test.go
@@ -793,6 +793,57 @@ func TestCleanupRoutine_cleanupExpiredDebugSessions(t *testing.T) {
 		assert.Contains(t, updated.Status.Message, "timed out")
 	})
 
+	t.Run("stale pending approval timeout list does not overwrite approved session", func(t *testing.T) {
+		oldCreationTime := time.Now().Add(-25 * time.Hour)
+		staleListItem := &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pending-approved-from-stale-list",
+				Namespace:         "default",
+				CreationTimestamp: metav1.NewTime(oldCreationTime),
+				ResourceVersion:   "1",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster: "test-cluster",
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State: breakglassv1alpha1.DebugSessionStatePendingApproval,
+				Approval: &breakglassv1alpha1.DebugSessionApproval{
+					Required: true,
+				},
+			},
+		}
+		liveSession := staleListItem.DeepCopy()
+		liveSession.ResourceVersion = "2"
+		liveSession.Status.State = breakglassv1alpha1.DebugSessionStateActive
+		liveSession.Status.Message = ""
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(liveSession).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if debugSessions, ok := list.(*breakglassv1alpha1.DebugSessionList); ok {
+						debugSessions.Items = []breakglassv1alpha1.DebugSession{*staleListItem}
+						return nil
+					}
+					return cl.List(ctx, list, opts...)
+				},
+			}).
+			Build()
+
+		manager := &SessionManager{Client: fakeClient}
+		routine := CleanupRoutine{Log: logger, Manager: manager}
+
+		routine.cleanupExpiredDebugSessions(context.Background())
+
+		var updated breakglassv1alpha1.DebugSession
+		err := fakeClient.Get(context.Background(), client.ObjectKey{Name: liveSession.Name, Namespace: liveSession.Namespace}, &updated)
+		assert.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, updated.Status.State)
+		assert.Empty(t, updated.Status.Message)
+	})
+
 	t.Run("active session expired sends email notification", func(t *testing.T) {
 		// Verify that when a debug session expires, an email notification is sent
 		// to the session owner

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -314,8 +314,9 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 		if err == nil {
 			until := time.Until(ds.Status.ExpiresAt.Time)
 			if until > 0 && until <= grace && ds.Status.Message != "Session expiring soon" {
-				ds.Status.Message = "Session expiring soon"
-				if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+				if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+					status.Message = "Session expiring soon"
+				}); err != nil {
 					return ctrl.Result{}, err
 				}
 			}
@@ -326,16 +327,18 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 	if ds.Status.ExpiresAt != nil && time.Now().After(ds.Status.ExpiresAt.Time) {
 		log.Info("Debug session expired")
 		if ds.Status.ResolvedTemplate != nil && ds.Status.ResolvedTemplate.ExpirationBehavior == "notify-only" {
-			ds.Status.Message = "Session expired (notify-only)"
-			ds.Status.ExpiresAt = nil
-			if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+			if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+				status.Message = "Session expired (notify-only)"
+				status.ExpiresAt = nil
+			}); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
 		}
-		ds.Status.State = breakglassv1alpha1.DebugSessionStateExpired
-		ds.Status.Message = "Session expired"
-		if err := breakglass.ApplyDebugSessionStatus(ctx, c.client, ds); err != nil {
+		if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+			status.State = breakglassv1alpha1.DebugSessionStateExpired
+			status.Message = "Session expired"
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 		metrics.DebugSessionsActive.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Dec()

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -317,6 +317,10 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 				if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
 					status.Message = "Session expiring soon"
 				}); err != nil {
+					if apierrors.IsConflict(err) {
+						log.Debugw("skipping expiring-soon status update after concurrent debug session change", "error", err)
+						return ctrl.Result{}, nil
+					}
 					return ctrl.Result{}, err
 				}
 			}
@@ -331,6 +335,10 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 				status.Message = "Session expired (notify-only)"
 				status.ExpiresAt = nil
 			}); err != nil {
+				if apierrors.IsConflict(err) {
+					log.Debugw("skipping notify-only expiration status update after concurrent debug session change", "error", err)
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -339,6 +347,10 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 			status.State = breakglassv1alpha1.DebugSessionStateExpired
 			status.Message = "Session expired"
 		}); err != nil {
+			if apierrors.IsConflict(err) {
+				log.Debugw("skipping expiration status update after concurrent debug session change", "error", err)
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		metrics.DebugSessionsActive.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Dec()

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -282,6 +282,16 @@ func (c *DebugSessionController) handlePendingApproval(ctx context.Context, ds *
 	timeout := breakglass.DebugSessionApprovalTimeout
 	if ds.CreationTimestamp.Add(timeout).Before(time.Now()) {
 		reason := fmt.Sprintf("Approval timed out after %s", timeout)
+		if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
+			status.State = breakglassv1alpha1.DebugSessionStateFailed
+			status.Message = reason
+		}); err != nil {
+			if apierrors.IsConflict(err) {
+				c.log.Debugw("skipping approval-timeout status update after concurrent debug session change", "error", err)
+				return ctrl.Result{}, nil
+			}
+			return ctrl.Result{}, err
+		}
 		c.log.Errorw("Debug session approval timed out",
 			"debugSession", ds.Name, "namespace", ds.Namespace,
 			"reason", reason)
@@ -291,13 +301,10 @@ func (c *DebugSessionController) handlePendingApproval(ctx context.Context, ds *
 				auditManager.DebugSessionApprovalTimeout(ctx, ds.Name, ds.Namespace, ds.Spec.Cluster)
 			}
 		}
-
-		ds.Status.State = breakglassv1alpha1.DebugSessionStateFailed
-		ds.Status.Message = reason
 		c.sendDebugSessionFailedEmail(ds, reason)
 		metrics.DebugSessionsFailed.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Inc()
 
-		return ctrl.Result{}, breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
+		return ctrl.Result{}, nil
 	}
 
 	// Still waiting for approval
@@ -329,7 +336,6 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 
 	// Check expiration
 	if ds.Status.ExpiresAt != nil && time.Now().After(ds.Status.ExpiresAt.Time) {
-		log.Info("Debug session expired")
 		if ds.Status.ResolvedTemplate != nil && ds.Status.ResolvedTemplate.ExpirationBehavior == "notify-only" {
 			if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
 				status.Message = "Session expired (notify-only)"
@@ -341,6 +347,7 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 				}
 				return ctrl.Result{}, err
 			}
+			log.Info("Debug session expired")
 			return ctrl.Result{}, nil
 		}
 		if err := breakglass.PatchDebugSessionStatusWithOptimisticLock(ctx, c.client, ds, func(status *breakglassv1alpha1.DebugSessionStatus) {
@@ -353,6 +360,7 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 			}
 			return ctrl.Result{}, err
 		}
+		log.Info("Debug session expired")
 		metrics.DebugSessionsActive.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Dec()
 		return ctrl.Result{RequeueAfter: ExpiredSessionRequeue}, nil
 	}

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -38,6 +38,7 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/metrics"
 )
 
 // Helper to create a fake client with status subresource support
@@ -987,9 +988,12 @@ func TestDebugSessionReconciler_HandleActiveDoesNotExpireRenewedStaleSnapshot(t 
 		client: fakeClient,
 	}
 
-	_, err := controller.handleActive(context.Background(), staleSession)
-	require.Error(t, err)
-	assert.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+	metrics.DebugSessionsActive.WithLabelValues(liveSession.Spec.Cluster, liveSession.Spec.TemplateRef).Set(3)
+
+	result, err := controller.handleActive(context.Background(), staleSession)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.DebugSessionsActive.WithLabelValues(liveSession.Spec.Cluster, liveSession.Spec.TemplateRef)))
 
 	var updated breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(context.Background(), types.NamespacedName{
@@ -1036,9 +1040,9 @@ func TestDebugSessionReconciler_HandleActiveDoesNotMarkRenewedSessionExpiringSoo
 		client: fakeClient,
 	}
 
-	_, err := controller.handleActive(context.Background(), staleSession)
-	require.Error(t, err)
-	assert.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+	result, err := controller.handleActive(context.Background(), staleSession)
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
 
 	var updated breakglassv1alpha1.DebugSession
 	err = fakeClient.Get(context.Background(), types.NamespacedName{

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -957,6 +958,100 @@ func TestDebugSessionReconciler_TerminalSharing(t *testing.T) {
 		assert.True(t, fetchedSession.Status.TerminalSharing.Enabled)
 		assert.Contains(t, fetchedSession.Status.TerminalSharing.AttachCommand, "tmux")
 	})
+}
+
+func TestDebugSessionReconciler_HandleActiveDoesNotExpireRenewedStaleSnapshot(t *testing.T) {
+	scheme := testScheme()
+	pastExpiry := metav1.NewTime(time.Now().Add(-time.Minute))
+	renewedExpiry := metav1.NewTime(time.Now().Add(time.Hour).Truncate(time.Second))
+
+	liveSession := newTestDebugSession("renewed-active-session", "test-template", "test-cluster", "user@example.com")
+	liveSession.ResourceVersion = "2"
+	liveSession.Status.State = breakglassv1alpha1.DebugSessionStateActive
+	liveSession.Status.ExpiresAt = &renewedExpiry
+	liveSession.Status.RenewalCount = 1
+
+	staleSession := liveSession.DeepCopy()
+	staleSession.ResourceVersion = "1"
+	staleSession.Status.ExpiresAt = &pastExpiry
+	staleSession.Status.RenewalCount = 0
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(liveSession).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	controller := &DebugSessionController{
+		log:    zap.NewNop().Sugar(),
+		client: fakeClient,
+	}
+
+	_, err := controller.handleActive(context.Background(), staleSession)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+
+	var updated breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      liveSession.Name,
+		Namespace: liveSession.Namespace,
+	}, &updated)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Status.ExpiresAt)
+	assert.True(t, updated.Status.ExpiresAt.Equal(&renewedExpiry),
+		"expiresAt mismatch: got %s, want %s", updated.Status.ExpiresAt.Time, renewedExpiry.Time)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, updated.Status.State)
+	assert.Equal(t, int32(1), updated.Status.RenewalCount)
+	assert.Empty(t, updated.Status.Message)
+}
+
+func TestDebugSessionReconciler_HandleActiveDoesNotMarkRenewedSessionExpiringSoonFromStaleSnapshot(t *testing.T) {
+	scheme := testScheme()
+	staleExpiry := metav1.NewTime(time.Now().Add(30 * time.Second))
+	renewedExpiry := metav1.NewTime(time.Now().Add(time.Hour).Truncate(time.Second))
+
+	liveSession := newTestDebugSession("renewed-grace-session", "test-template", "test-cluster", "user@example.com")
+	liveSession.ResourceVersion = "2"
+	liveSession.Status.State = breakglassv1alpha1.DebugSessionStateActive
+	liveSession.Status.ExpiresAt = &renewedExpiry
+	liveSession.Status.RenewalCount = 1
+	liveSession.Status.ResolvedTemplate = &breakglassv1alpha1.DebugSessionTemplateSpec{
+		GracePeriodBeforeExpiry: "1m",
+	}
+
+	staleSession := liveSession.DeepCopy()
+	staleSession.ResourceVersion = "1"
+	staleSession.Status.ExpiresAt = &staleExpiry
+	staleSession.Status.RenewalCount = 0
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(liveSession).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	controller := &DebugSessionController{
+		log:    zap.NewNop().Sugar(),
+		client: fakeClient,
+	}
+
+	_, err := controller.handleActive(context.Background(), staleSession)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+
+	var updated breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      liveSession.Name,
+		Namespace: liveSession.Namespace,
+	}, &updated)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Status.ExpiresAt)
+	assert.True(t, updated.Status.ExpiresAt.Equal(&renewedExpiry),
+		"expiresAt mismatch: got %s, want %s", updated.Status.ExpiresAt.Time, renewedExpiry.Time)
+	assert.Equal(t, int32(1), updated.Status.RenewalCount)
+	assert.Empty(t, updated.Status.Message)
 }
 
 func TestDebugSessionReconciler_KubectlDebugStatus(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -464,6 +464,47 @@ func TestDebugSessionReconciler_ApprovalWorkflow(t *testing.T) {
 		assert.Contains(t, updated.Status.Message, "Approval timed out")
 	})
 
+	t.Run("session approval timeout conflict preserves live status", func(t *testing.T) {
+		timeout := breakglass.DebugSessionApprovalTimeout
+
+		stale := newTestDebugSession("timeout-conflict-session", "test-template", "production", "user@example.com")
+		stale.ResourceVersion = "1"
+		stale.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * timeout))
+		stale.Status.State = breakglassv1alpha1.DebugSessionStatePendingApproval
+		stale.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{
+			Required: true,
+		}
+
+		live := stale.DeepCopy()
+		live.ResourceVersion = "2"
+		live.Status.State = breakglassv1alpha1.DebugSessionStateActive
+		live.Status.Message = "activated concurrently"
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(live).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := NewDebugSessionController(
+			zap.NewNop().Sugar(), fakeClient, nil,
+		)
+
+		result, err := controller.handlePendingApproval(context.Background(), stale)
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+		assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, stale.Status.State)
+
+		var updated breakglassv1alpha1.DebugSession
+		err = fakeClient.Get(context.Background(), types.NamespacedName{
+			Name:      "timeout-conflict-session",
+			Namespace: "breakglass",
+		}, &updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.DebugSessionStateActive, updated.Status.State)
+		assert.Equal(t, "activated concurrently", updated.Status.Message)
+	})
+
 	t.Run("session within approval timeout requeues", func(t *testing.T) {
 		// Use the current configured timeout and create a session well within it
 		timeout := breakglass.DebugSessionApprovalTimeout
@@ -989,6 +1030,9 @@ func TestDebugSessionReconciler_HandleActiveDoesNotExpireRenewedStaleSnapshot(t 
 	}
 
 	metrics.DebugSessionsActive.WithLabelValues(liveSession.Spec.Cluster, liveSession.Spec.TemplateRef).Set(3)
+	t.Cleanup(func() {
+		metrics.DebugSessionsActive.DeleteLabelValues(liveSession.Spec.Cluster, liveSession.Spec.TemplateRef)
+	})
 
 	result, err := controller.handleActive(context.Background(), staleSession)
 	require.NoError(t, err)

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -45,7 +45,7 @@ func PatchDebugSessionStatusWithOptimisticLock(
 	}
 
 	if err := c.Status().Patch(ctx, session, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-		return fmt.Errorf("patch DebugSession status with optimistic lock: %w", err)
+		return fmt.Errorf("patch DebugSession %s/%s status with optimistic lock: %w", session.Namespace, session.Name, err)
 	}
 	return nil
 }

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -43,14 +43,17 @@ func PatchDebugSessionStatusWithOptimisticLock(
 	}
 
 	base := session.DeepCopy()
-	mutate(&session.Status)
-	if session.Generation > 0 {
-		session.Status.ObservedGeneration = session.Generation
+	patched := session.DeepCopy()
+	mutate(&patched.Status)
+	if patched.Generation > 0 {
+		patched.Status.ObservedGeneration = patched.Generation
 	}
 
-	if err := c.Status().Patch(ctx, session, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+	if err := c.Status().Patch(ctx, patched, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
 		return fmt.Errorf("patch DebugSession %s/%s status with optimistic lock: %w", session.Namespace, session.Name, err)
 	}
+	session.Status = patched.Status
+	session.ResourceVersion = patched.ResourceVersion
 	return nil
 }
 

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -38,6 +38,10 @@ func PatchDebugSessionStatusWithOptimisticLock(
 	session *breakglassv1alpha1.DebugSession,
 	mutate func(*breakglassv1alpha1.DebugSessionStatus),
 ) error {
+	if session.ResourceVersion == "" {
+		return fmt.Errorf("patch DebugSession %s/%s status with optimistic lock: missing resourceVersion", session.Namespace, session.Name)
+	}
+
 	base := session.DeepCopy()
 	mutate(&session.Status)
 	if session.Generation > 0 {

--- a/pkg/breakglass/ssa.go
+++ b/pkg/breakglass/ssa.go
@@ -2,6 +2,7 @@ package breakglass
 
 import (
 	"context"
+	"fmt"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/api/v1alpha1/applyconfiguration/ssa"
@@ -26,6 +27,27 @@ func ApplyDebugSessionStatus(ctx context.Context, c client.Client, session *brea
 		session.Status.ObservedGeneration = session.Generation
 	}
 	return ssa.ApplyDebugSessionStatus(ctx, c, session)
+}
+
+// PatchDebugSessionStatusWithOptimisticLock applies a narrow status merge patch
+// and fails with a conflict if another writer updated the DebugSession since it
+// was read.
+func PatchDebugSessionStatusWithOptimisticLock(
+	ctx context.Context,
+	c client.Client,
+	session *breakglassv1alpha1.DebugSession,
+	mutate func(*breakglassv1alpha1.DebugSessionStatus),
+) error {
+	base := session.DeepCopy()
+	mutate(&session.Status)
+	if session.Generation > 0 {
+		session.Status.ObservedGeneration = session.Generation
+	}
+
+	if err := c.Status().Patch(ctx, session, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("patch DebugSession status with optimistic lock: %w", err)
+	}
+	return nil
 }
 
 // ApplyBreakglassEscalationStatus applies the escalation status using server-side apply.

--- a/pkg/breakglass/ssa_test.go
+++ b/pkg/breakglass/ssa_test.go
@@ -7,7 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPatchDebugSessionStatusWithOptimisticLockRequiresResourceVersion(t *testing.T) {
@@ -31,4 +35,41 @@ func TestPatchDebugSessionStatusWithOptimisticLockRequiresResourceVersion(t *tes
 	assert.Contains(t, err.Error(), "missing resourceVersion")
 	assert.False(t, mutateCalled)
 	assert.Equal(t, "unchanged", session.Status.Message)
+}
+
+func TestPatchDebugSessionStatusWithOptimisticLockLeavesInputUnchangedOnConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	live := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "debug-session",
+			Namespace:       "default",
+			ResourceVersion: "2",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			Message: "live",
+		},
+	}
+	stale := live.DeepCopy()
+	stale.ResourceVersion = "1"
+	stale.Status.Message = "stale"
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(live).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	err := PatchDebugSessionStatusWithOptimisticLock(context.Background(), fakeClient, stale, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Message = "mutated"
+	})
+
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Equal(t, "stale", stale.Status.Message)
+
+	var fetched breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "debug-session", Namespace: "default"}, &fetched))
+	assert.Equal(t, "live", fetched.Status.Message)
 }

--- a/pkg/breakglass/ssa_test.go
+++ b/pkg/breakglass/ssa_test.go
@@ -1,0 +1,34 @@
+package breakglass
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPatchDebugSessionStatusWithOptimisticLockRequiresResourceVersion(t *testing.T) {
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "debug-session",
+			Namespace: "default",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			Message: "unchanged",
+		},
+	}
+
+	mutateCalled := false
+	err := PatchDebugSessionStatusWithOptimisticLock(context.Background(), nil, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		mutateCalled = true
+		status.Message = "mutated"
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing resourceVersion")
+	assert.False(t, mutateCalled)
+	assert.Equal(t, "unchanged", session.Status.Message)
+}


### PR DESCRIPTION
## Summary

Prevents stale DebugSession lifecycle writers from overwriting newer API-side status updates.

The active reconciler and cleanup routine now use optimistic status merge patches for expiration-related writes (`Session expiring soon`, `Expired`, `notify-only` expiry, and approval timeout). If another writer renewed or otherwise updated the session after the object was read, the stale lifecycle write conflicts instead of reapplying old `expiresAt`, `renewalCount`, participants, or state.

## Evidence

- `handleActive` could read an active DebugSession near/past expiry, then apply the full cached status after only changing `status.message` or `status.state`.
- `cleanupExpiredDebugSessions` iterated list results and applied the full listed status when expiring sessions or failing approval timeouts.
- A renewal or participant update between read/list and status apply could be undone by those stale whole-status writes.
- Duplicate check before opening: no open/recent PR matched `DebugSession expiresAt cleanup renewal stale active optimistic status`.

## Tests

- `go test ./pkg/breakglass/debug -run 'TestDebugSessionReconciler_HandleActiveDoesNot(ExpireRenewedStaleSnapshot|MarkRenewedSessionExpiringSoonFromStaleSnapshot)' -count=1 -timeout=180s`
- `go test ./pkg/breakglass -run 'TestCleanupRoutine_cleanupExpiredDebugSessions/stale_active_expiration_list_does_not_overwrite_renewed_session' -count=1 -timeout=180s`
- `go test ./pkg/breakglass ./pkg/breakglass/debug -count=1 -timeout=240s`
- `make lint`
- `make test`
- `git diff --check`

## Screenshots

Not applicable; backend/controller status-write fix only.
