### PR TITLE
refactor(frontend): extract shared postSessionAction helper in session services

### DIFF
--- a/frontend/src/services/breakglassSession.ts
+++ b/frontend/src/services/breakglassSession.ts
@@ -84,62 +84,54 @@ export default class BreakglassSessionService {
     }
   }
 
-  public async approveReview(review: BreakglassSessionRequest) {
-    // RESTful: POST /breakglassSessions/:name/approve
-    if (!review.name) throw new Error("Missing session name for approve");
+  private async postSessionAction(
+    review: BreakglassSessionRequest,
+    action: string,
+    errorMessage: string,
+    body: Record<string, string> = {},
+  ) {
+    if (!review.name) throw new Error(`Missing session name for ${action}`);
     try {
-      const body: Record<string, string> = {};
-      if (review.reason && review.reason.trim().length > 0) body.reason = review.reason;
-      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/approve`, body);
+      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/${action}`, body);
     } catch (e) {
-      handleAxiosError("BreakglassSessionService.approveReview", e, "Failed to approve session");
+      handleAxiosError(`BreakglassSessionService.${action}`, e, errorMessage);
       throw e;
     }
+  }
+
+  private static buildReasonBody(review: BreakglassSessionRequest): Record<string, string> {
+    const body: Record<string, string> = {};
+    if (review.reason && review.reason.trim().length > 0) body.reason = review.reason;
+    return body;
+  }
+
+  public async approveReview(review: BreakglassSessionRequest) {
+    return this.postSessionAction(
+      review,
+      "approve",
+      "Failed to approve session",
+      BreakglassSessionService.buildReasonBody(review),
+    );
   }
 
   public async rejectReview(review: BreakglassSessionRequest) {
-    // RESTful: POST /breakglassSessions/:name/reject
-    if (!review.name) throw new Error("Missing session name for reject");
-    try {
-      const body: Record<string, string> = {};
-      if (review.reason && review.reason.trim().length > 0) body.reason = review.reason;
-      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/reject`, body);
-    } catch (e) {
-      handleAxiosError("BreakglassSessionService.rejectReview", e, "Failed to reject session");
-      throw e;
-    }
+    return this.postSessionAction(
+      review,
+      "reject",
+      "Failed to reject session",
+      BreakglassSessionService.buildReasonBody(review),
+    );
   }
 
   public async withdrawSession(review: BreakglassSessionRequest) {
-    // RESTful: POST /breakglassSessions/:name/withdraw
-    if (!review.name) throw new Error("Missing session name for withdraw");
-    try {
-      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/withdraw`, {});
-    } catch (e) {
-      handleAxiosError("BreakglassSessionService.withdrawSession", e, "Failed to withdraw session");
-      throw e;
-    }
+    return this.postSessionAction(review, "withdraw", "Failed to withdraw session");
   }
 
   public async dropSession(review: BreakglassSessionRequest) {
-    // RESTful: POST /breakglassSessions/:name/drop
-    if (!review.name) throw new Error("Missing session name for drop");
-    try {
-      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/drop`, {});
-    } catch (e) {
-      handleAxiosError("BreakglassSessionService.dropSession", e, "Failed to drop session");
-      throw e;
-    }
+    return this.postSessionAction(review, "drop", "Failed to drop session");
   }
 
   public async cancelSession(review: BreakglassSessionRequest) {
-    // RESTful: POST /breakglassSessions/:name/cancel (approver cancels running session)
-    if (!review.name) throw new Error("Missing session name for cancel");
-    try {
-      return await this.client.post(`/breakglassSessions/${encodeURIComponent(review.name)}/cancel`, {});
-    } catch (e) {
-      handleAxiosError("BreakglassSessionService.cancelSession", e, "Failed to cancel session");
-      throw e;
-    }
+    return this.postSessionAction(review, "cancel", "Failed to cancel session");
   }
 }

--- a/frontend/src/services/debugSession.ts
+++ b/frontend/src/services/debugSession.ts
@@ -101,92 +101,46 @@ export default class DebugSessionService {
     }
   }
 
-  /**
-   * Join an existing debug session
-   */
+  private async postSessionAction(
+    name: string,
+    action: string,
+    errorMessage: string,
+    body?: unknown,
+  ): Promise<DebugSession> {
+    try {
+      const response = await this.client.post<DebugSession>(
+        `/debugSessions/${encodeURIComponent(name)}/${action}`,
+        body,
+      );
+      return response.data;
+    } catch (e) {
+      handleAxiosError(`DebugSessionService.${action}Session`, e, errorMessage);
+      throw e;
+    }
+  }
+
   public async joinSession(name: string, request?: JoinDebugSessionRequest): Promise<DebugSession> {
-    try {
-      const body = request || { role: "viewer" };
-      const response = await this.client.post<DebugSession>(`/debugSessions/${encodeURIComponent(name)}/join`, body);
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.joinSession", e, "Failed to join debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "join", "Failed to join debug session", request || { role: "viewer" });
   }
 
-  /**
-   * Leave a debug session (participants only, not owner)
-   */
   public async leaveSession(name: string): Promise<DebugSession> {
-    try {
-      const response = await this.client.post<DebugSession>(`/debugSessions/${encodeURIComponent(name)}/leave`);
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.leaveSession", e, "Failed to leave debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "leave", "Failed to leave debug session");
   }
 
-  /**
-   * Renew a debug session (extend duration)
-   */
   public async renewSession(name: string, request: RenewDebugSessionRequest): Promise<DebugSession> {
-    try {
-      const response = await this.client.post<DebugSession>(
-        `/debugSessions/${encodeURIComponent(name)}/renew`,
-        request,
-      );
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.renewSession", e, "Failed to renew debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "renew", "Failed to renew debug session", request);
   }
 
-  /**
-   * Terminate a debug session (owner only)
-   */
   public async terminateSession(name: string): Promise<DebugSession> {
-    try {
-      const response = await this.client.post<DebugSession>(`/debugSessions/${encodeURIComponent(name)}/terminate`);
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.terminateSession", e, "Failed to terminate debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "terminate", "Failed to terminate debug session");
   }
 
-  /**
-   * Approve a debug session in PendingApproval state
-   */
   public async approveSession(name: string, request?: ApproveDebugSessionRequest): Promise<DebugSession> {
-    try {
-      const response = await this.client.post<DebugSession>(
-        `/debugSessions/${encodeURIComponent(name)}/approve`,
-        request || {},
-      );
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.approveSession", e, "Failed to approve debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "approve", "Failed to approve debug session", request || {});
   }
 
-  /**
-   * Reject a debug session in PendingApproval state
-   */
   public async rejectSession(name: string, request: RejectDebugSessionRequest): Promise<DebugSession> {
-    try {
-      const response = await this.client.post<DebugSession>(
-        `/debugSessions/${encodeURIComponent(name)}/reject`,
-        request,
-      );
-      return response.data;
-    } catch (e) {
-      handleAxiosError("DebugSessionService.rejectSession", e, "Failed to reject debug session");
-      throw e;
-    }
+    return this.postSessionAction(name, "reject", "Failed to reject debug session", request);
   }
 
   /**


### PR DESCRIPTION
## Summary

Both `BreakglassSessionService` and `DebugSessionService` had 5-6 methods each repeating the identical pattern: parameter check, try-catch, `client.post`, `handleAxiosError`, rethrow.

## Changes

- Extract `postSessionAction` private method in `BreakglassSessionService` (replaces 5 methods)
- Extract `buildReasonBody` static helper for approve/reject reason body construction
- Extract `postSessionAction` private method in `DebugSessionService` (replaces 6 methods)
- Net reduction: 54 lines removed

Closes #918