### PR TITLE
fix(audit): emit actual Kubernetes events from the kubernetes sink

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -452,7 +452,7 @@ func setupServices(ctx context.Context, cliConfig *cli.Config, cfg config.Config
 	}
 
 	// Create audit service for Kafka/webhook/log audit event emission
-	auditService := audit.NewService(uncachedClient, zapLogger, cliConfig.BreakglassNamespace)
+	auditService := audit.NewService(uncachedClient, reconcilerMgr.GetEventRecorderFor("breakglass-audit"), zapLogger, cliConfig.BreakglassNamespace)
 
 	// Enable multi-IDP support in auth handler for token verification
 	auth.WithIdentityProviderLoader(idpLoader)

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -41,6 +41,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
@@ -51,6 +52,7 @@ import (
 // It watches AuditConfig changes and reconfigures the audit manager accordingly.
 type Service struct {
 	client            client.Client
+	recorder          record.EventRecorder
 	logger            *zap.Logger
 	mu                sync.RWMutex
 	manager           *Manager
@@ -61,9 +63,10 @@ type Service struct {
 }
 
 // NewService creates a new audit Service.
-func NewService(kubeClient client.Client, logger *zap.Logger, controllerNamespace string) *Service {
+func NewService(kubeClient client.Client, recorder record.EventRecorder, logger *zap.Logger, controllerNamespace string) *Service {
 	return &Service{
 		client:   kubeClient,
+		recorder: recorder,
 		logger:   logger.Named("audit-service"),
 		enabled:  false,
 		configNS: controllerNamespace,
@@ -620,8 +623,13 @@ func (s *Service) buildWebhookSink(sinkCfg breakglassv1alpha1.AuditSinkConfig) (
 }
 
 func (s *Service) buildKubernetesSink(sinkCfg breakglassv1alpha1.AuditSinkConfig) (Sink, error) {
-	// Kubernetes event sink - placeholder for now
-	return NewLogSink(s.logger.Named("k8s-events")), nil
+	var eventTypes []EventType
+	if sinkCfg.Kubernetes != nil {
+		for _, et := range sinkCfg.Kubernetes.EventTypes {
+			eventTypes = append(eventTypes, EventType(et))
+		}
+	}
+	return NewKubernetesEventSink(s.recorder, eventTypes), nil
 }
 
 // getSecretKey retrieves a specific key from a Kubernetes secret.

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -26,7 +26,7 @@ func TestNewService(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 	assert.NotNil(t, svc)
 	assert.False(t, svc.IsEnabled())
 }
@@ -38,7 +38,7 @@ func TestService_ReloadDisablesOnNilConfig(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	err := svc.Reload(context.Background(), nil)
 	assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestService_ReloadDisablesOnDisabledConfig(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -73,7 +73,7 @@ func TestService_ReloadWithLogSink(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -109,7 +109,7 @@ func TestService_ReloadWithQueueConfig(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -144,7 +144,7 @@ func TestService_ReloadWithSampling(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -189,7 +189,7 @@ func TestService_ReloadNoSinks(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -212,7 +212,7 @@ func TestService_EmitWhenDisabled(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	// Service is disabled by default
 	event := &Event{
@@ -237,7 +237,7 @@ func TestService_EmitWhenEnabled(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -281,7 +281,7 @@ func TestService_CloseWhenNotInitialized(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	// Close without Reload
 	err := svc.Close()
@@ -295,7 +295,7 @@ func TestService_ReloadMultipleTimes(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config1 := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "config1"},
@@ -344,7 +344,7 @@ func TestService_BuildWebhookSink(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -381,7 +381,7 @@ func TestService_BuildKubernetesSink(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -411,7 +411,7 @@ func TestService_SkipsInvalidSinkType(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -446,7 +446,7 @@ func TestService_KafkaSinkMissingConfig(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -475,7 +475,7 @@ func TestService_WebhookSinkMissingConfig(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -519,7 +519,7 @@ func TestService_GetSecretKey(t *testing.T) {
 		WithObjects(secret).
 		Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	// Get existing key
 	data, err := svc.getSecretKey(context.Background(), "test-secret", "test-namespace", "username")
@@ -554,7 +554,7 @@ func TestService_GetSinkHealth_NoSinks(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	health := svc.GetSinkHealth()
 	assert.Empty(t, health)
@@ -567,7 +567,7 @@ func TestService_GetSinkHealth_WithLogSink(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -603,7 +603,7 @@ func TestService_GetQueuedSinkHealth_NoSinks(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	health := svc.GetQueuedSinkHealth()
 	assert.Nil(t, health)
@@ -616,7 +616,7 @@ func TestService_GetQueuedSinkHealth_WithSink(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-config"},
@@ -679,7 +679,7 @@ func TestService_BuildKafkaTLSConfig(t *testing.T) {
 		WithObjects(caSecret, clientCertSecret).
 		Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 	ctx := context.Background()
 
 	t.Run("with CA only", func(t *testing.T) {
@@ -759,7 +759,7 @@ func TestService_BuildKafkaTLSConfig(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(secretNoKey).
 			Build()
-		svcNoKey := NewService(clientWithNoKey, logger, "test-namespace")
+		svcNoKey := NewService(clientWithNoKey, nil, logger, "test-namespace")
 
 		tlsCfg := &breakglassv1alpha1.KafkaTLSSpec{
 			ClientCertSecretRef: &breakglassv1alpha1.SecretKeySelector{
@@ -795,7 +795,7 @@ func TestService_BuildKafkaSASLConfig(t *testing.T) {
 		WithObjects(saslSecret).
 		Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 	ctx := context.Background()
 
 	t.Run("with PLAIN mechanism", func(t *testing.T) {
@@ -853,7 +853,7 @@ func TestService_BuildKafkaSASLConfig(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(secretNoPass).
 			Build()
-		svcNoPass := NewService(clientNoPass, logger, "test-namespace")
+		svcNoPass := NewService(clientNoPass, nil, logger, "test-namespace")
 
 		saslCfg := &breakglassv1alpha1.KafkaSASLSpec{
 			Mechanism: "PLAIN",
@@ -882,7 +882,7 @@ func TestService_BuildKafkaSASLConfig(t *testing.T) {
 			WithScheme(scheme).
 			WithObjects(saslSecretOtherNS).
 			Build()
-		svcOtherNS := NewService(clientOtherNS, logger, "test-namespace")
+		svcOtherNS := NewService(clientOtherNS, nil, logger, "test-namespace")
 
 		saslCfg := &breakglassv1alpha1.KafkaSASLSpec{
 			Mechanism: "PLAIN",
@@ -905,7 +905,7 @@ func TestService_GetStats_NoManager(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	// No manager initialized
 	stats := svc.GetStats()
@@ -919,7 +919,7 @@ func TestService_GetStats_WithManager(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	// Reload with a valid config to initialize the manager
 	config := &breakglassv1alpha1.AuditConfig{
@@ -956,7 +956,7 @@ func TestService_Manager_NilBeforeReload(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 	assert.Nil(t, svc.Manager())
 }
 
@@ -967,7 +967,7 @@ func TestService_Manager_NonNilAfterSuccessfulReload(t *testing.T) {
 	_ = breakglassv1alpha1.AddToScheme(scheme)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	svc := NewService(client, logger, "test-namespace")
+	svc := NewService(client, nil, logger, "test-namespace")
 
 	config := &breakglassv1alpha1.AuditConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-manager-config"},

--- a/pkg/audit/sink.go
+++ b/pkg/audit/sink.go
@@ -26,7 +26,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 )
 
 // Sink defines the interface for audit event destinations.
@@ -303,13 +303,13 @@ func (s *WebhookSink) Name() string {
 
 // KubernetesEventSink creates Kubernetes Events for audit entries.
 type KubernetesEventSink struct {
-	recorder events.EventRecorder
+	recorder record.EventRecorder
 	// Only emit events for these types (empty means all)
 	includeTypes map[EventType]bool
 }
 
 // NewKubernetesEventSink creates a new KubernetesEventSink.
-func NewKubernetesEventSink(recorder events.EventRecorder, includeTypes []EventType) *KubernetesEventSink {
+func NewKubernetesEventSink(recorder record.EventRecorder, includeTypes []EventType) *KubernetesEventSink {
 	typeMap := make(map[EventType]bool)
 	for _, t := range includeTypes {
 		typeMap[t] = true
@@ -350,9 +350,18 @@ func (s *KubernetesEventSink) Write(_ context.Context, event *Event) error {
 		}
 	}
 
-	// Note: This is a placeholder - actual implementation would need the object reference
-	_ = eventType
-	_ = message
+	regarding := &corev1.ObjectReference{
+		Kind:      event.Target.Kind,
+		Name:      event.Target.Name,
+		Namespace: event.Target.Namespace,
+	}
+	if regarding.Kind == "BreakglassSession" || regarding.Kind == "DebugSession" || regarding.Kind == "DebugSessionTemplate" || regarding.Kind == "DebugSessionClusterBinding" {
+		regarding.APIVersion = "breakglass.t-caas.telekom.com/v1alpha1"
+	}
+
+	if s.recorder != nil {
+		s.recorder.Eventf(regarding, eventType, string(event.Type), "%s", message)
+	}
 	return nil
 }
 

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -2700,7 +2700,7 @@ func TestEmitPodSecurityAudit(t *testing.T) {
 
 			var auditSvc *audit.Service
 			if tt.auditService {
-				auditSvc = audit.NewService(cli, logger, "test-ns")
+				auditSvc = audit.NewService(cli, nil, logger, "test-ns")
 			}
 			wc.WithAuditService(auditSvc)
 
@@ -2827,7 +2827,7 @@ func TestEmitAccessDecisionAudit(t *testing.T) {
 			wc.emitAccessDecisionAudit(ctx, tt.sarSpec.User, []string{"group1", "group2"}, "test-cluster", sar, tt.allowed, tt.source, "test reason")
 
 			// Test with audit service set (but disabled - should still not panic)
-			auditSvc := audit.NewService(cli, logger, "test-ns")
+			auditSvc := audit.NewService(cli, nil, logger, "test-ns")
 			wc.WithAuditService(auditSvc)
 			wc.emitAccessDecisionAudit(ctx, tt.sarSpec.User, []string{"group1", "group2"}, "test-cluster", sar, tt.allowed, tt.source, "test reason with audit service")
 		})
@@ -2918,7 +2918,7 @@ func TestEmitPolicyDenialAudit(t *testing.T) {
 			wc.emitPolicyDenialAudit(ctx, tt.sarSpec.User, []string{"group1"}, "test-cluster", sar, tt.policyName, tt.scope)
 
 			// Test with audit service set
-			auditSvc := audit.NewService(cli, logger, "test-ns")
+			auditSvc := audit.NewService(cli, nil, logger, "test-ns")
 			wc.WithAuditService(auditSvc)
 			wc.emitPolicyDenialAudit(ctx, tt.sarSpec.User, []string{"group1"}, "test-cluster", sar, tt.policyName, tt.scope)
 		})
@@ -3323,7 +3323,7 @@ func TestEmitAuditWithResourceAndNonResourceAttributes(t *testing.T) {
 	wc := NewWebhookController(logger.Sugar(), config.Config{}, sesMgr, escalMgr, nil, policy.NewEvaluator(cli, logger.Sugar()))
 
 	// Set up audit service
-	auditSvc := audit.NewService(cli, logger, "test-ns")
+	auditSvc := audit.NewService(cli, nil, logger, "test-ns")
 	wc.WithAuditService(auditSvc)
 
 	t.Run("handles SAR with only ResourceAttributes", func(t *testing.T) {
@@ -3404,7 +3404,7 @@ func TestAuditEmitWithDifferentEventSeverities(t *testing.T) {
 	wc := NewWebhookController(logger.Sugar(), config.Config{}, sesMgr, escalMgr, nil, policy.NewEvaluator(cli, logger.Sugar()))
 
 	// Set up audit service
-	auditSvc := audit.NewService(cli, logger, "test-ns")
+	auditSvc := audit.NewService(cli, nil, logger, "test-ns")
 	wc.WithAuditService(auditSvc)
 
 	sar := &authorizationv1.SubjectAccessReview{


### PR DESCRIPTION
Closes #975

Plumbs `record.EventRecorder` into `audit.Service` and properly emits Kubernetes `Event` objects instead of just logging them.