### PR TITLE
fix: add cluster name validation to ephemeral container admission (#928)

### DIFF
--- a/pkg/webhook/ephemeral.go
+++ b/pkg/webhook/ephemeral.go
@@ -27,6 +27,10 @@ type DebugSessionHandler interface {
 }
 
 // EphemeralContainerWebhook handles admission of ephemeral containers
+type contextKey string
+
+const clusterContextKey contextKey = "cluster"
+
 type EphemeralContainerWebhook struct {
 	Client       client.Client
 	Decoder      admission.Decoder
@@ -58,9 +62,18 @@ func (w *EphemeralContainerWebhook) Handle(ctx context.Context, req admission.Re
 	}
 
 	user := req.UserInfo.Username
-	// Use explicit cluster from context if available, otherwise wildcard (empty)
-	// For Phase 1 we rely on finding *any* active session for the user
+	// Use explicit cluster from context if available, otherwise fail closed
 	cluster := ""
+	if val := ctx.Value(clusterContextKey); val != nil {
+		if c, ok := val.(string); ok {
+			cluster = c
+		}
+	}
+
+	if cluster == "" {
+		w.Log.Warnw("Cluster identity cannot be determined for ephemeral container validation", "user", user)
+		return admission.Denied("cluster identity cannot be determined for ephemeral container validation")
+	}
 
 	session, err := w.DebugHandler.FindActiveSession(ctx, user, cluster)
 	if err != nil {

--- a/pkg/webhook/ephemeral_test.go
+++ b/pkg/webhook/ephemeral_test.go
@@ -419,7 +419,8 @@ func TestEphemeralContainerWebhook_Handle(t *testing.T) {
 				},
 			}
 
-			resp := webhook.Handle(context.Background(), req)
+			ctx := context.WithValue(context.Background(), clusterContextKey, "test-cluster")
+			resp := webhook.Handle(ctx, req)
 
 			if tt.expectAllowed {
 				require.True(t, resp.Allowed, "expected allowed=true, got result: %+v", resp.Result)

--- a/pkg/webhook/manager.go
+++ b/pkg/webhook/manager.go
@@ -1,6 +1,8 @@
 package webhook
 
 import (
+	"net/http"
+
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -146,14 +148,26 @@ func Setup(
 
 		// Register ephemeral container webhook
 		log.Infof("Registering ephemeral container webhook at /validate-ephemeral-containers")
-		mgr.GetWebhookServer().Register("/validate-ephemeral-containers", &webhookserver.Admission{
+		admissionHandler := &webhookserver.Admission{
 			Handler: &EphemeralContainerWebhook{
 				Client:       mgr.GetClient(),
 				Log:          log,
 				Decoder:      admission.NewDecoder(mgr.GetScheme()),
 				DebugHandler: debug.NewKubectlDebugHandler(mgr.GetClient(), nil),
 			},
-		})
+		}
+
+		mgr.GetWebhookServer().Register("/validate-ephemeral-containers", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cluster := r.URL.Query().Get("cluster")
+			if cluster == "" {
+				cluster = strings.TrimPrefix(r.URL.Path, "/validate-ephemeral-containers/")
+				if cluster == "/validate-ephemeral-containers" {
+					cluster = ""
+				}
+			}
+			ctx := context.WithValue(r.Context(), clusterContextKey, cluster)
+			admissionHandler.ServeHTTP(w, r.WithContext(ctx))
+		}))
 	} else {
 		log.Infow("Validating webhooks disabled via --enable-validating-webhooks=false")
 	}


### PR DESCRIPTION
Closes #928
