### PR TITLE
fix(api): allow OIDC authority CORS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/docs/ingress-configuration.md
+++ b/docs/ingress-configuration.md
@@ -50,6 +50,12 @@ server:
 - Hostname (`breakglass.example.com`)
 - Port (omit for standard 443)
 
+If your ingress, reverse proxy, CDN, or API gateway enforces its own CORS
+request-header allow-list, include `X-OIDC-Authority` alongside `Origin`,
+`Authorization`, and `Content-Type`. Browser OIDC proxy requests use this
+header in multi-IDP deployments to select the configured authority before
+fetching discovery or JWKS endpoints.
+
 ### Frontend Base URL
 
 Configure the frontend base URL to match your external hostname:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -314,7 +314,7 @@ func NewServer(log *zap.Logger, cfg config.Config,
 		cors.New(cors.Config{
 			AllowOrigins:     allowedOrigins,
 			AllowMethods:     []string{http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodPost, http.MethodOptions},
-			AllowHeaders:     []string{"Origin", "Authorization", "Content-Type"},
+			AllowHeaders:     []string{"Origin", "Authorization", "Content-Type", "X-OIDC-Authority"},
 			ExposeHeaders:    []string{"Authorization", "X-Notification-Sent"},
 			AllowCredentials: true,
 			MaxAge:           12 * time.Hour,

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -360,6 +360,21 @@ func TestOriginValidationMiddleware(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.Code)
 	})
 
+	t.Run("allows OIDC authority header in preflight", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, "/api/probe", nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://allowed.example.com")
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		req.Header.Set("Access-Control-Request-Headers", "X-OIDC-Authority")
+		w := httptest.NewRecorder()
+
+		server.gin.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusNoContent, w.Code)
+		allowedHeaders := strings.Split(w.Header().Get("Access-Control-Allow-Headers"), ",")
+		require.True(t, headerListContains(allowedHeaders, "X-OIDC-Authority"))
+	})
+
 	t.Run("blocks disallowed origin", func(t *testing.T) {
 		resp := makeRequest(http.MethodGet, "https://evil.example.com")
 		require.Equal(t, http.StatusForbidden, resp.Code)
@@ -375,6 +390,15 @@ func TestOriginValidationMiddleware(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, resp.Code)
 		require.Empty(t, resp.Body.String(), "response should come from CORS middleware, not origin validator")
 	})
+}
+
+func headerListContains(headers []string, want string) bool {
+	for _, header := range headers {
+		if strings.EqualFold(strings.TrimSpace(header), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestServer_RegisterAll(t *testing.T) {


### PR DESCRIPTION
Summary:
- allow `X-OIDC-Authority` in API CORS
- add preflight coverage
- document ingress/proxy header allow-list

Tests:
- `go test ./pkg/api/...`
- `git diff --check`

Note: duplicate PR search found no open superseding OIDC CORS PR.