### PR TITLE
fix: propagate request context cancellation (fixes #939)

### DIFF
--- a/pkg/audit/queued_sink.go
+++ b/pkg/audit/queued_sink.go
@@ -39,7 +39,7 @@ type QueuedSinkConfig struct {
 	WorkerCount int
 
 	// Batching config for underlying BatchSinks
-	BatchSize int
+	BatchSize    int
 	BatchTimeout time.Duration
 
 	// WriteTimeout is the timeout for writing to the underlying sink.
@@ -157,7 +157,7 @@ func NewQueuedSink(sink Sink, cfg QueuedSinkConfig, logger *zap.Logger) *QueuedS
 		logger: logger.Named("queued-sink").With(zap.String("sink", sink.Name())),
 	}
 
-		batchSink, isBatchSink := sink.(BatchSink)
+	batchSink, isBatchSink := sink.(BatchSink)
 
 	// Start workers
 	for i := 0; i < cfg.WorkerCount; i++ {

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -606,12 +606,9 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 	reqLog := system.GetReqLogger(c, wc.log)
 	reqLog = system.EnrichReqLoggerWithAuth(c, reqLog)
 	reqLog.Debug("Handling GET /status for breakglass session")
-	// Use background context with timeout instead of request context to prevent
-	// "context canceled" errors when client closes connection during rapid refreshes.
-	// The Kubernetes API List operation needs to complete even if the HTTP client
-	// disconnects, otherwise users see errors on rapid tab switches in the UI.
+	// Use request context with timeout so cancellation propagates from the HTTP request.
 	// We use a timeout to prevent indefinite hangs. Timeout is configurable via APIContextTimeout.
-	ctx, cancel := context.WithTimeout(context.Background(), APIContextTimeout)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), APIContextTimeout)
 	defer cancel()
 
 	// Support server-side filtering when cluster/user/group query params are provided

--- a/pkg/cluster/oidc.go
+++ b/pkg/cluster/oidc.go
@@ -1103,7 +1103,6 @@ func tokenEndpointHostMatchesIssuer(tokenURL, issuerURL string) bool {
 	return tPort == iPort
 }
 
-
 // getClientSecret retrieves the client secret from the referenced secret
 func (p *OIDCTokenProvider) getClientSecret(ctx context.Context, oidc *breakglassv1alpha1.OIDCAuthConfig) (string, error) {
 	if oidc.ClientSecretRef == nil {


### PR DESCRIPTION
Closes #939. Use request context with timeout so cancellation propagates from the HTTP request.