### PR TITLE
test: reproduce group sync runtime diagnostics gaps

### DIFF
--- a/docs/group-sync-runtime-diagnostics-reproduction.md
+++ b/docs/group-sync-runtime-diagnostics-reproduction.md
@@ -1,0 +1,45 @@
+# Group Sync Runtime Diagnostics Reproduction
+
+This branch is reproduce-only. It documents two runtime diagnostics gaps seen
+during the T-CaaS rollout investigation and adds failing tests without changing
+controller behavior.
+
+## Reproduced Gaps
+
+1. Keycloak group search `403` returns the raw client error.
+
+   The controller logs include endpoint and parameter context, but
+   `KeycloakGroupMemberResolver.Members` returns only `403 Forbidden`. Operators
+   need the returned error to include the Keycloak groups endpoint and the
+   permission hint for the service account, for example `view-users`.
+
+2. `GroupFetchFailed` is emitted for a cluster-scoped `IdentityProvider` object
+   with an empty namespace.
+
+   The low-level Kubernetes event recorder has namespace fallback coverage, but
+   the updater call path currently creates a synthetic `IdentityProvider` with
+   only a name and passes it to `Eventf`. This reproduces the empty
+   involved-object namespace observed in rollout logs.
+
+## Reproduction Command
+
+Run the focused tests with localhost sockets available:
+
+```sh
+GOCACHE=/tmp/k8s-breakglass-repro-go-cache go test ./pkg/breakglass/escalation \
+  -run 'TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable|TestFetchGroupMembersFromMultipleIDPs_GroupFetchFailedEventHasNamespace' \
+  -count=1
+```
+
+Expected result on this branch: both tests fail.
+
+## Existing Upstream Coverage Not Duplicated
+
+Current `origin/main` already removed stale event text that pointed operators to
+`status.groupSyncErrors`, and `BreakglassEscalationStatus` still has no such
+field. That gap is not reproduced here because it appears to be fixed upstream
+and only present in older rolled-out versions.
+
+The existing event recorder tests cover generic namespace fallback behavior.
+This branch specifically reproduces the updater call path that passes a
+cluster-scoped `IdentityProvider` object to the recorder.

--- a/pkg/breakglass/escalation/escalation_status_updater_events_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_events_test.go
@@ -2,6 +2,10 @@ package escalation
 
 import (
 	"context"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -10,7 +14,9 @@ import (
 	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	cfgpkg "github.com/telekom/k8s-breakglass/pkg/config"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -132,6 +138,84 @@ func TestFetchGroupMembersFromMultipleIDPs_EventReasonMatchesFullFailure(t *test
 	))
 }
 
+func TestFetchGroupMembersFromMultipleIDPs_GroupFetchFailedEventHasNamespace(t *testing.T) {
+	const realm = "t-caas"
+	const idpName = "ref-keycloak"
+
+	keycloak := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/realms/"+realm+"/protocol/openid-connect/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token","expires_in":300,"token_type":"Bearer"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/"+realm+"/groups":
+			http.Error(w, "HTTP 403 Forbidden", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer keycloak.Close()
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: keycloak.Certificate().Raw,
+	})
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keycloak-secret", Namespace: "t-caas-breakglass"},
+		Data:       map[string][]byte{"clientSecret": []byte("secret")},
+	}
+	idp := &breakglassv1alpha1.IdentityProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: idpName},
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			Primary: true,
+			OIDC: breakglassv1alpha1.OIDCConfig{
+				Authority: "https://keycloak.example.com",
+				ClientID:  "breakglass",
+			},
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
+				BaseURL:              keycloak.URL,
+				Realm:                realm,
+				ClientID:             "breakglass",
+				CacheTTL:             "1m",
+				CertificateAuthority: string(caPEM),
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+					Key:       "clientSecret",
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithObjects(secret, idp).
+		Build()
+	recorder := &capturingEventRecorder{}
+	updater := &EscalationStatusUpdater{
+		IDPLoader:     cfgpkg.NewIdentityProviderLoader(cli),
+		EventRecorder: recorder,
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-emergency", Namespace: "vsphere-reftmdc-n"},
+	}
+
+	_, status, syncErrors := updater.fetchGroupMembersFromMultipleIDPs(
+		context.Background(),
+		escalation,
+		[]string{idpName},
+		[]string{"dttcaas-platform-poweruser"},
+		zap.NewNop().Sugar(),
+	)
+
+	assert.Equal(t, groupSyncStatusFailed, status)
+	assert.NotEmpty(t, syncErrors)
+	event := recorder.find("GroupFetchFailed")
+	if assert.NotNil(t, event) {
+		assert.NotEmpty(t, event.namespace, "GroupFetchFailed should not be emitted with an empty involved object namespace")
+	}
+}
+
 // TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback tests fallback to single IDP
 func TestFetchGroupMembersFromMultipleIDPs_EventEmission_NoResolverFallback(t *testing.T) {
 	log, _ := zap.NewProduction()
@@ -219,4 +303,34 @@ func recordedEventContains(events []string, parts ...string) bool {
 		}
 	}
 	return false
+}
+
+type capturedEvent struct {
+	reason    string
+	namespace string
+}
+
+type capturingEventRecorder struct {
+	events []capturedEvent
+}
+
+func (r *capturingEventRecorder) Eventf(regarding runtime.Object, _ runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	_ = eventtype
+	_ = action
+	_ = fmt.Sprintf(note, args...)
+
+	namespace := ""
+	if obj, ok := regarding.(metav1.Object); ok {
+		namespace = obj.GetNamespace()
+	}
+	r.events = append(r.events, capturedEvent{reason: reason, namespace: namespace})
+}
+
+func (r *capturingEventRecorder) find(reason string) *capturedEvent {
+	for i := range r.events {
+		if r.events[i].reason == reason {
+			return &r.events[i]
+		}
+	}
+	return nil
 }

--- a/pkg/breakglass/escalation/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_test.go
@@ -21,6 +21,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -605,6 +607,42 @@ func TestNewKeycloakGroupMemberResolver_CustomCacheTTL(t *testing.T) {
 	assert.NotNil(t, resolver.cache)
 	// Cache TTL should be 30 minutes
 	assert.Equal(t, "30m", resolver.cfg.CacheTTL)
+}
+
+func TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable(t *testing.T) {
+	const realm = "t-caas"
+	const group = "dttcaas-platform-poweruser"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/realms/"+realm+"/protocol/openid-connect/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token","expires_in":300,"token_type":"Bearer"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/"+realm+"/groups":
+			http.Error(w, "HTTP 403 Forbidden", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:      server.URL,
+		Realm:        realm,
+		ClientID:     "breakglass",
+		ClientSecret: "secret",
+		CacheTTL:     "1m",
+	})
+
+	_, err := resolver.Members(context.Background(), group)
+
+	if assert.Error(t, err) {
+		errText := err.Error()
+		assert.Contains(t, errText, "403")
+		assert.Contains(t, strings.ToLower(errText), "forbidden")
+		assert.Contains(t, errText, "/admin/realms/"+realm+"/groups")
+		assert.Contains(t, errText, "view-users")
+	}
 }
 
 func TestSetupResolverReturnsQuietNoopWhenGroupSyncDisabled(t *testing.T) {


### PR DESCRIPTION
## Scope

Reproduce-only PR for two T-CaaS rollout diagnostics gaps in k8s-breakglass group sync runtime behavior. This intentionally does not change controller behavior.

## Reproduced Gaps

- Keycloak group search `403` returns only the raw client error. Operators need the returned error to include the groups endpoint and a permission hint such as `view-users`.
- `GroupFetchFailed` is emitted for a synthetic cluster-scoped `IdentityProvider` object with an empty namespace, reproducing the empty involved-object namespace seen in rollout logs.

## Validation

Expected failing command:

```sh
GOCACHE=/tmp/k8s-breakglass-repro-go-cache go test ./pkg/breakglass/escalation \
  -run 'TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable|TestFetchGroupMembersFromMultipleIDPs_GroupFetchFailedEventHasNamespace' \
  -count=1
```

Observed failures:

- `TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable`: returned error is `403 Forbidden` and does not include `/admin/realms/t-caas/groups` or `view-users`.
- `TestFetchGroupMembersFromMultipleIDPs_GroupFetchFailedEventHasNamespace`: captured `GroupFetchFailed` event target namespace is empty.

## Not Duplicated

Current `origin/main` already removed stale `status.groupSyncErrors` wording, so this PR does not reproduce that older rolled-out-version symptom.