### PR TITLE
docs: remove stale Gateway API guide links

### DIFF
--- a/config/components/gateway-api/kustomization.yaml
+++ b/config/components/gateway-api/kustomization.yaml
@@ -12,8 +12,8 @@
 #   components:
 #     - ../../components/gateway-api
 #
-# Customize parentRefs and hostnames via strategic merge patches in your overlay.
-# See docs/gateway-api-configuration.md for details.
+# Customize parentRefs, hostnames, gateway class, listener section names, and
+# cross-namespace grants via strategic merge patches in your overlay.
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component

--- a/docs/ingress-configuration.md
+++ b/docs/ingress-configuration.md
@@ -2,8 +2,6 @@
 
 This document covers how to properly configure breakglass behind a Kubernetes ingress controller, including security headers, CORS, and proxy configuration.
 
-> **Using Gateway API?** If your cluster uses Gateway API instead of Ingress, see [Gateway API Configuration](gateway-api-configuration.md) for HTTPRoute setup with Istio, Envoy Gateway, and Kong.
-
 ## Overview
 
 When deploying breakglass behind an ingress controller (NGINX, Traefik, HAProxy, etc.), several considerations apply:
@@ -338,7 +336,6 @@ If rate limiting logs show ingress IPs instead of client IPs:
 
 ## Related Documentation
 
-- [Gateway API Configuration](gateway-api-configuration.md) — HTTPRoute-based alternative to Ingress
 - [Security Best Practices](security-best-practices.md)
 - [Configuration Reference](configuration-reference.md)
 - [Installation Guide](installation.md)

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -178,16 +178,6 @@ patches:
 2. Confirming zero false positives
 3. Verifying all existing resources pass VAP validation
 
-## Combining with Gateway API
-
-Both components can be used together:
-
-```yaml
-components:
-  - ../../components/gateway-api
-  - ../../components/vap
-```
-
 ## Troubleshooting
 
 ### Policy Not Taking Effect
@@ -229,6 +219,5 @@ In Phase 1, both webhook and VAP validate simultaneously. If they disagree:
 ## Related Documentation
 
 - [Ingress Configuration](ingress-configuration.md) — Network setup
-- [Gateway API Configuration](gateway-api-configuration.md) — HTTPRoute setup
 - [Installation Guide](installation.md) — Step-by-step deployment
 - [Kubernetes VAP Documentation](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) — Upstream reference


### PR DESCRIPTION
## Summary
- remove links to the deleted Gateway API guide from ingress and VAP docs
- keep the Gateway API kustomize component self-contained by documenting overlay fields inline

## Validation
- `rg -n "gateway-api-configuration" docs config || true`
- `git diff --check`

## Risk
Docs/config comments only; no runtime, chart, API, or generated manifest behavior changes.