### PR TITLE
feat(api): expose granted groups and target namespaces in CLI tables

### DIFF
--- a/api/v1alpha1/breakglass_session_types.go
+++ b/api/v1alpha1/breakglass_session_types.go
@@ -240,6 +240,7 @@ type BreakglassSessionStatus struct {
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=".status.state",description="The current state of the session"
 // +kubebuilder:printcolumn:name="User",type=string,JSONPath=".spec.user",description="The user associated with the session"
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=".spec.cluster",description="The cluster associated with the session"
+// +kubebuilder:printcolumn:name="Granted Group",type=string,JSONPath=".spec.grantedGroup",description="The granted group for the session"
 // +kubebuilder:printcolumn:name="Expires At",type=string,JSONPath=".status.expiresAt",description="The expiration time of the session"
 // +kubebuilder:printcolumn:name="Scheduled Start",type=string,JSONPath=".spec.scheduledStartTime",description="The scheduled start time of the session"
 // +kubebuilder:printcolumn:name="Retained Until",type=string,JSONPath=".status.retainedUntil",description="When the session object will be removed"

--- a/api/v1alpha1/debug_session_types.go
+++ b/api/v1alpha1/debug_session_types.go
@@ -548,6 +548,7 @@ type CopiedPodRef struct {
 // +kubebuilder:printcolumn:name="State",type=string,JSONPath=".status.state",description="Session state"
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=".spec.cluster",description="Target cluster"
 // +kubebuilder:printcolumn:name="Template",type=string,JSONPath=".spec.templateRef",description="Debug template"
+// +kubebuilder:printcolumn:name="Target NS",type=string,JSONPath=".spec.targetNamespace",description="Target namespace"
 // +kubebuilder:printcolumn:name="Requested By",type=string,JSONPath=".spec.requestedBy",description="Session owner"
 // +kubebuilder:printcolumn:name="Expires At",type=string,JSONPath=".status.expiresAt",description="Expiration time"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"

--- a/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_breakglasssessions.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.cluster
       name: Cluster
       type: string
+    - description: The granted group for the session
+      jsonPath: .spec.grantedGroup
+      name: Granted Group
+      type: string
     - description: The expiration time of the session
       jsonPath: .status.expiresAt
       name: Expires At

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.templateRef
       name: Template
       type: string
+    - description: Target namespace
+      jsonPath: .spec.targetNamespace
+      name: Target NS
+      type: string
     - description: Session owner
       jsonPath: .spec.requestedBy
       name: Requested By

--- a/pkg/bgctl/client/debug.go
+++ b/pkg/bgctl/client/debug.go
@@ -29,6 +29,7 @@ type DebugSessionListOptions struct {
 type DebugSessionSummary struct {
 	Name                 string                                   `json:"name"`
 	TemplateRef          string                                   `json:"templateRef"`
+	TargetNamespace      string                                   `json:"targetNamespace,omitempty"`
 	Cluster              string                                   `json:"cluster"`
 	RequestedBy          string                                   `json:"requestedBy"`
 	State                breakglassv1alpha1.DebugSessionState     `json:"state"`

--- a/pkg/bgctl/output/table.go
+++ b/pkg/bgctl/output/table.go
@@ -13,14 +13,14 @@ import (
 
 func WriteSessionTable(w io.Writer, sessions []breakglassv1alpha1.BreakglassSession) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tUSER\tSTATE\tCREATED\tEXPIRES")
+	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tUSER\tGROUP\tSTATE\tCREATED\tEXPIRES")
 	for _, s := range sessions {
 		created := formatTime(s.CreationTimestamp.Time)
 		expires := "-"
 		if !s.Status.ExpiresAt.IsZero() {
 			expires = formatTime(s.Status.ExpiresAt.Time)
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", s.Name, s.Spec.Cluster, s.Spec.User, string(s.Status.State), created, expires)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", s.Name, s.Spec.Cluster, s.Spec.User, s.Spec.GrantedGroup, string(s.Status.State), created, expires)
 	}
 	_ = tw.Flush()
 }
@@ -53,13 +53,13 @@ func WriteEscalationTable(w io.Writer, escs []breakglassv1alpha1.BreakglassEscal
 
 func WriteDebugSessionTable(w io.Writer, sessions []client.DebugSessionSummary) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tREQUESTED_BY\tSTATE\tEXPIRES")
+	_, _ = fmt.Fprintln(tw, "NAME\tCLUSTER\tTEMPLATE\tTARGET_NS\tREQUESTED_BY\tSTATE\tEXPIRES")
 	for _, s := range sessions {
 		expires := "-"
 		if s.ExpiresAt != nil {
 			expires = formatTime(s.ExpiresAt.Time)
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", s.Name, s.Cluster, s.RequestedBy, string(s.State), expires)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", s.Name, s.Cluster, s.TemplateRef, s.TargetNamespace, s.RequestedBy, string(s.State), expires)
 	}
 	_ = tw.Flush()
 }
@@ -67,7 +67,7 @@ func WriteDebugSessionTable(w io.Writer, sessions []client.DebugSessionSummary) 
 // WriteDebugSessionTableWide outputs debug sessions in wide table format with all available fields.
 func WriteDebugSessionTableWide(w io.Writer, sessions []client.DebugSessionSummary) {
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "NAME\tTEMPLATE\tCLUSTER\tREQUESTED_BY\tSTATE\tSTARTS\tEXPIRES\tPARTICIPANTS\tALLOWED_PODS\tOPERATIONS")
+	_, _ = fmt.Fprintln(tw, "NAME\tTEMPLATE\tTARGET_NS\tCLUSTER\tREQUESTED_BY\tSTATE\tSTARTS\tEXPIRES\tPARTICIPANTS\tALLOWED_PODS\tOPERATIONS")
 	for _, s := range sessions {
 		starts := "-"
 		if s.StartsAt != nil {
@@ -78,7 +78,7 @@ func WriteDebugSessionTableWide(w io.Writer, sessions []client.DebugSessionSumma
 			expires = formatTime(s.ExpiresAt.Time)
 		}
 		ops := formatAllowedPodOperations(s.AllowedPodOperations)
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n", s.Name, s.TemplateRef, s.Cluster, s.RequestedBy, string(s.State), starts, expires, s.Participants, s.AllowedPods, ops)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n", s.Name, s.TemplateRef, s.TargetNamespace, s.Cluster, s.RequestedBy, string(s.State), starts, expires, s.Participants, s.AllowedPods, ops)
 	}
 	_ = tw.Flush()
 }

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -316,6 +316,7 @@ type DebugSessionListResponse struct {
 type DebugSessionSummary struct {
 	Name                   string                                   `json:"name"`
 	TemplateRef            string                                   `json:"templateRef"`
+	TargetNamespace        string                                   `json:"targetNamespace,omitempty"`
 	Cluster                string                                   `json:"cluster"`
 	RequestedBy            string                                   `json:"requestedBy"`
 	RequestedByDisplayName string                                   `json:"requestedByDisplayName,omitempty"`
@@ -503,6 +504,7 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 		summaries = append(summaries, DebugSessionSummary{
 			Name:                   s.Name,
 			TemplateRef:            s.Spec.TemplateRef,
+			TargetNamespace:        s.Spec.TargetNamespace,
 			Cluster:                s.Spec.Cluster,
 			RequestedBy:            s.Spec.RequestedBy,
 			RequestedByDisplayName: s.Spec.RequestedByDisplayName,


### PR DESCRIPTION
Closes #957

Adds the `spec.grantedGroup` to BreakglassSession CRD print columns and the `bgctl` session table. Adds `spec.templateRef` and `spec.targetNamespace` to DebugSession CRD print columns and the `bgctl` debug session table.