### PR TITLE
fix: verify Keycloak group sync health

### DIFF
--- a/pkg/config/identity_provider_reconciler.go
+++ b/pkg/config/identity_provider_reconciler.go
@@ -2,9 +2,14 @@ package config
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/Nerzal/gocloak/v13"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +53,26 @@ type IdentityProviderReconciler struct {
 	onError func(ctx context.Context, err error)
 	// resyncPeriod defines the full list reconciliation interval (default 10m)
 	resyncPeriod time.Duration
+	// keycloakHealthChecker verifies that the configured group sync client can authenticate.
+	keycloakHealthChecker keycloakGroupSyncHealthChecker
+}
+
+type keycloakGroupSyncHealthChecker func(ctx context.Context, keycloak *breakglassv1alpha1.KeycloakGroupSync, clientSecret string) error
+
+type keycloakGroupSyncHealthError struct {
+	reason  string
+	message string
+}
+
+func (e *keycloakGroupSyncHealthError) Error() string {
+	return e.message
+}
+
+func newKeycloakGroupSyncHealthError(reason, format string, args ...interface{}) error {
+	return &keycloakGroupSyncHealthError{
+		reason:  reason,
+		message: fmt.Sprintf(format, args...),
+	}
 }
 
 // NewIdentityProviderReconciler creates a new controller-runtime reconciler for IdentityProvider
@@ -60,10 +85,11 @@ func NewIdentityProviderReconciler(
 		logger = zap.NewNop().Sugar()
 	}
 	return &IdentityProviderReconciler{
-		client:       kubeClient,
-		logger:       logger,
-		onReload:     reloadFn,
-		resyncPeriod: 10 * time.Minute, // Full list resync every 10 minutes
+		client:                kubeClient,
+		logger:                logger,
+		onReload:              reloadFn,
+		resyncPeriod:          10 * time.Minute, // Full list resync every 10 minutes
+		keycloakHealthChecker: checkKeycloakGroupSyncHealth,
 	}
 }
 
@@ -124,6 +150,11 @@ func (r *IdentityProviderReconciler) WithEventRecorder(recorder events.EventReco
 // WithResyncPeriod sets the resync period for full list reconciliation
 func (r *IdentityProviderReconciler) WithResyncPeriod(period time.Duration) *IdentityProviderReconciler {
 	r.resyncPeriod = period
+	return r
+}
+
+func (r *IdentityProviderReconciler) withKeycloakHealthChecker(fn keycloakGroupSyncHealthChecker) *IdentityProviderReconciler {
+	r.keycloakHealthChecker = fn
 	return r
 }
 
@@ -360,6 +391,77 @@ func (r *IdentityProviderReconciler) applyStatus(ctx context.Context, idp *break
 	return ssa.ApplyIdentityProviderStatus(ctx, r.client, idp)
 }
 
+func checkKeycloakGroupSyncHealth(ctx context.Context, keycloak *breakglassv1alpha1.KeycloakGroupSync, clientSecret string) error {
+	if keycloak == nil {
+		return newKeycloakGroupSyncHealthError("KeycloakMissing", "Keycloak configuration is missing")
+	}
+	if keycloak.InsecureSkipVerify {
+		return newKeycloakGroupSyncHealthError("KeycloakTLSConfigRejected", "insecureSkipVerify is not supported for Keycloak group synchronization")
+	}
+
+	timeout := 10 * time.Second
+	if keycloak.RequestTimeout != "" {
+		parsed, err := breakglassv1alpha1.ParseDuration(keycloak.RequestTimeout)
+		if err != nil || parsed <= 0 {
+			return newKeycloakGroupSyncHealthError("KeycloakRequestTimeoutInvalid", "invalid Keycloak requestTimeout %q", keycloak.RequestTimeout)
+		}
+		timeout = parsed
+	}
+
+	gc := gocloak.NewClient(keycloak.BaseURL)
+	restyClient := gc.RestyClient()
+	restyClient.SetTimeout(timeout)
+
+	tlsConfig, err := keycloakGroupSyncTLSConfig(keycloak)
+	if err != nil {
+		return err
+	}
+	restyClient.SetTLSClientConfig(tlsConfig)
+
+	token, err := gc.GetToken(ctx, keycloak.Realm, gocloak.TokenOptions{
+		ClientID:     &keycloak.ClientID,
+		ClientSecret: &clientSecret,
+		GrantType:    gocloak.StringP("client_credentials"),
+	})
+	if err != nil {
+		return newKeycloakGroupSyncHealthError(keycloakTokenFailureReason(err), "Keycloak token request failed: %v", err)
+	}
+	if token == nil || token.AccessToken == "" {
+		return newKeycloakGroupSyncHealthError("KeycloakTokenInvalid", "Keycloak token response did not contain an access token")
+	}
+	return nil
+}
+
+func keycloakGroupSyncTLSConfig(keycloak *breakglassv1alpha1.KeycloakGroupSync) (*tls.Config, error) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if keycloak.CertificateAuthority == "" {
+		return tlsConfig, nil
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if ok := rootCAs.AppendCertsFromPEM([]byte(keycloak.CertificateAuthority)); !ok {
+		return nil, newKeycloakGroupSyncHealthError("KeycloakTLSConfigInvalid", "failed to parse Keycloak certificateAuthority")
+	}
+	tlsConfig.RootCAs = rootCAs
+	return tlsConfig, nil
+}
+
+func keycloakTokenFailureReason(err error) string {
+	var apiErr *gocloak.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return "KeycloakAuthenticationFailed"
+		default:
+			return "KeycloakHealthCheckFailed"
+		}
+	}
+	return "KeycloakHealthCheckFailed"
+}
+
 // updateGroupSyncHealth checks the health of the group sync provider (if configured)
 // and updates the conditions accordingly. It also emits events on health status changes.
 func (r *IdentityProviderReconciler) updateGroupSyncHealth(ctx context.Context, idp *breakglassv1alpha1.IdentityProvider) {
@@ -495,7 +597,8 @@ func (r *IdentityProviderReconciler) updateGroupSyncHealth(ctx context.Context, 
 	if secretDataKey == "" {
 		secretDataKey = "value" // Default key if not specified
 	}
-	if _, exists := secret.Data[secretDataKey]; !exists {
+	clientSecret, exists := secret.Data[secretDataKey]
+	if !exists {
 		idp.SetCondition(metav1.Condition{
 			Type:               string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy),
 			Status:             metav1.ConditionFalse,
@@ -514,6 +617,56 @@ func (r *IdentityProviderReconciler) updateGroupSyncHealth(ctx context.Context, 
 				"Keycloak client secret key '%s' not found in secret '%s'",
 				secretDataKey, secretRef.Name)
 		}
+		return
+	}
+	if len(clientSecret) == 0 {
+		idp.SetCondition(metav1.Condition{
+			Type:               string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: idp.Generation,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "SecretKeyEmpty",
+			Message: fmt.Sprintf("Keycloak client secret key '%s' in secret '%s' is empty",
+				secretDataKey, secretRef.Name),
+		})
+
+		if r.recorder != nil && (oldCondition == nil || oldCondition.Status == metav1.ConditionTrue) {
+			eventIdp := idp.DeepCopy()
+			eventIdp.SetNamespace("")
+			r.recorder.Eventf(eventIdp, nil, corev1.EventTypeWarning, "GroupSyncSecretKeyEmpty", "GroupSyncSecretKeyEmpty",
+				"Keycloak client secret key '%s' in secret '%s' is empty",
+				secretDataKey, secretRef.Name)
+		}
+		return
+	}
+
+	healthChecker := r.keycloakHealthChecker
+	if healthChecker == nil {
+		healthChecker = checkKeycloakGroupSyncHealth
+	}
+	if err := healthChecker(ctx, idp.Spec.Keycloak, string(clientSecret)); err != nil {
+		reason := "KeycloakHealthCheckFailed"
+		var healthErr *keycloakGroupSyncHealthError
+		if errors.As(err, &healthErr) && healthErr.reason != "" {
+			reason = healthErr.reason
+		}
+		idp.SetCondition(metav1.Condition{
+			Type:               string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy),
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: idp.Generation,
+			LastTransitionTime: metav1.Now(),
+			Reason:             reason,
+			Message:            fmt.Sprintf("Keycloak group sync health check failed: %v", err),
+		})
+
+		if r.recorder != nil && (oldCondition == nil || oldCondition.Status == metav1.ConditionTrue) {
+			eventIdp := idp.DeepCopy()
+			eventIdp.SetNamespace("")
+			r.recorder.Eventf(eventIdp, nil, corev1.EventTypeWarning, "GroupSyncKeycloakHealthCheckFailed", "GroupSyncKeycloakHealthCheckFailed",
+				"Keycloak group sync health check failed: %v", err)
+		}
+		r.logger.Warnw("group sync provider health check failed",
+			"name", idp.Name, "provider", idp.Spec.GroupSyncProvider, "reason", reason, "error", err)
 		return
 	}
 

--- a/pkg/config/identity_provider_reconciler_test.go
+++ b/pkg/config/identity_provider_reconciler_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -416,6 +419,44 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretKeyMissing(t *te
 	assert.Equal(t, "SecretKeyNotFound", condition.Reason)
 }
 
+func TestIdentityProviderReconciler_UpdateGroupSyncHealth_SecretKeyEmpty(t *testing.T) {
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kc-secret", Namespace: "default"},
+		Data:       map[string][]byte{"value": []byte("")},
+	}
+	client := ctrltest.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	reconciler := NewIdentityProviderReconciler(client, zap.NewNop().Sugar(), func(ctx context.Context) error {
+		return nil
+	}).withKeycloakHealthChecker(func(ctx context.Context, keycloak *breakglassv1alpha1.KeycloakGroupSync, clientSecret string) error {
+		t.Fatal("health checker must not be called when the secret value is empty")
+		return nil
+	})
+
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
+				BaseURL:  "https://kc.example.com",
+				Realm:    "realm",
+				ClientID: "client",
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
+					Name:      "kc-secret",
+					Namespace: "default",
+					Key:       "value",
+				},
+			},
+		},
+	}
+
+	reconciler.updateGroupSyncHealth(context.Background(), idp)
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "SecretKeyEmpty", condition.Reason)
+}
+
 func TestIdentityProviderReconciler_UpdateGroupSyncHealth_Healthy(t *testing.T) {
 	scheme := newTestScheme(t)
 	secret := &corev1.Secret{
@@ -425,6 +466,12 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_Healthy(t *testing.T) 
 	client := ctrltest.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 
 	reconciler := NewIdentityProviderReconciler(client, zap.NewNop().Sugar(), func(ctx context.Context) error {
+		return nil
+	}).withKeycloakHealthChecker(func(ctx context.Context, keycloak *breakglassv1alpha1.KeycloakGroupSync, clientSecret string) error {
+		assert.Equal(t, "https://kc.example.com", keycloak.BaseURL)
+		assert.Equal(t, "realm", keycloak.Realm)
+		assert.Equal(t, "client", keycloak.ClientID)
+		assert.Equal(t, "secret", clientSecret)
 		return nil
 	})
 
@@ -449,6 +496,131 @@ func TestIdentityProviderReconciler_UpdateGroupSyncHealth_Healthy(t *testing.T) 
 	require.NotNil(t, condition)
 	assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	assert.Equal(t, "GroupSyncOperational", condition.Reason)
+}
+
+func TestIdentityProviderReconciler_UpdateGroupSyncHealth_KeycloakAuthFailed(t *testing.T) {
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kc-secret", Namespace: "default"},
+		Data:       map[string][]byte{"value": []byte("do-not-leak")},
+	}
+	client := ctrltest.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	reconciler := NewIdentityProviderReconciler(client, zap.NewNop().Sugar(), func(ctx context.Context) error {
+		return nil
+	}).withKeycloakHealthChecker(func(ctx context.Context, keycloak *breakglassv1alpha1.KeycloakGroupSync, clientSecret string) error {
+		assert.Equal(t, "do-not-leak", clientSecret)
+		return newKeycloakGroupSyncHealthError("KeycloakAuthenticationFailed", "Keycloak token request failed: 401 Unauthorized")
+	})
+
+	idp := &breakglassv1alpha1.IdentityProvider{
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
+				BaseURL:  "https://kc.example.com",
+				Realm:    "realm",
+				ClientID: "client",
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
+					Name:      "kc-secret",
+					Namespace: "default",
+					Key:       "value",
+				},
+			},
+		},
+	}
+
+	reconciler.updateGroupSyncHealth(context.Background(), idp)
+	condition := findConditionByType(idp.Status.Conditions, string(breakglassv1alpha1.IdentityProviderConditionGroupSyncHealthy))
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, "KeycloakAuthenticationFailed", condition.Reason)
+	assert.Contains(t, condition.Message, "401 Unauthorized")
+	assert.NotContains(t, condition.Message, "do-not-leak")
+}
+
+func TestCheckKeycloakGroupSyncHealth_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/realms/realm/protocol/openid-connect/token", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+		assert.Equal(t, "client", r.Form.Get("client_id"))
+		username, password, ok := r.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "client", username)
+		assert.Equal(t, "secret", password)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"token","expires_in":300,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	err := checkKeycloakGroupSyncHealth(context.Background(), &breakglassv1alpha1.KeycloakGroupSync{
+		BaseURL:        server.URL,
+		Realm:          "realm",
+		ClientID:       "client",
+		RequestTimeout: "2s",
+	}, "secret")
+
+	require.NoError(t, err)
+}
+
+func TestCheckKeycloakGroupSyncHealth_AuthenticationFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid_client"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	err := checkKeycloakGroupSyncHealth(context.Background(), &breakglassv1alpha1.KeycloakGroupSync{
+		BaseURL:  server.URL,
+		Realm:    "realm",
+		ClientID: "client",
+	}, "bad-secret")
+
+	require.Error(t, err)
+	var healthErr *keycloakGroupSyncHealthError
+	require.ErrorAs(t, err, &healthErr)
+	assert.Equal(t, "KeycloakAuthenticationFailed", healthErr.reason)
+	assert.NotContains(t, healthErr.Error(), "bad-secret")
+}
+
+func TestCheckKeycloakGroupSyncHealth_RequiresAccessToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"expires_in":300,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	err := checkKeycloakGroupSyncHealth(context.Background(), &breakglassv1alpha1.KeycloakGroupSync{
+		BaseURL:  server.URL,
+		Realm:    "realm",
+		ClientID: "client",
+	}, "secret")
+
+	require.Error(t, err)
+	var healthErr *keycloakGroupSyncHealthError
+	require.ErrorAs(t, err, &healthErr)
+	assert.Equal(t, "KeycloakTokenInvalid", healthErr.reason)
+}
+
+func TestCheckKeycloakGroupSyncHealth_UsesConfiguredCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"token","expires_in":300,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	require.NotEmpty(t, certPEM)
+
+	err := checkKeycloakGroupSyncHealth(context.Background(), &breakglassv1alpha1.KeycloakGroupSync{
+		BaseURL:              server.URL,
+		Realm:                "realm",
+		ClientID:             "client",
+		CertificateAuthority: string(certPEM),
+	}, "secret")
+
+	require.NoError(t, err)
 }
 
 func findConditionByType(conditions []metav1.Condition, conditionType string) *metav1.Condition {

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -192,7 +192,6 @@ func (wc *WebhookController) logSARAction(s *authorizeState) {
 		)
 	} else {
 		s.reqLog.Infow("SubjectAccessReview contains no resource or non-resource attributes")
-
 	}
 
 	// Extract issuer from SAR for multi-IDP session filtering


### PR DESCRIPTION
## Summary

- verify Keycloak group sync health by requesting a client-credentials token before setting `GroupSyncHealthy=True`
- report explicit false reasons for empty secrets, failed Keycloak auth, generic health-check failures, invalid token responses, rejected insecure TLS, invalid custom CA, and invalid request timeout
- add regression tests so a readable Kubernetes Secret no longer makes group sync appear healthy when Keycloak rejects the credentials

## Validation

- `gofmt -w pkg/config/identity_provider_reconciler.go pkg/config/identity_provider_reconciler_test.go`
- `git diff --check`
- `env GOCACHE=/tmp/k8s-breakglass-go-cache go test ./pkg/config`
- `env GOCACHE=/tmp/k8s-breakglass-go-cache go test ./api/... ./cmd/... ./pkg/...`

`env GOCACHE=/tmp/k8s-breakglass-go-cache go test ./...` was also run. It failed only in `github.com/telekom/k8s-breakglass/e2e` because those tests tried to load a Kubernetes config without `KUBERNETES_MASTER`/cluster config in this workstation context; the non-e2e packages in that run passed.
