### PR TITLE
fix: share multi-idp contract types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Frontend: share Multi-IDP contract types across model and service layers**: `frontend/src/services/multiIDP.ts` now imports and re-exports the canonical `IDPInfo` and `MultiIDPConfig` definitions from `frontend/src/model/multiIDP.ts`, and the frontend multi-IDP tests now exercise the real shared service/model contract instead of duplicating local interfaces.
 - **BreakglassEscalation reconciliation and events**: Escalation reconciliation now reacts to all spec generation changes and deletion timestamp updates, and Kubernetes Events emitted through the breakglass recorder retain a valid involved-object namespace when the scheme reference omits one.
 - **CI: pin ORT scan image**: The ORT workflow now uses a digest-pinned `ghcr.io/oss-review-toolkit/ort:89.2.0` image instead of the moving `latest` tag, avoiding transient ORT CLI startup failures from mutable container image updates.
 - **Debug session namespace semantics**: `POST /api/debugSessions` now treats legacy body `namespace` as a deprecated alias for `targetNamespace` and rejects conflicting values. DebugSession objects are always created in the matching `ClusterConfig` namespace, and named debug-session routes honor an explicit `?namespace=` hint strictly instead of falling back to another namespace.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -778,6 +778,7 @@ GET /api/config/idps
 - If `escalationIDPMapping[escalationName]` is empty or missing, the escalation allows any IDP
 - Frontend uses this to pre-populate IDP selection based on escalation choice
 - Data is cached by the reconciler to prevent API server overload
+- The frontend maintains `IDPInfo` and `MultiIDPConfig` as a single shared TypeScript contract in `frontend/src/model/multiIDP.ts`; service helpers import those shared types rather than redefining the response shape.
 
 ### OIDC Authority Proxy
 

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -14,8 +14,8 @@ vi.mock("@/services/logger", () => ({
 import AuthService, { useUser, AuthRedirect, AuthSilentRedirect } from "./auth";
 import { User } from "oidc-client-ts";
 import { getMultiIDPConfig } from "@/services/multiIDP";
-import type { MultiIDPConfig } from "@/services/multiIDP";
 import type Config from "@/model/config";
+import type { MultiIDPConfig } from "@/model/multiIDP";
 
 const mockedGetMultiIDPConfig = getMultiIDPConfig as Mock<typeof getMultiIDPConfig>;
 const TOKEN_PERSISTENCE_KEY = "breakglass_oidc_token_persistence";

--- a/frontend/src/services/multiIDP.spec.ts
+++ b/frontend/src/services/multiIDP.spec.ts
@@ -1,10 +1,6 @@
 import { vi, type Mock } from "vitest";
 import axios from "axios";
-import {
-  getMultiIDPConfig,
-  getAllowedIDPsForEscalation,
-  isIDPAllowedForEscalation,
-} from "./multiIDP";
+import { getMultiIDPConfig, getAllowedIDPsForEscalation, isIDPAllowedForEscalation } from "./multiIDP";
 import { error as logError } from "@/services/logger";
 import type { MultiIDPConfig } from "@/model/multiIDP";
 

--- a/frontend/src/services/multiIDP.spec.ts
+++ b/frontend/src/services/multiIDP.spec.ts
@@ -4,9 +4,9 @@ import {
   getMultiIDPConfig,
   getAllowedIDPsForEscalation,
   isIDPAllowedForEscalation,
-  type MultiIDPConfig,
 } from "./multiIDP";
 import { error as logError } from "@/services/logger";
+import type { MultiIDPConfig } from "@/model/multiIDP";
 
 vi.mock("axios", () => ({
   __esModule: true,

--- a/frontend/src/services/multiIDP.ts
+++ b/frontend/src/services/multiIDP.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { debug, error as logError } from "@/services/logger";
+import type { IDPInfo, MultiIDPConfig } from "@/model/multiIDP";
 
 /**
  * Phase 8: Multi-IDP Configuration Service
@@ -15,38 +16,7 @@ import { debug, error as logError } from "@/services/logger";
  * - Enforce authorization constraints at UI level
  */
 
-/**
- * Information about a single identity provider
- * Used for rendering the IDP selection dropdown and displaying metadata
- */
-export interface IDPInfo {
-  /** Unique identifier for the IDP (used in session.identityProvider) */
-  name: string;
-  /** Human-readable name for UI display in dropdowns and labels */
-  displayName: string;
-  /** OIDC issuer URL (for frontend debugging/validation) */
-  issuer: string;
-  /** Whether this IDP is currently active/enabled */
-  enabled: boolean;
-  /** OIDC authority endpoint for direct IDP login (optional) */
-  oidcAuthority?: string;
-  /** OIDC client ID for direct IDP login (optional) */
-  oidcClientID?: string;
-}
-
-/**
- * Multi-IDP configuration response from the backend
- * Combines available IDPs with authorization context
- */
-export interface MultiIDPConfig {
-  /** List of enabled identity providers available for selection */
-  identityProviders: IDPInfo[];
-  /** Maps escalation names to their allowed IDP names
-   *  Empty array [] means all IDPs are allowed (backward compatibility)
-   *  Example: { "prod-admin": ["corporate-idp"], "dev-admin": [] }
-   */
-  escalationIDPMapping: Record<string, string[]>;
-}
+export type { IDPInfo, MultiIDPConfig } from "@/model/multiIDP";
 
 const emptyMultiIDPConfig = (): MultiIDPConfig => ({
   identityProviders: [],

--- a/frontend/tests/unit/IDPSelector.spec.ts
+++ b/frontend/tests/unit/IDPSelector.spec.ts
@@ -66,11 +66,14 @@ describe("IDPSelector Utilities", () => {
   describe("getAllowedIDPsForEscalation()", () => {
     const mockConfig: MultiIDPConfig = {
       identityProviders: [
-        { name: "keycloak", displayName: "Keycloak SSO", enabled: true },
-        { name: "azure", displayName: "Azure AD", enabled: true },
-        { name: "disabled-idp", displayName: "Disabled IDP", enabled: false },
+        { name: "keycloak", displayName: "Keycloak SSO", issuer: "https://keycloak", enabled: true },
+        { name: "azure", displayName: "Azure AD", issuer: "https://azure", enabled: true },
+        { name: "disabled-idp", displayName: "Disabled IDP", issuer: "https://disabled", enabled: false },
       ],
-      defaultIDP: "keycloak",
+      escalationIDPMapping: {
+        "production-access": ["keycloak"],
+        "azure-only": ["azure"],
+      },
     };
 
     const mockEscalations: EscalationInfo[] = [
@@ -84,7 +87,7 @@ describe("IDPSelector Utilities", () => {
     });
 
     it("returns empty array when config has no IDPs", () => {
-      const emptyConfig = { identityProviders: [] };
+      const emptyConfig: MultiIDPConfig = { identityProviders: [], escalationIDPMapping: {} };
       expect(getAllowedIDPsForEscalation(emptyConfig, "production-access", mockEscalations)).toEqual([]);
     });
 
@@ -109,9 +112,10 @@ describe("IDPSelector Utilities", () => {
     it("filters out disabled IDPs from allowed list", () => {
       const config: MultiIDPConfig = {
         identityProviders: [
-          { name: "disabled-idp", enabled: false },
-          { name: "enabled-idp", enabled: true },
+          { name: "disabled-idp", displayName: "Disabled", issuer: "https://disabled", enabled: false },
+          { name: "enabled-idp", displayName: "Enabled", issuer: "https://enabled", enabled: true },
         ],
+        escalationIDPMapping: {},
       };
       const escalations: EscalationInfo[] = [{ name: "test", allowedIDPs: ["disabled-idp", "enabled-idp"] }];
       const result = getAllowedIDPsForEscalation(config, "test", escalations);
@@ -122,25 +126,25 @@ describe("IDPSelector Utilities", () => {
 
   describe("getIDPDisplayName()", () => {
     it("returns displayName when present", () => {
-      const idp: IDPInfo = { name: "keycloak", displayName: "Keycloak SSO", enabled: true };
+      const idp: IDPInfo = { name: "keycloak", displayName: "Keycloak SSO", issuer: "https://keycloak", enabled: true };
       expect(getIDPDisplayName(idp)).toBe("Keycloak SSO");
     });
 
     it("returns name when displayName is not present", () => {
-      const idp: IDPInfo = { name: "keycloak", enabled: true };
+      const idp: IDPInfo = { name: "keycloak", displayName: "", issuer: "https://keycloak", enabled: true };
       expect(getIDPDisplayName(idp)).toBe("keycloak");
     });
 
     it("returns name when displayName is empty string", () => {
-      const idp: IDPInfo = { name: "keycloak", displayName: "", enabled: true };
+      const idp: IDPInfo = { name: "keycloak", displayName: "", issuer: "https://keycloak", enabled: true };
       expect(getIDPDisplayName(idp)).toBe("keycloak");
     });
   });
 
   describe("isIDPSelectionValid()", () => {
     const allowedIDPs: IDPInfo[] = [
-      { name: "keycloak", enabled: true },
-      { name: "azure", enabled: true },
+      { name: "keycloak", displayName: "Keycloak", issuer: "https://keycloak", enabled: true },
+      { name: "azure", displayName: "Azure", issuer: "https://azure", enabled: true },
     ];
 
     it("returns true when IDP is in allowed list", () => {

--- a/frontend/tests/unit/IDPSelector.spec.ts
+++ b/frontend/tests/unit/IDPSelector.spec.ts
@@ -9,16 +9,7 @@
  * @vitest-environment jsdom
  */
 
-interface IDPInfo {
-  name: string;
-  displayName?: string;
-  enabled: boolean;
-}
-
-interface MultiIDPConfig {
-  identityProviders: IDPInfo[];
-  defaultIDP?: string;
-}
+import type { IDPInfo, MultiIDPConfig } from "@/model/multiIDP";
 
 interface EscalationInfo {
   name: string;

--- a/frontend/tests/unit/multiIDP.spec.ts
+++ b/frontend/tests/unit/multiIDP.spec.ts
@@ -10,11 +10,8 @@
  * @vitest-environment jsdom
  */
 
-import {
-  getAllowedIDPsForEscalation,
-  isIDPAllowedForEscalation,
-} from "@/services/multiIDP";
-import type { IDPInfo, MultiIDPConfig } from "@/model/multiIDP";
+import { getAllowedIDPsForEscalation, isIDPAllowedForEscalation } from "@/services/multiIDP";
+import type { MultiIDPConfig } from "@/model/multiIDP";
 
 describe("Frontend Multi-IDP: shared contract wiring", () => {
   it("keeps the shared model as the canonical Multi-IDP contract definition", async () => {

--- a/frontend/tests/unit/multiIDP.spec.ts
+++ b/frontend/tests/unit/multiIDP.spec.ts
@@ -18,6 +18,9 @@ describe("Frontend Multi-IDP: shared contract wiring", () => {
     const serviceModule = await import("@/services/multiIDP");
     const modelModule = await import("@/model/multiIDP");
 
+    // Note: The shared types (IDPInfo, MultiIDPConfig) are strictly TS constructs and erased at runtime.
+    // This compile-time-only validation is intentional. The below assertions only prove the service module
+    // doesn't export conflicting runtime values with those names.
     expect(serviceModule).not.toHaveProperty("IDPInfo");
     expect(serviceModule).not.toHaveProperty("MultiIDPConfig");
     expect(modelModule).toBeTypeOf("object");

--- a/frontend/tests/unit/multiIDP.spec.ts
+++ b/frontend/tests/unit/multiIDP.spec.ts
@@ -10,42 +10,22 @@
  * @vitest-environment jsdom
  */
 
-// Mock types
-interface IDPInfo {
-  name: string;
-  displayName: string;
-  issuer: string;
-  enabled: boolean;
-}
+import {
+  getAllowedIDPsForEscalation,
+  isIDPAllowedForEscalation,
+} from "@/services/multiIDP";
+import type { IDPInfo, MultiIDPConfig } from "@/model/multiIDP";
 
-interface MultiIDPConfig {
-  identityProviders: IDPInfo[];
-  escalationIDPMapping: Record<string, string[]>;
-}
+describe("Frontend Multi-IDP: shared contract wiring", () => {
+  it("keeps the shared model as the canonical Multi-IDP contract definition", async () => {
+    const serviceModule = await import("@/services/multiIDP");
+    const modelModule = await import("@/model/multiIDP");
 
-// Service implementations (simulated from multiIDP.ts)
-function getAllowedIDPsForEscalation(escalationName: string, config: MultiIDPConfig): IDPInfo[] {
-  const allowedIDPNames = config.escalationIDPMapping[escalationName];
-
-  // Empty array [] means all IDPs allowed (backward compatibility)
-  if (allowedIDPNames === undefined || allowedIDPNames.length === 0) {
-    return config.identityProviders;
-  }
-
-  // Filter to only allowed IDPs
-  return config.identityProviders.filter((idp) => allowedIDPNames.includes(idp.name));
-}
-
-function isIDPAllowedForEscalation(idpName: string, escalationName: string, config: MultiIDPConfig): boolean {
-  const allowedIDPNames = config.escalationIDPMapping[escalationName];
-
-  // Empty array [] means all IDPs allowed
-  if (allowedIDPNames === undefined || allowedIDPNames.length === 0) {
-    return true;
-  }
-
-  return allowedIDPNames.includes(idpName);
-}
+    expect(serviceModule).not.toHaveProperty("IDPInfo");
+    expect(serviceModule).not.toHaveProperty("MultiIDPConfig");
+    expect(modelModule).toBeTypeOf("object");
+  });
+});
 
 // ============================================================================
 // PHASE 9 TEST SUITE: Multi-IDP Services


### PR DESCRIPTION
## Summary
- move the Multi-IDP service layer to the shared model contract types
- update frontend tests to consume the shared types instead of duplicating interfaces
- document the single-source-of-truth frontend contract

Closes #959

## Verification
- make test
- npm test
- npm run typecheck
