### PR TITLE
fix: guard DebugSession API status updates

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1002,6 +1002,9 @@ Only invited users can join an active, unexpired session, and only when terminal
 
 This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
 
+If the session changes concurrently while recording the joined participant, the
+endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
+
 ### Leave Debug Session
 
 ```http
@@ -1014,6 +1017,9 @@ excluded from active participant checks and cannot use debug-session pod
 operations.
 
 This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
+
+If the session changes concurrently while recording `leftAt`, the endpoint
+returns `409 Conflict`; refresh the `DebugSession` before retrying.
 
 ### Renew Debug Session
 
@@ -1035,6 +1041,9 @@ Extends the session duration. Subject to template constraints (`maxDuration`,
 `participant` status entry can renew; `viewer` entries and participants with
 `leftAt` set cannot renew sessions.
 
+If the session changes concurrently while updating expiration status, the
+endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
+
 ### Terminate Debug Session
 
 ```http
@@ -1044,6 +1053,9 @@ POST /api/debugSessions/:name/terminate
 Terminates the session early. Only the session owner can terminate.
 
 This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
+
+If the session changes concurrently while recording termination status, the
+endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
 
 **Response:** Updated `DebugSession` object with `state: Terminated`.
 
@@ -1068,6 +1080,9 @@ Approves a session in `PendingApproval` state.
 `reason` is required when the session's stored `approvalReasonConfig.mandatory`
 is `true`, and must satisfy the configured `minLength` after sanitization.
 
+If the session changes concurrently while recording approval status, the
+endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
+
 **Response:** Updated `DebugSession` object with `state: Approved`.
 
 ### Reject Debug Session
@@ -1091,6 +1106,9 @@ When present, the rejection body must contain only the known `reason` field and 
 `reason` is required when the session's stored `approvalReasonConfig.mandatory`
 or `approvalReasonConfig.mandatoryForRejection` is `true`, and must satisfy the
 configured `minLength` after sanitization.
+
+If the session changes concurrently while recording rejection status, the
+endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
 
 **Response:** Updated `DebugSession` object with `state: Rejected`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1083,7 +1083,8 @@ is `true`, and must satisfy the configured `minLength` after sanitization.
 If the session changes concurrently while recording approval status, the
 endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
 
-**Response:** Updated `DebugSession` object with `state: Approved`.
+**Response:** Updated `DebugSession` object with recorded approval fields. The
+controller transitions approved sessions after the API update.
 
 ### Reject Debug Session
 
@@ -1110,7 +1111,7 @@ configured `minLength` after sanitization.
 If the session changes concurrently while recording rejection status, the
 endpoint returns `409 Conflict`; refresh the `DebugSession` before retrying.
 
-**Response:** Updated `DebugSession` object with `state: Rejected`.
+**Response:** Updated `DebugSession` object with `state: Terminated`.
 
 ### List Debug Session Templates
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -984,6 +984,8 @@ ClusterConfig readiness, missing-cluster, and tenant-alias errors are returned o
 
 The same strict JSON parsing applies to DebugSession renew, approve, reject, and kubectl-debug operation bodies. Bodyless actions such as join, leave, and terminate reject any non-empty body before JSON parsing.
 
+Status-changing DebugSession actions such as renew, terminate, approve, reject, join, and leave use optimistic locking. If another request updates the same session between the API read and status write, the endpoint returns `409 Conflict`; clients should refresh the session before retrying.
+
 **Response:** Created `DebugSession` object (201 Created).
 
 **Error Responses:**

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1574,6 +1574,10 @@ current caller. The web UI uses these fields to show approve/reject controls
 only to authorized approvers for sessions in `PendingApproval`; unauthorized
 callers may still read visible sessions but do not see approval actions.
 
+Status-changing actions use optimistic locking. If another request changes the
+same `DebugSession` between read and write, the API returns `409 Conflict`; the
+client should refresh the session and retry when appropriate.
+
 ### Kubectl Debug API Endpoints
 
 These endpoints are available for sessions in `kubectl-debug` or `hybrid` mode.

--- a/e2e/api/session_lifecycle_advanced_test.go
+++ b/e2e/api/session_lifecycle_advanced_test.go
@@ -48,12 +48,12 @@ func TestSessionActualStartTimeTracking(t *testing.T) {
 		requesterClient := tc.RequesterClient()
 		approverClient := tc.ApproverClient()
 
-		session, err := requesterClient.CreateSession(s.Ctx, t, helpers.SessionRequest{
+		session, err := requesterClient.CreateSessionAndWaitForPending(s.Ctx, t, helpers.SessionRequest{
 			Cluster: s.Cluster,
 			User:    helpers.TestUsers.Requester.Email,
 			Group:   escalation.Spec.EscalatedGroup,
 			Reason:  "Test actual start time tracking",
-		})
+		}, helpers.WaitForStateTimeout)
 		require.NoError(t, err, "Session creation should succeed in E2E environment")
 		s.Cleanup.Add(&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: session.Name, Namespace: session.Namespace},

--- a/pkg/breakglass/debug/debug_session_api_session_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_session_ops.go
@@ -105,17 +105,18 @@ func (c *DebugSessionAPIController) handleJoinDebugSession(ctx *gin.Context) {
 
 	// Add participant
 	now := metav1.Now()
-	session.Status.Participants = append(session.Status.Participants, breakglassv1alpha1.DebugSessionParticipant{
+	participant := breakglassv1alpha1.DebugSessionParticipant{
 		User:        username,
 		Email:       userEmail,
 		DisplayName: displayName,
 		Role:        role,
 		JoinedAt:    now,
-	})
+	}
 
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to add participant", "session", name, "user", username, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to join session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Participants = append(status.Participants, participant)
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "add participant", "failed to join session", name, err)
 		return
 	}
 
@@ -237,12 +238,13 @@ func (c *DebugSessionAPIController) handleRenewDebugSession(ctx *gin.Context) {
 		}
 	}
 
-	session.Status.ExpiresAt = &newExpiry
-	session.Status.RenewalCount++
+	newRenewalCount := session.Status.RenewalCount + 1
 
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to renew session", "session", name, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to renew session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.ExpiresAt = &newExpiry
+		status.RenewalCount = newRenewalCount
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "renew session", "failed to renew session", name, err)
 		return
 	}
 
@@ -362,13 +364,11 @@ func (c *DebugSessionAPIController) handleTerminateDebugSession(ctx *gin.Context
 		return
 	}
 
-	// Mark as terminated
-	session.Status.State = breakglassv1alpha1.DebugSessionStateTerminated
-	session.Status.Message = fmt.Sprintf("Terminated by %s", username)
-
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to terminate session", "session", name, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to terminate session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.State = breakglassv1alpha1.DebugSessionStateTerminated
+		status.Message = fmt.Sprintf("Terminated by %s", username)
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "terminate session", "failed to terminate session", name, err)
 		return
 	}
 
@@ -444,16 +444,19 @@ func (c *DebugSessionAPIController) handleApproveDebugSession(ctx *gin.Context) 
 
 	// Mark as approved
 	now := metav1.Now()
-	if session.Status.Approval == nil {
-		session.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{}
+	approval := &breakglassv1alpha1.DebugSessionApproval{}
+	if session.Status.Approval != nil {
+		existingApproval := *session.Status.Approval
+		approval = &existingApproval
 	}
-	session.Status.Approval.ApprovedBy = username
-	session.Status.Approval.ApprovedAt = &now
-	session.Status.Approval.Reason = req.Reason
+	approval.ApprovedBy = username
+	approval.ApprovedAt = &now
+	approval.Reason = req.Reason
 
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to approve session", "session", name, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to approve session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Approval = approval
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "approve session", "failed to approve session", name, err)
 		return
 	}
 
@@ -534,20 +537,21 @@ func (c *DebugSessionAPIController) handleRejectDebugSession(ctx *gin.Context) {
 
 	// Mark as rejected
 	now := metav1.Now()
-	if session.Status.Approval == nil {
-		session.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{}
+	approval := &breakglassv1alpha1.DebugSessionApproval{}
+	if session.Status.Approval != nil {
+		existingApproval := *session.Status.Approval
+		approval = &existingApproval
 	}
-	session.Status.Approval.RejectedBy = username
-	session.Status.Approval.RejectedAt = &now
-	session.Status.Approval.Reason = sanitizedReason
+	approval.RejectedBy = username
+	approval.RejectedAt = &now
+	approval.Reason = sanitizedReason
 
-	// Move to terminated state
-	session.Status.State = breakglassv1alpha1.DebugSessionStateTerminated
-	session.Status.Message = fmt.Sprintf("Rejected by %s: %s", username, sanitizedReason)
-
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to reject session", "session", name, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to reject session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Approval = approval
+		status.State = breakglassv1alpha1.DebugSessionStateTerminated
+		status.Message = fmt.Sprintf("Rejected by %s: %s", username, sanitizedReason)
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "reject session", "failed to reject session", name, err)
 		return
 	}
 
@@ -595,8 +599,9 @@ func (c *DebugSessionAPIController) handleLeaveDebugSession(ctx *gin.Context) {
 
 	// Find the participant
 	participantIndex := -1
-	for i := range session.Status.Participants {
-		if session.Status.Participants[i].User == username {
+	participants := append([]breakglassv1alpha1.DebugSessionParticipant(nil), session.Status.Participants...)
+	for i := range participants {
+		if participants[i].User == username {
 			participantIndex = i
 			break
 		}
@@ -606,7 +611,7 @@ func (c *DebugSessionAPIController) handleLeaveDebugSession(ctx *gin.Context) {
 		apiresponses.RespondNotFoundSimple(ctx, "user is not a participant in this session")
 		return
 	}
-	if session.Status.Participants[participantIndex].Role == breakglassv1alpha1.ParticipantRoleOwner {
+	if participants[participantIndex].Role == breakglassv1alpha1.ParticipantRoleOwner {
 		apiresponses.RespondForbidden(ctx, "session owner cannot leave; use terminate instead")
 		return
 	}
@@ -621,18 +626,19 @@ func (c *DebugSessionAPIController) handleLeaveDebugSession(ctx *gin.Context) {
 	}
 
 	now := metav1.Now()
-	session.Status.Participants[participantIndex].LeftAt = &now
+	participants[participantIndex].LeftAt = &now
 
-	if err := breakglass.ApplyDebugSessionStatus(apiCtx, c.client, session); err != nil {
-		reqLog.Errorw("Failed to leave session", "session", name, "user", username, "error", err)
-		apiresponses.RespondInternalErrorSimple(ctx, "failed to leave session")
+	if err := c.patchDebugSessionStatusWithOptimisticLock(apiCtx, session, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Participants = participants
+	}); err != nil {
+		respondDebugSessionStatusPatchError(ctx, reqLog, "leave session", "failed to leave session", name, err)
 		return
 	}
 
 	reqLog.Infow("User left debug session", "session", name, "user", username)
 	// Update active participant count (exclude those who left)
 	activeCount := 0
-	for _, p := range session.Status.Participants {
+	for _, p := range participants {
 		if p.LeftAt == nil {
 			activeCount++
 		}

--- a/pkg/breakglass/debug/debug_session_api_status_patch.go
+++ b/pkg/breakglass/debug/debug_session_api_status_patch.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	apiresponses "github.com/telekom/k8s-breakglass/pkg/apiresponses"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (c *DebugSessionAPIController) patchDebugSessionStatusWithOptimisticLock(
+	ctx context.Context,
+	session *breakglassv1alpha1.DebugSession,
+	mutate func(*breakglassv1alpha1.DebugSessionStatus),
+) error {
+	base := session.DeepCopy()
+	mutate(&session.Status)
+	if session.Generation > 0 {
+		session.Status.ObservedGeneration = session.Generation
+	}
+
+	if err := c.client.Status().Patch(ctx, session, ctrlclient.MergeFromWithOptions(base, ctrlclient.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("patch DebugSession API status with optimistic lock: %w", err)
+	}
+	return nil
+}
+
+func respondDebugSessionStatusPatchError(ctx *gin.Context, reqLog *zap.SugaredLogger, action, responseMessage, sessionName string, err error) {
+	if apierrors.IsConflict(err) {
+		reqLog.Warnw("Debug session status update conflict", "action", action, "session", sessionName, "error", err)
+		apiresponses.RespondConflict(ctx, "debug session was updated concurrently; retry the request")
+		return
+	}
+
+	reqLog.Errorw("Failed to "+action, "session", sessionName, "error", err)
+	apiresponses.RespondInternalErrorSimple(ctx, responseMessage)
+}

--- a/pkg/breakglass/debug/debug_session_api_status_patch.go
+++ b/pkg/breakglass/debug/debug_session_api_status_patch.go
@@ -48,7 +48,7 @@ func (c *DebugSessionAPIController) patchDebugSessionStatusWithOptimisticLock(
 func respondDebugSessionStatusPatchError(ctx *gin.Context, reqLog *zap.SugaredLogger, action, responseMessage, sessionName string, err error) {
 	if apierrors.IsConflict(err) {
 		reqLog.Warnw("Debug session status update conflict", "action", action, "session", sessionName, "error", err)
-		apiresponses.RespondConflict(ctx, "debug session was updated concurrently; retry the request")
+		apiresponses.RespondConflict(ctx, "debug session was updated concurrently; refresh the session before retrying")
 		return
 	}
 

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -34,9 +34,11 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
@@ -6225,6 +6227,68 @@ func TestDebugSessionAPIController_HandleLeaveDebugSession(t *testing.T) {
 	})
 }
 
+func TestDebugSessionAPIController_StatusPatchOptimisticLockRejectsStaleParticipantUpdateAfterRenewal(t *testing.T) {
+	scheme := testScheme()
+	logger := zap.NewNop().Sugar()
+
+	oldExpiry := metav1.NewTime(time.Now().Add(30 * time.Minute).Truncate(time.Second))
+	renewedExpiry := metav1.NewTime(time.Now().Add(2 * time.Hour).Truncate(time.Second))
+	joinedAt := metav1.Now()
+
+	liveSession := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "status-lock-session",
+			Namespace:       "default",
+			ResourceVersion: "2",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "owner@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State:        breakglassv1alpha1.DebugSessionStateActive,
+			ExpiresAt:    &renewedExpiry,
+			RenewalCount: 1,
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
+				{User: "owner@example.com", Role: breakglassv1alpha1.ParticipantRoleOwner, JoinedAt: joinedAt},
+			},
+		},
+	}
+	staleSession := liveSession.DeepCopy()
+	staleSession.ResourceVersion = "1"
+	staleSession.Status.ExpiresAt = &oldExpiry
+	staleSession.Status.RenewalCount = 0
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(liveSession).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	err := ctrl.patchDebugSessionStatusWithOptimisticLock(context.Background(), staleSession, func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.Participants = append(status.Participants, breakglassv1alpha1.DebugSessionParticipant{
+			User:     "peer@example.com",
+			Role:     breakglassv1alpha1.ParticipantRoleViewer,
+			JoinedAt: joinedAt,
+		})
+	})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err), "expected conflict, got %v", err)
+
+	var updated breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(context.Background(), client.ObjectKey{Name: liveSession.Name, Namespace: liveSession.Namespace}, &updated)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Status.ExpiresAt)
+	assert.True(t, updated.Status.ExpiresAt.Equal(&renewedExpiry),
+		"expiresAt mismatch: got %s, want %s", updated.Status.ExpiresAt.Time, renewedExpiry.Time)
+	assert.Equal(t, int32(1), updated.Status.RenewalCount)
+	require.Len(t, updated.Status.Participants, 1)
+	assert.Equal(t, "owner@example.com", updated.Status.Participants[0].User)
+}
+
 // TestDebugSessionAPIController_HandleRenewDebugSession tests the handleRenewDebugSession handler
 func TestDebugSessionAPIController_HandleRenewDebugSession(t *testing.T) {
 	scheme := testScheme()
@@ -6495,6 +6559,71 @@ func TestDebugSessionAPIController_HandleRenewDebugSession(t *testing.T) {
 				assert.Equal(t, tt.wantCount, updatedSession.Status.RenewalCount)
 			})
 		}
+	})
+
+	t.Run("renew status conflict returns conflict", func(t *testing.T) {
+		session := breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-session",
+				Namespace: "default",
+				Labels: map[string]string{
+					DebugSessionLabelKey: "test-session",
+				},
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster:     "production",
+				TemplateRef: "standard-debug",
+				RequestedBy: "alice@example.com",
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State:     breakglassv1alpha1.DebugSessionStateActive,
+				StartsAt:  &now,
+				ExpiresAt: &expiresAt,
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(&session).
+			WithStatusSubresource(&session).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					if _, ok := obj.(*breakglassv1alpha1.DebugSession); ok && subResourceName == "status" {
+						return apierrors.NewConflict(schema.GroupResource{
+							Group:    breakglassv1alpha1.GroupVersion.Group,
+							Resource: "debugsessions",
+						}, obj.GetName(), fmt.Errorf("stale status"))
+					}
+					return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "alice@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"extendBy":"1h"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions/test-session/renew", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+
+		var updatedSession breakglassv1alpha1.DebugSession
+		err = fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-session", Namespace: "default"}, &updatedSession)
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), updatedSession.Status.RenewalCount)
+		require.NotNil(t, updatedSession.Status.ExpiresAt)
+		assert.WithinDuration(t, expiresAt.Time, updatedSession.Status.ExpiresAt.Time, time.Second)
 	})
 
 	t.Run("renew rejects extension beyond max duration", func(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -6289,6 +6289,55 @@ func TestDebugSessionAPIController_StatusPatchOptimisticLockRejectsStaleParticip
 	assert.Equal(t, "owner@example.com", updated.Status.Participants[0].User)
 }
 
+func TestDebugSessionAPIController_StatusPatchOptimisticLockUpdatesStatus(t *testing.T) {
+	scheme := testScheme()
+	logger := zap.NewNop().Sugar()
+
+	joinedAt := metav1.Now()
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "status-lock-session",
+			Namespace:       "default",
+			Generation:      3,
+			ResourceVersion: "1",
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "production",
+			TemplateRef: "standard-debug",
+			RequestedBy: "owner@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			Participants: []breakglassv1alpha1.DebugSessionParticipant{
+				{User: "owner@example.com", Role: breakglassv1alpha1.ParticipantRoleOwner, JoinedAt: joinedAt},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+	err := ctrl.patchDebugSessionStatusWithOptimisticLock(context.Background(), session.DeepCopy(), func(status *breakglassv1alpha1.DebugSessionStatus) {
+		status.State = breakglassv1alpha1.DebugSessionStateTerminated
+		status.Message = "terminated by owner@example.com"
+	})
+	require.NoError(t, err)
+
+	var updated breakglassv1alpha1.DebugSession
+	err = fakeClient.Get(context.Background(), client.ObjectKey{Name: session.Name, Namespace: session.Namespace}, &updated)
+	require.NoError(t, err)
+
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStateTerminated, updated.Status.State)
+	assert.Equal(t, "terminated by owner@example.com", updated.Status.Message)
+	assert.Equal(t, int64(3), updated.Status.ObservedGeneration)
+	require.Len(t, updated.Status.Participants, 1)
+	assert.Equal(t, "owner@example.com", updated.Status.Participants[0].User)
+}
+
 // TestDebugSessionAPIController_HandleRenewDebugSession tests the handleRenewDebugSession handler
 func TestDebugSessionAPIController_HandleRenewDebugSession(t *testing.T) {
 	scheme := testScheme()


### PR DESCRIPTION
## Summary

Prevents concurrent DebugSession API actions from losing each other's status updates.

Join, leave, renew, terminate, approve, and reject now use optimistic status merge patches instead of applying a full status snapshot. If a concurrent request updates the DebugSession between read and write, the API returns `409 Conflict` so the client can refresh and retry instead of dropping a participant, renewal, approval decision, or terminal state.

## Evidence

- DebugSession API status endpoints previously read a session, changed one logical status area, and called full `ApplyDebugSessionStatus`.
- Concurrent requests such as renew-vs-join, join-vs-terminate, or approve-vs-reject could last-writer-win and erase disjoint updates from the earlier request.
- Duplicate check before opening: no open/recent PR matched `DebugSession API status conflict renew join participants optimistic lock`.

## Tests

- `go test ./pkg/breakglass/debug -run 'TestDebugSessionAPIController_(StatusPatchOptimisticLockRejectsStaleParticipantUpdateAfterRenewal|HandleRenewDebugSession/renew_status_conflict_returns_conflict)$' -count=1 -timeout=180s`
- `go test ./pkg/breakglass/debug -count=1 -timeout=240s`
- `make lint`
- `make test`
- `git diff --check`

## Screenshots

Not applicable; backend/API status-write fix only.
