### PR TITLE
fix(webhook): add UID check to activity tracker to prevent cross-session contamination

### DIFF
--- a/pkg/webhook/activity_tracker.go
+++ b/pkg/webhook/activity_tracker.go
@@ -50,6 +50,9 @@ type activityEntry struct {
 	// namespace and name of the session
 	namespace string
 	name      string
+	// uid is the Kubernetes UID of the session at recording time.
+	// Used to detect session identity changes (delete+recreate with same name).
+	uid types.UID
 	// lastSeen is the most recent activity time
 	lastSeen time.Time
 	// count is the number of requests since last flush
@@ -138,7 +141,7 @@ func NewActivityTracker(c client.Client, opts ...ActivityTrackerOption) *Activit
 // This method is safe for concurrent use and does not block on API calls.
 // If the tracker has reached maxEntries, new sessions are silently dropped
 // to prevent unbounded memory growth.
-func (at *ActivityTracker) RecordActivity(namespace, name string, ts time.Time) {
+func (at *ActivityTracker) RecordActivity(namespace, name string, uid types.UID, ts time.Time) {
 	key := types.NamespacedName{Namespace: namespace, Name: name}
 
 	at.mu.Lock()
@@ -170,12 +173,24 @@ func (at *ActivityTracker) RecordActivity(namespace, name string, ts time.Time) 
 		at.entries[key] = &activityEntry{
 			namespace: namespace,
 			name:      name,
+			uid:       uid,
 			lastSeen:  ts,
 			count:     1,
 		}
 		metrics.SessionActivityBufferSize.Set(float64(len(at.entries)))
 		return
 	}
+
+	// If the UID changed, the old session was deleted and a new one created
+	// with the same name. Reset the entry to avoid cross-contamination.
+	if entry.uid != uid {
+		entry.uid = uid
+		entry.count = 1
+		entry.lastSeen = ts
+		entry.retries = 0
+		return
+	}
+
 	if ts.After(entry.lastSeen) {
 		entry.lastSeen = ts
 	}
@@ -338,6 +353,12 @@ func (at *ActivityTracker) updateSessionActivity(ctx context.Context, key types.
 				return nil
 			}
 			return err
+		}
+
+		// Guard against name reuse: if the session was deleted and recreated
+		// with the same name, the UID will differ. Discard stale entries.
+		if entry.uid != "" && session.UID != entry.uid {
+			return nil
 		}
 
 		// Only update active sessions — skip terminal states

--- a/pkg/webhook/activity_tracker_test.go
+++ b/pkg/webhook/activity_tracker_test.go
@@ -51,7 +51,7 @@ func TestActivityTracker_RecordActivity(t *testing.T) {
 		)
 		defer tracker.Stop(context.Background())
 
-		tracker.RecordActivity("breakglass", "session-1", time.Now())
+		tracker.RecordActivity("breakglass", "session-1", "", time.Now())
 		assert.Equal(t, 1, tracker.Pending())
 	})
 
@@ -65,9 +65,9 @@ func TestActivityTracker_RecordActivity(t *testing.T) {
 		defer tracker.Stop(context.Background())
 
 		now := time.Now()
-		tracker.RecordActivity("breakglass", "session-1", now)
-		tracker.RecordActivity("breakglass", "session-1", now.Add(1*time.Second))
-		tracker.RecordActivity("breakglass", "session-1", now.Add(2*time.Second))
+		tracker.RecordActivity("breakglass", "session-1", "", now)
+		tracker.RecordActivity("breakglass", "session-1", "", now.Add(1*time.Second))
+		tracker.RecordActivity("breakglass", "session-1", "", now.Add(2*time.Second))
 		assert.Equal(t, 1, tracker.Pending(), "Multiple activities for same session should be buffered as one entry")
 	})
 
@@ -81,8 +81,8 @@ func TestActivityTracker_RecordActivity(t *testing.T) {
 		defer tracker.Stop(context.Background())
 
 		now := time.Now()
-		tracker.RecordActivity("breakglass", "session-1", now)
-		tracker.RecordActivity("breakglass", "session-2", now)
+		tracker.RecordActivity("breakglass", "session-1", "", now)
+		tracker.RecordActivity("breakglass", "session-2", "", now)
 		assert.Equal(t, 2, tracker.Pending())
 	})
 }
@@ -118,9 +118,9 @@ func TestActivityTracker_Flush(t *testing.T) {
 	defer tracker.Stop(context.Background())
 
 	now := time.Now()
-	tracker.RecordActivity("breakglass", "session-flush", now)
-	tracker.RecordActivity("breakglass", "session-flush", now.Add(5*time.Second))
-	tracker.RecordActivity("breakglass", "session-flush", now.Add(10*time.Second))
+	tracker.RecordActivity("breakglass", "session-flush", "", now)
+	tracker.RecordActivity("breakglass", "session-flush", "", now.Add(5*time.Second))
+	tracker.RecordActivity("breakglass", "session-flush", "", now.Add(10*time.Second))
 
 	// Manually trigger flush
 	tracker.flush(context.Background())
@@ -170,7 +170,7 @@ func TestActivityTracker_FlushSkipsTerminalSessions(t *testing.T) {
 	)
 	defer tracker.Stop(context.Background())
 
-	tracker.RecordActivity("breakglass", "session-expired", time.Now())
+	tracker.RecordActivity("breakglass", "session-expired", "", time.Now())
 	tracker.flush(context.Background())
 
 	// Verify the session status was NOT updated (terminal state)
@@ -217,12 +217,12 @@ func TestActivityTracker_CumulativeFlushes(t *testing.T) {
 	now := time.Now()
 
 	// First batch
-	tracker.RecordActivity("breakglass", "session-cumulative", now)
-	tracker.RecordActivity("breakglass", "session-cumulative", now.Add(1*time.Second))
+	tracker.RecordActivity("breakglass", "session-cumulative", "", now)
+	tracker.RecordActivity("breakglass", "session-cumulative", "", now.Add(1*time.Second))
 	tracker.flush(context.Background())
 
 	// Second batch
-	tracker.RecordActivity("breakglass", "session-cumulative", now.Add(30*time.Second))
+	tracker.RecordActivity("breakglass", "session-cumulative", "", now.Add(30*time.Second))
 	tracker.flush(context.Background())
 
 	// Verify cumulative counts
@@ -283,7 +283,7 @@ func TestActivityTracker_Stop(t *testing.T) {
 		WithActivityLogger(zap.NewNop().Sugar()),
 	)
 
-	tracker.RecordActivity("breakglass", "session-stop", time.Now())
+	tracker.RecordActivity("breakglass", "session-stop", "", time.Now())
 
 	// Stop should flush remaining entries
 	tracker.Stop(context.Background())
@@ -444,7 +444,7 @@ func TestActivityTracker_FlushRetriesOnError(t *testing.T) {
 	)
 	defer tracker.Stop(context.Background())
 
-	tracker.RecordActivity("breakglass", "session-retry", time.Now())
+	tracker.RecordActivity("breakglass", "session-retry", "", time.Now())
 
 	// First flush — should fail and re-queue with retries=1
 	tracker.flush(context.Background())
@@ -470,7 +470,7 @@ func TestActivityTracker_FlushDiscardsAfterMaxRetries(t *testing.T) {
 	)
 	defer tracker.Stop(context.Background())
 
-	tracker.RecordActivity("breakglass", "session-discard", time.Now())
+	tracker.RecordActivity("breakglass", "session-discard", "", time.Now())
 
 	// Flush maxFlushRetries times to exhaust retries
 	for i := 0; i < maxFlushRetries; i++ {
@@ -492,7 +492,7 @@ func TestActivityTracker_FlushDeletedSession(t *testing.T) {
 	)
 	defer tracker.Stop(context.Background())
 
-	tracker.RecordActivity("breakglass", "deleted-session", time.Now())
+	tracker.RecordActivity("breakglass", "deleted-session", "", time.Now())
 	tracker.flush(context.Background())
 
 	assert.Equal(t, 0, tracker.Pending(),
@@ -517,7 +517,7 @@ func TestActivityTracker_FlushMergesFailedWithNewActivity(t *testing.T) {
 	defer tracker.Stop(context.Background())
 
 	now := time.Now()
-	tracker.RecordActivity("breakglass", "session-merge", now)
+	tracker.RecordActivity("breakglass", "session-merge", "", now)
 
 	flushDone := make(chan struct{})
 	go func() {
@@ -529,7 +529,7 @@ func TestActivityTracker_FlushMergesFailedWithNewActivity(t *testing.T) {
 	<-reader.enterCh
 
 	// Record new activity while flush is blocked — writes to the new (swapped) map
-	tracker.RecordActivity("breakglass", "session-merge", now.Add(10*time.Second))
+	tracker.RecordActivity("breakglass", "session-merge", "", now.Add(10*time.Second))
 
 	// Release the reader so flush fails and re-queues, merging with the new entry
 	close(reader.blockCh)
@@ -568,7 +568,7 @@ func TestActivityTracker_StopContextExpired(t *testing.T) {
 		close(at.done)
 	}()
 
-	at.RecordActivity("breakglass", "session-ctx", time.Now())
+	at.RecordActivity("breakglass", "session-ctx", "", time.Now())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -610,7 +610,7 @@ func TestActivityTracker_RunTickerFlush(t *testing.T) {
 	)
 	defer tracker.Stop(context.Background())
 
-	tracker.RecordActivity("breakglass", "session-ticker", time.Now())
+	tracker.RecordActivity("breakglass", "session-ticker", "", time.Now())
 
 	// Verify the ticker-driven flush processes the pending entry.
 	// Status updates are already validated by TestActivityTracker_Flush;
@@ -635,16 +635,16 @@ func TestActivityTracker_MaxEntriesCap(t *testing.T) {
 
 	// Fill up to the cap
 	for i := 0; i < maxEntries; i++ {
-		tracker.RecordActivity("ns", fmt.Sprintf("session-%d", i), now)
+		tracker.RecordActivity("ns", fmt.Sprintf("session-%d", i), "", now)
 	}
 	assert.Equal(t, maxEntries, tracker.Pending(), "Should accept entries up to maxEntries")
 
 	// One more should be dropped
-	tracker.RecordActivity("ns", "session-overflow", now)
+	tracker.RecordActivity("ns", "session-overflow", "", now)
 	assert.Equal(t, maxEntries, tracker.Pending(), "Should not exceed maxEntries")
 
 	// Existing entry should still be updateable
-	tracker.RecordActivity("ns", "session-0", now.Add(time.Second))
+	tracker.RecordActivity("ns", "session-0", "", now.Add(time.Second))
 	assert.Equal(t, maxEntries, tracker.Pending(), "Updating existing entry should not change count")
 }
 
@@ -662,7 +662,7 @@ func TestActivityTracker_Cleanup(t *testing.T) {
 
 	// Record activity for 5 sessions
 	for i := 0; i < 5; i++ {
-		tracker.RecordActivity("breakglass", fmt.Sprintf("session-%d", i), now)
+		tracker.RecordActivity("breakglass", fmt.Sprintf("session-%d", i), "", now)
 	}
 	assert.Equal(t, 5, tracker.Pending())
 

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -1058,7 +1058,7 @@ func (wc *WebhookController) recordSessionActivity(sessions []breakglassv1alpha1
 	// map lookup unnecessary overhead for the common case.
 	for i := range sessions {
 		if sessions[i].Name == sessionName {
-			wc.activityTracker.RecordActivity(sessions[i].Namespace, sessions[i].Name, time.Now())
+			wc.activityTracker.RecordActivity(sessions[i].Namespace, sessions[i].Name, sessions[i].UID, time.Now())
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

The ActivityTracker identified sessions solely by namespace/name. If a session was deleted while buffered activity entries remained, and a new session was created with the same name, the stale entries would be applied to the new session, falsely inflating ActivityCount and corrupting LastActivity timestamps.

## Fix

- Add `uid types.UID` field to `activityEntry`
- Thread UID through `RecordActivity` from the caller in `controller.go`
- In `updateSessionActivity`, verify the fetched session's UID matches before patching
- In `RecordActivity`, reset entry when UID change detected (delete+recreate scenario)

Closes #941