### PR TITLE
fix(oidc): actually use per-IDP CA certs for proxy client (#977)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1107,29 +1107,54 @@ func (s *Server) newOIDCProxyHTTPClient(requiresTLS bool, authority string) (*ht
 		return client, nil
 	}
 
-	s.idpMutex.RLock()
-	idpCfg := s.idpConfig
-	s.idpMutex.RUnlock()
-	if idpCfg == nil {
-		return nil, fmt.Errorf("identity provider not loaded")
+	var idpName string
+	var authorityURL string
+	var insecureSkipVerify bool
+	var certAuthority string
+
+	found := false
+	if s.idpReconciler != nil && authority != "" {
+		for _, idp := range s.idpReconciler.GetCachedIdentityProviders() {
+			if idp.Spec.OIDC.Authority == authority {
+				idpName = idp.Name
+				authorityURL = idp.Spec.OIDC.Authority
+				insecureSkipVerify = idp.Spec.OIDC.InsecureSkipVerify
+				certAuthority = idp.Spec.OIDC.CertificateAuthority
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		s.idpMutex.RLock()
+		idpCfg := s.idpConfig
+		s.idpMutex.RUnlock()
+		if idpCfg == nil {
+			return nil, fmt.Errorf("identity provider not loaded")
+		}
+		idpName = idpCfg.Name
+		authorityURL = idpCfg.Authority
+		insecureSkipVerify = idpCfg.InsecureSkipVerify || (idpCfg.Keycloak != nil && idpCfg.Keycloak.InsecureSkipVerify)
+		certAuthority = idpCfg.CertificateAuthority
 	}
 
 	mode := tlsModeSystemCA
 	var tlsConfig *tls.Config
 
-	if idpCfg.InsecureSkipVerify || (idpCfg.Keycloak != nil && idpCfg.Keycloak.InsecureSkipVerify) {
+	if insecureSkipVerify {
 		s.log.Sugar().Warnw("refusing insecure TLS verification for identity provider",
-			"idpName", idpCfg.Name,
-			"authority", idpCfg.Authority,
+			"idpName", idpName,
+			"authority", authorityURL,
 			"remediation", "configure certificateAuthority for private or self-signed identity provider certificates")
-		return nil, fmt.Errorf("insecureSkipVerify is not supported for OIDC proxy IDP %s; configure certificateAuthority", idpCfg.Name)
+		return nil, fmt.Errorf("insecureSkipVerify is not supported for OIDC proxy IDP %s; configure certificateAuthority", idpName)
 	}
 
 	switch {
-	case idpCfg.CertificateAuthority != "":
+	case certAuthority != "":
 		roots := x509.NewCertPool()
-		if ok := roots.AppendCertsFromPEM([]byte(idpCfg.CertificateAuthority)); !ok {
-			return nil, fmt.Errorf("failed to parse certificateAuthority for IDP %s", idpCfg.Name)
+		if ok := roots.AppendCertsFromPEM([]byte(certAuthority)); !ok {
+			return nil, fmt.Errorf("failed to parse certificateAuthority for IDP %s", idpName)
 		}
 		tlsConfig = &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
 		mode = tlsModeCustomCA

--- a/pkg/cluster/circuitbreaker.go
+++ b/pkg/cluster/circuitbreaker.go
@@ -223,7 +223,9 @@ func (cb *clusterBreaker) RecordSuccess(epoch int64) {
 	metrics.ClusterCircuitBreakerSuccesses.WithLabelValues(cb.name).Inc()
 	metrics.ClusterCircuitBreakerConsecutiveFailures.WithLabelValues(cb.name).Set(0)
 
-	if cb.generation.Load() != epoch { return }
+	if cb.generation.Load() != epoch {
+		return
+	}
 	if CircuitState(cb.state.Load()) == CircuitHalfOpen {
 		cb.mu.Lock()
 		// Re-check under lock to avoid TOCTOU race on state transitions
@@ -245,7 +247,9 @@ func (cb *clusterBreaker) RecordFailure(epoch int64, err error) {
 	if cb.untracked {
 		return // sentinel breaker — no metrics or state transitions
 	}
-	if cb.generation.Load() != epoch { return }
+	if cb.generation.Load() != epoch {
+		return
+	}
 	if !IsTransientError(err) {
 		// Non-transient errors (auth, not-found) should not trip the breaker
 		return

--- a/pkg/cluster/circuitbreaker_test.go
+++ b/pkg/cluster/circuitbreaker_test.go
@@ -328,8 +328,10 @@ func TestRegistry_Remove(t *testing.T) {
 func TestRegistry_AllStats(t *testing.T) {
 	r := NewCircuitBreakerRegistry(testConfig(), testLogger())
 
-	cbA := r.Get("cluster-a"); cbA.RecordSuccess(cbA.Generation())
-	cbB := r.Get("cluster-b"); cbB.RecordFailure(cbB.Generation(), fmt.Errorf("connection refused"))
+	cbA := r.Get("cluster-a")
+	cbA.RecordSuccess(cbA.Generation())
+	cbB := r.Get("cluster-b")
+	cbB.RecordFailure(cbB.Generation(), fmt.Errorf("connection refused"))
 
 	stats := r.AllStats()
 	assert.Len(t, stats, 2)


### PR DESCRIPTION
Closes #977. The previous PR #1118 added the authority parameter but did not actually use it inside newOIDCProxyHTTPClient. This commit fixes that bug.