### PR TITLE
fix: pass per-IDP CA certs to the proxy client (#977)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -992,7 +992,7 @@ func (s *Server) handleOIDCProxy(c *gin.Context) {
 	target := targetURL.String()
 	s.log.Sugar().Debugw("oidc_proxy_request", "path", proxyPath, "target_scheme", targetURL.Scheme, "target_host", targetURL.Host, "target_path", targetURL.Path)
 
-	client, err := s.newOIDCProxyHTTPClient(targetURL.Scheme == "https")
+	client, err := s.newOIDCProxyHTTPClient(targetURL.Scheme == "https", targetAuthority.String())
 	if err != nil {
 		s.log.Sugar().Errorw("oidc_proxy_client_error", "error", err)
 		recordOIDCProxyFailure("tls_configuration_error", start)
@@ -1098,7 +1098,7 @@ const (
 	tlsModeCustomCA = "custom_ca"
 )
 
-func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool) (*http.Client, error) {
+func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool, authority string) (*http.Client, error) {
 	transport := &http.Transport{}
 	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
 

--- a/pkg/api/api_oidc_proxy_test.go
+++ b/pkg/api/api_oidc_proxy_test.go
@@ -809,7 +809,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				Authority: "https://keycloak.example.com",
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, "")
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		require.NotNil(t, transport.TLSClientConfig)
@@ -825,7 +825,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, "")
 		require.Error(t, err)
 		assert.Nil(t, client)
 		assert.Contains(t, err.Error(), "configure certificateAuthority")
@@ -841,7 +841,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				InsecureSkipVerify:   true,
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, "")
 		require.Error(t, err)
 		assert.Nil(t, client)
 		assert.Contains(t, err.Error(), "insecureSkipVerify is not supported")
@@ -856,7 +856,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				CertificateAuthority: testCertificatePEM(t),
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, "")
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		require.NotNil(t, transport.TLSClientConfig)
@@ -871,7 +871,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				Authority: "https://keycloak.example.com",
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(false)
+		client, err := server.newOIDCProxyHTTPClient(false, "")
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		assert.Nil(t, transport.TLSClientConfig)


### PR DESCRIPTION
Closes #977
