### PR TITLE
fix: use live reader for binding collision admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Deployment topologies**: Added `--enable-controllers` (`ENABLE_CONTROLLERS`) to isolate backend reconcilers, controller field indexes, cache invalidation handlers, and status updaters from component-specific pods. Lease creation is skipped whenever the effective role configuration does not need leader election, reducing RBAC requirements for webhook-only or frontend-only deployments.
 - **BreakglassSession validation**: `BreakglassSession` objects with whitespace-only `cluster`, `user`, or `grantedGroup` fields are now rejected during validation.
+- **DebugSessionClusterBinding collision admission**: Duplicate effective binding display names for the same template and cluster are now checked with a live API reader during admission, preventing cache lag from allowing conflicting bindings immediately after another binding is created.
 
 
 - **Frontend: share Multi-IDP contract types across model and service layers**: `frontend/src/services/multiIDP.ts` now imports and re-exports the canonical `IDPInfo` and `MultiIDPConfig` definitions from `frontend/src/model/multiIDP.ts`, and the frontend multi-IDP tests now exercise the real shared service/model contract instead of duplicating local interfaces.

--- a/api/v1alpha1/debug_session_cluster_binding_types.go
+++ b/api/v1alpha1/debug_session_cluster_binding_types.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -445,6 +446,7 @@ func (b *DebugSessionClusterBinding) ValidateDelete(ctx context.Context, obj *De
 // SetupWebhookWithManager registers webhooks for DebugSessionClusterBinding.
 func (b *DebugSessionClusterBinding) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	InitWebhookClient(mgr.GetClient(), mgr.GetCache())
+	InitWebhookReader(mgr.GetAPIReader())
 	return ctrl.NewWebhookManagedBy(mgr, &DebugSessionClusterBinding{}).
 		WithValidator(b).
 		Complete()
@@ -558,21 +560,28 @@ func GetEffectiveDisplayName(binding *DebugSessionClusterBinding, templateDispla
 // A collision occurs when the same template+cluster produces the same effective display name.
 // Returns a list of collisions found.
 func CheckNameCollisions(ctx context.Context, binding *DebugSessionClusterBinding) ([]NameCollision, error) {
-	client := GetWebhookClient()
-	if client == nil {
-		// No client available - skip collision check
+	bindingReader := GetWebhookReader()
+	if bindingReader == nil {
+		// No reader available - skip collision check
 		return nil, nil
 	}
 
-	// List all other bindings
+	// Bindings must be read live so admission does not miss freshly created
+	// bindings before the informer cache observes them.
 	bindingList := &DebugSessionClusterBindingList{}
-	if err := client.List(ctx, bindingList); err != nil {
+	if err := bindingReader.List(ctx, bindingList); err != nil {
 		return nil, err
 	}
 
-	// Get template information for computing effective names
+	// Templates change less frequently, so prefer the cached webhook client to
+	// avoid an additional live API request on every admission. Fall back to the
+	// binding reader when no cached client is configured.
+	var templateReader client.Reader = GetWebhookClient()
+	if templateReader == nil {
+		templateReader = bindingReader
+	}
 	templateList := &DebugSessionTemplateList{}
-	if err := client.List(ctx, templateList); err != nil {
+	if err := templateReader.List(ctx, templateList); err != nil {
 		return nil, err
 	}
 

--- a/api/v1alpha1/debug_session_cluster_binding_types_test.go
+++ b/api/v1alpha1/debug_session_cluster_binding_types_test.go
@@ -803,11 +803,16 @@ func TestCheckNameCollisions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = AddToScheme(scheme)
 
-	t.Run("returns nil when client is nil", func(t *testing.T) {
-		// Reset webhookClient to nil for this test
+	t.Run("returns nil when webhook reader and client are nil", func(t *testing.T) {
+		// Reset webhookReader and webhookClient to nil for this test.
 		originalClient := webhookClient
+		originalReader := webhookReader
 		webhookClient = nil
-		defer func() { webhookClient = originalClient }()
+		webhookReader = nil
+		defer func() {
+			webhookClient = originalClient
+			webhookReader = originalReader
+		}()
 
 		binding := &DebugSessionClusterBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -926,6 +931,62 @@ func TestCheckNameCollisions(t *testing.T) {
 		require.Len(t, collisions, 1)
 		assert.Equal(t, "shared-template", collisions[0].TemplateName)
 		assert.Equal(t, "cluster-1", collisions[0].ClusterName)
+		assert.Equal(t, "existing-binding", collisions[0].CollidingBinding)
+	})
+
+	t.Run("uses live reader instead of stale cached client", func(t *testing.T) {
+		existingBinding := &DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-binding",
+				Namespace: "default",
+			},
+			Spec: DebugSessionClusterBindingSpec{
+				TemplateRef: &TemplateReference{Name: "shared-template"},
+				Clusters:    []string{"cluster-1"},
+			},
+		}
+
+		template := &DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "shared-template",
+			},
+			Spec: DebugSessionTemplateSpec{
+				DisplayName: "Shared Template",
+			},
+		}
+
+		staleClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(template).
+			Build()
+		liveReader := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(existingBinding, template).
+			Build()
+
+		originalClient := webhookClient
+		originalReader := webhookReader
+		webhookClient = staleClient
+		webhookReader = liveReader
+		defer func() {
+			webhookClient = originalClient
+			webhookReader = originalReader
+		}()
+
+		newBinding := &DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "new-binding",
+				Namespace: "default",
+			},
+			Spec: DebugSessionClusterBindingSpec{
+				TemplateRef: &TemplateReference{Name: "shared-template"},
+				Clusters:    []string{"cluster-1"},
+			},
+		}
+
+		collisions, err := CheckNameCollisions(context.Background(), newBinding)
+		assert.NoError(t, err)
+		require.Len(t, collisions, 1)
 		assert.Equal(t, "existing-binding", collisions[0].CollidingBinding)
 	})
 

--- a/api/v1alpha1/webhook_vars.go
+++ b/api/v1alpha1/webhook_vars.go
@@ -10,11 +10,17 @@ import (
 // webhookClientOnce ensures the webhook client is initialized exactly once,
 // preventing race conditions when multiple SetupWebhookWithManager calls occur.
 var webhookClientOnce sync.Once
+var webhookReaderOnce sync.Once
 
 // webhookClient and webhookCache are populated by each CRD's SetupWebhookWithManager
-// and used by validators to perform cluster-scoped checks.
-// These are protected by webhookClientOnce to prevent race conditions.
+// and used by validators to perform cluster-scoped checks. They are protected by
+// webhookClientOnce to prevent race conditions.
 var webhookClient client.Client
+
+// webhookReader is initialized separately with the manager's live API reader for
+// admission checks that must bypass the informer cache. It is protected by
+// webhookReaderOnce to prevent race conditions during parallel setup.
+var webhookReader client.Reader
 var webhookCache cache.Cache
 
 // InitWebhookClient initializes the webhook client and cache exactly once.
@@ -27,8 +33,25 @@ func InitWebhookClient(c client.Client, ca cache.Cache) {
 	})
 }
 
+// InitWebhookReader initializes the live API reader used by validators that
+// must not rely on the informer cache for admission-time uniqueness checks.
+func InitWebhookReader(r client.Reader) {
+	webhookReaderOnce.Do(func() {
+		webhookReader = r
+	})
+}
+
 // GetWebhookClient returns the webhook client for use in validators.
 func GetWebhookClient() client.Client {
+	return webhookClient
+}
+
+// GetWebhookReader returns the live API reader for validators, falling back to
+// the webhook client when no dedicated reader has been configured.
+func GetWebhookReader() client.Reader {
+	if webhookReader != nil {
+		return webhookReader
+	}
 	return webhookClient
 }
 

--- a/api/v1alpha1/webhook_vars_test.go
+++ b/api/v1alpha1/webhook_vars_test.go
@@ -1,11 +1,13 @@
 package v1alpha1
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
@@ -78,4 +80,36 @@ func TestInitWebhookClient_OnlyOnce(t *testing.T) {
 	})
 
 	assert.Equal(t, 1, counter, "sync.Once should only execute the function once")
+}
+
+func TestInitWebhookReader_OnlyOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = AddToScheme(scheme)
+
+	binding := &DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "first-reader-binding"},
+	}
+	firstReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(binding).
+		Build()
+	secondReader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	originalReader := webhookReader
+	webhookReader = nil
+	webhookReaderOnce = sync.Once{}
+	defer func() {
+		webhookReader = originalReader
+		webhookReaderOnce = sync.Once{}
+	}()
+
+	InitWebhookReader(firstReader)
+	InitWebhookReader(secondReader)
+
+	bindings := &DebugSessionClusterBindingList{}
+	require.NoError(t, GetWebhookReader().List(context.Background(), bindings))
+	require.Len(t, bindings.Items, 1)
+	assert.Equal(t, "first-reader-binding", bindings.Items[0].Name)
 }


### PR DESCRIPTION
## Summary
- use the manager API reader for DebugSessionClusterBinding collision admission checks
- keep the cached webhook client as fallback for validators that do not need live reads
- add regression coverage for stale cached client vs live reader collision detection

## Evidence
- #1009 Single-Cluster E2E failed in `TestClusterBindingNameCollision`: the second binding with the same effective display name was admitted
- #1009 only changes docs/config comments, so this points to an existing main admission/cache-lag regression

## Validation
- `gofmt -w api/v1alpha1/webhook_vars.go api/v1alpha1/debug_session_cluster_binding_types.go api/v1alpha1/debug_session_cluster_binding_types_test.go`
- `git diff --check`
- `go test ./api/v1alpha1 -run 'TestCheckNameCollisions|TestGetWebhookClient|TestInitWebhookClient|TestDebugSessionClusterBinding_ValidateCreate' -count=1`