### PR TITLE
fix(config): remove periodic event emissions from reconcilers

### DIFF
--- a/pkg/config/audit_config_reconciler.go
+++ b/pkg/config/audit_config_reconciler.go
@@ -248,16 +248,6 @@ func (r *AuditConfigReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		"configNames", configNames,
 		"totalSinks", totalSinks)
 
-	// Send success event to each valid config
-	for _, cfg := range allConfigs.Items {
-		if cfg.Spec.Enabled && r.isConfigInList(cfg.Name, validConfigs) {
-			if r.recorder != nil {
-				r.recorder.Eventf(&cfg, nil, corev1.EventTypeNormal, "Reconciled", "Reconciled",
-					"AuditConfig %s reconciled successfully (aggregated with %d other configs)", cfg.Name, len(validConfigs)-1)
-			}
-		}
-	}
-
 	metrics.AuditConfigReloads.WithLabelValues("success").Inc()
 	return reconcile.Result{RequeueAfter: r.resyncPeriod}, nil
 }

--- a/pkg/config/audit_config_reconciler_test.go
+++ b/pkg/config/audit_config_reconciler_test.go
@@ -129,12 +129,12 @@ func TestAuditConfigReconciler_Reconcile_ValidConfig(t *testing.T) {
 	assert.True(t, reloadCalled)
 	assert.Equal(t, time.Minute, result.RequeueAfter)
 
-	// Check event was recorded
+	// No periodic event should be emitted on successful reconciliation
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "Reconciled")
+		t.Errorf("Expected no event on periodic reconcile, got: %s", event)
 	default:
-		t.Error("Expected event to be recorded")
+		// OK — no event emitted
 	}
 }
 

--- a/pkg/config/identity_provider_reconciler.go
+++ b/pkg/config/identity_provider_reconciler.go
@@ -309,12 +309,6 @@ func (r *IdentityProviderReconciler) Reconcile(ctx context.Context, req reconcil
 			"skipReason", skipInfo.Reason,
 			"lastUpdateAge", skipInfo.LastUpdateAge,
 		)
-		if r.recorder != nil {
-			eventIdp := latest.DeepCopy()
-			eventIdp.SetNamespace("")
-			r.recorder.Eventf(eventIdp, nil, corev1.EventTypeNormal, "StatusUpdateSkipped", "StatusUpdateSkipped",
-				"Skipped status update: %s (last update %v ago)", skipInfo.Reason, skipInfo.LastUpdateAge.Truncate(time.Second))
-		}
 		return reconcile.Result{RequeueAfter: r.resyncPeriod}, nil
 	}
 

--- a/pkg/config/mail_provider_reconciler.go
+++ b/pkg/config/mail_provider_reconciler.go
@@ -299,10 +299,6 @@ func (r *MailProviderReconciler) updateStatusHealthy(ctx context.Context, mp *br
 			"skipReason", skipInfo.Reason,
 			"lastUpdateAge", skipInfo.LastUpdateAge,
 		)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(&latest, nil, corev1.EventTypeNormal, "StatusUpdateSkipped", "StatusUpdateSkipped",
-				"Skipped status update: %s (last update %v ago)", skipInfo.Reason, skipInfo.LastUpdateAge.Truncate(time.Second))
-		}
 		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
@@ -384,10 +380,6 @@ func (r *MailProviderReconciler) updateStatusUnhealthy(ctx context.Context, mp *
 			"skipReason", skipInfo.Reason,
 			"lastUpdateAge", skipInfo.LastUpdateAge,
 		)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(&latest, nil, corev1.EventTypeNormal, "StatusUpdateSkipped", "StatusUpdateSkipped",
-				"Skipped status update: %s (last update %v ago)", skipInfo.Reason, skipInfo.LastUpdateAge.Truncate(time.Second))
-		}
 		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
@@ -454,10 +446,6 @@ func (r *MailProviderReconciler) updateStatusDisabled(ctx context.Context, mp *b
 			"skipReason", skipInfo.Reason,
 			"lastUpdateAge", skipInfo.LastUpdateAge,
 		)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(&latest, nil, corev1.EventTypeNormal, "StatusUpdateSkipped", "StatusUpdateSkipped",
-				"Skipped status update: %s (last update %v ago)", skipInfo.Reason, skipInfo.LastUpdateAge.Truncate(time.Second))
-		}
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
## Summary

The IdentityProvider, MailProvider, and AuditConfig reconcilers emitted Kubernetes events on every periodic requeue (`StatusUpdateSkipped`, `Reconciled`) even when no state transition occurred. This violated controller idempotency patterns, spammed the cluster event stream, and accelerated etcd churn.

## Changes

- Remove `StatusUpdateSkipped` event emission from `identity_provider_reconciler.go` (1 site)
- Remove `StatusUpdateSkipped` event emission from `mail_provider_reconciler.go` (3 sites)
- Remove periodic `Reconciled` event loop from `audit_config_reconciler.go` (1 site)

Error/warning events (`StatusUpdateFailed`) are preserved — they represent actual state transitions.

Closes #930