### PR TITLE
feat: add shell completion for enum flags (fixes #952)

### DIFF
--- a/pkg/bgctl/cmd/debug.go
+++ b/pkg/bgctl/cmd/debug.go
@@ -225,6 +225,9 @@ func newDebugSessionGetCommand() *cobra.Command {
 		Use:   "get NAME",
 		Short: "Get a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -350,6 +353,9 @@ func newDebugSessionJoinCommand() *cobra.Command {
 		Use:   "join NAME",
 		Short: "Join a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -367,6 +373,9 @@ func newDebugSessionJoinCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&role, "role", "viewer", "Role: participant|viewer")
+	_ = cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"participant", "viewer"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Namespace hint")
 	return cmd
 }
@@ -377,6 +386,9 @@ func newDebugSessionLeaveCommand() *cobra.Command {
 		Use:   "leave NAME",
 		Short: "Leave a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -406,6 +418,9 @@ func newDebugSessionRenewCommand() *cobra.Command {
 		Use:   "renew NAME",
 		Short: "Renew a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -435,6 +450,9 @@ func newDebugSessionTerminateCommand() *cobra.Command {
 		Use:   "terminate NAME",
 		Short: "Terminate a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -468,6 +486,9 @@ func newDebugSessionApproveCommand() *cobra.Command {
 		Use:   "approve NAME",
 		Short: "Approve a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -498,6 +519,9 @@ func newDebugSessionRejectCommand() *cobra.Command {
 		Use:   "reject NAME",
 		Short: "Reject a debug session",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -577,6 +601,9 @@ func newDebugTemplateGetCommand() *cobra.Command {
 		Use:   "get NAME",
 		Short: "Get a debug session template",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -753,6 +780,9 @@ func newDebugPodTemplateGetCommand() *cobra.Command {
 		Use:   "get NAME",
 		Short: "Get a debug pod template",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -795,6 +825,9 @@ func newDebugKubectlInjectCommand() *cobra.Command {
 		Use:   "inject NAME",
 		Short: "Inject an ephemeral container",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -840,6 +873,9 @@ func newDebugKubectlCopyPodCommand() *cobra.Command {
 		Use:   "copy-pod NAME",
 		Short: "Create a debug copy of a pod",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -878,6 +914,9 @@ func newDebugKubectlNodeDebugCommand() *cobra.Command {
 		Use:   "node-debug SESSION",
 		Short: "Create a node debug pod",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {

--- a/pkg/bgctl/cmd/root.go
+++ b/pkg/bgctl/cmd/root.go
@@ -109,6 +109,9 @@ func NewRootCommand(cfg Config) *cobra.Command {
 	root.PersistentFlags().StringVar(&rt.configPath, "config", rt.configPath, "Path to config file")
 	root.PersistentFlags().StringVarP(&rt.contextOverride, "context", "c", "", "Context name override")
 	root.PersistentFlags().StringVarP(&rt.outputFormat, "output", "o", "", "Output format override: table, wide, json, yaml (support depends on command)")
+	_ = root.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"table", "wide", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	root.PersistentFlags().StringVar(&rt.serverOverride, "server", "", "Server override (bypass config)")
 	root.PersistentFlags().StringVar(&rt.tokenOverride, "token", "", "Bearer token override")
 	root.PersistentFlags().StringVar(&rt.tokenStorageOverride, "token-storage", "", "Token storage backend: keychain or file")

--- a/pkg/bgctl/cmd/version.go
+++ b/pkg/bgctl/cmd/version.go
@@ -45,6 +45,9 @@ func NewVersionCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format: json, yaml")
+	_ = cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	return cmd
 }


### PR DESCRIPTION
Closes #952. Adds flag completion functions for static enums (e.g. --role, --output).