### PR TITLE
fix(api): wrap bare array list responses with items/total envelope

### DIFF
--- a/pkg/api/api_end_to_end_test.go
+++ b/pkg/api/api_end_to_end_test.go
@@ -246,9 +246,12 @@ func (env *apiEndToEndEnv) listSessions(t *testing.T) []breakglassv1alpha1.Break
 	t.Helper()
 	rr := env.doRequest(t, http.MethodGet, sessionsBasePath, nil)
 	require.Equal(t, http.StatusOK, rr.Code)
-	var sessions []breakglassv1alpha1.BreakglassSession
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &sessions))
-	return sessions
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassSession `json:"items"`
+		Total int                                    `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &envelope))
+	return envelope.Items
 }
 
 func (env *apiEndToEndEnv) approveSession(t *testing.T, name string) {

--- a/pkg/breakglass/clusterconfig/binding_api.go
+++ b/pkg/breakglass/clusterconfig/binding_api.go
@@ -183,7 +183,7 @@ func (c *ClusterBindingAPIController) handleListClusterBindings(ctx *gin.Context
 		return responses[i].Name < responses[j].Name
 	})
 
-	ctx.JSON(http.StatusOK, responses)
+	ctx.JSON(http.StatusOK, gin.H{"items": responses, "total": len(responses)})
 }
 
 // handleGetClusterBinding returns a single cluster binding by namespace and name
@@ -258,7 +258,7 @@ func (c *ClusterBindingAPIController) handleListBindingsForCluster(ctx *gin.Cont
 		return matchingBindings[i].Name < matchingBindings[j].Name
 	})
 
-	ctx.JSON(http.StatusOK, matchingBindings)
+	ctx.JSON(http.StatusOK, gin.H{"items": matchingBindings, "total": len(matchingBindings)})
 }
 
 // bindingMatchesCluster checks if a binding applies to the given cluster

--- a/pkg/breakglass/clusterconfig/binding_api_test.go
+++ b/pkg/breakglass/clusterconfig/binding_api_test.go
@@ -41,6 +41,16 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+func decodeBindingListEnvelope(t *testing.T, body []byte) []ClusterBindingResponse {
+	t.Helper()
+	var envelope struct {
+		Items []ClusterBindingResponse `json:"items"`
+		Total int                      `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	return envelope.Items
+}
+
 func TestNewClusterBindingAPIController(t *testing.T) {
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -169,9 +179,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 2)
 		// Should be sorted by namespace then name
@@ -196,9 +204,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 		assert.Len(t, response, 0)
 	})
 
@@ -219,9 +225,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.NotNil(t, response[0].TemplateRef)
 		assert.Equal(t, "template-1", response[0].TemplateRef.Name)
@@ -245,9 +249,7 @@ func TestClusterBindingAPIController_handleListClusterBindings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Equal(t, map[string]string{"env": "prod"}, response[0].TemplateSelector)
 		assert.Equal(t, map[string]string{"tier": "production"}, response[0].ClusterSelector)
@@ -458,9 +460,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "explicit-binding", response[0].Name)
@@ -486,9 +486,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "selector-binding", response[0].Name)
@@ -552,9 +550,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster(t *testing.T) 
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 		assert.Len(t, response, 0)
 	})
 }
@@ -894,9 +890,7 @@ func TestClusterBindingAPIController_Integration(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 		assert.Len(t, response, 1)
 		assert.Equal(t, "integration-test-binding", response[0].Name)
 	})
@@ -1107,9 +1101,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "visible-binding", response[0].Name)
@@ -1133,9 +1125,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 2)
 		// Check both bindings are present
@@ -1161,9 +1151,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_HiddenFilter(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "hidden-binding", response[0].Name)
@@ -1253,9 +1241,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 4)
 	})
@@ -1277,9 +1263,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		// Only active-binding should be returned
 		assert.Len(t, response, 1)
@@ -1334,9 +1318,7 @@ func TestClusterBindingAPIController_handleListClusterBindings_ActiveOnlyFilter(
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		// Only active bindings (including hidden active)
 		assert.Len(t, response, 2)
@@ -1491,9 +1473,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster_EmptyList(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 0)
 	})
@@ -1518,9 +1498,7 @@ func TestClusterBindingAPIController_handleListBindingsForCluster_EmptyList(t *t
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response []ClusterBindingResponse
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		require.NoError(t, err)
+		response := decodeBindingListEnvelope(t, w.Body.Bytes())
 
 		assert.Len(t, response, 1)
 		assert.Equal(t, "cluster-a-binding", response[0].Name)

--- a/pkg/breakglass/escalation/escalation_controller.go
+++ b/pkg/breakglass/escalation/escalation_controller.go
@@ -191,7 +191,8 @@ func (ec *BreakglassEscalationController) handleGetEscalations(c *gin.Context) {
 	}
 
 	reqLog.Debugw("Returning escalations response (filtered, hidden groups removed)", "responseCount", len(response))
-	c.JSON(http.StatusOK, dropK8sInternalFieldsEscalationList(response))
+	items := dropK8sInternalFieldsEscalationList(response)
+	c.JSON(http.StatusOK, gin.H{"items": items, "total": len(items)})
 }
 
 func (*BreakglassEscalationController) BasePath() string {

--- a/pkg/breakglass/escalation/escalation_controller_handlers_test.go
+++ b/pkg/breakglass/escalation/escalation_controller_handlers_test.go
@@ -17,6 +17,18 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
+func decodeEscalationListEnvelope(t *testing.T, w *httptest.ResponseRecorder) []breakglassv1alpha1.BreakglassEscalation {
+	t.Helper()
+	var envelope struct {
+		Items []breakglassv1alpha1.BreakglassEscalation `json:"items"`
+		Total int                                        `json:"total"`
+	}
+	if err := json.NewDecoder(w.Result().Body).Decode(&envelope); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return envelope.Items
+}
+
 // TestHandleGetEscalations_ReturnsEscalationsForTokenGroups
 //
 // Purpose:
@@ -83,10 +95,7 @@ func TestHandleGetEscalations_ReturnsEscalationsForTokenGroups(t *testing.T) {
 		t.Fatalf("expected 200 OK, got %d", w.Result().StatusCode)
 	}
 
-	var out []breakglassv1alpha1.BreakglassEscalation
-	if err := json.NewDecoder(w.Result().Body).Decode(&out); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	out := decodeEscalationListEnvelope(t, w)
 
 	// Only esc1 should be returned because the token groups include system:authenticated
 	if len(out) != 1 {
@@ -165,10 +174,7 @@ func TestHandleGetEscalations_HidesEscalationsForUnreadyClusterConfig(t *testing
 		t.Fatalf("expected 200 OK, got %d", w.Result().StatusCode)
 	}
 
-	var out []breakglassv1alpha1.BreakglassEscalation
-	if err := json.NewDecoder(w.Result().Body).Decode(&out); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	out := decodeEscalationListEnvelope(t, w)
 	if len(out) != 1 {
 		t.Fatalf("expected only ready escalation, got %#v", out)
 	}
@@ -244,10 +250,7 @@ func TestHandleGetEscalations_ClusterFilterGlobUsesClusterConfigReadiness(t *tes
 				t.Fatalf("expected 200 OK, got %d", w.Result().StatusCode)
 			}
 
-			var out []breakglassv1alpha1.BreakglassEscalation
-			if err := json.NewDecoder(w.Result().Body).Decode(&out); err != nil {
-				t.Fatalf("failed to decode response: %v", err)
-			}
+			out := decodeEscalationListEnvelope(t, w)
 			if len(out) != tt.wantCount {
 				t.Fatalf("expected %d escalations, got %#v", tt.wantCount, out)
 			}
@@ -314,10 +317,7 @@ func TestHandleGetEscalations_HidesEscalationsForDuplicateClusterConfigNames(t *
 		t.Fatalf("expected 200 OK, got %d", w.Result().StatusCode)
 	}
 
-	var out []breakglassv1alpha1.BreakglassEscalation
-	if err := json.NewDecoder(w.Result().Body).Decode(&out); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	out := decodeEscalationListEnvelope(t, w)
 	if len(out) != 0 {
 		t.Fatalf("expected duplicate cluster config name to hide escalation, got %#v", out)
 	}

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -747,7 +747,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	enriched := wc.enrichSessionsWithApprovalReason(ctx, filtered, reqLog)
 
 	reqLog.Infow("Returning filtered breakglass sessions", "count", len(enriched))
-	c.JSON(http.StatusOK, enriched)
+	c.JSON(http.StatusOK, gin.H{"items": enriched, "total": len(enriched)})
 }
 
 // SessionApprovalMeta contains authorization metadata for a session


### PR DESCRIPTION
## Summary

Multiple list endpoints returned raw JSON arrays without count or pagination metadata, inconsistent with the debug-session API that already uses `DebugSessionListResponse{Sessions, Total}`.

## Changes

Wrap 4 endpoints with `{items, total}` envelopes:
- `GET /breakglassSessions` (`session_controller_status.go`)
- `GET /breakglassEscalations` (`escalation_controller.go`)
- `GET /clusterBindings` (`binding_api.go` — list all)
- `GET /clusterBindings/:cluster` (`binding_api.go` — per-cluster)

**Before:** `[{...}, {...}]`
**After:** `{"items": [{...}, {...}], "total": 2}`

Closes #940