### PR TITLE
api: standardize remaining error responses

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -331,10 +331,13 @@ API errors are returned in consistent JSON format:
 ```json
 {
   "error": "User email not found in token",
-  "cid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "meta": "metadata about the error"
+  "code": "UNAUTHORIZED",
+  "details": "metadata about the error"
 }
 ```
+
+Use the `X-Request-ID` response header, not the JSON body, as the correlation ID
+for logs and support requests.
 
 ### HTTP Status Codes
 

--- a/docs/extra-deploy-variables.md
+++ b/docs/extra-deploy-variables.md
@@ -203,9 +203,8 @@ The API error response includes the required groups:
 ```json
 {
   "error": "extraDeployValues validation failed",
-  "errors": [
-    "test[hostNetwork]: Forbidden: variable \"hostNetwork\" is restricted; requires membership in one of: [platform_poweruser schiff-admin]"
-  ]
+  "code": "BAD_REQUEST",
+  "details": "test[hostNetwork]: Forbidden: variable \"hostNetwork\" is restricted; requires membership in one of: [platform_poweruser schiff-admin]"
 }
 ```
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -130,6 +130,7 @@ When a request is rate limited, the server returns HTTP `429 Too Many Requests` 
 ```json
 {
   "error": "Rate limit exceeded. Please authenticate for higher limits.",
+  "code": "TOO_MANY_REQUESTS",
   "authenticated": false
 }
 ```
@@ -138,6 +139,7 @@ When a request is rate limited, the server returns HTTP `429 Too Many Requests` 
 ```json
 {
   "error": "Rate limit exceeded, please try again later",
+  "code": "TOO_MANY_REQUESTS",
   "authenticated": true
 }
 ```

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -238,6 +238,7 @@ func NewServer(log *zap.Logger, cfg config.Config,
 			log.Info("http_request", zap.String("cid", fmt.Sprintf("%v", cid)), zap.String("method", c.Request.Method), zap.String("path", c.FullPath()), zap.Int("status", c.Writer.Status()), zap.Duration("latency", time.Since(start)))
 		},
 		func(c *gin.Context) { // unified error propagation: if handler set context error, respond JSON
+			c.Next()
 			if len(c.Errors) > 0 {
 				cid, _ := c.Get("cid")
 				first := c.Errors[0]
@@ -254,7 +255,7 @@ func NewServer(log *zap.Logger, cfg config.Config,
 					// Use zap.String to avoid stacktrace in error logs
 					log.Error("handler_error", zap.String("cid", fmt.Sprintf("%v", cid)), zap.String("error", first.Error()), zap.String("meta", metaStr))
 				}
-				if !c.IsAborted() {
+				if !c.IsAborted() && !c.Writer.Written() {
 					status := c.Writer.Status()
 					if status < http.StatusBadRequest {
 						status = http.StatusInternalServerError

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -255,7 +255,11 @@ func NewServer(log *zap.Logger, cfg config.Config,
 					log.Error("handler_error", zap.String("cid", fmt.Sprintf("%v", cid)), zap.String("error", first.Error()), zap.String("meta", metaStr))
 				}
 				if !c.IsAborted() {
-					c.JSON(c.Writer.Status(), gin.H{"error": first.Error(), "cid": cid, "meta": metaStr})
+					status := c.Writer.Status()
+					if status < http.StatusBadRequest {
+						status = http.StatusInternalServerError
+					}
+					RespondError(c, status, first.Error(), metaStr)
 				}
 			}
 		},
@@ -303,9 +307,9 @@ func NewServer(log *zap.Logger, cfg config.Config,
 
 		cid, _ := c.Get("cid")
 		log.Warn("blocked_request_origin", zap.String("origin", originHeader), zap.String("normalized_origin", normalized), zap.String("cid", fmt.Sprintf("%v", cid)))
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-			"error": "origin not allowed",
-			"cid":   cid,
+		c.AbortWithStatusJSON(http.StatusForbidden, APIError{
+			Error: "origin not allowed",
+			Code:  "FORBIDDEN",
 		})
 	})
 
@@ -338,7 +342,7 @@ func NewServer(log *zap.Logger, cfg config.Config,
 	// Custom NoRoute: JSON 404 for /api/*, SPA fallback for others
 	engine.NoRoute(func(c *gin.Context) {
 		if len(c.Request.URL.Path) >= 5 && c.Request.URL.Path[:5] == "/api/" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "API endpoint not found", "path": c.Request.URL.Path})
+			RespondError(c, http.StatusNotFound, "API endpoint not found", c.Request.URL.Path)
 		} else {
 			ServeSPA("/", "/frontend/dist/")(c)
 		}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -378,6 +378,11 @@ func TestOriginValidationMiddleware(t *testing.T) {
 	t.Run("blocks disallowed origin", func(t *testing.T) {
 		resp := makeRequest(http.MethodGet, "https://evil.example.com")
 		require.Equal(t, http.StatusForbidden, resp.Code)
+
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+		require.Equal(t, "origin not allowed", body["error"])
+		require.Equal(t, "FORBIDDEN", body["code"])
 	})
 
 	t.Run("skips when origin header missing", func(t *testing.T) {
@@ -518,13 +523,13 @@ func TestServer_NoRoute_API_Json404(t *testing.T) {
 	server.gin.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
-	// Response should be JSON containing error and path
-	var body map[string]interface{}
+	// Response should use the standard API error shape and include the path as details.
+	var body map[string]string
 	err = json.Unmarshal(w.Body.Bytes(), &body)
 	assert.NoError(t, err)
-	assert.Contains(t, body, "error")
-	assert.Contains(t, body, "path")
-	assert.Equal(t, "/api/unknown/thing", body["path"])
+	assert.Equal(t, "API endpoint not found", body["error"])
+	assert.Equal(t, "NOT_FOUND", body["code"])
+	assert.Equal(t, "/api/unknown/thing", body["details"])
 }
 
 func TestServer_NoRoute_SPA_Fallback(t *testing.T) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -59,6 +59,33 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
+func TestServerUnifiedErrorMiddlewareRespondsAfterHandlerError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logger := zaptest.NewLogger(t)
+	server := NewServer(logger, config.Config{
+		Server: config.Server{
+			AllowedOrigins: []string{"https://test.example.com"},
+		},
+	}, true, &AuthHandler{})
+	server.gin.GET("/handler-error", func(c *gin.Context) {
+		_ = c.Error(errors.New("boom")).SetMeta("route failed")
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/handler-error", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+
+	server.gin.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	var response APIError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "boom", response.Error)
+	assert.Equal(t, "INTERNAL_ERROR", response.Code)
+	assert.Equal(t, "route failed", response.Details)
+}
+
 func TestServer_getConfig(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -825,10 +825,7 @@ func (a *AuthHandler) MiddlewareWithRateLimiting(rl RateLimiter) gin.HandlerFunc
 			if !isAuthenticated {
 				msg = "Rate limit exceeded. Please authenticate for higher limits."
 			}
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":         msg,
-				"authenticated": isAuthenticated,
-			})
+			RespondTooManyRequestsWithAuthState(c, msg, isAuthenticated)
 			c.Abort()
 			return
 		}
@@ -858,10 +855,7 @@ func (a *AuthHandler) OptionalAuthRateLimitMiddleware(rl RateLimiter) gin.Handle
 			if !isAuthenticated {
 				msg = "Rate limit exceeded. Please authenticate for higher limits."
 			}
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error":         msg,
-				"authenticated": isAuthenticated,
-			})
+			RespondTooManyRequestsWithAuthState(c, msg, isAuthenticated)
 			c.Abort()
 			return
 		}

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -525,6 +525,7 @@ func TestMiddlewareWithRateLimiting(t *testing.T) {
 			if tt.expectedStatus == http.StatusTooManyRequests {
 				var body map[string]interface{}
 				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+				assert.Equal(t, "TOO_MANY_REQUESTS", body["code"])
 				assert.Equal(t, tt.expectedAuth, body["authenticated"])
 			}
 		})

--- a/pkg/api/responses.go
+++ b/pkg/api/responses.go
@@ -45,6 +45,8 @@ func errorCodeForStatus(status int) string {
 		return "NOT_FOUND"
 	case http.StatusConflict:
 		return "CONFLICT"
+	case http.StatusUnprocessableEntity:
+		return "UNPROCESSABLE_ENTITY"
 	case http.StatusTooManyRequests:
 		return "TOO_MANY_REQUESTS"
 	case http.StatusBadGateway:

--- a/pkg/api/responses.go
+++ b/pkg/api/responses.go
@@ -27,9 +27,46 @@ import (
 // APIError represents a standardized error response.
 // This ensures consistent error message formatting across all API endpoints.
 type APIError struct {
-	Error   string `json:"error"`
-	Code    string `json:"code,omitempty"`
-	Details string `json:"details,omitempty"`
+	Error         string `json:"error"`
+	Code          string `json:"code,omitempty"`
+	Details       string `json:"details,omitempty"`
+	Authenticated *bool  `json:"authenticated,omitempty"`
+}
+
+func errorCodeForStatus(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "BAD_REQUEST"
+	case http.StatusUnauthorized:
+		return "UNAUTHORIZED"
+	case http.StatusForbidden:
+		return "FORBIDDEN"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	case http.StatusConflict:
+		return "CONFLICT"
+	case http.StatusTooManyRequests:
+		return "TOO_MANY_REQUESTS"
+	case http.StatusBadGateway:
+		return "BAD_GATEWAY"
+	case http.StatusServiceUnavailable:
+		return "SERVICE_UNAVAILABLE"
+	default:
+		if status >= http.StatusInternalServerError {
+			return "INTERNAL_ERROR"
+		}
+		return "ERROR"
+	}
+}
+
+// RespondError sends a standardized error response for middleware paths that
+// do not map to one of the specialized helpers below.
+func RespondError(c *gin.Context, status int, message, details string) {
+	c.JSON(status, APIError{
+		Error:   message,
+		Code:    errorCodeForStatus(status),
+		Details: details,
+	})
 }
 
 // RespondNotFound sends a 404 Not Found response with a standardized message.
@@ -139,6 +176,30 @@ func RespondTooManyRequestsWithRetryAfter(c *gin.Context, retryAfter string, mes
 	c.JSON(http.StatusTooManyRequests, APIError{
 		Error: message,
 		Code:  "TOO_MANY_REQUESTS",
+	})
+}
+
+// RespondTooManyRequests sends a 429 Too Many Requests response.
+func RespondTooManyRequests(c *gin.Context, message string) {
+	if message == "" {
+		message = "too many requests"
+	}
+	c.JSON(http.StatusTooManyRequests, APIError{
+		Error: message,
+		Code:  "TOO_MANY_REQUESTS",
+	})
+}
+
+// RespondTooManyRequestsWithAuthState sends a 429 response while preserving
+// the authenticated marker expected by rate-limit clients.
+func RespondTooManyRequestsWithAuthState(c *gin.Context, message string, authenticated bool) {
+	if message == "" {
+		message = "too many requests"
+	}
+	c.JSON(http.StatusTooManyRequests, APIError{
+		Error:         message,
+		Code:          "TOO_MANY_REQUESTS",
+		Authenticated: &authenticated,
 	})
 }
 

--- a/pkg/api/responses_test.go
+++ b/pkg/api/responses_test.go
@@ -64,19 +64,40 @@ func TestRespondNotFoundSimple(t *testing.T) {
 }
 
 func TestRespondError(t *testing.T) {
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
+	tests := []struct {
+		name         string
+		status       int
+		expectedCode string
+	}{
+		{
+			name:         "not found",
+			status:       http.StatusNotFound,
+			expectedCode: "NOT_FOUND",
+		},
+		{
+			name:         "unprocessable entity",
+			status:       http.StatusUnprocessableEntity,
+			expectedCode: "UNPROCESSABLE_ENTITY",
+		},
+	}
 
-	RespondError(c, http.StatusNotFound, "API endpoint not found", "/api/missing")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
+			RespondError(c, tt.status, "API endpoint error", "/api/missing")
 
-	var resp APIError
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	assert.Equal(t, "API endpoint not found", resp.Error)
-	assert.Equal(t, "NOT_FOUND", resp.Code)
-	assert.Equal(t, "/api/missing", resp.Details)
+			assert.Equal(t, tt.status, w.Code)
+
+			var resp APIError
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, "API endpoint error", resp.Error)
+			assert.Equal(t, tt.expectedCode, resp.Code)
+			assert.Equal(t, "/api/missing", resp.Details)
+		})
+	}
 }
 
 func TestRespondUnauthorized(t *testing.T) {

--- a/pkg/api/responses_test.go
+++ b/pkg/api/responses_test.go
@@ -63,6 +63,22 @@ func TestRespondNotFoundSimple(t *testing.T) {
 	assert.Equal(t, "NOT_FOUND", resp.Code)
 }
 
+func TestRespondError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RespondError(c, http.StatusNotFound, "API endpoint not found", "/api/missing")
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp APIError
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "API endpoint not found", resp.Error)
+	assert.Equal(t, "NOT_FOUND", resp.Code)
+	assert.Equal(t, "/api/missing", resp.Details)
+}
+
 func TestRespondUnauthorized(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -203,6 +219,23 @@ func TestRespondInternalErrorSimple(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "unexpected error", resp.Error)
 	assert.Equal(t, "INTERNAL_ERROR", resp.Code)
+}
+
+func TestRespondTooManyRequestsWithAuthState(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RespondTooManyRequestsWithAuthState(c, "rate limit exceeded", true)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	var resp APIError
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "rate limit exceeded", resp.Error)
+	assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+	require.NotNil(t, resp.Authenticated)
+	assert.True(t, *resp.Authenticated)
 }
 
 func TestRespondServiceUnavailable(t *testing.T) {

--- a/pkg/api/responses_test.go
+++ b/pkg/api/responses_test.go
@@ -70,14 +70,59 @@ func TestRespondError(t *testing.T) {
 		expectedCode string
 	}{
 		{
+			name:         "bad request",
+			status:       http.StatusBadRequest,
+			expectedCode: "BAD_REQUEST",
+		},
+		{
+			name:         "unauthorized",
+			status:       http.StatusUnauthorized,
+			expectedCode: "UNAUTHORIZED",
+		},
+		{
+			name:         "forbidden",
+			status:       http.StatusForbidden,
+			expectedCode: "FORBIDDEN",
+		},
+		{
 			name:         "not found",
 			status:       http.StatusNotFound,
 			expectedCode: "NOT_FOUND",
 		},
 		{
+			name:         "conflict",
+			status:       http.StatusConflict,
+			expectedCode: "CONFLICT",
+		},
+		{
 			name:         "unprocessable entity",
 			status:       http.StatusUnprocessableEntity,
 			expectedCode: "UNPROCESSABLE_ENTITY",
+		},
+		{
+			name:         "too many requests",
+			status:       http.StatusTooManyRequests,
+			expectedCode: "TOO_MANY_REQUESTS",
+		},
+		{
+			name:         "bad gateway",
+			status:       http.StatusBadGateway,
+			expectedCode: "BAD_GATEWAY",
+		},
+		{
+			name:         "service unavailable",
+			status:       http.StatusServiceUnavailable,
+			expectedCode: "SERVICE_UNAVAILABLE",
+		},
+		{
+			name:         "unknown client status",
+			status:       http.StatusTeapot,
+			expectedCode: "ERROR",
+		},
+		{
+			name:         "unknown server status",
+			status:       http.StatusGatewayTimeout,
+			expectedCode: "INTERNAL_ERROR",
 		},
 	}
 
@@ -242,21 +287,81 @@ func TestRespondInternalErrorSimple(t *testing.T) {
 	assert.Equal(t, "INTERNAL_ERROR", resp.Code)
 }
 
+func TestRespondTooManyRequests(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "custom message",
+			message:  "session creation rate limit exceeded",
+			expected: "session creation rate limit exceeded",
+		},
+		{
+			name:     "default message",
+			message:  "",
+			expected: "too many requests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			RespondTooManyRequests(c, tt.message)
+
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+			var resp APIError
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, resp.Error)
+			assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+		})
+	}
+}
+
 func TestRespondTooManyRequestsWithAuthState(t *testing.T) {
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
+	tests := []struct {
+		name          string
+		message       string
+		authenticated bool
+		expected      string
+	}{
+		{
+			name:          "authenticated custom message",
+			message:       "rate limit exceeded",
+			authenticated: true,
+			expected:      "rate limit exceeded",
+		},
+		{
+			name:          "anonymous default message",
+			message:       "",
+			authenticated: false,
+			expected:      "too many requests",
+		},
+	}
 
-	RespondTooManyRequestsWithAuthState(c, "rate limit exceeded", true)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
 
-	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+			RespondTooManyRequestsWithAuthState(c, tt.message, tt.authenticated)
 
-	var resp APIError
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	assert.Equal(t, "rate limit exceeded", resp.Error)
-	assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
-	require.NotNil(t, resp.Authenticated)
-	assert.True(t, *resp.Authenticated)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+			var resp APIError
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, resp.Error)
+			assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+			require.NotNil(t, resp.Authenticated)
+			assert.Equal(t, tt.authenticated, *resp.Authenticated)
+		})
+	}
 }
 
 func TestRespondServiceUnavailable(t *testing.T) {

--- a/pkg/apiresponses/responses.go
+++ b/pkg/apiresponses/responses.go
@@ -129,6 +129,19 @@ func RespondInternalErrorSimple(c *gin.Context, message string) {
 	})
 }
 
+// RespondTooManyRequestsWithRetryAfter sends a 429 Too Many Requests response
+// with a Retry-After header indicating when the client should retry.
+func RespondTooManyRequestsWithRetryAfter(c *gin.Context, retryAfter string, message string) {
+	if message == "" {
+		message = "too many requests"
+	}
+	c.Header("Retry-After", retryAfter)
+	c.JSON(http.StatusTooManyRequests, APIError{
+		Error: message,
+		Code:  "TOO_MANY_REQUESTS",
+	})
+}
+
 // RespondBadGateway sends a 502 Bad Gateway response.
 // Useful when proxying upstream services.
 func RespondBadGateway(c *gin.Context, message string) {

--- a/pkg/apiresponses/responses_test.go
+++ b/pkg/apiresponses/responses_test.go
@@ -224,6 +224,22 @@ func TestRespondInternalErrorSimple(t *testing.T) {
 	assert.Equal(t, "INTERNAL_ERROR", resp.Code)
 }
 
+func TestRespondTooManyRequestsWithRetryAfter(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	RespondTooManyRequestsWithRetryAfter(c, "3", "session creation rate limit exceeded")
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Equal(t, "3", w.Header().Get("Retry-After"))
+
+	var resp APIError
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "session creation rate limit exceeded", resp.Error)
+	assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+}
+
 func TestRespondBadGateway(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/apiresponses/responses_test.go
+++ b/pkg/apiresponses/responses_test.go
@@ -225,19 +225,40 @@ func TestRespondInternalErrorSimple(t *testing.T) {
 }
 
 func TestRespondTooManyRequestsWithRetryAfter(t *testing.T) {
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "custom message",
+			message:  "session creation rate limit exceeded",
+			expected: "session creation rate limit exceeded",
+		},
+		{
+			name:     "default message",
+			message:  "",
+			expected: "too many requests",
+		},
+	}
 
-	RespondTooManyRequestsWithRetryAfter(c, "3", "session creation rate limit exceeded")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
 
-	assert.Equal(t, http.StatusTooManyRequests, w.Code)
-	assert.Equal(t, "3", w.Header().Get("Retry-After"))
+			RespondTooManyRequestsWithRetryAfter(c, "3", tt.message)
 
-	var resp APIError
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	assert.Equal(t, "session creation rate limit exceeded", resp.Error)
-	assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+			assert.Equal(t, http.StatusTooManyRequests, w.Code)
+			assert.Equal(t, "3", w.Header().Get("Retry-After"))
+
+			var resp APIError
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, resp.Error)
+			assert.Equal(t, "TOO_MANY_REQUESTS", resp.Code)
+		})
+	}
 }
 
 func TestRespondBadGateway(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1178,10 +1178,11 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 				"userGroupCount", len(userGroups),
 				"errors", errMessages,
 			)
-			ctx.JSON(http.StatusBadRequest, gin.H{
-				"error":  "extraDeployValues validation failed",
-				"errors": errMessages,
-			})
+			apiresponses.RespondBadRequestWithDetails(
+				ctx,
+				"extraDeployValues validation failed",
+				strings.Join(errMessages, "; "),
+			)
 			return
 		}
 	}

--- a/pkg/breakglass/session_controller.go
+++ b/pkg/breakglass/session_controller.go
@@ -265,8 +265,11 @@ func (wc *BreakglassSessionController) handleRequestBreakglassSession(c *gin.Con
 		allowed, retryAfter := wc.sessionCreationLimiter.AllowWithRetryAfter(rateLimitKey)
 		if !allowed {
 			retrySecs := int(math.Ceil(retryAfter.Seconds()))
-			c.Header("Retry-After", fmt.Sprintf("%d", retrySecs))
-			c.JSON(http.StatusTooManyRequests, gin.H{"error": "session creation rate limit exceeded, please try again later"})
+			apiresponses.RespondTooManyRequestsWithRetryAfter(
+				c,
+				fmt.Sprintf("%d", retrySecs),
+				"session creation rate limit exceeded, please try again later",
+			)
 			return
 		}
 	}
@@ -323,7 +326,7 @@ func (wc *BreakglassSessionController) handleRequestBreakglassSession(c *gin.Con
 		if _, loaded := wc.inFlightCreates.LoadOrStore(createKey, true); loaded {
 			reqLog.Infow("Concurrent session creation already in-flight, returning conflict",
 				"cluster", request.Clustername, "user", userIdentifier, "group", system.RedactGroupName(request.GroupName))
-			c.JSON(http.StatusConflict, gin.H{"error": "session creation already in progress"})
+			apiresponses.RespondConflict(c, "session creation already in progress")
 			return
 		}
 		defer wc.inFlightCreates.Delete(createKey)

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -23,31 +23,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type breakglassSessionErrorResponse struct {
-	Error   string                               `json:"error"`
-	Code    string                               `json:"code"`
-	Session breakglassv1alpha1.BreakglassSession `json:"session"`
-}
-
-type breakglassSessionNameErrorResponse struct {
-	Error   string `json:"error"`
-	Code    string `json:"code"`
-	Session string `json:"session"`
-}
-
 func respondBreakglassSessionError(c *gin.Context, status int, message string, session breakglassv1alpha1.BreakglassSession) {
-	c.JSON(status, breakglassSessionErrorResponse{
-		Error:   message,
-		Code:    breakglassSessionErrorCode(status),
-		Session: session,
+	c.JSON(status, gin.H{
+		"error":   message,
+		"code":    breakglassSessionErrorCode(status),
+		"session": session,
 	})
 }
 
 func respondBreakglassSessionNotFound(c *gin.Context, sessionName string) {
-	c.JSON(http.StatusNotFound, breakglassSessionNameErrorResponse{
-		Error:   "session not found",
-		Code:    "NOT_FOUND",
-		Session: sessionName,
+	c.JSON(http.StatusNotFound, gin.H{
+		"error":   "session not found",
+		"code":    "NOT_FOUND",
+		"session": sessionName,
 	})
 }
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -24,19 +24,11 @@ import (
 )
 
 func respondBreakglassSessionError(c *gin.Context, status int, message string, session breakglassv1alpha1.BreakglassSession) {
-	c.JSON(status, gin.H{
-		"error":   message,
-		"code":    breakglassSessionErrorCode(status),
-		"session": session,
-	})
+	c.JSON(status, gin.H{"error": message, "code": breakglassSessionErrorCode(status), "session": session})
 }
 
 func respondBreakglassSessionNotFound(c *gin.Context, sessionName string) {
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "session not found",
-		"code":    "NOT_FOUND",
-		"session": sessionName,
-	})
+	c.JSON(http.StatusNotFound, gin.H{"error": "session not found", "code": "NOT_FOUND", "session": sessionName})
 }
 
 func breakglassSessionErrorCode(status int) string {

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -23,6 +23,50 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type breakglassSessionErrorResponse struct {
+	Error   string                               `json:"error"`
+	Code    string                               `json:"code"`
+	Session breakglassv1alpha1.BreakglassSession `json:"session"`
+}
+
+type breakglassSessionNameErrorResponse struct {
+	Error   string `json:"error"`
+	Code    string `json:"code"`
+	Session string `json:"session"`
+}
+
+func respondBreakglassSessionError(c *gin.Context, status int, message string, session breakglassv1alpha1.BreakglassSession) {
+	c.JSON(status, breakglassSessionErrorResponse{
+		Error:   message,
+		Code:    breakglassSessionErrorCode(status),
+		Session: session,
+	})
+}
+
+func respondBreakglassSessionNotFound(c *gin.Context, sessionName string) {
+	c.JSON(http.StatusNotFound, breakglassSessionNameErrorResponse{
+		Error:   "session not found",
+		Code:    "NOT_FOUND",
+		Session: sessionName,
+	})
+}
+
+func breakglassSessionErrorCode(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "BAD_REQUEST"
+	case http.StatusConflict:
+		return "CONFLICT"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	default:
+		if status >= http.StatusInternalServerError {
+			return "INTERNAL_ERROR"
+		}
+		return "ERROR"
+	}
+}
+
 func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondition breakglassv1alpha1.BreakglassSessionConditionType) {
 	reqLog := system.GetReqLogger(c, wc.log)
 	reqLog = system.EnrichReqLoggerWithAuth(c, reqLog)
@@ -111,15 +155,7 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 
 	// If the session already has the same last condition, return conflict to avoid repeated transitions.
 	if lastCondition.Type == string(sesCondition) {
-		c.JSON(http.StatusConflict, struct {
-			Error   string                               `json:"error"`
-			Code    string                               `json:"code"`
-			Session breakglassv1alpha1.BreakglassSession `json:"session"`
-		}{
-			Error:   "session already in requested state",
-			Code:    "CONFLICT",
-			Session: bs,
-		})
+		respondBreakglassSessionError(c, http.StatusConflict, "session already in requested state", bs)
 		return
 	}
 
@@ -135,40 +171,16 @@ func (wc *BreakglassSessionController) setSessionStatus(c *gin.Context, sesCondi
 			if sesCondition == breakglassv1alpha1.SessionConditionTypeRejected {
 				action = "rejection"
 			}
-			c.JSON(http.StatusBadRequest, struct {
-				Error   string                               `json:"error"`
-				Code    string                               `json:"code"`
-				Session breakglassv1alpha1.BreakglassSession `json:"session"`
-			}{
-				Error:   fmt.Sprintf("session approval timeout has elapsed; cannot perform %s", action),
-				Code:    "BAD_REQUEST",
-				Session: bs,
-			})
+			respondBreakglassSessionError(c, http.StatusBadRequest, fmt.Sprintf("session approval timeout has elapsed; cannot perform %s", action), bs)
 			return
 		}
 		if currState != breakglassv1alpha1.SessionStatePending {
-			c.JSON(http.StatusBadRequest, struct {
-				Error   string                               `json:"error"`
-				Code    string                               `json:"code"`
-				Session breakglassv1alpha1.BreakglassSession `json:"session"`
-			}{
-				Error:   fmt.Sprintf("session must be pending to perform %s; current state: %s", sesCondition, currState),
-				Code:    "BAD_REQUEST",
-				Session: bs,
-			})
+			respondBreakglassSessionError(c, http.StatusBadRequest, fmt.Sprintf("session must be pending to perform %s; current state: %s", sesCondition, currState), bs)
 			return
 		}
 	} else {
 		if currState == breakglassv1alpha1.SessionStateRejected || currState == breakglassv1alpha1.SessionStateWithdrawn || currState == breakglassv1alpha1.SessionStateExpired || currState == breakglassv1alpha1.SessionStateTimeout || currState == breakglassv1alpha1.SessionStateIdleExpired {
-			c.JSON(http.StatusBadRequest, struct {
-				Error   string                               `json:"error"`
-				Code    string                               `json:"code"`
-				Session breakglassv1alpha1.BreakglassSession `json:"session"`
-			}{
-				Error:   fmt.Sprintf("session is in terminal state %s and cannot be modified", currState),
-				Code:    "BAD_REQUEST",
-				Session: bs,
-			})
+			respondBreakglassSessionError(c, http.StatusBadRequest, fmt.Sprintf("session is in terminal state %s and cannot be modified", currState), bs)
 			return
 		}
 	}
@@ -1042,7 +1054,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionByName(c *gin.C
 	ses, err := wc.sessionManager.GetBreakglassSessionByName(c.Request.Context(), sessionName)
 	if err != nil {
 		reqLog.Warnw("Session not found", "session", sessionName, "error", err)
-		apiresponses.RespondNotFound(c, "session", sessionName)
+		respondBreakglassSessionNotFound(c, sessionName)
 		return
 	}
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -1042,15 +1042,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionByName(c *gin.C
 	ses, err := wc.sessionManager.GetBreakglassSessionByName(c.Request.Context(), sessionName)
 	if err != nil {
 		reqLog.Warnw("Session not found", "session", sessionName, "error", err)
-		c.JSON(http.StatusNotFound, struct {
-			Error   string `json:"error"`
-			Code    string `json:"code"`
-			Session string `json:"session"`
-		}{
-			Error:   "session not found",
-			Code:    "NOT_FOUND",
-			Session: sessionName,
-		})
+		apiresponses.RespondNotFound(c, "session", sessionName)
 		return
 	}
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -1045,8 +1045,12 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionByName(c *gin.C
 
 	ses, err := wc.sessionManager.GetBreakglassSessionByName(c.Request.Context(), sessionName)
 	if err != nil {
-		reqLog.Warnw("Session not found", "session", sessionName, "error", err)
-		respondBreakglassSessionNotFound(c, sessionName)
+		if apierrors.IsNotFound(err) {
+			reqLog.Warnw("Session not found", "session", sessionName, "error", err)
+			respondBreakglassSessionNotFound(c, sessionName)
+		} else {
+			apiresponses.RespondInternalError(c, "lookup session", err, reqLog)
+		}
 		return
 	}
 

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -55,10 +55,22 @@ func breakglassSessionErrorCode(status int) string {
 	switch status {
 	case http.StatusBadRequest:
 		return "BAD_REQUEST"
+	case http.StatusUnauthorized:
+		return "UNAUTHORIZED"
+	case http.StatusForbidden:
+		return "FORBIDDEN"
 	case http.StatusConflict:
 		return "CONFLICT"
 	case http.StatusNotFound:
 		return "NOT_FOUND"
+	case http.StatusUnprocessableEntity:
+		return "UNPROCESSABLE_ENTITY"
+	case http.StatusTooManyRequests:
+		return "TOO_MANY_REQUESTS"
+	case http.StatusBadGateway:
+		return "BAD_GATEWAY"
+	case http.StatusServiceUnavailable:
+		return "SERVICE_UNAVAILABLE"
 	default:
 		if status >= http.StatusInternalServerError {
 			return "INTERNAL_ERROR"

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -23,12 +23,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type breakglassSessionErrorResponse struct {
+	Error   string                               `json:"error"`
+	Code    string                               `json:"code"`
+	Session breakglassv1alpha1.BreakglassSession `json:"session"`
+}
+
+type breakglassSessionNameErrorResponse struct {
+	Error   string `json:"error"`
+	Code    string `json:"code"`
+	Session string `json:"session"`
+}
+
 func respondBreakglassSessionError(c *gin.Context, status int, message string, session breakglassv1alpha1.BreakglassSession) {
-	c.JSON(status, gin.H{"error": message, "code": breakglassSessionErrorCode(status), "session": session})
+	c.JSON(status, breakglassSessionErrorResponse{Error: message, Code: breakglassSessionErrorCode(status), Session: session})
 }
 
 func respondBreakglassSessionNotFound(c *gin.Context, sessionName string) {
-	c.JSON(http.StatusNotFound, gin.H{"error": "session not found", "code": "NOT_FOUND", "session": sessionName})
+	c.JSON(http.StatusNotFound, breakglassSessionNameErrorResponse{Error: "session not found", Code: "NOT_FOUND", Session: sessionName})
 }
 
 func breakglassSessionErrorCode(status int) string {

--- a/pkg/breakglass/session_controller_status_test.go
+++ b/pkg/breakglass/session_controller_status_test.go
@@ -55,6 +55,74 @@ func TestRespondBreakglassSessionNotFoundPreservesSessionField(t *testing.T) {
 	assert.Equal(t, "missing-session", response["session"])
 }
 
+func TestSetSessionStatusHelperRejectsTerminalNonApprovalTransition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	log := zaptest.NewLogger(t).Sugar()
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "expired-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "test-cluster",
+			User:         "requester@example.com",
+			GrantedGroup: "admin-group",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateExpired,
+		},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-escalation"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"test-cluster"},
+				Groups:   []string{"system:authenticated"},
+			},
+			EscalatedGroup: "admin-group",
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Users: []string{"approver@example.com"},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(session, escalation).Build()
+	ctrl := &BreakglassSessionController{
+		log:               log,
+		sessionManager:    &SessionManager{Client: fakeClient},
+		escalationManager: &testEscalationLookup{Client: fakeClient},
+		identityProvider:  KeycloakIdentityProvider{log: log},
+	}
+	ctrl.getUserGroupsFn = func(context.Context, ClusterUserGroup) ([]string, error) {
+		return []string{"system:authenticated"}, nil
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// setSessionStatus is currently registered only for approve/reject routes.
+	// This direct helper call documents the defensive branch used if an internal
+	// caller adds a non-approval transition later.
+	c.Request = httptest.NewRequest(http.MethodPost, "/internal/session-status-helper", nil)
+	c.Params = gin.Params{{Key: "name", Value: "expired-session"}}
+	c.Set("email", "approver@example.com")
+	c.Set("username", "approver")
+	c.Set("user_id", "approver@example.com")
+	c.Set("groups", []string{"system:authenticated"})
+
+	ctrl.setSessionStatus(c, breakglassv1alpha1.SessionConditionTypeExpired)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var response map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	var message, code string
+	require.NoError(t, json.Unmarshal(response["error"], &message))
+	require.NoError(t, json.Unmarshal(response["code"], &code))
+	var responseSession breakglassv1alpha1.BreakglassSession
+	require.NoError(t, json.Unmarshal(response["session"], &responseSession))
+	assert.Equal(t, "session is in terminal state Expired and cannot be modified", message)
+	assert.Equal(t, "BAD_REQUEST", code)
+	assert.Equal(t, "expired-session", responseSession.Name)
+}
+
 func TestBreakglassSessionErrorCode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/breakglass/session_controller_status_test.go
+++ b/pkg/breakglass/session_controller_status_test.go
@@ -28,11 +28,16 @@ func TestRespondBreakglassSessionErrorIncludesSession(t *testing.T) {
 	respondBreakglassSessionError(c, http.StatusConflict, "session already in requested state", session)
 
 	require.Equal(t, http.StatusConflict, w.Code)
-	var response breakglassSessionErrorResponse
+	var response map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.Equal(t, "session already in requested state", response.Error)
-	assert.Equal(t, "CONFLICT", response.Code)
-	assert.Equal(t, "session-1", response.Session.Name)
+	var message, code string
+	require.NoError(t, json.Unmarshal(response["error"], &message))
+	require.NoError(t, json.Unmarshal(response["code"], &code))
+	var responseSession breakglassv1alpha1.BreakglassSession
+	require.NoError(t, json.Unmarshal(response["session"], &responseSession))
+	assert.Equal(t, "session already in requested state", message)
+	assert.Equal(t, "CONFLICT", code)
+	assert.Equal(t, "session-1", responseSession.Name)
 }
 
 func TestRespondBreakglassSessionNotFoundPreservesSessionField(t *testing.T) {
@@ -43,11 +48,11 @@ func TestRespondBreakglassSessionNotFoundPreservesSessionField(t *testing.T) {
 	respondBreakglassSessionNotFound(c, "missing-session")
 
 	require.Equal(t, http.StatusNotFound, w.Code)
-	var response breakglassSessionNameErrorResponse
+	var response map[string]string
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.Equal(t, "session not found", response.Error)
-	assert.Equal(t, "NOT_FOUND", response.Code)
-	assert.Equal(t, "missing-session", response.Session)
+	assert.Equal(t, "session not found", response["error"])
+	assert.Equal(t, "NOT_FOUND", response["code"])
+	assert.Equal(t, "missing-session", response["session"])
 }
 
 func TestBreakglassSessionErrorCode(t *testing.T) {

--- a/pkg/breakglass/session_controller_status_test.go
+++ b/pkg/breakglass/session_controller_status_test.go
@@ -62,6 +62,16 @@ func TestBreakglassSessionErrorCode(t *testing.T) {
 			expected: "BAD_REQUEST",
 		},
 		{
+			name:     "unauthorized",
+			status:   http.StatusUnauthorized,
+			expected: "UNAUTHORIZED",
+		},
+		{
+			name:     "forbidden",
+			status:   http.StatusForbidden,
+			expected: "FORBIDDEN",
+		},
+		{
 			name:     "conflict",
 			status:   http.StatusConflict,
 			expected: "CONFLICT",
@@ -72,13 +82,33 @@ func TestBreakglassSessionErrorCode(t *testing.T) {
 			expected: "NOT_FOUND",
 		},
 		{
+			name:     "unprocessable entity",
+			status:   http.StatusUnprocessableEntity,
+			expected: "UNPROCESSABLE_ENTITY",
+		},
+		{
+			name:     "too many requests",
+			status:   http.StatusTooManyRequests,
+			expected: "TOO_MANY_REQUESTS",
+		},
+		{
+			name:     "bad gateway",
+			status:   http.StatusBadGateway,
+			expected: "BAD_GATEWAY",
+		},
+		{
+			name:     "service unavailable",
+			status:   http.StatusServiceUnavailable,
+			expected: "SERVICE_UNAVAILABLE",
+		},
+		{
 			name:     "unknown client status",
 			status:   http.StatusTeapot,
 			expected: "ERROR",
 		},
 		{
 			name:     "unknown server status",
-			status:   http.StatusBadGateway,
+			status:   http.StatusGatewayTimeout,
 			expected: "INTERNAL_ERROR",
 		},
 	}

--- a/pkg/breakglass/session_controller_status_test.go
+++ b/pkg/breakglass/session_controller_status_test.go
@@ -50,6 +50,46 @@ func TestRespondBreakglassSessionNotFoundPreservesSessionField(t *testing.T) {
 	assert.Equal(t, "missing-session", response.Session)
 }
 
+func TestBreakglassSessionErrorCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		expected string
+	}{
+		{
+			name:     "bad request",
+			status:   http.StatusBadRequest,
+			expected: "BAD_REQUEST",
+		},
+		{
+			name:     "conflict",
+			status:   http.StatusConflict,
+			expected: "CONFLICT",
+		},
+		{
+			name:     "not found",
+			status:   http.StatusNotFound,
+			expected: "NOT_FOUND",
+		},
+		{
+			name:     "unknown client status",
+			status:   http.StatusTeapot,
+			expected: "ERROR",
+		},
+		{
+			name:     "unknown server status",
+			status:   http.StatusBadGateway,
+			expected: "INTERNAL_ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, breakglassSessionErrorCode(tt.status))
+		})
+	}
+}
+
 func TestCheckSessionLimits_MissingIDP(t *testing.T) {
 	log := zaptest.NewLogger(t).Sugar()
 	scheme := runtime.NewScheme()

--- a/pkg/breakglass/session_controller_status_test.go
+++ b/pkg/breakglass/session_controller_status_test.go
@@ -2,15 +2,53 @@ package breakglass
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestRespondBreakglassSessionErrorIncludesSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-1"},
+	}
+	respondBreakglassSessionError(c, http.StatusConflict, "session already in requested state", session)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	var response breakglassSessionErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "session already in requested state", response.Error)
+	assert.Equal(t, "CONFLICT", response.Code)
+	assert.Equal(t, "session-1", response.Session.Name)
+}
+
+func TestRespondBreakglassSessionNotFoundPreservesSessionField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	respondBreakglassSessionNotFound(c, "missing-session")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	var response breakglassSessionNameErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "session not found", response.Error)
+	assert.Equal(t, "NOT_FOUND", response.Code)
+	assert.Equal(t, "missing-session", response.Session)
+}
 
 func TestCheckSessionLimits_MissingIDP(t *testing.T) {
 	log := zaptest.NewLogger(t).Sugar()

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -5491,6 +5491,30 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 			TimeoutAt: metav1.NewTime(time.Now().UTC().Add(time.Hour)),
 		},
 	}
+	ambiguousA := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "ambiguous-reader-session", Namespace: "team-a"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-read",
+			User:         "alice@example.com",
+			GrantedGroup: "approvable",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStatePending,
+			TimeoutAt: metav1.NewTime(time.Now().UTC().Add(time.Hour)),
+		},
+	}
+	ambiguousB := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "ambiguous-reader-session", Namespace: "team-b"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cl-read",
+			User:         "alice@example.com",
+			GrantedGroup: "approvable",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStatePending,
+			TimeoutAt: metav1.NewTime(time.Now().UTC().Add(time.Hour)),
+		},
+	}
 	esc := &breakglassv1alpha1.BreakglassEscalation{
 		ObjectMeta: metav1.ObjectMeta{Name: "esc-readable"},
 		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
@@ -5500,7 +5524,7 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 		},
 	}
 
-	cli := builder.WithObjects(pending, approved, usernameRequester, esc).Build()
+	cli := builder.WithObjects(pending, approved, usernameRequester, ambiguousA, ambiguousB, esc).Build()
 	sesmanager := SessionManager{Client: cli}
 	escmanager := testEscalationLookup{Client: cli}
 	logger, _ := zap.NewDevelopment()
@@ -5601,6 +5625,11 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 	require.Equal(t, "session not found", body["error"])
 	require.Equal(t, "NOT_FOUND", body["code"])
 	require.Equal(t, "missing-reader-session", body["session"])
+
+	status, body = serveAs("alice@example.com", "ambiguous-reader-session")
+	require.Equal(t, http.StatusInternalServerError, status)
+	require.Equal(t, "failed to lookup session", body["error"])
+	require.Equal(t, "INTERNAL_ERROR", body["code"])
 }
 
 func TestGetBreakglassSessionByNameApprovalTimedOutMetadata(t *testing.T) {

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -5595,6 +5595,12 @@ func TestGetBreakglassSessionByNameRequiresParticipantAuthorization(t *testing.T
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "reader-sess-3", sessionNameFromBody(body))
 	require.True(t, isRequesterFromBody(body), "expected approval metadata to recognize requester without email claim")
+
+	status, body = serveAs("alice@example.com", "missing-reader-session")
+	require.Equal(t, http.StatusNotFound, status)
+	require.Equal(t, "session not found", body["error"])
+	require.Equal(t, "NOT_FOUND", body["code"])
+	require.Equal(t, "missing-reader-session", body["session"])
 }
 
 func TestGetBreakglassSessionByNameApprovalTimedOutMetadata(t *testing.T) {
@@ -8680,6 +8686,30 @@ func TestWaitingForScheduledTimeSessionsOccupyRequestSlots(t *testing.T) {
 		require.False(t, ok)
 		require.Equal(t, http.StatusConflict, w.Code)
 		require.Contains(t, w.Body.String(), "already approved")
+	})
+
+	t.Run("duplicate request returns generic conflict for malformed slot-occupying session", func(t *testing.T) {
+		session := waitingSession("malformed-waiting-session")
+		session.Status.ApprovedAt = metav1.Time{}
+		cli := newIndexedClient(session)
+		ctrl := newController(cli)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		ok := ctrl.checkDuplicateSession(
+			c,
+			context.Background(),
+			"user@example.com",
+			"test-cluster",
+			"admin-group",
+			zap.NewNop().Sugar(),
+		)
+
+		require.False(t, ok)
+		require.Equal(t, http.StatusConflict, w.Code)
+		require.Contains(t, w.Body.String(), "session exists")
+		require.Contains(t, w.Body.String(), `"code":"CONFLICT"`)
 	})
 
 	t.Run("per-user limit counts scheduled waiting sessions", func(t *testing.T) {

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -38,11 +38,7 @@ type escalationResolutionResult struct {
 }
 
 func respondDuplicateSessionConflict(c *gin.Context, message string, ses breakglassv1alpha1.BreakglassSession) {
-	c.JSON(http.StatusConflict, gin.H{
-		"error":   message,
-		"code":    "CONFLICT",
-		"session": ses,
-	})
+	c.JSON(http.StatusConflict, gin.H{"error": message, "code": "CONFLICT", "session": ses})
 }
 
 // sessionCreateParams bundles the inputs needed for session creation and persistence.

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -37,17 +37,11 @@ type escalationResolutionResult struct {
 	selectedDenyPolicies []string
 }
 
-type duplicateSessionConflictResponse struct {
-	Error   string                               `json:"error"`
-	Code    string                               `json:"code"`
-	Session breakglassv1alpha1.BreakglassSession `json:"session"`
-}
-
 func respondDuplicateSessionConflict(c *gin.Context, message string, ses breakglassv1alpha1.BreakglassSession) {
-	c.JSON(http.StatusConflict, duplicateSessionConflictResponse{
-		Error:   message,
-		Code:    "CONFLICT",
-		Session: ses,
+	c.JSON(http.StatusConflict, gin.H{
+		"error":   message,
+		"code":    "CONFLICT",
+		"session": ses,
 	})
 }
 

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -37,6 +37,20 @@ type escalationResolutionResult struct {
 	selectedDenyPolicies []string
 }
 
+type duplicateSessionConflictResponse struct {
+	Error   string                               `json:"error"`
+	Code    string                               `json:"code"`
+	Session breakglassv1alpha1.BreakglassSession `json:"session"`
+}
+
+func respondDuplicateSessionConflict(c *gin.Context, message string, ses breakglassv1alpha1.BreakglassSession) {
+	c.JSON(http.StatusConflict, duplicateSessionConflictResponse{
+		Error:   message,
+		Code:    "CONFLICT",
+		Session: ses,
+	})
+}
+
 // sessionCreateParams bundles the inputs needed for session creation and persistence.
 type sessionCreateParams struct {
 	spec           breakglassv1alpha1.BreakglassSessionSpec
@@ -437,18 +451,18 @@ func (wc *BreakglassSessionController) checkDuplicateSession(
 
 	// Approved session -> explicit "already approved" error
 	if ses.Status.State == breakglassv1alpha1.SessionStateApproved || !ses.Status.ApprovedAt.IsZero() {
-		c.JSON(http.StatusConflict, gin.H{"error": "already approved", "session": ses})
+		respondDuplicateSessionConflict(c, "already approved", ses)
 		return false
 	}
 
 	// Pending (requested but not yet approved/rejected) -> "already requested" with linked session
 	if IsSessionPendingApproval(ses) {
-		c.JSON(http.StatusConflict, gin.H{"error": "already requested", "session": ses})
+		respondDuplicateSessionConflict(c, "already requested", ses)
 		return false
 	}
 
 	// Fallback: session exists but in another terminal state (e.g. timeout) — return generic conflict with session
-	c.JSON(http.StatusConflict, gin.H{"error": "session exists", "session": ses})
+	respondDuplicateSessionConflict(c, "session exists", ses)
 	return false
 }
 

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -37,8 +37,14 @@ type escalationResolutionResult struct {
 	selectedDenyPolicies []string
 }
 
+type duplicateSessionConflictResponse struct {
+	Error   string                               `json:"error"`
+	Code    string                               `json:"code"`
+	Session breakglassv1alpha1.BreakglassSession `json:"session"`
+}
+
 func respondDuplicateSessionConflict(c *gin.Context, message string, ses breakglassv1alpha1.BreakglassSession) {
-	c.JSON(http.StatusConflict, gin.H{"error": message, "code": "CONFLICT", "session": ses})
+	c.JSON(http.StatusConflict, duplicateSessionConflictResponse{Error: message, Code: "CONFLICT", Session: ses})
 }
 
 // sessionCreateParams bundles the inputs needed for session creation and persistence.


### PR DESCRIPTION
## Summary
- standardize remaining raw API and Breakglass error responses behind shared helpers
- preserve existing compatibility fields where clients already consume them, including rate-limit `authenticated` and duplicate-session `session` payloads
- add focused regression coverage for origin rejection, no-route JSON, auth rate limits, API helpers, and Breakglass response helpers

Refs #538.

## Validation
- `go test ./pkg/api ./pkg/apiresponses ./pkg/breakglass/... -run 'Respond|NoRoute|OriginValidation|RateLimiting|Duplicate|ExtraDeployValues|GetBreakglassSessionByName|RequestBreakglassSession'`\n- `make test`\n- `git diff --check`\n\n## Notes\n- Kept this scoped to response-shape consistency. Broader API error taxonomy and public documentation can remain separate follow-up work if needed.