### PR TITLE
fix(metrics): decrement DebugSessionsActive gauge on session termination

### DIFF
--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -343,6 +343,12 @@ func (c *DebugSessionController) handleCleanup(ctx context.Context, ds *breakgla
 		return ctrl.Result{RequeueAfter: ExpiredSessionRequeue}, nil
 	}
 
+	// Decrement active gauge for terminated sessions. Expired sessions are
+	// already decremented in handleActive before entering cleanup.
+	if ds.Status.State == breakglassv1alpha1.DebugSessionStateTerminated {
+		metrics.DebugSessionsActive.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Dec()
+	}
+
 	// Record metrics
 	if ds.Status.StartsAt != nil {
 		duration := time.Since(ds.Status.StartsAt.Time).Seconds()


### PR DESCRIPTION
## Summary

The `DebugSessionsActive` gauge was only decremented when a session expired naturally via `handleActive`. Sessions that were manually terminated entered `handleCleanup` without ever decrementing the gauge, causing unbounded growth of stale metric values.

## Fix

Add a `Dec()` call in `handleCleanup` for Terminated sessions. Expired sessions are already decremented in `handleActive` before transitioning to cleanup, so the check is state-specific to avoid double-decrement.

Closes #932