### PR TITLE
ci: delay image publish until all quality gates pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,13 +483,26 @@ jobs:
 
   # ============================================================================
   # Publish Image — SBOM, registry push, attestation, Artifactory push
-  # Runs in parallel with E2E tests (does not block them).
+  # Runs after all quality gates pass.
   # ============================================================================
 
   publish-image:
     name: Publish Image
     runs-on: ubuntu-latest
-    needs: [build-image]
+    needs: 
+      - build-image
+      - lint
+      - unit-tests-controller
+      - unit-tests-cli
+      - crd-validation
+      - npm-audit
+      - manifest-validation
+      - frontend-tests
+      - helm-lint
+      - single-cluster-e2e
+      - oidc-comprehensive-e2e
+      - ui-e2e
+      - multi-cluster-e2e
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Closes #988

Delays the registry push and attestation in `ci.yml` until all required quality gates (tests and E2E) have succeeded.