### PR TITLE
ci: normalize tool release tags

### DIFF
--- a/.github/workflows/tool-updates.yml
+++ b/.github/workflows/tool-updates.yml
@@ -45,10 +45,18 @@ jobs:
             local repo=$1
             local current=$2
             local name=$3
+            local latest
             latest=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "unknown")
-            if [ "$latest" != "unknown" ] && [ "$latest" != "$current" ]; then
-              echo "  - **${name}**: ${current} → ${latest} ([releases](https://github.com/${repo}/releases))" >> updates.md
-              echo "found=true" >> $GITHUB_OUTPUT
+            if [ "$latest" = "unknown" ]; then
+              return
+            fi
+
+            # Some projects publish component-prefixed tags, for example kustomize/v5.8.1.
+            # Compare against the version suffix used by versions.env to avoid false positives.
+            local latest_version="${latest##*/}"
+            if [ "$latest_version" != "$current" ]; then
+              echo "  - **${name}**: ${current} → ${latest_version} ([releases](https://github.com/${repo}/releases))" >> updates.md
+              echo "found=true" >> "$GITHUB_OUTPUT"
             fi
           }
 


### PR DESCRIPTION
## Summary
- normalize component-prefixed GitHub release tags before comparing them with versions.env
- keeps kustomize/kustomize-style tags from producing stale tool-update reports

Refs #629.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tool-updates.yml")'\n- extracted Check for updates run block piped through bash -n\n- shell normalization smoke test for kustomize/v5.8.1 -> v5.8.1