### PR TITLE
chart: add opt-in validating admission policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,23 @@ jobs:
       - name: Template validation
         run: |
           helm template test-release charts/escalation-config --values charts/escalation-config/ci/test-values.yaml --debug
+      - name: Template optional ValidatingAdmissionPolicy resources
+        run: |
+          helm template test-release charts/escalation-config \
+            --show-only templates/validatingadmissionpolicy.yaml \
+            --values charts/escalation-config/ci/test-values.yaml \
+            --set validatingAdmissionPolicy.enabled=true \
+            --kube-version 1.30.0 \
+            --debug >/tmp/escalation-config-vap.yaml
+      - name: Install kind
+        run: |
+          curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+      - name: Server dry-run optional ValidatingAdmissionPolicy resources
+        run: |
+          kind create cluster --name vap-validation --image "${KIND_NODE_IMAGE}" --wait 120s
+          kubectl apply --dry-run=server -f /tmp/escalation-config-vap.yaml
 
   build-image:
     name: Build Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,10 @@ jobs:
             --set validatingAdmissionPolicy.enabled=true \
             --kube-version 1.30.0 \
             --debug >/tmp/escalation-config-vap.yaml
+      - name: Validate VAP resource coverage
+        run: |
+          make kustomize
+          bash charts/escalation-config/ci/test-vap.sh
       - name: Install kind
         run: |
           curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,23 @@ jobs:
       - name: Template validation
         run: |
           helm template test-release charts/escalation-config --values charts/escalation-config/ci/test-values.yaml --debug
+      - name: Template optional ValidatingAdmissionPolicy resources
+        run: |
+          helm template test-release charts/escalation-config \
+            --show-only templates/validatingadmissionpolicy.yaml \
+            --values charts/escalation-config/ci/test-values.yaml \
+            --set validatingAdmissionPolicy.enabled=true \
+            --kube-version 1.30.0 \
+            --debug >/tmp/escalation-config-vap.yaml
+      - name: Install kind
+        run: |
+          curl -fsSL -o /tmp/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+      - name: Server dry-run optional ValidatingAdmissionPolicy resources
+        run: |
+          kind create cluster --name vap-validation --image "${KIND_NODE_IMAGE}" --wait 120s
+          kubectl apply --dry-run=server -f /tmp/escalation-config-vap.yaml
 
   build-image:
     name: Build Image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Helm ValidatingAdmissionPolicy opt-in**: The `escalation-config` chart can optionally render phase-1 ValidatingAdmissionPolicy and binding resources with Kubernetes 1.30+ server-side validation coverage.
 - **`--disable-session-rate-limit` flag**: New CLI flag (`BREAKGLASS_DISABLE_SESSION_RATE_LIMIT` env var) replaces the strict session-creation rate limiter with a permissive one (1000 req/s, burst 10000). Intended for E2E testing and development environments only. Do not use in production.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,7 @@ non-buggy case:
 
 ### Added
 
+- **Helm ValidatingAdmissionPolicy opt-in**: The `escalation-config` chart can optionally render phase-1 ValidatingAdmissionPolicy and binding resources with Kubernetes 1.30+ server-side validation coverage.
 - **`--disable-session-rate-limit` flag**: New CLI flag (`BREAKGLASS_DISABLE_SESSION_RATE_LIMIT` env var) replaces the strict session-creation rate limiter with a permissive one (1000 req/s, burst 10000). Intended for E2E testing and development environments only. Do not use in production.
 
 ### Fixed

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -546,6 +546,25 @@ escalations:
 helm upgrade my-escalation ./charts/escalation-config -f values.yaml
 ```
 
+## ValidatingAdmissionPolicy
+
+The chart can install the phase-1 ValidatingAdmissionPolicy resources that mirror the existing webhook validations. These objects are cluster-scoped, require Kubernetes 1.30 or newer, and should be enabled only once per cluster.
+
+They are disabled by default:
+
+```yaml
+validatingAdmissionPolicy:
+  enabled: true
+  validationActions:
+    - Warn
+    - Audit
+```
+
+| Value | Description | Default |
+|-------|-------------|---------|
+| `validatingAdmissionPolicy.enabled` | Create ValidatingAdmissionPolicy and binding resources | `false` |
+| `validatingAdmissionPolicy.validationActions` | Binding actions for policy violations (`Deny`, `Warn`, `Audit`) | `[Warn, Audit]` |
+
 ## Uninstalling
 
 ```bash

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -550,6 +550,8 @@ helm upgrade my-escalation ./charts/escalation-config -f values.yaml
 
 The chart can install the phase-1 ValidatingAdmissionPolicy resources that mirror the existing webhook validations. These objects are cluster-scoped, require Kubernetes 1.30 or newer, and should be enabled only once per cluster.
 
+The rendered policy and binding names are static. A second release with this option enabled will collide with the first release, and uninstalling the enabled release removes the cluster-wide policy and binding resources for every namespace that relies on them.
+
 They are disabled by default:
 
 ```yaml
@@ -563,7 +565,7 @@ validatingAdmissionPolicy:
 | Value | Description | Default |
 |-------|-------------|---------|
 | `validatingAdmissionPolicy.enabled` | Create ValidatingAdmissionPolicy and binding resources | `false` |
-| `validatingAdmissionPolicy.validationActions` | Binding actions for policy violations (`Deny`, `Warn`, `Audit`) | `[Warn, Audit]` |
+| `validatingAdmissionPolicy.validationActions` | Binding actions for policy violations (`Deny`, `Warn`, `Audit`). `Deny` and `Warn` cannot be combined. | `[Warn, Audit]` |
 
 ## Uninstalling
 

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -552,7 +552,7 @@ The chart can install the phase-1 ValidatingAdmissionPolicy resources that mirro
 
 The rendered policy and binding names are static. A second release with this option enabled will collide with the first release, and uninstalling the enabled release removes the cluster-wide policy and binding resources for every namespace that relies on them. If these objects are already managed by `config/components/vap`, keep this chart value disabled, or delete/adopt those cluster-scoped resources before enabling Helm management.
 
-They are disabled by default:
+They are disabled by default. Enable them explicitly for the single release that should own the cluster-scoped policies:
 
 ```yaml
 validatingAdmissionPolicy:

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -550,7 +550,7 @@ helm upgrade my-escalation ./charts/escalation-config -f values.yaml
 
 The chart can install the phase-1 ValidatingAdmissionPolicy resources that mirror the existing webhook validations. These objects are cluster-scoped, require Kubernetes 1.30 or newer, and should be enabled only once per cluster.
 
-The rendered policy and binding names are static. A second release with this option enabled will collide with the first release, and uninstalling the enabled release removes the cluster-wide policy and binding resources for every namespace that relies on them.
+The rendered policy and binding names are static. A second release with this option enabled will collide with the first release, and uninstalling the enabled release removes the cluster-wide policy and binding resources for every namespace that relies on them. If these objects are already managed by `config/components/vap`, keep this chart value disabled, or delete/adopt those cluster-scoped resources before enabling Helm management.
 
 They are disabled by default:
 

--- a/charts/escalation-config/README.md
+++ b/charts/escalation-config/README.md
@@ -567,6 +567,9 @@ validatingAdmissionPolicy:
 | `validatingAdmissionPolicy.enabled` | Create ValidatingAdmissionPolicy and binding resources | `false` |
 | `validatingAdmissionPolicy.validationActions` | Binding actions for policy violations (`Deny`, `Warn`, `Audit`). `Deny` and `Warn` cannot be combined. | `[Warn, Audit]` |
 
+`Deny` is enforcing: a policy violation blocks the API request. Keep the default
+`Warn, Audit` actions during phase 1 unless request blocking is intentional.
+
 ## Uninstalling
 
 ```bash

--- a/charts/escalation-config/ci/test-vap.sh
+++ b/charts/escalation-config/ci/test-vap.sh
@@ -9,26 +9,32 @@ helm_output=$(helm template test-release charts/escalation-config \
 
 resource_count=$(printf '%s\n' "$helm_output" | grep -Ec '^(kind: ValidatingAdmissionPolicy|kind: ValidatingAdmissionPolicyBinding)$' || true)
 test "$resource_count" = 8
-printf '%s\n' "$helm_output" | grep -Fq 'resources: ["breakglasssessions", "breakglasssessions/status"]'
-printf '%s\n' "$helm_output" | grep -Fq 'oldObject == null || object.spec == oldObject.spec'
-printf '%s\n' "$helm_output" | grep -Fq 'oldObject.status.state == object.status.state'
+
+check_session_policy() {
+  awk '
+    /^---$/ { in_policy = 0; in_rules = 0 }
+    /^[[:space:]]*name: breakglass-session-validation$/ { in_policy = 1 }
+    in_policy && /^[[:space:]]*resources:/ {
+      in_rules = 1
+      if ($0 ~ /breakglasssessions/) parent = 1
+      if ($0 ~ /breakglasssessions\/status/) status = 1
+    }
+    in_policy && in_rules && /breakglasssessions$/ { parent = 1 }
+    in_policy && in_rules && /breakglasssessions\/status$/ { status = 1 }
+    in_policy && /^[[:space:]]*validations:/ { in_rules = 0 }
+    in_policy && /oldObject == null \|\| object.spec == oldObject.spec/ { spec = 1 }
+    in_policy && /oldObject.status.state == object.status.state/ { state = 1 }
+    END { exit(parent && status && spec && state ? 0 : 1) }
+  '
+}
+
+printf '%s\n' "$helm_output" | check_session_policy
 
 kustomize_bin=${KUSTOMIZE_BIN:-./bin/kustomize}
 if [[ ! -x "$kustomize_bin" ]]; then
   kustomize_bin=kustomize
 fi
 kustomize_output=$("$kustomize_bin" build config/test-overlays/vap)
-printf '%s\n' "$kustomize_output" | awk '
-  /^[[:space:]]*resources:/ {
-    getline first
-    getline second
-    if (first ~ /^[[:space:]]+- breakglasssessions$/ && second ~ /^[[:space:]]+- breakglasssessions\/status$/) {
-      found = 1
-    }
-  }
-  END { exit(found ? 0 : 1) }
-'
-printf '%s\n' "$kustomize_output" | grep -Fq 'oldObject == null || object.spec == oldObject.spec'
-printf '%s\n' "$kustomize_output" | grep -Fq 'oldObject.status.state == object.status.state'
+printf '%s\n' "$kustomize_output" | check_session_policy
 
 printf '%s\n' "VAP render coverage passed: Helm=8 resources, status subresource covered in Helm and Kustomize"

--- a/charts/escalation-config/ci/test-vap.sh
+++ b/charts/escalation-config/ci/test-vap.sh
@@ -7,19 +7,28 @@ helm_output=$(helm template test-release charts/escalation-config \
   --set validatingAdmissionPolicy.enabled=true \
   --kube-version 1.30.0)
 
-resource_count=$(printf '%s\n' "$helm_output" | rg -c '^kind: ValidatingAdmissionPolicy$|^kind: ValidatingAdmissionPolicyBinding$' || true)
+resource_count=$(printf '%s\n' "$helm_output" | grep -Ec '^(kind: ValidatingAdmissionPolicy|kind: ValidatingAdmissionPolicyBinding)$' || true)
 test "$resource_count" = 8
-printf '%s\n' "$helm_output" | rg -q 'resources: \["breakglasssessions", "breakglasssessions/status"\]'
-printf '%s\n' "$helm_output" | rg -q 'oldObject == null \|\| object.spec == oldObject.spec'
-printf '%s\n' "$helm_output" | rg -q 'oldObject.status.state == object.status.state'
+printf '%s\n' "$helm_output" | grep -Fq 'resources: ["breakglasssessions", "breakglasssessions/status"]'
+printf '%s\n' "$helm_output" | grep -Fq 'oldObject == null || object.spec == oldObject.spec'
+printf '%s\n' "$helm_output" | grep -Fq 'oldObject.status.state == object.status.state'
 
 kustomize_bin=${KUSTOMIZE_BIN:-./bin/kustomize}
 if [[ ! -x "$kustomize_bin" ]]; then
   kustomize_bin=kustomize
 fi
 kustomize_output=$("$kustomize_bin" build config/test-overlays/vap)
-printf '%s\n' "$kustomize_output" | rg -q -U 'resources:\n\s+- breakglasssessions\n\s+- breakglasssessions/status'
-printf '%s\n' "$kustomize_output" | rg -q 'oldObject == null \|\| object.spec == oldObject.spec'
-printf '%s\n' "$kustomize_output" | rg -q 'oldObject.status.state == object.status.state'
+printf '%s\n' "$kustomize_output" | awk '
+  /^[[:space:]]*resources:/ {
+    getline first
+    getline second
+    if (first ~ /^[[:space:]]+- breakglasssessions$/ && second ~ /^[[:space:]]+- breakglasssessions\/status$/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+'
+printf '%s\n' "$kustomize_output" | grep -Fq 'oldObject == null || object.spec == oldObject.spec'
+printf '%s\n' "$kustomize_output" | grep -Fq 'oldObject.status.state == object.status.state'
 
 printf '%s\n' "VAP render coverage passed: Helm=8 resources, status subresource covered in Helm and Kustomize"

--- a/charts/escalation-config/ci/test-vap.sh
+++ b/charts/escalation-config/ci/test-vap.sh
@@ -16,11 +16,11 @@ check_session_policy() {
     /^[[:space:]]*name: breakglass-session-validation$/ { in_policy = 1 }
     in_policy && /^[[:space:]]*resources:/ {
       in_rules = 1
-      if ($0 ~ /breakglasssessions/) parent = 1
-      if ($0 ~ /breakglasssessions\/status/) status = 1
+      if ($0 ~ /"breakglasssessions"/ || $0 ~ /^[[:space:]]*-[[:space:]]+breakglasssessions[[:space:]]*$/) parent = 1
+      if ($0 ~ /"breakglasssessions\/status"/ || $0 ~ /^[[:space:]]*-[[:space:]]+breakglasssessions\/status[[:space:]]*$/) status = 1
     }
-    in_policy && in_rules && /breakglasssessions$/ { parent = 1 }
-    in_policy && in_rules && /breakglasssessions\/status$/ { status = 1 }
+    in_policy && in_rules && /^[[:space:]]*-[[:space:]]+breakglasssessions[[:space:]]*$/ { parent = 1 }
+    in_policy && in_rules && /^[[:space:]]*-[[:space:]]+breakglasssessions\/status[[:space:]]*$/ { status = 1 }
     in_policy && /^[[:space:]]*validations:/ { in_rules = 0 }
     in_policy && /oldObject == null \|\| object.spec == oldObject.spec/ { spec = 1 }
     in_policy && /oldObject.status.state == object.status.state/ { state = 1 }
@@ -29,6 +29,14 @@ check_session_policy() {
 }
 
 printf '%s\n' "$helm_output" | check_session_policy
+if printf '%s\n' "$helm_output" | sed 's/"breakglasssessions", //' | check_session_policy; then
+  echo "session policy check accepted missing parent resource" >&2
+  exit 1
+fi
+if printf '%s\n' "$helm_output" | sed 's/"breakglasssessions\/status"//' | check_session_policy; then
+  echo "session policy check accepted missing status resource" >&2
+  exit 1
+fi
 
 kustomize_bin=${KUSTOMIZE_BIN:-./bin/kustomize}
 if [[ ! -x "$kustomize_bin" ]]; then
@@ -36,5 +44,13 @@ if [[ ! -x "$kustomize_bin" ]]; then
 fi
 kustomize_output=$("$kustomize_bin" build config/test-overlays/vap)
 printf '%s\n' "$kustomize_output" | check_session_policy
+if printf '%s\n' "$kustomize_output" | sed '/^[[:space:]]*-[[:space:]]*breakglasssessions[[:space:]]*$/d' | check_session_policy; then
+  echo "kustomize session policy check accepted missing parent resource" >&2
+  exit 1
+fi
+if printf '%s\n' "$kustomize_output" | sed '/^[[:space:]]*-[[:space:]]*breakglasssessions\/status[[:space:]]*$/d' | check_session_policy; then
+  echo "kustomize session policy check accepted missing status resource" >&2
+  exit 1
+fi
 
 printf '%s\n' "VAP render coverage passed: Helm=8 resources, status subresource covered in Helm and Kustomize"

--- a/charts/escalation-config/ci/test-vap.sh
+++ b/charts/escalation-config/ci/test-vap.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+values=charts/escalation-config/ci/test-values.yaml
+helm_output=$(helm template test-release charts/escalation-config \
+  --values "$values" \
+  --set validatingAdmissionPolicy.enabled=true \
+  --kube-version 1.30.0)
+
+resource_count=$(printf '%s\n' "$helm_output" | rg -c '^kind: ValidatingAdmissionPolicy$|^kind: ValidatingAdmissionPolicyBinding$' || true)
+test "$resource_count" = 8
+printf '%s\n' "$helm_output" | rg -q 'resources: \["breakglasssessions", "breakglasssessions/status"\]'
+printf '%s\n' "$helm_output" | rg -q 'oldObject == null \|\| object.spec == oldObject.spec'
+printf '%s\n' "$helm_output" | rg -q 'oldObject.status.state == object.status.state'
+
+kustomize_bin=${KUSTOMIZE_BIN:-./bin/kustomize}
+if [[ ! -x "$kustomize_bin" ]]; then
+  kustomize_bin=kustomize
+fi
+kustomize_output=$("$kustomize_bin" build config/test-overlays/vap)
+printf '%s\n' "$kustomize_output" | rg -q -U 'resources:\n\s+- breakglasssessions\n\s+- breakglasssessions/status'
+printf '%s\n' "$kustomize_output" | rg -q 'oldObject == null \|\| object.spec == oldObject.spec'
+printf '%s\n' "$kustomize_output" | rg -q 'oldObject.status.state == object.status.state'
+
+printf '%s\n' "VAP render coverage passed: Helm=8 resources, status subresource covered in Helm and Kustomize"

--- a/charts/escalation-config/templates/validatingadmissionpolicy.yaml
+++ b/charts/escalation-config/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,240 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- $vap := .Values.validatingAdmissionPolicy | default dict -}}
+{{- if $vap.enabled }}
+{{- if not (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version) }}
+{{- fail "validatingAdmissionPolicy.enabled requires Kubernetes 1.30 or newer" }}
+{{- end }}
+{{- $actions := default (list "Warn" "Audit") $vap.validationActions }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: breakglass-session-validation
+  labels:
+    {{- include "escalation-config.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+    breakglass.t-caas.telekom.com/phase: "1"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["breakglass.t-caas.telekom.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["breakglasssessions"]
+  validations:
+    - expression: >-
+        has(oldSelf) || object.spec.cluster.size() > 0
+      message: "spec.cluster is required"
+      reason: Invalid
+    - expression: >-
+        has(oldSelf) || object.spec.user.size() > 0
+      message: "spec.user is required"
+      reason: Invalid
+    - expression: >-
+        has(oldSelf) || object.spec.grantedGroup.size() > 0
+      message: "spec.grantedGroup is required"
+      reason: Invalid
+    - expression: >-
+        has(oldSelf) || object.spec.requestReason.size() >= 10
+      message: "spec.requestReason must be at least 10 characters"
+      reason: Invalid
+    - expression: >-
+        !has(oldSelf) || object.spec == oldSelf.spec
+      message: "spec is immutable after creation"
+      reason: Invalid
+    - expression: >-
+        !has(oldSelf) ||
+        !has(oldSelf.status) ||
+        !has(oldSelf.status.state) ||
+        oldSelf.status.state == "" ||
+        oldSelf.status.state == object.status.state ||
+        (oldSelf.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) ||
+        (oldSelf.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) ||
+        (oldSelf.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])
+      message: "invalid state transition"
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: breakglass-escalation-validation
+  labels:
+    {{- include "escalation-config.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+    breakglass.t-caas.telekom.com/phase: "1"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["breakglass.t-caas.telekom.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["breakglassescalations"]
+  validations:
+    - expression: >-
+        !has(object.spec.approvers) ||
+        (has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) ||
+        (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0)
+      message: "at least one approver group or user must be specified"
+      reason: Invalid
+    - expression: >-
+        object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')
+      message: "spec.escalatedGroup must match identifier format [a-zA-Z0-9._:-]+"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.allowed) ||
+        !has(object.spec.allowed.groups) ||
+        object.spec.allowed.groups.all(g, g.size() > 0)
+      message: "spec.allowed.groups must not contain empty entries"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.allowed) ||
+        !has(object.spec.allowed.clusters) ||
+        object.spec.allowed.clusters.all(c, c.size() > 0)
+      message: "spec.allowed.clusters must not contain empty entries"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.allowed) ||
+        !has(object.spec.allowed.groups) ||
+        object.spec.allowed.groups.size() == object.spec.allowed.groups.toSet().size()
+      message: "spec.allowed.groups must not contain duplicates"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.allowed) ||
+        !has(object.spec.allowed.clusters) ||
+        object.spec.allowed.clusters.size() == object.spec.allowed.clusters.toSet().size()
+      message: "spec.allowed.clusters must not contain duplicates"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.allowedIdentityProviders) ||
+        object.spec.allowedIdentityProviders.size() == 0 ||
+        (!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) &&
+        (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)
+      message: "allowedIdentityProviders cannot be used together with allowedIdentityProvidersForRequests or allowedIdentityProvidersForApprovers"
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: breakglass-clusterconfig-validation
+  labels:
+    {{- include "escalation-config.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+    breakglass.t-caas.telekom.com/phase: "1"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["breakglass.t-caas.telekom.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusterconfigs"]
+  validations:
+    - expression: >-
+        (has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) !=
+        ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) ||
+         (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))
+      message: "exactly one of spec.kubeconfigSecretRef or spec.oidcAuth/oidcFromIdentityProvider must be configured"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.kubeconfigSecretRef) ||
+        object.spec.kubeconfigSecretRef.name.size() > 0
+      message: "spec.kubeconfigSecretRef.name is required when kubeconfigSecretRef is set"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.identityProviderRefs) ||
+        object.spec.identityProviderRefs.size() == object.spec.identityProviderRefs.toSet().size()
+      message: "spec.identityProviderRefs must not contain duplicates"
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: breakglass-identityprovider-validation
+  labels:
+    {{- include "escalation-config.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission
+    breakglass.t-caas.telekom.com/phase: "1"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["breakglass.t-caas.telekom.com"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["identityproviders"]
+  validations:
+    - expression: >-
+        has(object.spec.oidc) &&
+        has(object.spec.oidc.authority) &&
+        object.spec.oidc.authority.startsWith('https://')
+      message: "spec.oidc.authority is required and must be an HTTPS URL"
+      reason: Invalid
+    - expression: >-
+        has(object.spec.oidc) &&
+        has(object.spec.oidc.clientID) &&
+        object.spec.oidc.clientID.size() > 0
+      message: "spec.oidc.clientID is required"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.oidc) ||
+        !has(object.spec.oidc.jwksEndpoint) ||
+        object.spec.oidc.jwksEndpoint.size() == 0 ||
+        object.spec.oidc.jwksEndpoint.startsWith('https://')
+      message: "spec.oidc.jwksEndpoint must be an HTTPS URL when specified"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.oidc) ||
+        !has(object.spec.oidc.insecureSkipVerify) ||
+        object.spec.oidc.insecureSkipVerify == false
+      message: "spec.oidc.insecureSkipVerify is not supported; configure spec.oidc.certificateAuthority"
+      reason: Forbidden
+    - expression: >-
+        !has(object.spec.issuer) ||
+        object.spec.issuer.size() == 0 ||
+        object.spec.issuer.startsWith('https://')
+      message: "spec.issuer must be an HTTPS URL when specified"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.groupSyncProvider) ||
+        object.spec.groupSyncProvider != 'Keycloak' ||
+        (has(object.spec.keycloak) &&
+         has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 &&
+         has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 &&
+         has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)
+      message: "spec.keycloak (baseURL, realm, clientID) is required when groupSyncProvider is Keycloak"
+      reason: Invalid
+    - expression: >-
+        !has(object.spec.keycloak) ||
+        !has(object.spec.keycloak.insecureSkipVerify) ||
+        object.spec.keycloak.insecureSkipVerify == false
+      message: "spec.keycloak.insecureSkipVerify is not supported; configure spec.keycloak.certificateAuthority"
+      reason: Forbidden
+    - expression: >-
+        !has(object.spec.keycloak) ||
+        !has(object.spec.groupSyncProvider) ||
+        object.spec.groupSyncProvider == 'Keycloak'
+      message: "spec.keycloak must not be set when groupSyncProvider is not Keycloak"
+      reason: Invalid
+{{- range $name := list "breakglass-session-validation" "breakglass-escalation-validation" "breakglass-clusterconfig-validation" "breakglass-identityprovider-validation" }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $name }}-binding
+  labels:
+    {{- include "escalation-config.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: admission
+    breakglass.t-caas.telekom.com/phase: "1"
+spec:
+  policyName: {{ $name }}
+  validationActions:
+    {{- toYaml $actions | nindent 4 }}
+  matchResources: {}
+{{- end }}
+{{- end }}

--- a/charts/escalation-config/templates/validatingadmissionpolicy.yaml
+++ b/charts/escalation-config/templates/validatingadmissionpolicy.yaml
@@ -9,6 +9,9 @@ SPDX-License-Identifier: Apache-2.0
 {{- fail "validatingAdmissionPolicy.enabled requires Kubernetes 1.30 or newer" }}
 {{- end }}
 {{- $actions := default (list "Warn" "Audit") $vap.validationActions }}
+{{- if and (has "Deny" $actions) (has "Warn" $actions) }}
+{{- fail "validatingAdmissionPolicy.validationActions cannot combine Deny and Warn" }}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -28,34 +31,34 @@ spec:
         resources: ["breakglasssessions"]
   validations:
     - expression: >-
-        has(oldSelf) || object.spec.cluster.size() > 0
+        oldObject != null || object.spec.cluster.size() > 0
       message: "spec.cluster is required"
       reason: Invalid
     - expression: >-
-        has(oldSelf) || object.spec.user.size() > 0
+        oldObject != null || object.spec.user.size() > 0
       message: "spec.user is required"
       reason: Invalid
     - expression: >-
-        has(oldSelf) || object.spec.grantedGroup.size() > 0
+        oldObject != null || object.spec.grantedGroup.size() > 0
       message: "spec.grantedGroup is required"
       reason: Invalid
     - expression: >-
-        has(oldSelf) || object.spec.requestReason.size() >= 10
+        oldObject != null || object.spec.requestReason.size() >= 10
       message: "spec.requestReason must be at least 10 characters"
       reason: Invalid
     - expression: >-
-        !has(oldSelf) || object.spec == oldSelf.spec
+        oldObject == null || object.spec == oldObject.spec
       message: "spec is immutable after creation"
       reason: Invalid
     - expression: >-
-        !has(oldSelf) ||
-        !has(oldSelf.status) ||
-        !has(oldSelf.status.state) ||
-        oldSelf.status.state == "" ||
-        oldSelf.status.state == object.status.state ||
-        (oldSelf.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) ||
-        (oldSelf.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) ||
-        (oldSelf.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])
+        oldObject == null ||
+        !has(oldObject.status) ||
+        !has(oldObject.status.state) ||
+        oldObject.status.state == "" ||
+        oldObject.status.state == object.status.state ||
+        (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) ||
+        (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) ||
+        (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])
       message: "invalid state transition"
       reason: Invalid
 ---
@@ -101,13 +104,13 @@ spec:
     - expression: >-
         !has(object.spec.allowed) ||
         !has(object.spec.allowed.groups) ||
-        object.spec.allowed.groups.size() == object.spec.allowed.groups.toSet().size()
+        object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))
       message: "spec.allowed.groups must not contain duplicates"
       reason: Invalid
     - expression: >-
         !has(object.spec.allowed) ||
         !has(object.spec.allowed.clusters) ||
-        object.spec.allowed.clusters.size() == object.spec.allowed.clusters.toSet().size()
+        object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))
       message: "spec.allowed.clusters must not contain duplicates"
       reason: Invalid
     - expression: >-
@@ -148,7 +151,7 @@ spec:
       reason: Invalid
     - expression: >-
         !has(object.spec.identityProviderRefs) ||
-        object.spec.identityProviderRefs.size() == object.spec.identityProviderRefs.toSet().size()
+        object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))
       message: "spec.identityProviderRefs must not contain duplicates"
       reason: Invalid
 ---

--- a/charts/escalation-config/templates/validatingadmissionpolicy.yaml
+++ b/charts/escalation-config/templates/validatingadmissionpolicy.yaml
@@ -31,20 +31,23 @@ spec:
         resources: ["breakglasssessions"]
   validations:
     - expression: >-
-        oldObject != null || object.spec.cluster.size() > 0
+        oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)
       message: "spec.cluster is required"
       reason: Invalid
     - expression: >-
-        oldObject != null || object.spec.user.size() > 0
+        oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)
       message: "spec.user is required"
       reason: Invalid
     - expression: >-
-        oldObject != null || object.spec.grantedGroup.size() > 0
+        oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)
       message: "spec.grantedGroup is required"
       reason: Invalid
     - expression: >-
-        oldObject != null || object.spec.requestReason.size() >= 10
-      message: "spec.requestReason must be at least 10 characters"
+        oldObject != null ||
+        !has(object.spec.requestReason) ||
+        object.spec.requestReason.size() == 0 ||
+        object.spec.requestReason.size() >= 10
+      message: "spec.requestReason must be at least 10 characters when supplied"
       reason: Invalid
     - expression: >-
         oldObject == null || object.spec == oldObject.spec
@@ -80,12 +83,16 @@ spec:
         resources: ["breakglassescalations"]
   validations:
     - expression: >-
-        !has(object.spec.approvers) ||
-        (has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) ||
-        (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0)
+        has(object.spec.approvers) &&
+        (
+          (has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) ||
+          (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0)
+        )
       message: "at least one approver group or user must be specified"
       reason: Invalid
     - expression: >-
+        has(object.spec.escalatedGroup) &&
+        object.spec.escalatedGroup.size() > 0 &&
         object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')
       message: "spec.escalatedGroup must match identifier format [a-zA-Z0-9._:-]+"
       reason: Invalid

--- a/charts/escalation-config/templates/validatingadmissionpolicy.yaml
+++ b/charts/escalation-config/templates/validatingadmissionpolicy.yaml
@@ -43,13 +43,6 @@ spec:
       message: "spec.grantedGroup is required"
       reason: Invalid
     - expression: >-
-        oldObject != null ||
-        !has(object.spec.requestReason) ||
-        object.spec.requestReason.size() == 0 ||
-        object.spec.requestReason.size() >= 10
-      message: "spec.requestReason must be at least 10 characters when supplied"
-      reason: Invalid
-    - expression: >-
         oldObject == null || object.spec == oldObject.spec
       message: "spec is immutable after creation"
       reason: Invalid
@@ -126,6 +119,11 @@ spec:
         (!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) &&
         (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)
       message: "allowedIdentityProviders cannot be used together with allowedIdentityProvidersForRequests or allowedIdentityProvidersForApprovers"
+      reason: Invalid
+    - expression: >-
+        (!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) ==
+        (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)
+      message: "allowedIdentityProvidersForRequests and allowedIdentityProvidersForApprovers must both be set or both be empty"
       reason: Invalid
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/escalation-config/templates/validatingadmissionpolicy.yaml
+++ b/charts/escalation-config/templates/validatingadmissionpolicy.yaml
@@ -28,7 +28,7 @@ spec:
       - apiGroups: ["breakglass.t-caas.telekom.com"]
         apiVersions: ["v1alpha1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["breakglasssessions"]
+        resources: ["breakglasssessions", "breakglasssessions/status"]
   validations:
     - expression: >-
         oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -1034,6 +1034,20 @@
             "type": "string"
           },
           "minItems": 1,
+          "not": {
+            "allOf": [
+              {
+                "contains": {
+                  "const": "Deny"
+                }
+              },
+              {
+                "contains": {
+                  "const": "Warn"
+                }
+              }
+            ]
+          },
           "type": "array",
           "uniqueItems": true
         }

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -1031,6 +1031,20 @@
             "type": "string"
           },
           "minItems": 1,
+          "not": {
+            "allOf": [
+              {
+                "contains": {
+                  "const": "Deny"
+                }
+              },
+              {
+                "contains": {
+                  "const": "Warn"
+                }
+              }
+            ]
+          },
           "type": "array",
           "uniqueItems": true
         }

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -1010,6 +1010,36 @@
       },
       "type": "array"
     },
+    "validatingAdmissionPolicy": {
+      "additionalProperties": false,
+      "description": "Optional cluster-scoped ValidatingAdmissionPolicy resources. Requires Kubernetes 1.30 or newer.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Create ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding resources.",
+          "type": "boolean"
+        },
+        "validationActions": {
+          "default": [
+            "Warn",
+            "Audit"
+          ],
+          "description": "Admission actions used by the policy bindings.",
+          "items": {
+            "enum": [
+              "Deny",
+              "Warn",
+              "Audit"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
     "networkPolicy": {
       "description": "NetworkPolicy for the breakglass controller pods.",
       "properties": {

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -1007,6 +1007,36 @@
       },
       "type": "array"
     },
+    "validatingAdmissionPolicy": {
+      "additionalProperties": false,
+      "description": "Optional cluster-scoped ValidatingAdmissionPolicy resources. Requires Kubernetes 1.30 or newer.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Create ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding resources.",
+          "type": "boolean"
+        },
+        "validationActions": {
+          "default": [
+            "Warn",
+            "Audit"
+          ],
+          "description": "Admission actions used by the policy bindings.",
+          "items": {
+            "enum": [
+              "Deny",
+              "Warn",
+              "Audit"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
     "networkPolicy": {
       "description": "NetworkPolicy for the breakglass controller pods.",
       "properties": {

--- a/charts/escalation-config/values.yaml
+++ b/charts/escalation-config/values.yaml
@@ -1,4 +1,18 @@
 # ==========================================
+# ValidatingAdmissionPolicy Configuration
+# ==========================================
+# ValidatingAdmissionPolicy resources are cluster-scoped and require Kubernetes
+# 1.30 or newer. Keep this disabled unless the policies should be installed
+# once for the whole cluster.
+validatingAdmissionPolicy:
+  enabled: false
+  # validationActions controls how the API server handles policy violations.
+  # Warn/Audit is the safe phase-1 default alongside the existing webhooks.
+  validationActions:
+    - Warn
+    - Audit
+
+# ==========================================
 # NetworkPolicy Configuration
 # ==========================================
 # Controls ingress traffic to the breakglass controller pods.

--- a/config/components/vap/breakglass-escalation-policy.yaml
+++ b/config/components/vap/breakglass-escalation-policy.yaml
@@ -29,14 +29,18 @@ spec:
   validations:
     # At least one approver group or user must be specified
     - expression: >-
-        !has(object.spec.approvers) ||
-        (has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) ||
-        (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0)
+        has(object.spec.approvers) &&
+        (
+          (has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) ||
+          (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0)
+        )
       message: "at least one approver group or user must be specified"
       reason: Invalid
 
     # escalatedGroup must use identifier format
     - expression: >-
+        has(object.spec.escalatedGroup) &&
+        object.spec.escalatedGroup.size() > 0 &&
         object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')
       message: "spec.escalatedGroup must match identifier format [a-zA-Z0-9._:-]+"
       reason: Invalid

--- a/config/components/vap/breakglass-escalation-policy.yaml
+++ b/config/components/vap/breakglass-escalation-policy.yaml
@@ -86,3 +86,8 @@ spec:
         (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)
       message: "allowedIdentityProviders cannot be used together with allowedIdentityProvidersForRequests or allowedIdentityProvidersForApprovers"
       reason: Invalid
+    - expression: >-
+        (!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) ==
+        (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)
+      message: "allowedIdentityProvidersForRequests and allowedIdentityProvidersForApprovers must both be set or both be empty"
+      reason: Invalid

--- a/config/components/vap/breakglass-escalation-policy.yaml
+++ b/config/components/vap/breakglass-escalation-policy.yaml
@@ -61,7 +61,7 @@ spec:
     - expression: >-
         !has(object.spec.allowed) ||
         !has(object.spec.allowed.groups) ||
-        object.spec.allowed.groups.size() == object.spec.allowed.groups.toSet().size()
+        object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))
       message: "spec.allowed.groups must not contain duplicates"
       reason: Invalid
 
@@ -69,7 +69,7 @@ spec:
     - expression: >-
         !has(object.spec.allowed) ||
         !has(object.spec.allowed.clusters) ||
-        object.spec.allowed.clusters.size() == object.spec.allowed.clusters.toSet().size()
+        object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))
       message: "spec.allowed.clusters must not contain duplicates"
       reason: Invalid
 

--- a/config/components/vap/breakglass-session-policy.yaml
+++ b/config/components/vap/breakglass-session-policy.yaml
@@ -36,26 +36,29 @@ spec:
 
     # Cluster must be non-empty
     - expression: >-
-        oldObject != null || object.spec.cluster.size() > 0
+        oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)
       message: "spec.cluster is required"
       reason: Invalid
 
     # User must be non-empty
     - expression: >-
-        oldObject != null || object.spec.user.size() > 0
+        oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)
       message: "spec.user is required"
       reason: Invalid
 
     # GrantedGroup must be non-empty
     - expression: >-
-        oldObject != null || object.spec.grantedGroup.size() > 0
+        oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)
       message: "spec.grantedGroup is required"
       reason: Invalid
 
-    # Reason must be at least 10 characters
+    # Reason must be at least 10 characters when supplied
     - expression: >-
-        oldObject != null || object.spec.requestReason.size() >= 10
-      message: "spec.requestReason must be at least 10 characters"
+        oldObject != null ||
+        !has(object.spec.requestReason) ||
+        object.spec.requestReason.size() == 0 ||
+        object.spec.requestReason.size() >= 10
+      message: "spec.requestReason must be at least 10 characters when supplied"
       reason: Invalid
 
     # --- UPDATE-only validations ---

--- a/config/components/vap/breakglass-session-policy.yaml
+++ b/config/components/vap/breakglass-session-policy.yaml
@@ -52,15 +52,6 @@ spec:
       message: "spec.grantedGroup is required"
       reason: Invalid
 
-    # Reason must be at least 10 characters when supplied
-    - expression: >-
-        oldObject != null ||
-        !has(object.spec.requestReason) ||
-        object.spec.requestReason.size() == 0 ||
-        object.spec.requestReason.size() >= 10
-      message: "spec.requestReason must be at least 10 characters when supplied"
-      reason: Invalid
-
     # --- UPDATE-only validations ---
 
     # Spec is immutable after creation

--- a/config/components/vap/breakglass-session-policy.yaml
+++ b/config/components/vap/breakglass-session-policy.yaml
@@ -32,29 +32,29 @@ spec:
         resources: ["breakglasssessions"]
 
   validations:
-    # --- CREATE-only validations (skip on UPDATE via has(oldSelf)) ---
+    # --- CREATE-only validations (skip on UPDATE when oldObject exists) ---
 
     # Cluster must be non-empty
     - expression: >-
-        has(oldSelf) || object.spec.cluster.size() > 0
+        oldObject != null || object.spec.cluster.size() > 0
       message: "spec.cluster is required"
       reason: Invalid
 
     # User must be non-empty
     - expression: >-
-        has(oldSelf) || object.spec.user.size() > 0
+        oldObject != null || object.spec.user.size() > 0
       message: "spec.user is required"
       reason: Invalid
 
     # GrantedGroup must be non-empty
     - expression: >-
-        has(oldSelf) || object.spec.grantedGroup.size() > 0
+        oldObject != null || object.spec.grantedGroup.size() > 0
       message: "spec.grantedGroup is required"
       reason: Invalid
 
     # Reason must be at least 10 characters
     - expression: >-
-        has(oldSelf) || object.spec.requestReason.size() >= 10
+        oldObject != null || object.spec.requestReason.size() >= 10
       message: "spec.requestReason must be at least 10 characters"
       reason: Invalid
 
@@ -62,7 +62,7 @@ spec:
 
     # Spec is immutable after creation
     - expression: >-
-        !has(oldSelf) || object.spec == oldSelf.spec
+        oldObject == null || object.spec == oldObject.spec
       message: "spec is immutable after creation"
       reason: Invalid
 
@@ -71,13 +71,13 @@ spec:
     #        WaitingForScheduledTime → {Approved, Withdrawn}, Approved → Expired
     # Terminal states (Rejected, Withdrawn, Expired, ApprovalTimeout) cannot transition
     - expression: >-
-        !has(oldSelf) ||
-        !has(oldSelf.status) ||
-        !has(oldSelf.status.state) ||
-        oldSelf.status.state == "" ||
-        oldSelf.status.state == object.status.state ||
-        (oldSelf.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) ||
-        (oldSelf.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) ||
-        (oldSelf.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])
+        oldObject == null ||
+        !has(oldObject.status) ||
+        !has(oldObject.status.state) ||
+        oldObject.status.state == "" ||
+        oldObject.status.state == object.status.state ||
+        (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) ||
+        (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) ||
+        (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])
       message: "invalid state transition"
       reason: Invalid

--- a/config/components/vap/breakglass-session-policy.yaml
+++ b/config/components/vap/breakglass-session-policy.yaml
@@ -29,7 +29,7 @@ spec:
       - apiGroups: ["breakglass.t-caas.telekom.com"]
         apiVersions: ["v1alpha1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["breakglasssessions"]
+        resources: ["breakglasssessions", "breakglasssessions/status"]
 
   validations:
     # --- CREATE-only validations (skip on UPDATE when oldObject exists) ---

--- a/config/components/vap/clusterconfig-policy.yaml
+++ b/config/components/vap/clusterconfig-policy.yaml
@@ -45,6 +45,6 @@ spec:
     # No duplicate identityProviderRefs
     - expression: >-
         !has(object.spec.identityProviderRefs) ||
-        object.spec.identityProviderRefs.size() == object.spec.identityProviderRefs.toSet().size()
+        object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))
       message: "spec.identityProviderRefs must not contain duplicates"
       reason: Invalid

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -54,8 +54,8 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | `escalatedGroup` identifier format | `has(object.spec.escalatedGroup) && object.spec.escalatedGroup.size() > 0 && object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')` |
 | No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
 | No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
-| No duplicate `allowed.groups` | `object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
-| No duplicate `allowed.clusters` | `object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
+| No duplicate `allowed.groups` | `!has(object.spec.allowed) || !has(object.spec.allowed.groups) || object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
+| No duplicate `allowed.clusters` | `!has(object.spec.allowed) || !has(object.spec.allowed.clusters) || object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
 | IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) || object.spec.allowedIdentityProviders.size() == 0 || ((!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0))` |
 | IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
 

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -43,7 +43,6 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | `spec.cluster` required on create | `oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
 | `spec.user` required on create | `oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)` |
 | `spec.grantedGroup` required on create | `oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
-| `spec.requestReason` ≥ 10 chars when supplied | Guarded `has(object.spec.requestReason)` size check |
 | Spec immutability on update | `oldObject == null || object.spec == oldObject.spec` |
 | Valid state transitions | Enumerated allowed transitions |
 
@@ -51,13 +50,13 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Approvers non-empty | `has(object.spec.approvers) && ((has(groups) && groups.size() > 0) || (has(users) && users.size() > 0))` |
+| Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) || (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
 | `escalatedGroup` identifier format | Guarded `has(object.spec.escalatedGroup)` regex check |
 | No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
 | No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
 | No duplicate `allowed.groups` | `all(... exists_one(...))` uniqueness check |
 | No duplicate `allowed.clusters` | `all(... exists_one(...))` uniqueness check |
-| IDP field mutual exclusivity | `allowedIdentityProviders` vs `forRequests`/`forApprovers` |
+| IDP field compatibility | Legacy `allowedIdentityProviders` mutual exclusion plus request/approver split-field symmetry |
 
 #### ClusterConfig
 
@@ -89,6 +88,7 @@ These validations **cannot** be expressed in CEL without cross-resource lookups:
 - **`validateIdentityProviderRefs`** — Requires looking up referenced IdentityProviders
 - **`validateMailProviderReference`** — Requires looking up referenced MailProviders
 - **`validateSessionIdentityProviderAuthorization`** — Requires cross-referencing escalations and IDPs
+- **BreakglassSession request reason policy** — Depends on the matched escalation's stored reason policy
 - **Go template syntax validation** — Cannot validate Go templates via CEL
 - **Template dry-run rendering** — Requires full Go runtime
 
@@ -139,9 +139,9 @@ Expected output:
 ```
 NAME                                       VALIDATIONS   PARAMKIND   MATCHCONDITIONS
 breakglass-clusterconfig-validation        3             <unset>     0
-breakglass-escalation-validation           7             <unset>     0
+breakglass-escalation-validation           8             <unset>     0
 breakglass-identityprovider-validation     8             <unset>     0
-breakglass-session-validation              6             <unset>     0
+breakglass-session-validation              5             <unset>     0
 ```
 
 Check bindings:

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -40,10 +40,10 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 
 | Validation | CEL Expression |
 |------------|---------------|
-| `spec.cluster` required | `object.spec.cluster.size() > 0` |
-| `spec.user` required | `object.spec.user.size() > 0` |
-| `spec.grantedGroup` required | `object.spec.grantedGroup.size() > 0` |
-| `spec.requestReason` ≥ 10 chars | `oldObject != null || object.spec.requestReason.size() >= 10` |
+| `spec.cluster` required on create | `oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
+| `spec.user` required on create | `oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)` |
+| `spec.grantedGroup` required on create | `oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
+| `spec.requestReason` ≥ 10 chars when supplied | Guarded `has(object.spec.requestReason)` size check |
 | Spec immutability on update | `oldObject == null || object.spec == oldObject.spec` |
 | Valid state transitions | Enumerated allowed transitions |
 
@@ -51,8 +51,8 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Approvers non-empty | At least one group or user |
-| `escalatedGroup` identifier format | Regex `^[a-zA-Z0-9._:-]+$` |
+| Approvers non-empty | `has(object.spec.approvers) && ((has(groups) && groups.size() > 0) || (has(users) && users.size() > 0))` |
+| `escalatedGroup` identifier format | Guarded `has(object.spec.escalatedGroup)` regex check |
 | No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
 | No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
 | No duplicate `allowed.groups` | `all(... exists_one(...))` uniqueness check |

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -51,12 +51,13 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | Validation | CEL Expression |
 |------------|---------------|
 | Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) || (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
-| `escalatedGroup` identifier format | Guarded `has(object.spec.escalatedGroup)` regex check |
+| `escalatedGroup` identifier format | `has(object.spec.escalatedGroup) && object.spec.escalatedGroup.size() > 0 && object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')` |
 | No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
 | No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
-| No duplicate `allowed.groups` | `all(... exists_one(...))` uniqueness check |
-| No duplicate `allowed.clusters` | `all(... exists_one(...))` uniqueness check |
-| IDP field compatibility | Legacy `allowedIdentityProviders` mutual exclusion plus request/approver split-field symmetry |
+| No duplicate `allowed.groups` | `object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
+| No duplicate `allowed.clusters` | `object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
+| IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) || object.spec.allowedIdentityProviders.size() == 0 || ((!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0))` |
+| IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
 
 #### ClusterConfig
 

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -43,8 +43,8 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | `spec.cluster` required | `object.spec.cluster.size() > 0` |
 | `spec.user` required | `object.spec.user.size() > 0` |
 | `spec.grantedGroup` required | `object.spec.grantedGroup.size() > 0` |
-| `spec.reason` ≥ 10 chars | `object.spec.reason.size() >= 10` |
-| Spec immutability on update | `object.spec == oldSelf.spec` |
+| `spec.requestReason` ≥ 10 chars | `oldObject != null || object.spec.requestReason.size() >= 10` |
+| Spec immutability on update | `oldObject == null || object.spec == oldObject.spec` |
 | Valid state transitions | Enumerated allowed transitions |
 
 #### BreakglassEscalation
@@ -55,8 +55,8 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | `escalatedGroup` identifier format | Regex `^[a-zA-Z0-9._:-]+$` |
 | No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
 | No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
-| No duplicate `allowed.groups` | Size matches `toSet()` size |
-| No duplicate `allowed.clusters` | Size matches `toSet()` size |
+| No duplicate `allowed.groups` | `all(... exists_one(...))` uniqueness check |
+| No duplicate `allowed.clusters` | `all(... exists_one(...))` uniqueness check |
 | IDP field mutual exclusivity | `allowedIdentityProviders` vs `forRequests`/`forApprovers` |
 
 #### ClusterConfig
@@ -65,7 +65,7 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 |------------|---------------|
 | Auth config mutual exclusivity | Exactly one of `kubeconfigSecretRef` or `oidcAuth` |
 | `kubeconfigSecretRef.name` required | Non-empty when set |
-| No duplicate `identityProviderRefs` | Size matches `toSet()` size |
+| No duplicate `identityProviderRefs` | `all(... exists_one(...))` uniqueness check |
 
 #### IdentityProvider
 
@@ -114,6 +114,17 @@ Build and apply:
 ```bash
 kustomize build config/test-overlays/vap/ | kubectl apply -f -
 ```
+
+### Helm deployments
+
+The `escalation-config` chart can also render these VAP objects through
+`validatingAdmissionPolicy.enabled=true`. The policy and binding names are
+static cluster-scoped names. Enable them from only one release per cluster.
+
+If a cluster already installed the VAP objects through this kustomize component,
+leave the chart value disabled. To move ownership to Helm, first remove or adopt
+the existing `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding`
+objects so Helm does not collide with unmanaged cluster-scoped resources.
 
 ### Verify
 

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -48,6 +48,8 @@ existing webhook remains the enforcement point. If `validationActions` includes
 | Spec immutability on update | `oldObject == null \|\| object.spec == oldObject.spec` |
 | Valid state transitions | `oldObject == null \|\| !has(oldObject.status) \|\| !has(oldObject.status.state) \|\| oldObject.status.state == "" \|\| oldObject.status.state == object.status.state \|\| (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) \|\| (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) \|\| (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
 
+Session state validation matches both the main resource and its `/status` subresource, so controller status updates are covered while the guarded spec checks continue to require an unchanged spec.
+
 #### BreakglassEscalation
 
 | Validation | CEL Expression |

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -40,32 +40,32 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 
 | Validation | CEL Expression |
 |------------|---------------|
-| `spec.cluster` required on create | `oldObject != null || (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
-| `spec.user` required on create | `oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)` |
-| `spec.grantedGroup` required on create | `oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
-| Spec immutability on update | `oldObject == null || object.spec == oldObject.spec` |
-| Valid state transitions | `oldObject == null || !has(oldObject.status) || !has(oldObject.status.state) || oldObject.status.state == "" || oldObject.status.state == object.status.state || (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) || (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) || (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
+| `spec.cluster` required on create | `oldObject != null &#124;&#124; (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
+| `spec.user` required on create | `oldObject != null &#124;&#124; (has(object.spec.user) && object.spec.user.size() > 0)` |
+| `spec.grantedGroup` required on create | `oldObject != null &#124;&#124; (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
+| Spec immutability on update | `oldObject == null &#124;&#124; object.spec == oldObject.spec` |
+| Valid state transitions | `oldObject == null &#124;&#124; !has(oldObject.status) &#124;&#124; !has(oldObject.status.state) &#124;&#124; oldObject.status.state == "" &#124;&#124; oldObject.status.state == object.status.state &#124;&#124; (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) &#124;&#124; (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) &#124;&#124; (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
 
 #### BreakglassEscalation
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) || (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
+| Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) &#124;&#124; (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
 | `escalatedGroup` identifier format | `has(object.spec.escalatedGroup) && object.spec.escalatedGroup.size() > 0 && object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')` |
-| No empty `allowed.groups` entries | `!has(object.spec.allowed) || !has(object.spec.allowed.groups) || object.spec.allowed.groups.all(g, g.size() > 0)` |
-| No empty `allowed.clusters` entries | `!has(object.spec.allowed) || !has(object.spec.allowed.clusters) || object.spec.allowed.clusters.all(c, c.size() > 0)` |
-| No duplicate `allowed.groups` | `!has(object.spec.allowed) || !has(object.spec.allowed.groups) || object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
-| No duplicate `allowed.clusters` | `!has(object.spec.allowed) || !has(object.spec.allowed.clusters) || object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
-| IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) || object.spec.allowedIdentityProviders.size() == 0 || ((!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0))` |
-| IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
+| No empty `allowed.groups` entries | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.groups) &#124;&#124; object.spec.allowed.groups.all(g, g.size() > 0)` |
+| No empty `allowed.clusters` entries | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.clusters) &#124;&#124; object.spec.allowed.clusters.all(c, c.size() > 0)` |
+| No duplicate `allowed.groups` | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.groups) &#124;&#124; object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
+| No duplicate `allowed.clusters` | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.clusters) &#124;&#124; object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
+| IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) &#124;&#124; object.spec.allowedIdentityProviders.size() == 0 &#124;&#124; (!has(object.spec.allowedIdentityProvidersForRequests) &#124;&#124; object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) &#124;&#124; object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
+| IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) &#124;&#124; object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) &#124;&#124; object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
 
 #### ClusterConfig
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Auth config mutual exclusivity | `(has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) != ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) || (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))` |
-| `kubeconfigSecretRef.name` required | `!has(object.spec.kubeconfigSecretRef) || object.spec.kubeconfigSecretRef.name.size() > 0` |
-| No duplicate `identityProviderRefs` | `!has(object.spec.identityProviderRefs) || object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))` |
+| Auth config mutual exclusivity | `(has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) != ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) &#124;&#124; (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))` |
+| `kubeconfigSecretRef.name` required | `!has(object.spec.kubeconfigSecretRef) &#124;&#124; object.spec.kubeconfigSecretRef.name.size() > 0` |
+| No duplicate `identityProviderRefs` | `!has(object.spec.identityProviderRefs) &#124;&#124; object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))` |
 
 #### IdentityProvider
 
@@ -73,12 +73,12 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 |------------|---------------|
 | OIDC authority required + HTTPS | `has(object.spec.oidc) && has(object.spec.oidc.authority) && object.spec.oidc.authority.startsWith('https://')` |
 | OIDC clientID required | `has(object.spec.oidc) && has(object.spec.oidc.clientID) && object.spec.oidc.clientID.size() > 0` |
-| JWKS endpoint HTTPS | `!has(object.spec.oidc) || !has(object.spec.oidc.jwksEndpoint) || object.spec.oidc.jwksEndpoint.size() == 0 || object.spec.oidc.jwksEndpoint.startsWith('https://')` |
-| OIDC insecure TLS forbidden | `!has(object.spec.oidc) || !has(object.spec.oidc.insecureSkipVerify) || object.spec.oidc.insecureSkipVerify == false` |
-| Issuer HTTPS | `!has(object.spec.issuer) || object.spec.issuer.size() == 0 || object.spec.issuer.startsWith('https://')` |
-| Keycloak config conditional | `!has(object.spec.groupSyncProvider) || object.spec.groupSyncProvider != 'Keycloak' || (has(object.spec.keycloak) && has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 && has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 && has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)` |
-| Keycloak insecure TLS forbidden | `!has(object.spec.keycloak) || !has(object.spec.keycloak.insecureSkipVerify) || object.spec.keycloak.insecureSkipVerify == false` |
-| Keycloak config forbidden | `!has(object.spec.keycloak) || !has(object.spec.groupSyncProvider) || object.spec.groupSyncProvider == 'Keycloak'` |
+| JWKS endpoint HTTPS | `!has(object.spec.oidc) &#124;&#124; !has(object.spec.oidc.jwksEndpoint) &#124;&#124; object.spec.oidc.jwksEndpoint.size() == 0 &#124;&#124; object.spec.oidc.jwksEndpoint.startsWith('https://')` |
+| OIDC insecure TLS forbidden | `!has(object.spec.oidc) &#124;&#124; !has(object.spec.oidc.insecureSkipVerify) &#124;&#124; object.spec.oidc.insecureSkipVerify == false` |
+| Issuer HTTPS | `!has(object.spec.issuer) &#124;&#124; object.spec.issuer.size() == 0 &#124;&#124; object.spec.issuer.startsWith('https://')` |
+| Keycloak config conditional | `!has(object.spec.groupSyncProvider) &#124;&#124; object.spec.groupSyncProvider != 'Keycloak' &#124;&#124; (has(object.spec.keycloak) && has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 && has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 && has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)` |
+| Keycloak insecure TLS forbidden | `!has(object.spec.keycloak) &#124;&#124; !has(object.spec.keycloak.insecureSkipVerify) &#124;&#124; object.spec.keycloak.insecureSkipVerify == false` |
+| Keycloak config forbidden | `!has(object.spec.keycloak) &#124;&#124; !has(object.spec.groupSyncProvider) &#124;&#124; object.spec.groupSyncProvider == 'Keycloak'` |
 
 ### Validations Remaining in Webhook
 
@@ -137,7 +137,7 @@ is intentional. `Deny` and `Warn` cannot be combined.
 Check policies are deployed:
 
 ```bash
-kubectl get validatingadmissionpolicies -l app.kubernetes.io/name=breakglass
+kubectl get validatingadmissionpolicies -l breakglass.t-caas.telekom.com/phase=1
 ```
 
 Expected output:
@@ -153,7 +153,7 @@ breakglass-session-validation              5             <unset>     0
 Check bindings:
 
 ```bash
-kubectl get validatingadmissionpolicybindings -l app.kubernetes.io/name=breakglass
+kubectl get validatingadmissionpolicybindings -l breakglass.t-caas.telekom.com/phase=1
 ```
 
 ### Monitor Warnings

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -127,6 +127,11 @@ leave the chart value disabled. To move ownership to Helm, first remove or adopt
 the existing `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding`
 objects so Helm does not collide with unmanaged cluster-scoped resources.
 
+The Helm value `validatingAdmissionPolicy.validationActions` accepts `Deny`,
+`Warn`, and `Audit`. `Deny` is enforcing and blocks requests that fail a policy,
+so keep the default `Warn, Audit` actions during phase 1 unless request blocking
+is intentional. `Deny` and `Warn` cannot be combined.
+
 ### Verify
 
 Check policies are deployed:

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -44,7 +44,7 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 | `spec.user` required on create | `oldObject != null || (has(object.spec.user) && object.spec.user.size() > 0)` |
 | `spec.grantedGroup` required on create | `oldObject != null || (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
 | Spec immutability on update | `oldObject == null || object.spec == oldObject.spec` |
-| Valid state transitions | Enumerated allowed transitions |
+| Valid state transitions | `oldObject == null || !has(oldObject.status) || !has(oldObject.status.state) || oldObject.status.state == "" || oldObject.status.state == object.status.state || (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) || (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) || (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
 
 #### BreakglassEscalation
 
@@ -52,8 +52,8 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 |------------|---------------|
 | Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) || (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
 | `escalatedGroup` identifier format | `has(object.spec.escalatedGroup) && object.spec.escalatedGroup.size() > 0 && object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')` |
-| No empty `allowed.groups` entries | `all(g, g.size() > 0)` |
-| No empty `allowed.clusters` entries | `all(c, c.size() > 0)` |
+| No empty `allowed.groups` entries | `!has(object.spec.allowed) || !has(object.spec.allowed.groups) || object.spec.allowed.groups.all(g, g.size() > 0)` |
+| No empty `allowed.clusters` entries | `!has(object.spec.allowed) || !has(object.spec.allowed.clusters) || object.spec.allowed.clusters.all(c, c.size() > 0)` |
 | No duplicate `allowed.groups` | `!has(object.spec.allowed) || !has(object.spec.allowed.groups) || object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
 | No duplicate `allowed.clusters` | `!has(object.spec.allowed) || !has(object.spec.allowed.clusters) || object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
 | IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) || object.spec.allowedIdentityProviders.size() == 0 || ((!has(object.spec.allowedIdentityProvidersForRequests) || object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) || object.spec.allowedIdentityProvidersForApprovers.size() == 0))` |
@@ -63,22 +63,22 @@ Requests are **never blocked** by VAP in Phase 1 — the existing webhook remain
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Auth config mutual exclusivity | Exactly one of `kubeconfigSecretRef` or `oidcAuth` |
-| `kubeconfigSecretRef.name` required | Non-empty when set |
-| No duplicate `identityProviderRefs` | `all(... exists_one(...))` uniqueness check |
+| Auth config mutual exclusivity | `(has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) != ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) || (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))` |
+| `kubeconfigSecretRef.name` required | `!has(object.spec.kubeconfigSecretRef) || object.spec.kubeconfigSecretRef.name.size() > 0` |
+| No duplicate `identityProviderRefs` | `!has(object.spec.identityProviderRefs) || object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))` |
 
 #### IdentityProvider
 
 | Validation | CEL Expression |
 |------------|---------------|
-| OIDC authority required + HTTPS | `startsWith('https://')` |
-| OIDC clientID required | Non-empty |
-| JWKS endpoint HTTPS | HTTPS when specified |
-| OIDC insecure TLS forbidden | `insecureSkipVerify == false` |
-| Issuer HTTPS | HTTPS when specified |
-| Keycloak config conditional | Required when `groupSyncProvider == "Keycloak"` |
-| Keycloak insecure TLS forbidden | `insecureSkipVerify == false` |
-| Keycloak config forbidden | Not allowed when `groupSyncProvider != "Keycloak"` |
+| OIDC authority required + HTTPS | `has(object.spec.oidc) && has(object.spec.oidc.authority) && object.spec.oidc.authority.startsWith('https://')` |
+| OIDC clientID required | `has(object.spec.oidc) && has(object.spec.oidc.clientID) && object.spec.oidc.clientID.size() > 0` |
+| JWKS endpoint HTTPS | `!has(object.spec.oidc) || !has(object.spec.oidc.jwksEndpoint) || object.spec.oidc.jwksEndpoint.size() == 0 || object.spec.oidc.jwksEndpoint.startsWith('https://')` |
+| OIDC insecure TLS forbidden | `!has(object.spec.oidc) || !has(object.spec.oidc.insecureSkipVerify) || object.spec.oidc.insecureSkipVerify == false` |
+| Issuer HTTPS | `!has(object.spec.issuer) || object.spec.issuer.size() == 0 || object.spec.issuer.startsWith('https://')` |
+| Keycloak config conditional | `!has(object.spec.groupSyncProvider) || object.spec.groupSyncProvider != 'Keycloak' || (has(object.spec.keycloak) && has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 && has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 && has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)` |
+| Keycloak insecure TLS forbidden | `!has(object.spec.keycloak) || !has(object.spec.keycloak.insecureSkipVerify) || object.spec.keycloak.insecureSkipVerify == false` |
+| Keycloak config forbidden | `!has(object.spec.keycloak) || !has(object.spec.groupSyncProvider) || object.spec.groupSyncProvider == 'Keycloak'` |
 
 ### Validations Remaining in Webhook
 

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -32,7 +32,9 @@ Phase 1 deploys VAP resources in **Warn** mode. Validation failures produce:
 - **Warnings** in API responses (visible to `kubectl` users)
 - **Audit log entries** for monitoring and alerting
 
-Requests are **never blocked** by VAP in Phase 1 — the existing webhook remains the enforcement point.
+By default, Phase 1 uses `Warn` + `Audit`, so VAP does not block requests and the
+existing webhook remains the enforcement point. If `validationActions` includes
+`Deny`, VAP becomes enforcing and can block failing requests.
 
 ### Covered Validations
 

--- a/docs/validating-admission-policy.md
+++ b/docs/validating-admission-policy.md
@@ -42,32 +42,32 @@ existing webhook remains the enforcement point. If `validationActions` includes
 
 | Validation | CEL Expression |
 |------------|---------------|
-| `spec.cluster` required on create | `oldObject != null &#124;&#124; (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
-| `spec.user` required on create | `oldObject != null &#124;&#124; (has(object.spec.user) && object.spec.user.size() > 0)` |
-| `spec.grantedGroup` required on create | `oldObject != null &#124;&#124; (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
-| Spec immutability on update | `oldObject == null &#124;&#124; object.spec == oldObject.spec` |
-| Valid state transitions | `oldObject == null &#124;&#124; !has(oldObject.status) &#124;&#124; !has(oldObject.status.state) &#124;&#124; oldObject.status.state == "" &#124;&#124; oldObject.status.state == object.status.state &#124;&#124; (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) &#124;&#124; (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) &#124;&#124; (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
+| `spec.cluster` required on create | `oldObject != null \|\| (has(object.spec.cluster) && object.spec.cluster.size() > 0)` |
+| `spec.user` required on create | `oldObject != null \|\| (has(object.spec.user) && object.spec.user.size() > 0)` |
+| `spec.grantedGroup` required on create | `oldObject != null \|\| (has(object.spec.grantedGroup) && object.spec.grantedGroup.size() > 0)` |
+| Spec immutability on update | `oldObject == null \|\| object.spec == oldObject.spec` |
+| Valid state transitions | `oldObject == null \|\| !has(oldObject.status) \|\| !has(oldObject.status.state) \|\| oldObject.status.state == "" \|\| oldObject.status.state == object.status.state \|\| (oldObject.status.state == "Pending" && object.status.state in ["Approved", "WaitingForScheduledTime", "Rejected", "Withdrawn", "ApprovalTimeout"]) \|\| (oldObject.status.state == "WaitingForScheduledTime" && object.status.state in ["Approved", "Withdrawn", "Expired"]) \|\| (oldObject.status.state == "Approved" && object.status.state in ["Expired", "IdleExpired"])` |
 
 #### BreakglassEscalation
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) &#124;&#124; (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
+| Approvers non-empty | `has(object.spec.approvers) && ((has(object.spec.approvers.groups) && object.spec.approvers.groups.size() > 0) \|\| (has(object.spec.approvers.users) && object.spec.approvers.users.size() > 0))` |
 | `escalatedGroup` identifier format | `has(object.spec.escalatedGroup) && object.spec.escalatedGroup.size() > 0 && object.spec.escalatedGroup.matches('^[a-zA-Z0-9._:-]+$')` |
-| No empty `allowed.groups` entries | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.groups) &#124;&#124; object.spec.allowed.groups.all(g, g.size() > 0)` |
-| No empty `allowed.clusters` entries | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.clusters) &#124;&#124; object.spec.allowed.clusters.all(c, c.size() > 0)` |
-| No duplicate `allowed.groups` | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.groups) &#124;&#124; object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
-| No duplicate `allowed.clusters` | `!has(object.spec.allowed) &#124;&#124; !has(object.spec.allowed.clusters) &#124;&#124; object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
-| IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) &#124;&#124; object.spec.allowedIdentityProviders.size() == 0 &#124;&#124; (!has(object.spec.allowedIdentityProvidersForRequests) &#124;&#124; object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) &#124;&#124; object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
-| IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) &#124;&#124; object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) &#124;&#124; object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
+| No empty `allowed.groups` entries | `!has(object.spec.allowed) \|\| !has(object.spec.allowed.groups) \|\| object.spec.allowed.groups.all(g, g.size() > 0)` |
+| No empty `allowed.clusters` entries | `!has(object.spec.allowed) \|\| !has(object.spec.allowed.clusters) \|\| object.spec.allowed.clusters.all(c, c.size() > 0)` |
+| No duplicate `allowed.groups` | `!has(object.spec.allowed) \|\| !has(object.spec.allowed.groups) \|\| object.spec.allowed.groups.all(g, object.spec.allowed.groups.exists_one(x, x == g))` |
+| No duplicate `allowed.clusters` | `!has(object.spec.allowed) \|\| !has(object.spec.allowed.clusters) \|\| object.spec.allowed.clusters.all(c, object.spec.allowed.clusters.exists_one(x, x == c))` |
+| IDP legacy mutual exclusion | `!has(object.spec.allowedIdentityProviders) \|\| object.spec.allowedIdentityProviders.size() == 0 \|\| (!has(object.spec.allowedIdentityProvidersForRequests) \|\| object.spec.allowedIdentityProvidersForRequests.size() == 0) && (!has(object.spec.allowedIdentityProvidersForApprovers) \|\| object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
+| IDP split-field symmetry | `(!has(object.spec.allowedIdentityProvidersForRequests) \|\| object.spec.allowedIdentityProvidersForRequests.size() == 0) == (!has(object.spec.allowedIdentityProvidersForApprovers) \|\| object.spec.allowedIdentityProvidersForApprovers.size() == 0)` |
 
 #### ClusterConfig
 
 | Validation | CEL Expression |
 |------------|---------------|
-| Auth config mutual exclusivity | `(has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) != ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) &#124;&#124; (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))` |
-| `kubeconfigSecretRef.name` required | `!has(object.spec.kubeconfigSecretRef) &#124;&#124; object.spec.kubeconfigSecretRef.name.size() > 0` |
-| No duplicate `identityProviderRefs` | `!has(object.spec.identityProviderRefs) &#124;&#124; object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))` |
+| Auth config mutual exclusivity | `(has(object.spec.kubeconfigSecretRef) && object.spec.kubeconfigSecretRef.name.size() > 0) != ((has(object.spec.oidcAuth) && has(object.spec.oidcAuth.issuerURL) && object.spec.oidcAuth.issuerURL.size() > 0) \|\| (has(object.spec.oidcFromIdentityProvider) && has(object.spec.oidcFromIdentityProvider.name) && object.spec.oidcFromIdentityProvider.name.size() > 0))` |
+| `kubeconfigSecretRef.name` required | `!has(object.spec.kubeconfigSecretRef) \|\| object.spec.kubeconfigSecretRef.name.size() > 0` |
+| No duplicate `identityProviderRefs` | `!has(object.spec.identityProviderRefs) \|\| object.spec.identityProviderRefs.all(ref, object.spec.identityProviderRefs.exists_one(x, x == ref))` |
 
 #### IdentityProvider
 
@@ -75,12 +75,12 @@ existing webhook remains the enforcement point. If `validationActions` includes
 |------------|---------------|
 | OIDC authority required + HTTPS | `has(object.spec.oidc) && has(object.spec.oidc.authority) && object.spec.oidc.authority.startsWith('https://')` |
 | OIDC clientID required | `has(object.spec.oidc) && has(object.spec.oidc.clientID) && object.spec.oidc.clientID.size() > 0` |
-| JWKS endpoint HTTPS | `!has(object.spec.oidc) &#124;&#124; !has(object.spec.oidc.jwksEndpoint) &#124;&#124; object.spec.oidc.jwksEndpoint.size() == 0 &#124;&#124; object.spec.oidc.jwksEndpoint.startsWith('https://')` |
-| OIDC insecure TLS forbidden | `!has(object.spec.oidc) &#124;&#124; !has(object.spec.oidc.insecureSkipVerify) &#124;&#124; object.spec.oidc.insecureSkipVerify == false` |
-| Issuer HTTPS | `!has(object.spec.issuer) &#124;&#124; object.spec.issuer.size() == 0 &#124;&#124; object.spec.issuer.startsWith('https://')` |
-| Keycloak config conditional | `!has(object.spec.groupSyncProvider) &#124;&#124; object.spec.groupSyncProvider != 'Keycloak' &#124;&#124; (has(object.spec.keycloak) && has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 && has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 && has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)` |
-| Keycloak insecure TLS forbidden | `!has(object.spec.keycloak) &#124;&#124; !has(object.spec.keycloak.insecureSkipVerify) &#124;&#124; object.spec.keycloak.insecureSkipVerify == false` |
-| Keycloak config forbidden | `!has(object.spec.keycloak) &#124;&#124; !has(object.spec.groupSyncProvider) &#124;&#124; object.spec.groupSyncProvider == 'Keycloak'` |
+| JWKS endpoint HTTPS | `!has(object.spec.oidc) \|\| !has(object.spec.oidc.jwksEndpoint) \|\| object.spec.oidc.jwksEndpoint.size() == 0 \|\| object.spec.oidc.jwksEndpoint.startsWith('https://')` |
+| OIDC insecure TLS forbidden | `!has(object.spec.oidc) \|\| !has(object.spec.oidc.insecureSkipVerify) \|\| object.spec.oidc.insecureSkipVerify == false` |
+| Issuer HTTPS | `!has(object.spec.issuer) \|\| object.spec.issuer.size() == 0 \|\| object.spec.issuer.startsWith('https://')` |
+| Keycloak config conditional | `!has(object.spec.groupSyncProvider) \|\| object.spec.groupSyncProvider != 'Keycloak' \|\| (has(object.spec.keycloak) && has(object.spec.keycloak.baseURL) && object.spec.keycloak.baseURL.size() > 0 && has(object.spec.keycloak.realm) && object.spec.keycloak.realm.size() > 0 && has(object.spec.keycloak.clientID) && object.spec.keycloak.clientID.size() > 0)` |
+| Keycloak insecure TLS forbidden | `!has(object.spec.keycloak) \|\| !has(object.spec.keycloak.insecureSkipVerify) \|\| object.spec.keycloak.insecureSkipVerify == false` |
+| Keycloak config forbidden | `!has(object.spec.keycloak) \|\| !has(object.spec.groupSyncProvider) \|\| object.spec.groupSyncProvider == 'Keycloak'` |
 
 ### Validations Remaining in Webhook
 
@@ -216,7 +216,7 @@ patches:
 3. Verify binding exists:
 
    ```bash
-   kubectl get validatingadmissionpolicybindings -l app.kubernetes.io/name=breakglass
+   kubectl get validatingadmissionpolicybindings -l breakglass.t-caas.telekom.com/phase=1
    ```
 
 ### False Positives in Warn Mode


### PR DESCRIPTION
## Summary
- add opt-in Helm rendering for the phase-1 ValidatingAdmissionPolicy resources
- keep default chart output unchanged; VAP objects render only when explicitly enabled
- add values schema validation, Kubernetes 1.30 guard, and README guidance for cluster-scoped rollout

Refs #315.

## Validation
- `ruby -rjson -e 'JSON.parse(File.read("charts/escalation-config/values.schema.json"))'`\n- `helm lint charts/escalation-config --strict --values charts/escalation-config/ci/test-values.yaml`\n- `make helm-validate`\n- `helm lint charts/escalation-config --strict --values charts/escalation-config/ci/test-values.yaml --set validatingAdmissionPolicy.enabled=true --kube-version 1.30.0`\n- `helm template ...` default rendered `policies=0 bindings=0`\n- `helm template ... --set validatingAdmissionPolicy.enabled=true --kube-version 1.30.0` rendered `policies=4 bindings=4`\n- invalid `validationActions[0]=Block` was rejected by the values schema\n- `reuse lint`\n- `git diff --check`\n\n## Notes\n- This is a small Helm integration slice for #315. It does not remove webhook validation or change the default install surface.