### PR TITLE
cli: improve bgctl session help and update progress

### DIFF
--- a/pkg/bgctl/cmd/session.go
+++ b/pkg/bgctl/cmd/session.go
@@ -48,6 +48,13 @@ func newSessionWatchCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Watch session changes",
+		Long: `Watch breakglass session changes by polling the API.
+
+The command prints sessions when they first appear or when their state changes.
+Use filters to reduce noise in busy environments.`,
+		Example: `  bgctl session watch --mine
+  bgctl session watch -C prod -s Pending,Approved -i 5s
+  bgctl session watch --show-full -o json`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -138,15 +145,15 @@ func newSessionWatchCommand() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().DurationVar(&interval, "interval", 2*time.Second, "Polling interval (Go duration, e.g. 2s, 1m)")
-	cmd.Flags().StringVar(&cluster, "cluster", "", "Filter by cluster")
-	cmd.Flags().StringVar(&user, "user", "", "Filter by user")
-	cmd.Flags().StringVar(&group, "group", "", "Filter by group")
-	cmd.Flags().StringVar(&state, "state", "", "Filter by state (comma-separated)")
-	cmd.Flags().BoolVar(&mine, "mine", false, "Only show sessions created by the current user")
+	cmd.Flags().DurationVarP(&interval, "interval", "i", 2*time.Second, "Polling interval (Go duration, e.g. 2s, 1m)")
+	cmd.Flags().StringVarP(&cluster, "cluster", "C", "", "Filter by cluster")
+	cmd.Flags().StringVarP(&user, "user", "u", "", "Filter by user")
+	cmd.Flags().StringVarP(&group, "group", "g", "", "Filter by group")
+	cmd.Flags().StringVarP(&state, "state", "s", "", "Filter by state (comma-separated)")
+	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Only show sessions created by the current user")
 	cmd.Flags().BoolVar(&approver, "approver", true, "Include sessions where you are an approver")
-	cmd.Flags().BoolVar(&activeOnly, "active", false, "Only show active sessions")
-	cmd.Flags().BoolVar(&showFull, "show-full", false, "Show full session on change (respects -o json|yaml)")
+	cmd.Flags().BoolVarP(&activeOnly, "active", "A", false, "Only show active sessions")
+	cmd.Flags().BoolVarP(&showFull, "show-full", "f", false, "Show full session JSON on change")
 	return cmd
 }
 
@@ -167,6 +174,13 @@ func newSessionListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List breakglass sessions",
+		Long: `List breakglass sessions visible to the current user.
+
+By default the command includes sessions where you are an approver. Use --mine
+to show only your own requests, or --approved-by-me for sessions you approved.`,
+		Example: `  bgctl session list --mine
+  bgctl session list -C prod -s Pending,Approved -o wide
+  bgctl session list --approved-by-me --all`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -218,17 +232,17 @@ func newSessionListCommand() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().BoolVar(&mine, "mine", false, "Only show sessions created by the current user")
+	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Only show sessions created by the current user")
 	cmd.Flags().BoolVar(&approver, "approver", true, "Include sessions where you are an approver")
-	cmd.Flags().BoolVar(&approvedByMe, "approved-by-me", false, "Only show sessions approved by you")
-	cmd.Flags().BoolVar(&activeOnly, "active", false, "Only show active sessions")
-	cmd.Flags().StringVar(&cluster, "cluster", "", "Filter by cluster name")
-	cmd.Flags().StringVar(&user, "user", "", "Filter by user")
-	cmd.Flags().StringVar(&group, "group", "", "Filter by group")
-	cmd.Flags().StringVar(&state, "state", "", "Filter by state (comma-separated)")
-	cmd.Flags().IntVar(&page, "page", 1, "Page number")
+	cmd.Flags().BoolVarP(&approvedByMe, "approved-by-me", "M", false, "Only show sessions approved by you")
+	cmd.Flags().BoolVarP(&activeOnly, "active", "A", false, "Only show active sessions")
+	cmd.Flags().StringVarP(&cluster, "cluster", "C", "", "Filter by cluster name")
+	cmd.Flags().StringVarP(&user, "user", "u", "", "Filter by user")
+	cmd.Flags().StringVarP(&group, "group", "g", "", "Filter by group")
+	cmd.Flags().StringVarP(&state, "state", "s", "", "Filter by state (comma-separated)")
+	cmd.Flags().IntVarP(&page, "page", "p", 1, "Page number")
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "Items per page")
-	cmd.Flags().BoolVar(&allPages, "all", false, "Disable pagination")
+	cmd.Flags().BoolVarP(&allPages, "all", "a", false, "Disable pagination")
 	return cmd
 }
 
@@ -280,6 +294,13 @@ func newSessionRequestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request",
 		Short: "Request a new breakglass session",
+		Long: `Request a new breakglass session for a cluster and group.
+
+The user defaults to the authenticated token identity when available. Provide a
+reason when the escalation policy requires one.`,
+		Example: `  bgctl session request -C prod -g platform-admin -r "debug incident INC-123"
+  bgctl session request --cluster prod --group read-only --duration 3600
+  bgctl session request -C prod -g platform-admin --scheduled-start 2026-07-02T12:00:00Z`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -315,12 +336,12 @@ func newSessionRequestCommand() *cobra.Command {
 			return writeRuntimeObject(rt, session, output.FormatTable, output.FormatJSON, output.FormatYAML)
 		},
 	}
-	cmd.Flags().StringVar(&cluster, "cluster", "", "Target cluster")
-	cmd.Flags().StringVar(&group, "group", "", "Group to request")
-	cmd.Flags().StringVar(&user, "user", "", "User identifier (defaults to token user)")
-	cmd.Flags().StringVar(&reason, "reason", "", "Reason for request")
-	cmd.Flags().Int64Var(&duration, "duration", 0, "Requested duration in seconds")
-	cmd.Flags().StringVar(&scheduled, "scheduled-start", "", "Scheduled start time (RFC3339)")
+	cmd.Flags().StringVarP(&cluster, "cluster", "C", "", "Target cluster")
+	cmd.Flags().StringVarP(&group, "group", "g", "", "Group to request")
+	cmd.Flags().StringVarP(&user, "user", "u", "", "User identifier (defaults to token user)")
+	cmd.Flags().StringVarP(&reason, "reason", "r", "", "Reason for request")
+	cmd.Flags().Int64VarP(&duration, "duration", "d", 0, "Requested duration in seconds")
+	cmd.Flags().StringVarP(&scheduled, "scheduled-start", "S", "", "Scheduled start time (RFC3339)")
 	_ = cmd.MarkFlagRequired("cluster")
 	_ = cmd.MarkFlagRequired("group")
 	return cmd
@@ -353,7 +374,7 @@ func newSessionApproveCommand() *cobra.Command {
 			return writeRuntimeObject(rt, session, output.FormatTable, output.FormatJSON, output.FormatYAML)
 		},
 	}
-	cmd.Flags().StringVar(&reason, "reason", "", "Approval reason")
+	cmd.Flags().StringVarP(&reason, "reason", "r", "", "Approval reason")
 	return cmd
 }
 
@@ -384,7 +405,7 @@ func newSessionRejectCommand() *cobra.Command {
 			return writeRuntimeObject(rt, session, output.FormatTable, output.FormatJSON, output.FormatYAML)
 		},
 	}
-	cmd.Flags().StringVar(&reason, "reason", "", "Rejection reason")
+	cmd.Flags().StringVarP(&reason, "reason", "r", "", "Rejection reason")
 	return cmd
 }
 

--- a/pkg/bgctl/cmd/session.go
+++ b/pkg/bgctl/cmd/session.go
@@ -300,7 +300,7 @@ The user defaults to the authenticated token identity when available. Provide a
 reason when the escalation policy requires one.`,
 		Example: `  bgctl session request -C prod -g platform-admin -r "debug incident INC-123"
   bgctl session request --cluster prod --group read-only --duration 3600
-  bgctl session request -C prod -g platform-admin --scheduled-start 2026-07-02T12:00:00Z`,
+  bgctl session request -C prod -g platform-admin --scheduled-start <RFC3339_TIMESTAMP>`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {

--- a/pkg/bgctl/cmd/session_command_test.go
+++ b/pkg/bgctl/cmd/session_command_test.go
@@ -48,6 +48,20 @@ func TestSessionListCommand_DefaultFlags(t *testing.T) {
 	assert.False(t, activeOnly)
 }
 
+func TestSessionListCommand_ShorthandFlags(t *testing.T) {
+	cmd := newSessionListCommand()
+
+	assert.Equal(t, "C", cmd.Flags().Lookup("cluster").Shorthand)
+	assert.Equal(t, "u", cmd.Flags().Lookup("user").Shorthand)
+	assert.Equal(t, "g", cmd.Flags().Lookup("group").Shorthand)
+	assert.Equal(t, "s", cmd.Flags().Lookup("state").Shorthand)
+	assert.Equal(t, "m", cmd.Flags().Lookup("mine").Shorthand)
+	assert.Equal(t, "A", cmd.Flags().Lookup("active").Shorthand)
+	assert.Equal(t, "M", cmd.Flags().Lookup("approved-by-me").Shorthand)
+	assert.Equal(t, "p", cmd.Flags().Lookup("page").Shorthand)
+	assert.Equal(t, "a", cmd.Flags().Lookup("all").Shorthand)
+}
+
 func TestSessionApproverOption(t *testing.T) {
 	t.Run("unset flag omits option", func(t *testing.T) {
 		cmd := newSessionListCommand()
@@ -288,4 +302,33 @@ func TestSessionWatchCommand_ShowFullRejectsUnsupportedOutputFormat(t *testing.T
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `unsupported output format: "xml"`)
+}
+
+func TestSessionWatchCommand_ShorthandFlags(t *testing.T) {
+	cmd := newSessionWatchCommand()
+
+	assert.Equal(t, "i", cmd.Flags().Lookup("interval").Shorthand)
+	assert.Equal(t, "C", cmd.Flags().Lookup("cluster").Shorthand)
+	assert.Equal(t, "u", cmd.Flags().Lookup("user").Shorthand)
+	assert.Equal(t, "g", cmd.Flags().Lookup("group").Shorthand)
+	assert.Equal(t, "s", cmd.Flags().Lookup("state").Shorthand)
+	assert.Equal(t, "m", cmd.Flags().Lookup("mine").Shorthand)
+	assert.Equal(t, "A", cmd.Flags().Lookup("active").Shorthand)
+	assert.Equal(t, "f", cmd.Flags().Lookup("show-full").Shorthand)
+}
+
+func TestSessionRequestCommand_ShorthandFlags(t *testing.T) {
+	cmd := newSessionRequestCommand()
+
+	assert.Equal(t, "C", cmd.Flags().Lookup("cluster").Shorthand)
+	assert.Equal(t, "g", cmd.Flags().Lookup("group").Shorthand)
+	assert.Equal(t, "u", cmd.Flags().Lookup("user").Shorthand)
+	assert.Equal(t, "r", cmd.Flags().Lookup("reason").Shorthand)
+	assert.Equal(t, "d", cmd.Flags().Lookup("duration").Shorthand)
+	assert.Equal(t, "S", cmd.Flags().Lookup("scheduled-start").Shorthand)
+}
+
+func TestSessionDecisionCommand_ShorthandFlags(t *testing.T) {
+	assert.Equal(t, "r", newSessionApproveCommand().Flags().Lookup("reason").Shorthand)
+	assert.Equal(t, "r", newSessionRejectCommand().Flags().Lookup("reason").Shorthand)
 }

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -90,8 +90,9 @@ func newUpdateCheckCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(os.Stdout, "Current version: %s\n", version.Version)
-			_, _ = fmt.Fprintf(os.Stdout, "Latest version:  %s\n", release.TagName)
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintf(out, "Current version: %s\n", version.Version)
+			_, _ = fmt.Fprintf(out, "Latest version:  %s\n", release.TagName)
 			return nil
 		},
 	}
@@ -113,7 +114,7 @@ func newUpdateRollbackCommand() *cobra.Command {
 			}
 			oldPath := exe + ".old"
 			if dryRun {
-				_, _ = fmt.Fprintf(os.Stdout, "Would rollback to %s\n", oldPath)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would rollback to %s\n", oldPath)
 				return nil
 			}
 			if _, err := os.Stat(oldPath); err != nil {
@@ -156,11 +157,11 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	updateStatusf("Selected release %s asset %s", release.TagName, assetName)
 
 	if dryRun {
-		_, _ = fmt.Fprintf(os.Stdout, "Would download %s\n", assetURL)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would download %s\n", assetURL)
 		return nil
 	}
 	if !confirm {
-		_, _ = fmt.Fprintf(os.Stdout, "Updating to %s. Use --yes to skip confirmation.\n", release.TagName)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating to %s. Use --yes to skip confirmation.\n", release.TagName)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "bgctl-update")
@@ -199,7 +200,7 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	return nil
 }
 
-func updateStatusf(format string, args ...interface{}) {
+func updateStatusf(format string, args ...any) {
 	if updateStatusWriter == nil {
 		return
 	}

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -67,6 +67,7 @@ one is published, extracts the bgctl binary, and replaces the current binary.`,
 		Example: `  bgctl update --dry-run
   bgctl update --yes
   bgctl update --version v1.2.3 --yes`,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			versionTag, err := cmd.Flags().GetString("version")
 			if err != nil {
@@ -88,8 +89,9 @@ one is published, extracts the bgctl binary, and replaces the current binary.`,
 
 func newUpdateCheckCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "check",
-		Short: "Check for updates",
+		Use:          "check",
+		Short:        "Check for updates",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			release, err := fetchLatestRelease(commandContext(cmd))
 			if err != nil {
@@ -105,8 +107,9 @@ func newUpdateCheckCommand() *cobra.Command {
 
 func newUpdateRollbackCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rollback",
-		Short: "Rollback to previous version",
+		Use:          "rollback",
+		Short:        "Rollback to previous version",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			versionTag, err := cmd.Flags().GetString("version")
 			if err != nil {
@@ -132,12 +135,7 @@ func newUpdateRollbackCommand() *cobra.Command {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would rollback to %s\n", oldPath)
 				return nil
 			}
-			rt, err := getRuntime(cmd)
-			if err != nil {
-				rt = &runtimeState{writer: cmd.OutOrStdout()}
-			} else if rt.writer == nil {
-				rt.writer = cmd.OutOrStdout()
-			}
+			rt := updatePromptRuntime(cmd)
 			if err := confirmAction(cmd, rt, "rollback bgctl to", oldPath, confirm); err != nil {
 				return err
 			}
@@ -190,12 +188,7 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would download %s\n", assetURL)
 		return nil
 	}
-	rt, err := getRuntime(cmd)
-	if err != nil {
-		rt = &runtimeState{writer: cmd.OutOrStdout()}
-	} else if rt.writer == nil {
-		rt.writer = cmd.OutOrStdout()
-	}
+	rt := updatePromptRuntime(cmd)
 	action := "update bgctl to"
 	if cmd.Name() == "rollback" {
 		action = "rollback bgctl to"
@@ -238,6 +231,20 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	}
 	updateStatusf("Updated bgctl to %s", release.TagName)
 	return nil
+}
+
+func updatePromptRuntime(cmd *cobra.Command) *runtimeState {
+	rt, err := getRuntime(cmd)
+	if err != nil {
+		rt = &runtimeState{}
+	}
+	promptRuntime := *rt
+	if updateStatusWriter != nil {
+		promptRuntime.writer = updateStatusWriter
+	} else {
+		promptRuntime.writer = os.Stderr
+	}
+	return &promptRuntime
 }
 
 func updateStatusf(format string, args ...any) {

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -126,6 +126,7 @@ func newUpdateRollbackCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().String("version", "", "Rollback to specific version tag")
+	cmd.Flags().Bool("yes", false, "Skip confirmation")
 	cmd.Flags().Bool("dry-run", false, "Show actions without rollback")
 	return cmd
 }

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -333,6 +333,7 @@ func downloadFileWithLimit(ctx context.Context, url, path string, maxBytes int64
 		reader = &progressReader{
 			reader: resp.Body,
 			total:  resp.ContentLength,
+			writer: updateStatusWriter,
 		}
 	}
 
@@ -345,7 +346,9 @@ func downloadFileWithLimit(ctx context.Context, url, path string, maxBytes int64
 
 	// Clear the progress line
 	if resp.ContentLength > 0 {
-		_, _ = fmt.Fprint(os.Stderr, "\r                                                  \r")
+		if updateStatusWriter != nil {
+			_, _ = fmt.Fprint(updateStatusWriter, "\r                                                  \r")
+		}
 	}
 	if err != nil {
 		_ = os.Remove(path)
@@ -383,17 +386,18 @@ func limitedDownloadCopy(dst io.Writer, src io.Reader, maxBytes int64) error {
 	}
 }
 
-// progressReader wraps an io.Reader and prints download progress to stderr.
+// progressReader wraps an io.Reader and prints download progress.
 type progressReader struct {
 	reader      io.Reader
 	total       int64
 	downloaded  int64
 	lastPercent int
+	writer      io.Writer
 }
 
 func (pr *progressReader) Read(p []byte) (int, error) {
 	n, err := pr.reader.Read(p)
-	if n > 0 {
+	if n > 0 && pr.writer != nil {
 		pr.downloaded += int64(n)
 		percent := int(float64(pr.downloaded) / float64(pr.total) * 100)
 		// Only update display when percent changes to avoid excessive output
@@ -402,7 +406,7 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 			downloaded := formatBytes(pr.downloaded)
 			total := formatBytes(pr.total)
 			bar := progressBar(percent, 30)
-			_, _ = fmt.Fprintf(os.Stderr, "\r%s %s/%s %d%%", bar, downloaded, total, percent)
+			_, _ = fmt.Fprintf(pr.writer, "\r%s %s/%s %d%%", bar, downloaded, total, percent)
 		}
 	}
 	return n, err

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -135,12 +135,12 @@ func newUpdateRollbackCommand() *cobra.Command {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would rollback to %s\n", oldPath)
 				return nil
 			}
+			if _, err := os.Stat(oldPath); err != nil {
+				return fmt.Errorf("rollback binary not found: %s", oldPath)
+			}
 			rt := updatePromptRuntime(cmd)
 			if err := confirmAction(cmd, rt, "rollback bgctl to", oldPath, confirm); err != nil {
 				return err
-			}
-			if _, err := os.Stat(oldPath); err != nil {
-				return fmt.Errorf("rollback binary not found: %s", oldPath)
 			}
 			return replaceBinaryFunc(exe, oldPath)
 		},

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -66,7 +66,8 @@ one is published, extracts the bgctl binary, and replaces the current binary.`,
   bgctl update --yes
   bgctl update --version v1.2.3 --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUpdate(cmd, "")
+			versionTag, _ := cmd.Flags().GetString("version")
+			return runUpdate(cmd, versionTag)
 		},
 	}
 
@@ -235,7 +236,7 @@ func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
 }
 
 func fetchReleaseByTag(ctx context.Context, tag string) (*githubRelease, error) {
-	releaseURL := fmt.Sprintf("https://api.github.com/repos/telekom/k8s-breakglass/releases/tags/%s", url.PathEscape(strings.TrimPrefix(tag, "v")))
+	releaseURL := fmt.Sprintf("https://api.github.com/repos/telekom/k8s-breakglass/releases/tags/%s", url.PathEscape(tag))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -116,6 +116,10 @@ func newUpdateRollbackCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			confirm, err := cmd.Flags().GetBool("yes")
+			if err != nil {
+				return err
+			}
 			if versionTag != "" {
 				return runUpdate(cmd, versionTag)
 			}
@@ -127,6 +131,15 @@ func newUpdateRollbackCommand() *cobra.Command {
 			if dryRun {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would rollback to %s\n", oldPath)
 				return nil
+			}
+			rt, err := getRuntime(cmd)
+			if err != nil {
+				rt = &runtimeState{writer: cmd.OutOrStdout()}
+			} else if rt.writer == nil {
+				rt.writer = cmd.OutOrStdout()
+			}
+			if err := confirmAction(cmd, rt, "rollback bgctl to", oldPath, confirm); err != nil {
+				return err
 			}
 			if _, err := os.Stat(oldPath); err != nil {
 				return fmt.Errorf("rollback binary not found: %s", oldPath)
@@ -183,7 +196,11 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	} else if rt.writer == nil {
 		rt.writer = cmd.OutOrStdout()
 	}
-	if err := confirmAction(cmd, rt, "update bgctl to", release.TagName, confirm); err != nil {
+	action := "update bgctl to"
+	if cmd.Name() == "rollback" {
+		action = "rollback bgctl to"
+	}
+	if err := confirmAction(cmd, rt, action, release.TagName, confirm); err != nil {
 		return err
 	}
 

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -39,8 +39,9 @@ const (
 )
 
 var (
-	updateHTTPClient         = &http.Client{Timeout: defaultUpdateAPIHTTPTimeout}
-	updateDownloadHTTPClient = &http.Client{Timeout: defaultUpdateDownloadHTTPTimeout}
+	updateHTTPClient                   = &http.Client{Timeout: defaultUpdateAPIHTTPTimeout}
+	updateDownloadHTTPClient           = &http.Client{Timeout: defaultUpdateDownloadHTTPTimeout}
+	updateStatusWriter       io.Writer = os.Stderr
 )
 
 type githubRelease struct {
@@ -57,6 +58,13 @@ func NewUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update bgctl",
+		Long: `Update bgctl from the k8s-breakglass GitHub releases.
+
+The command downloads the platform-specific archive, verifies a checksum when
+one is published, extracts the bgctl binary, and replaces the current binary.`,
+		Example: `  bgctl update --dry-run
+  bgctl update --yes
+  bgctl update --version v1.2.3 --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runUpdate(cmd, "")
 		},
@@ -130,8 +138,10 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	var release *githubRelease
 	var err error
 	if versionTag == "" {
+		updateStatusf("Checking latest bgctl release...")
 		release, err = fetchLatestRelease(ctx)
 	} else {
+		updateStatusf("Fetching bgctl release %s...", versionTag)
 		release, err = fetchReleaseByTag(ctx, versionTag)
 	}
 	if err != nil {
@@ -142,6 +152,7 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	if assetURL == "" {
 		return fmt.Errorf("asset not found for %s", assetName)
 	}
+	updateStatusf("Selected release %s asset %s", release.TagName, assetName)
 
 	if dryRun {
 		_, _ = fmt.Fprintf(os.Stdout, "Would download %s\n", assetURL)
@@ -160,14 +171,17 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	}()
 
 	archivePath := filepath.Join(tmpDir, assetName)
+	updateStatusf("Downloading %s...", assetName)
 	if err := downloadFile(ctx, assetURL, archivePath); err != nil {
 		return err
 	}
 
+	updateStatusf("Verifying checksum...")
 	if err := verifyChecksum(ctx, release.Assets, assetName, archivePath); err != nil {
 		return err
 	}
 
+	updateStatusf("Extracting bgctl...")
 	extracted, err := extractBinary(archivePath, tmpDir)
 	if err != nil {
 		return err
@@ -176,7 +190,19 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	if err != nil {
 		return err
 	}
-	return replaceBinary(exe, extracted)
+	updateStatusf("Installing bgctl to %s...", exe)
+	if err := replaceBinary(exe, extracted); err != nil {
+		return err
+	}
+	updateStatusf("Updated bgctl to %s", release.TagName)
+	return nil
+}
+
+func updateStatusf(format string, args ...interface{}) {
+	if updateStatusWriter == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(updateStatusWriter, format+"\n", args...)
 }
 
 func commandContext(cmd *cobra.Command) context.Context {

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -42,6 +42,8 @@ var (
 	updateHTTPClient                   = &http.Client{Timeout: defaultUpdateAPIHTTPTimeout}
 	updateDownloadHTTPClient           = &http.Client{Timeout: defaultUpdateDownloadHTTPTimeout}
 	updateStatusWriter       io.Writer = os.Stderr
+	currentExecutable                  = os.Executable
+	replaceBinaryFunc                  = replaceBinary
 )
 
 type githubRelease struct {
@@ -108,7 +110,7 @@ func newUpdateRollbackCommand() *cobra.Command {
 			if versionTag != "" {
 				return runUpdate(cmd, versionTag)
 			}
-			exe, err := os.Executable()
+			exe, err := currentExecutable()
 			if err != nil {
 				return err
 			}
@@ -120,7 +122,7 @@ func newUpdateRollbackCommand() *cobra.Command {
 			if _, err := os.Stat(oldPath); err != nil {
 				return fmt.Errorf("rollback binary not found: %s", oldPath)
 			}
-			return replaceBinary(exe, oldPath)
+			return replaceBinaryFunc(exe, oldPath)
 		},
 	}
 	cmd.Flags().String("version", "", "Rollback to specific version tag")
@@ -188,12 +190,12 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	if err != nil {
 		return err
 	}
-	exe, err := os.Executable()
+	exe, err := currentExecutable()
 	if err != nil {
 		return err
 	}
 	updateStatusf("Installing bgctl to %s...", exe)
-	if err := replaceBinary(exe, extracted); err != nil {
+	if err := replaceBinaryFunc(exe, extracted); err != nil {
 		return err
 	}
 	updateStatusf("Updated bgctl to %s", release.TagName)

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -229,7 +229,11 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	if err := replaceBinaryFunc(exe, extracted); err != nil {
 		return err
 	}
-	updateStatusf("Updated bgctl to %s", release.TagName)
+	completion := "Updated bgctl to"
+	if cmd.Name() == "rollback" {
+		completion = "Rolled back bgctl to"
+	}
+	updateStatusf("%s %s", completion, release.TagName)
 	return nil
 }
 

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -68,7 +68,10 @@ one is published, extracts the bgctl binary, and replaces the current binary.`,
   bgctl update --yes
   bgctl update --version v1.2.3 --yes`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			versionTag, _ := cmd.Flags().GetString("version")
+			versionTag, err := cmd.Flags().GetString("version")
+			if err != nil {
+				return err
+			}
 			return runUpdate(cmd, versionTag)
 		},
 	}
@@ -105,8 +108,14 @@ func newUpdateRollbackCommand() *cobra.Command {
 		Use:   "rollback",
 		Short: "Rollback to previous version",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			versionTag, _ := cmd.Flags().GetString("version")
-			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			versionTag, err := cmd.Flags().GetString("version")
+			if err != nil {
+				return err
+			}
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return err
+			}
 			if versionTag != "" {
 				return runUpdate(cmd, versionTag)
 			}
@@ -137,11 +146,16 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 	if strings.EqualFold(os.Getenv("BGCTL_DISABLE_UPDATE"), "true") {
 		return fmt.Errorf("update disabled by BGCTL_DISABLE_UPDATE")
 	}
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	confirm, _ := cmd.Flags().GetBool("yes")
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return err
+	}
+	confirm, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return err
+	}
 
 	var release *githubRelease
-	var err error
 	if versionTag == "" {
 		updateStatusf("Checking latest bgctl release...")
 		release, err = fetchLatestRelease(ctx)

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -163,8 +163,14 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would download %s\n", assetURL)
 		return nil
 	}
-	if !confirm {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Updating to %s. Use --yes to skip confirmation.\n", release.TagName)
+	rt, err := getRuntime(cmd)
+	if err != nil {
+		rt = &runtimeState{writer: cmd.OutOrStdout()}
+	} else if rt.writer == nil {
+		rt.writer = cmd.OutOrStdout()
+	}
+	if err := confirmAction(cmd, rt, "update bgctl to", release.TagName, confirm); err != nil {
+		return err
 	}
 
 	tmpDir, err := os.MkdirTemp("", "bgctl-update")

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -83,24 +83,6 @@ func TestUpdateStatusf(t *testing.T) {
 	assert.Equal(t, "Downloading bgctl_linux_amd64.tar.gz...\n", buf.String())
 }
 
-func captureStdout(t *testing.T, run func()) string {
-	t.Helper()
-
-	oldStdout := os.Stdout
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = writer
-	t.Cleanup(func() { os.Stdout = oldStdout })
-
-	run()
-
-	require.NoError(t, writer.Close())
-	output, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.NoError(t, reader.Close())
-	return string(output)
-}
-
 func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -121,15 +103,15 @@ func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 	})}
 	updateStatusWriter = io.Discard
 
-	output := captureStdout(t, func() {
-		cmd := NewUpdateCommand()
-		cmd.SetArgs([]string{"--version", "v0.1.0-beta.29", "--dry-run"})
+	var output bytes.Buffer
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--version", "v0.1.0-beta.29", "--dry-run"})
 
-		require.NoError(t, cmd.Execute())
-	})
+	require.NoError(t, cmd.Execute())
 
 	assert.True(t, strings.HasSuffix(requestedPath, "/releases/tags/v0.1.0-beta.29"), "unexpected release lookup path: %s", requestedPath)
-	assert.Contains(t, output, "Would download https://example.com/bgctl.tar.gz")
+	assert.Contains(t, output.String(), "Would download https://example.com/bgctl.tar.gz")
 }
 
 func TestDownloadFile(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -564,6 +564,62 @@ func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
 	assert.Contains(t, status.String(), "Updated bgctl to v0.1.0-beta.30")
 }
 
+func TestUpdateRollbackVersionRunsInstallFlowWithRollbackStatus(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	oldCurrentExecutable := currentExecutable
+	oldReplaceBinary := replaceBinaryFunc
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+		currentExecutable = oldCurrentExecutable
+		replaceBinaryFunc = oldReplaceBinary
+	})
+
+	archivePath := filepath.Join(t.TempDir(), assetFileName())
+	require.NoError(t, writeTarGz(archivePath, map[string]string{
+		"bgctl": "binary",
+	}))
+	archiveBytes, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer downloadServer.Close()
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.28","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	executablePath := filepath.Join(t.TempDir(), "bgctl")
+	currentExecutable = func() (string, error) {
+		return executablePath, nil
+	}
+	replaceBinaryFunc = func(exe, replacement string) error {
+		assert.Equal(t, executablePath, exe)
+		content, readErr := os.ReadFile(replacement)
+		require.NoError(t, readErr)
+		assert.Equal(t, "binary", string(content))
+		return nil
+	}
+
+	var status bytes.Buffer
+	updateStatusWriter = &status
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"rollback", "--version", "v0.1.0-beta.28", "--yes"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, status.String(), "Rolled back bgctl to v0.1.0-beta.28")
+	assert.NotContains(t, status.String(), "Updated bgctl to v0.1.0-beta.28")
+}
+
 func TestUpdateCommandReturnsDownloadError(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldDownloadClient := updateDownloadHTTPClient

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -37,6 +37,27 @@ func useUpdateDownloadClient(t *testing.T, client *http.Client) {
 	})
 }
 
+func releaseTransportWithChecksum(tag, assetURL string, assetBytes []byte) roundTripFunc {
+	return func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, ".sha256") {
+			hash := sha256.Sum256(assetBytes)
+			checksum := hex.EncodeToString(hash[:]) + "  " + assetFileName() + "\n"
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(checksum)),
+				Header:     make(http.Header),
+			}, nil
+		}
+
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"` + tag + `","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + assetURL + `"},{"name":"` + assetFileName() + `.sha256","browser_download_url":"` + assetURL + `.sha256"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	}
+}
+
 func TestAssetFileName_CurrentPlatform(t *testing.T) {
 	name := assetFileName()
 	if runtime.GOOS == "windows" {
@@ -530,14 +551,7 @@ func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
 	}))
 	defer downloadServer.Close()
 
-	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       body,
-			Header:     make(http.Header),
-		}, nil
-	})}
+	updateHTTPClient = &http.Client{Transport: releaseTransportWithChecksum("v0.1.0-beta.30", downloadServer.URL+"/bgctl.tar.gz", archiveBytes)}
 
 	executablePath := filepath.Join(t.TempDir(), "bgctl")
 	currentExecutable = func() (string, error) {
@@ -594,14 +608,7 @@ func TestUpdateRollbackVersionRunsInstallFlowWithRollbackStatus(t *testing.T) {
 	}))
 	defer downloadServer.Close()
 
-	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.28","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       body,
-			Header:     make(http.Header),
-		}, nil
-	})}
+	updateHTTPClient = &http.Client{Transport: releaseTransportWithChecksum("v0.1.0-beta.28", downloadServer.URL+"/bgctl.tar.gz", archiveBytes)}
 
 	executablePath := filepath.Join(t.TempDir(), "bgctl")
 	currentExecutable = func() (string, error) {
@@ -664,19 +671,13 @@ func TestUpdateCommandReturnsExtractError(t *testing.T) {
 		updateStatusWriter = oldStatusWriter
 	})
 
+	archiveBytes := []byte("not an archive")
 	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("not an archive"))
+		_, _ = w.Write(archiveBytes)
 	}))
 	defer downloadServer.Close()
-	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       body,
-			Header:     make(http.Header),
-		}, nil
-	})}
+	updateHTTPClient = &http.Client{Transport: releaseTransportWithChecksum("v0.1.0-beta.30", downloadServer.URL+"/bgctl.tar.gz", archiveBytes)}
 	updateStatusWriter = io.Discard
 
 	cmd := NewUpdateCommand()
@@ -707,14 +708,7 @@ func TestUpdateCommandReturnsCurrentExecutableError(t *testing.T) {
 		_, _ = w.Write(archiveBytes)
 	}))
 	defer downloadServer.Close()
-	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       body,
-			Header:     make(http.Header),
-		}, nil
-	})}
+	updateHTTPClient = &http.Client{Transport: releaseTransportWithChecksum("v0.1.0-beta.30", downloadServer.URL+"/bgctl.tar.gz", archiveBytes)}
 	currentExecutable = func() (string, error) {
 		return "", assert.AnError
 	}
@@ -750,14 +744,7 @@ func TestUpdateCommandReturnsReplaceError(t *testing.T) {
 		_, _ = w.Write(archiveBytes)
 	}))
 	defer downloadServer.Close()
-	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       body,
-			Header:     make(http.Header),
-		}, nil
-	})}
+	updateHTTPClient = &http.Client{Transport: releaseTransportWithChecksum("v0.1.0-beta.30", downloadServer.URL+"/bgctl.tar.gz", archiveBytes)}
 	executablePath := filepath.Join(t.TempDir(), "bgctl")
 	currentExecutable = func() (string, error) {
 		return executablePath, nil

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -156,6 +156,41 @@ func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 	assert.Contains(t, output.String(), "Would download https://example.com/bgctl.tar.gz")
 }
 
+func TestUpdateCommandDisabledByEnvironment(t *testing.T) {
+	t.Setenv("BGCTL_DISABLE_UPDATE", "true")
+
+	cmd := NewUpdateCommand()
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update disabled by BGCTL_DISABLE_UPDATE")
+}
+
+func TestUpdateCommandReturnsMissingAssetError(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--dry-run"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset not found for "+assetFileName())
+}
+
 func TestUpdateRollbackVersionAcceptsYesFlag(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -211,6 +246,26 @@ func TestUpdateCheckWritesToCommandOutput(t *testing.T) {
 	assert.Contains(t, output.String(), "Latest version:  v0.1.0-beta.30")
 }
 
+func TestUpdateCheckReturnsFetchError(t *testing.T) {
+	oldClient := updateHTTPClient
+	t.Cleanup(func() { updateHTTPClient = oldClient })
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader("release api unavailable"))
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"check"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch release: release api unavailable")
+}
+
 func TestUpdateRollbackDryRunWritesToCommandOutput(t *testing.T) {
 	var output bytes.Buffer
 	cmd := NewUpdateCommand()
@@ -221,6 +276,70 @@ func TestUpdateRollbackDryRunWritesToCommandOutput(t *testing.T) {
 
 	assert.Contains(t, output.String(), "Would rollback to ")
 	assert.Contains(t, output.String(), ".old")
+}
+
+func TestUpdateRollbackPreviousReturnsExecutableError(t *testing.T) {
+	oldCurrentExecutable := currentExecutable
+	t.Cleanup(func() { currentExecutable = oldCurrentExecutable })
+
+	currentExecutable = func() (string, error) {
+		return "", assert.AnError
+	}
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"rollback", "--yes"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestUpdateRollbackPreviousMissingBackupReportsPath(t *testing.T) {
+	oldCurrentExecutable := currentExecutable
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		currentExecutable = oldCurrentExecutable
+		updateStatusWriter = oldStatusWriter
+	})
+
+	executablePath := filepath.Join(t.TempDir(), "bgctl")
+	currentExecutable = func() (string, error) {
+		return executablePath, nil
+	}
+	updateStatusWriter = io.Discard
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"rollback", "--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rollback binary not found: "+executablePath+".old")
+}
+
+func TestUpdateRollbackPreviousReturnsReplaceError(t *testing.T) {
+	oldCurrentExecutable := currentExecutable
+	oldReplaceBinary := replaceBinaryFunc
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		currentExecutable = oldCurrentExecutable
+		replaceBinaryFunc = oldReplaceBinary
+		updateStatusWriter = oldStatusWriter
+	})
+
+	executablePath := filepath.Join(t.TempDir(), "bgctl")
+	oldPath := executablePath + ".old"
+	require.NoError(t, os.WriteFile(oldPath, []byte("old binary"), 0o755))
+	currentExecutable = func() (string, error) {
+		return executablePath, nil
+	}
+	replaceBinaryFunc = func(gotExe, gotOld string) error {
+		assert.Equal(t, executablePath, gotExe)
+		assert.Equal(t, oldPath, gotOld)
+		return assert.AnError
+	}
+	updateStatusWriter = io.Discard
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"rollback", "--yes"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 func TestUpdateRollbackPreviousRequiresConfirmationInNonInteractiveMode(t *testing.T) {
@@ -364,6 +483,23 @@ func TestUpdateRollbackVersionPromptUsesRollbackAction(t *testing.T) {
 	assert.Empty(t, stdout.String())
 }
 
+func TestUpdatePromptRuntimeDefaultsToStderr(t *testing.T) {
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() { updateStatusWriter = oldStatusWriter })
+
+	updateStatusWriter = nil
+	cmd := NewUpdateCommand()
+	cmd.SetContext(context.WithValue(context.Background(), runtimeKey{}, &runtimeState{
+		nonInteractive: true,
+		writer:         io.Discard,
+	}))
+
+	rt := updatePromptRuntime(cmd)
+
+	assert.True(t, rt.nonInteractive)
+	assert.Same(t, os.Stderr, rt.writer)
+}
+
 func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -426,6 +562,156 @@ func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
 	assert.Contains(t, status.String(), "Extracting bgctl...")
 	assert.Contains(t, status.String(), "Installing bgctl to "+executablePath+"...")
 	assert.Contains(t, status.String(), "Updated bgctl to v0.1.0-beta.30")
+}
+
+func TestUpdateCommandReturnsDownloadError(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldDownloadClient := updateDownloadHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateDownloadHTTPClient = oldDownloadClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateDownloadHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})}
+	updateStatusWriter = io.Discard
+
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestUpdateCommandReturnsExtractError(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not an archive"))
+	}))
+	defer downloadServer.Close()
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--yes"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestUpdateCommandReturnsCurrentExecutableError(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	oldCurrentExecutable := currentExecutable
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+		currentExecutable = oldCurrentExecutable
+	})
+
+	archivePath := filepath.Join(t.TempDir(), assetFileName())
+	require.NoError(t, writeTarGz(archivePath, map[string]string{
+		"bgctl": "binary",
+	}))
+	archiveBytes, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer downloadServer.Close()
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	currentExecutable = func() (string, error) {
+		return "", assert.AnError
+	}
+	updateStatusWriter = io.Discard
+
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--yes"})
+
+	err = cmd.Execute()
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestUpdateCommandReturnsReplaceError(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	oldCurrentExecutable := currentExecutable
+	oldReplaceBinary := replaceBinaryFunc
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+		currentExecutable = oldCurrentExecutable
+		replaceBinaryFunc = oldReplaceBinary
+	})
+
+	archivePath := filepath.Join(t.TempDir(), assetFileName())
+	require.NoError(t, writeTarGz(archivePath, map[string]string{
+		"bgctl": "binary",
+	}))
+	archiveBytes, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer downloadServer.Close()
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	executablePath := filepath.Join(t.TempDir(), "bgctl")
+	currentExecutable = func() (string, error) {
+		return executablePath, nil
+	}
+	replaceBinaryFunc = func(gotExe, replacement string) error {
+		assert.Equal(t, executablePath, gotExe)
+		assert.NotEmpty(t, replacement)
+		return assert.AnError
+	}
+	updateStatusWriter = io.Discard
+
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--yes"})
+
+	err = cmd.Execute()
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 func TestDownloadFile(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -243,6 +243,33 @@ func TestUpdateRollbackPreviousRequiresConfirmationInNonInteractiveMode(t *testi
 	assert.Contains(t, err.Error(), "confirmation required")
 }
 
+func TestUpdateRollbackPreviousPromptUsesStatusWriter(t *testing.T) {
+	oldCurrentExecutable := currentExecutable
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		currentExecutable = oldCurrentExecutable
+		updateStatusWriter = oldStatusWriter
+	})
+
+	currentExecutable = func() (string, error) {
+		return filepath.Join(t.TempDir(), "bgctl"), nil
+	}
+
+	var stdout bytes.Buffer
+	var status bytes.Buffer
+	updateStatusWriter = &status
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{"rollback"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
+	assert.Contains(t, status.String(), "rollback bgctl to")
+	assert.Empty(t, stdout.String())
+}
+
 func TestUpdateCommandRequiresConfirmationInNonInteractiveMode(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -273,6 +300,38 @@ func TestUpdateCommandRequiresConfirmationInNonInteractiveMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "confirmation required")
 }
 
+func TestUpdateCommandPromptUsesStatusWriter(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	var stdout bytes.Buffer
+	var status bytes.Buffer
+	updateStatusWriter = &status
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{"--version", "v0.1.0-beta.30"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
+	assert.Contains(t, status.String(), "update bgctl to v0.1.0-beta.30")
+	assert.Empty(t, stdout.String())
+}
+
 func TestUpdateRollbackVersionPromptUsesRollbackAction(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -289,13 +348,12 @@ func TestUpdateRollbackVersionPromptUsesRollbackAction(t *testing.T) {
 			Header:     make(http.Header),
 		}, nil
 	})}
-	updateStatusWriter = io.Discard
 
 	var prompt bytes.Buffer
+	updateStatusWriter = &prompt
+	var stdout bytes.Buffer
 	cmd := NewUpdateCommand()
-	cmd.SetContext(context.WithValue(context.Background(), runtimeKey{}, &runtimeState{
-		writer: &prompt,
-	}))
+	cmd.SetOut(&stdout)
 	cmd.SetIn(strings.NewReader("n\n"))
 	cmd.SetArgs([]string{"rollback", "--version", "v0.1.0-beta.28"})
 
@@ -303,6 +361,7 @@ func TestUpdateRollbackVersionPromptUsesRollbackAction(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canceled")
 	assert.Contains(t, prompt.String(), "rollback bgctl to v0.1.0-beta.28")
+	assert.Empty(t, stdout.String())
 }
 
 func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -335,6 +335,28 @@ func TestDownloadFile(t *testing.T) {
 	assert.Equal(t, "payload", string(content))
 }
 
+func TestDownloadFileWritesProgressToStatusWriter(t *testing.T) {
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() { updateStatusWriter = oldStatusWriter })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "7")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	var status bytes.Buffer
+	updateStatusWriter = &status
+
+	path := filepath.Join(t.TempDir(), "download.bin")
+	err := downloadFile(context.Background(), server.URL, path)
+	require.NoError(t, err)
+
+	assert.Contains(t, status.String(), "7 B/7 B")
+	assert.Contains(t, status.String(), "100%")
+}
+
 func TestDownloadFileErrorStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -83,6 +83,48 @@ func TestUpdateStatusf(t *testing.T) {
 	assert.Equal(t, "Downloading bgctl_linux_amd64.tar.gz...\n", buf.String())
 }
 
+func TestUpdateStatusfNilWriter(t *testing.T) {
+	oldWriter := updateStatusWriter
+	t.Cleanup(func() { updateStatusWriter = oldWriter })
+
+	updateStatusWriter = nil
+	updateStatusf("this should be ignored")
+}
+
+func TestUpdateCommandUsesLatestReleaseForDryRun(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	var requestedPath string
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestedPath = req.URL.EscapedPath()
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/latest-bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	var output bytes.Buffer
+	var status bytes.Buffer
+	updateStatusWriter = &status
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "/repos/telekom/k8s-breakglass/releases/latest", requestedPath)
+	assert.Contains(t, status.String(), "Checking latest bgctl release...")
+	assert.Contains(t, status.String(), "Selected release v0.1.0-beta.30 asset")
+	assert.Contains(t, output.String(), "Would download https://example.com/latest-bgctl.tar.gz")
+}
+
 func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -112,6 +154,106 @@ func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 
 	assert.True(t, strings.HasSuffix(requestedPath, "/releases/tags/v0.1.0-beta.29"), "unexpected release lookup path: %s", requestedPath)
 	assert.Contains(t, output.String(), "Would download https://example.com/bgctl.tar.gz")
+}
+
+func TestUpdateCheckWritesToCommandOutput(t *testing.T) {
+	oldClient := updateHTTPClient
+	t.Cleanup(func() { updateHTTPClient = oldClient })
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	var output bytes.Buffer
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"check"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, output.String(), "Current version:")
+	assert.Contains(t, output.String(), "Latest version:  v0.1.0-beta.30")
+}
+
+func TestUpdateRollbackDryRunWritesToCommandOutput(t *testing.T) {
+	var output bytes.Buffer
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"rollback", "--dry-run"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, output.String(), "Would rollback to ")
+	assert.Contains(t, output.String(), ".old")
+}
+
+func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	oldCurrentExecutable := currentExecutable
+	oldReplaceBinary := replaceBinaryFunc
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+		currentExecutable = oldCurrentExecutable
+		replaceBinaryFunc = oldReplaceBinary
+	})
+
+	archivePath := filepath.Join(t.TempDir(), assetFileName())
+	require.NoError(t, writeTarGz(archivePath, map[string]string{
+		"bgctl": "binary",
+	}))
+	archiveBytes, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(archiveBytes)
+	}))
+	defer downloadServer.Close()
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"` + downloadServer.URL + `/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	executablePath := filepath.Join(t.TempDir(), "bgctl")
+	currentExecutable = func() (string, error) {
+		return executablePath, nil
+	}
+	var replacedFrom string
+	replaceBinaryFunc = func(exe, replacement string) error {
+		assert.Equal(t, executablePath, exe)
+		replacedFrom = replacement
+		content, readErr := os.ReadFile(replacement)
+		require.NoError(t, readErr)
+		assert.Equal(t, "binary", string(content))
+		return nil
+	}
+
+	var status bytes.Buffer
+	updateStatusWriter = &status
+	cmd := NewUpdateCommand()
+	cmd.SetArgs([]string{"--yes"})
+
+	require.NoError(t, cmd.Execute())
+
+	require.NotEmpty(t, replacedFrom)
+	assert.Contains(t, status.String(), "Checking latest bgctl release...")
+	assert.Contains(t, status.String(), "Selected release v0.1.0-beta.30 asset")
+	assert.Contains(t, status.String(), "Downloading "+assetFileName()+"...")
+	assert.Contains(t, status.String(), "Verifying checksum...")
+	assert.Contains(t, status.String(), "Extracting bgctl...")
+	assert.Contains(t, status.String(), "Installing bgctl to "+executablePath+"...")
+	assert.Contains(t, status.String(), "Updated bgctl to v0.1.0-beta.30")
 }
 
 func TestDownloadFile(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -83,6 +83,55 @@ func TestUpdateStatusf(t *testing.T) {
 	assert.Equal(t, "Downloading bgctl_linux_amd64.tar.gz...\n", buf.String())
 }
 
+func captureStdout(t *testing.T, run func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	run()
+
+	require.NoError(t, writer.Close())
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	return string(output)
+}
+
+func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	var requestedPath string
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestedPath = req.URL.EscapedPath()
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.29","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+
+	output := captureStdout(t, func() {
+		cmd := NewUpdateCommand()
+		cmd.SetArgs([]string{"--version", "v0.1.0-beta.29", "--dry-run"})
+
+		require.NoError(t, cmd.Execute())
+	})
+
+	assert.True(t, strings.HasSuffix(requestedPath, "/releases/tags/v0.1.0-beta.29"), "unexpected release lookup path: %s", requestedPath)
+	assert.Contains(t, output, "Would download https://example.com/bgctl.tar.gz")
+}
+
 func TestDownloadFile(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -291,7 +340,7 @@ func TestFetchReleaseByTagEscapesPathSegment(t *testing.T) {
 
 	_, err := fetchReleaseByTag(context.Background(), "v1.0.0/../x")
 	require.NoError(t, err)
-	assert.True(t, strings.HasSuffix(escapedPath, "/releases/tags/1.0.0%2F..%2Fx"), "unexpected escaped path: %s", escapedPath)
+	assert.True(t, strings.HasSuffix(escapedPath, "/releases/tags/v1.0.0%2F..%2Fx"), "unexpected escaped path: %s", escapedPath)
 }
 
 func TestVerifyChecksum(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -156,6 +156,37 @@ func TestUpdateCommandUsesVersionFlagForDryRun(t *testing.T) {
 	assert.Contains(t, output.String(), "Would download https://example.com/bgctl.tar.gz")
 }
 
+func TestUpdateRollbackVersionAcceptsYesFlag(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	var requestedPath string
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestedPath = req.URL.EscapedPath()
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.28","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/rollback-bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+
+	var output bytes.Buffer
+	cmd := NewUpdateCommand()
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"rollback", "--version", "v0.1.0-beta.28", "--yes", "--dry-run"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, strings.HasSuffix(requestedPath, "/releases/tags/v0.1.0-beta.28"), "unexpected release lookup path: %s", requestedPath)
+	assert.Contains(t, output.String(), "Would download https://example.com/rollback-bgctl.tar.gz")
+}
+
 func TestUpdateCheckWritesToCommandOutput(t *testing.T) {
 	oldClient := updateHTTPClient
 	t.Cleanup(func() { updateHTTPClient = oldClient })

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -223,6 +223,26 @@ func TestUpdateRollbackDryRunWritesToCommandOutput(t *testing.T) {
 	assert.Contains(t, output.String(), ".old")
 }
 
+func TestUpdateRollbackPreviousRequiresConfirmationInNonInteractiveMode(t *testing.T) {
+	oldCurrentExecutable := currentExecutable
+	t.Cleanup(func() { currentExecutable = oldCurrentExecutable })
+
+	currentExecutable = func() (string, error) {
+		return filepath.Join(t.TempDir(), "bgctl"), nil
+	}
+
+	cmd := NewUpdateCommand()
+	cmd.SetContext(context.WithValue(context.Background(), runtimeKey{}, &runtimeState{
+		nonInteractive: true,
+		writer:         io.Discard,
+	}))
+	cmd.SetArgs([]string{"rollback"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required")
+}
+
 func TestUpdateCommandRequiresConfirmationInNonInteractiveMode(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter
@@ -251,6 +271,38 @@ func TestUpdateCommandRequiresConfirmationInNonInteractiveMode(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "confirmation required")
+}
+
+func TestUpdateRollbackVersionPromptUsesRollbackAction(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.28","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/rollback-bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+
+	var prompt bytes.Buffer
+	cmd := NewUpdateCommand()
+	cmd.SetContext(context.WithValue(context.Background(), runtimeKey{}, &runtimeState{
+		writer: &prompt,
+	}))
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{"rollback", "--version", "v0.1.0-beta.28"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
+	assert.Contains(t, prompt.String(), "rollback bgctl to v0.1.0-beta.28")
 }
 
 func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -223,6 +223,36 @@ func TestUpdateRollbackDryRunWritesToCommandOutput(t *testing.T) {
 	assert.Contains(t, output.String(), ".old")
 }
 
+func TestUpdateCommandRequiresConfirmationInNonInteractiveMode(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldStatusWriter := updateStatusWriter
+	t.Cleanup(func() {
+		updateHTTPClient = oldClient
+		updateStatusWriter = oldStatusWriter
+	})
+
+	updateHTTPClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(`{"tag_name":"v0.1.0-beta.30","assets":[{"name":"` + assetFileName() + `","browser_download_url":"https://example.com/bgctl.tar.gz"}]}`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	updateStatusWriter = io.Discard
+
+	cmd := NewUpdateCommand()
+	cmd.SetContext(context.WithValue(context.Background(), runtimeKey{}, &runtimeState{
+		nonInteractive: true,
+		writer:         io.Discard,
+	}))
+	cmd.SetArgs([]string{"--version", "v0.1.0-beta.30"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required")
+}
+
 func TestUpdateCommandRunsInstallFlowWithStatusMessages(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldStatusWriter := updateStatusWriter

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -71,6 +71,18 @@ func TestFormatBytes(t *testing.T) {
 	assert.Equal(t, "1.0 MB", formatBytes(1024*1024))
 }
 
+func TestUpdateStatusf(t *testing.T) {
+	oldWriter := updateStatusWriter
+	t.Cleanup(func() { updateStatusWriter = oldWriter })
+
+	var buf bytes.Buffer
+	updateStatusWriter = &buf
+
+	updateStatusf("Downloading %s...", "bgctl_linux_amd64.tar.gz")
+
+	assert.Equal(t, "Downloading bgctl_linux_amd64.tar.gz...\n", buf.String())
+}
+
 func TestDownloadFile(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -304,13 +304,15 @@ func TestUpdateRollbackPreviousMissingBackupReportsPath(t *testing.T) {
 	currentExecutable = func() (string, error) {
 		return executablePath, nil
 	}
-	updateStatusWriter = io.Discard
+	var status bytes.Buffer
+	updateStatusWriter = &status
 	cmd := NewUpdateCommand()
 	cmd.SetArgs([]string{"rollback", "--yes"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rollback binary not found: "+executablePath+".old")
+	assert.Empty(t, status.String())
 }
 
 func TestUpdateRollbackPreviousReturnsReplaceError(t *testing.T) {
@@ -347,7 +349,9 @@ func TestUpdateRollbackPreviousRequiresConfirmationInNonInteractiveMode(t *testi
 	t.Cleanup(func() { currentExecutable = oldCurrentExecutable })
 
 	currentExecutable = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bgctl"), nil
+		executablePath := filepath.Join(t.TempDir(), "bgctl")
+		require.NoError(t, os.WriteFile(executablePath+".old", []byte("old binary"), 0o755))
+		return executablePath, nil
 	}
 
 	cmd := NewUpdateCommand()
@@ -371,7 +375,9 @@ func TestUpdateRollbackPreviousPromptUsesStatusWriter(t *testing.T) {
 	})
 
 	currentExecutable = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bgctl"), nil
+		executablePath := filepath.Join(t.TempDir(), "bgctl")
+		require.NoError(t, os.WriteFile(executablePath+".old", []byte("old binary"), 0o755))
+		return executablePath, nil
 	}
 
 	var stdout bytes.Buffer

--- a/pkg/bgctl/output/output.go
+++ b/pkg/bgctl/output/output.go
@@ -109,6 +109,6 @@ func WriteObject(w io.Writer, format Format, obj any) error {
 		return fmt.Errorf("wide format requires a specific formatter for type %T", obj)
 
 	default:
-		return fmt.Errorf("unsupported output format: %q (choose from: table, wide, json, yaml)", format)
+		return fmt.Errorf("unsupported output format: %q (choose from: %s, %s, %s, %s)", format, FormatTable, FormatWide, FormatJSON, FormatYAML)
 	}
 }

--- a/pkg/bgctl/output/output.go
+++ b/pkg/bgctl/output/output.go
@@ -109,6 +109,6 @@ func WriteObject(w io.Writer, format Format, obj any) error {
 		return fmt.Errorf("wide format requires a specific formatter for type %T", obj)
 
 	default:
-		return fmt.Errorf("unknown output format: %q", format)
+		return fmt.Errorf("unsupported output format: %q (choose from: table, wide, json, yaml)", format)
 	}
 }

--- a/pkg/bgctl/output/output_test.go
+++ b/pkg/bgctl/output/output_test.go
@@ -150,7 +150,7 @@ func TestWriteObject_UnknownFormat(t *testing.T) {
 	buf := &bytes.Buffer{}
 	err := WriteObject(buf, Format("invalid"), struct{}{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `unknown output format: "invalid"`)
+	assert.Contains(t, err.Error(), `unsupported output format: "invalid" (choose from: table, wide, json, yaml)`)
 }
 
 func TestWriteObject_JSONMarshalError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Long help and examples for common bgctl session workflows
- add practical short flags for list/watch/request/approve/reject without conflicting with global context flags
- report update phases to stderr so long downloads and installs are observable
- make unsupported output-format errors list the valid choices

Refs #544.

## Validation
- `go test ./pkg/bgctl/cmd ./pkg/bgctl/output`
- `make test-cli`
- `make lint`
- `git diff --check`

## Notes
- This keeps the existing command behavior and output formats intact; it only improves discoverability and progress reporting.