### PR TITLE
fix(oidc): use per-IDP CA for multi-IDP proxy requests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -992,7 +992,7 @@ func (s *Server) handleOIDCProxy(c *gin.Context) {
 	target := targetURL.String()
 	s.log.Sugar().Debugw("oidc_proxy_request", "path", proxyPath, "target_scheme", targetURL.Scheme, "target_host", targetURL.Host, "target_path", targetURL.Path)
 
-	client, err := s.newOIDCProxyHTTPClient(targetURL.Scheme == "https")
+	client, err := s.newOIDCProxyHTTPClient(targetURL.Scheme == "https", targetAuthority)
 	if err != nil {
 		s.log.Sugar().Errorw("oidc_proxy_client_error", "error", err)
 		recordOIDCProxyFailure("tls_configuration_error", start)
@@ -1098,7 +1098,7 @@ const (
 	tlsModeCustomCA = "custom_ca"
 )
 
-func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool) (*http.Client, error) {
+func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool, targetAuthority *url.URL) (*http.Client, error) {
 	transport := &http.Transport{}
 	client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
 
@@ -1107,29 +1107,55 @@ func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool) (*http.Client, error) 
 		return client, nil
 	}
 
-	s.idpMutex.RLock()
-	idpCfg := s.idpConfig
-	s.idpMutex.RUnlock()
-	if idpCfg == nil {
-		return nil, fmt.Errorf("identity provider not loaded")
+	var idpName string
+	var authorityURL string
+	var insecureSkipVerify bool
+	var certAuthority string
+
+	found := false
+	if s.idpReconciler != nil && targetAuthority != nil {
+		targetAuthStr := targetAuthority.String()
+		for _, idp := range s.idpReconciler.GetCachedIdentityProviders() {
+			if idp.Spec.OIDC.Authority == targetAuthStr {
+				idpName = idp.Name
+				authorityURL = idp.Spec.OIDC.Authority
+				insecureSkipVerify = idp.Spec.OIDC.InsecureSkipVerify
+				certAuthority = idp.Spec.OIDC.CertificateAuthority
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		s.idpMutex.RLock()
+		idpCfg := s.idpConfig
+		s.idpMutex.RUnlock()
+		if idpCfg == nil {
+			return nil, fmt.Errorf("identity provider not loaded")
+		}
+		idpName = idpCfg.Name
+		authorityURL = idpCfg.Authority
+		insecureSkipVerify = idpCfg.InsecureSkipVerify || (idpCfg.Keycloak != nil && idpCfg.Keycloak.InsecureSkipVerify)
+		certAuthority = idpCfg.CertificateAuthority
 	}
 
 	mode := tlsModeSystemCA
 	var tlsConfig *tls.Config
 
-	if idpCfg.InsecureSkipVerify || (idpCfg.Keycloak != nil && idpCfg.Keycloak.InsecureSkipVerify) {
+	if insecureSkipVerify {
 		s.log.Sugar().Warnw("refusing insecure TLS verification for identity provider",
-			"idpName", idpCfg.Name,
-			"authority", idpCfg.Authority,
+			"idpName", idpName,
+			"authority", authorityURL,
 			"remediation", "configure certificateAuthority for private or self-signed identity provider certificates")
-		return nil, fmt.Errorf("insecureSkipVerify is not supported for OIDC proxy IDP %s; configure certificateAuthority", idpCfg.Name)
+		return nil, fmt.Errorf("insecureSkipVerify is not supported for OIDC proxy IDP %s; configure certificateAuthority", idpName)
 	}
 
 	switch {
-	case idpCfg.CertificateAuthority != "":
+	case certAuthority != "":
 		roots := x509.NewCertPool()
-		if ok := roots.AppendCertsFromPEM([]byte(idpCfg.CertificateAuthority)); !ok {
-			return nil, fmt.Errorf("failed to parse certificateAuthority for IDP %s", idpCfg.Name)
+		if ok := roots.AppendCertsFromPEM([]byte(certAuthority)); !ok {
+			return nil, fmt.Errorf("failed to parse certificateAuthority for IDP %s", idpName)
 		}
 		tlsConfig = &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
 		mode = tlsModeCustomCA

--- a/pkg/api/api_oidc_proxy_test.go
+++ b/pkg/api/api_oidc_proxy_test.go
@@ -809,7 +809,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				Authority: "https://keycloak.example.com",
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, nil)
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		require.NotNil(t, transport.TLSClientConfig)
@@ -825,7 +825,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, nil)
 		require.Error(t, err)
 		assert.Nil(t, client)
 		assert.Contains(t, err.Error(), "configure certificateAuthority")
@@ -841,7 +841,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				InsecureSkipVerify:   true,
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, nil)
 		require.Error(t, err)
 		assert.Nil(t, client)
 		assert.Contains(t, err.Error(), "insecureSkipVerify is not supported")
@@ -856,7 +856,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				CertificateAuthority: testCertificatePEM(t),
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(true)
+		client, err := server.newOIDCProxyHTTPClient(true, nil)
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		require.NotNil(t, transport.TLSClientConfig)
@@ -871,7 +871,7 @@ func TestNewOIDCProxyHTTPClientTLSModes(t *testing.T) {
 				Authority: "https://keycloak.example.com",
 			},
 		}
-		client, err := server.newOIDCProxyHTTPClient(false)
+		client, err := server.newOIDCProxyHTTPClient(false, nil)
 		require.NoError(t, err)
 		transport := client.Transport.(*http.Transport)
 		assert.Nil(t, transport.TLSClientConfig)

--- a/pkg/cluster/circuitbreaker.go
+++ b/pkg/cluster/circuitbreaker.go
@@ -223,7 +223,9 @@ func (cb *clusterBreaker) RecordSuccess(epoch int64) {
 	metrics.ClusterCircuitBreakerSuccesses.WithLabelValues(cb.name).Inc()
 	metrics.ClusterCircuitBreakerConsecutiveFailures.WithLabelValues(cb.name).Set(0)
 
-	if cb.generation.Load() != epoch { return }
+	if cb.generation.Load() != epoch {
+		return
+	}
 	if CircuitState(cb.state.Load()) == CircuitHalfOpen {
 		cb.mu.Lock()
 		// Re-check under lock to avoid TOCTOU race on state transitions
@@ -245,7 +247,9 @@ func (cb *clusterBreaker) RecordFailure(epoch int64, err error) {
 	if cb.untracked {
 		return // sentinel breaker — no metrics or state transitions
 	}
-	if cb.generation.Load() != epoch { return }
+	if cb.generation.Load() != epoch {
+		return
+	}
 	if !IsTransientError(err) {
 		// Non-transient errors (auth, not-found) should not trip the breaker
 		return

--- a/pkg/cluster/circuitbreaker_test.go
+++ b/pkg/cluster/circuitbreaker_test.go
@@ -328,8 +328,10 @@ func TestRegistry_Remove(t *testing.T) {
 func TestRegistry_AllStats(t *testing.T) {
 	r := NewCircuitBreakerRegistry(testConfig(), testLogger())
 
-	cbA := r.Get("cluster-a"); cbA.RecordSuccess(cbA.Generation())
-	cbB := r.Get("cluster-b"); cbB.RecordFailure(cbB.Generation(), fmt.Errorf("connection refused"))
+	cbA := r.Get("cluster-a")
+	cbA.RecordSuccess(cbA.Generation())
+	cbB := r.Get("cluster-b")
+	cbB.RecordFailure(cbB.Generation(), fmt.Errorf("connection refused"))
 
 	stats := r.AllStats()
 	assert.Len(t, stats, 2)


### PR DESCRIPTION
Closes #977. Fixes multi-IDP proxy requests so they use the target IDP's CA bundle rather than always using the default IDP's CA.