### PR TITLE
fix(bgctl): honor session watch output format

### DIFF
--- a/pkg/bgctl/cmd/session.go
+++ b/pkg/bgctl/cmd/session.go
@@ -48,6 +48,19 @@ func newSessionWatchCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Watch session changes",
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			rt, err := getRuntime(cmd)
+			if err != nil {
+				return err
+			}
+			if err := validateOutputFormat(output.Format(rt.OutputFormat()), output.FormatTable, output.FormatWide, output.FormatJSON, output.FormatYAML); err != nil {
+				return err
+			}
+			if interval <= 0 {
+				return fmt.Errorf("interval must be greater than 0")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt, err := getRuntime(cmd)
 			if err != nil {
@@ -89,9 +102,17 @@ func newSessionWatchCommand() *cobra.Command {
 					if prev, ok := seen[key]; !ok || prev != value {
 						seen[key] = value
 						if showFull {
-							_ = output.WriteObject(rt.Writer(), output.FormatJSON, s)
+							format := output.Format(rt.OutputFormat())
+							if format == output.FormatTable || format == output.FormatWide {
+								format = output.FormatJSON
+							}
+							if err := output.WriteObject(rt.Writer(), format, s); err != nil {
+								return err
+							}
 						} else {
-							_, _ = fmt.Fprintf(rt.Writer(), "%s\t%s\t%s\t%s\n", s.Name, s.Spec.Cluster, s.Spec.User, s.Status.State)
+							if _, err := fmt.Fprintf(rt.Writer(), "%s\t%s\t%s\t%s\n", s.Name, s.Spec.Cluster, s.Spec.User, s.Status.State); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -125,7 +146,7 @@ func newSessionWatchCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&mine, "mine", false, "Only show sessions created by the current user")
 	cmd.Flags().BoolVar(&approver, "approver", true, "Include sessions where you are an approver")
 	cmd.Flags().BoolVar(&activeOnly, "active", false, "Only show active sessions")
-	cmd.Flags().BoolVar(&showFull, "show-full", false, "Show full session JSON on change")
+	cmd.Flags().BoolVar(&showFull, "show-full", false, "Show full session on change (respects -o json|yaml)")
 	return cmd
 }
 

--- a/pkg/bgctl/cmd/session_command_test.go
+++ b/pkg/bgctl/cmd/session_command_test.go
@@ -1,10 +1,18 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewSessionCommand_Subcommands(t *testing.T) {
@@ -83,4 +91,201 @@ func TestSessionWatchCommand_DefaultFlags(t *testing.T) {
 	assert.True(t, approver)
 	assert.False(t, activeOnly)
 	assert.False(t, showFull)
+}
+
+func TestSessionWatchCommand_RejectsNonPositiveInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval string
+	}{
+		{
+			name:     "zero",
+			interval: "0",
+		},
+		{
+			name:     "negative",
+			interval: "-1s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := NewRootCommand(Config{OutputWriter: &bytes.Buffer{}})
+			root.SetArgs([]string{
+				"--server", "https://breakglass.example.com",
+				"--token", "test-token",
+				"session", "watch",
+				"--interval=" + tt.interval,
+			})
+
+			err := root.Execute()
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "interval must be greater than 0")
+		})
+	}
+}
+
+func TestSessionWatchCommand_ShowFullRespectsOutputFormat(t *testing.T) {
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "watch-session-1"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster: "cluster-a",
+			User:    "user@example.com",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		outputFlag string
+		want       string
+		notWant    string
+	}{
+		{
+			name:    "show-full with default output emits JSON",
+			want:    `"name": "watch-session-1"`,
+			notWant: "name: watch-session-1",
+		},
+		{
+			name:       "show-full with -o table emits JSON",
+			outputFlag: "table",
+			want:       `"name": "watch-session-1"`,
+			notWant:    "name: watch-session-1",
+		},
+		{
+			name:       "show-full with -o wide emits JSON",
+			outputFlag: "wide",
+			want:       `"name": "watch-session-1"`,
+			notWant:    "name: watch-session-1",
+		},
+		{
+			name:       "show-full with -o yaml outputs YAML",
+			outputFlag: "yaml",
+			want:       "name: watch-session-1",
+			notWant:    `"name": "watch-session-1"`,
+		},
+		{
+			name:       "show-full with -o json outputs JSON",
+			outputFlag: "json",
+			want:       `"name": "watch-session-1"`,
+			notWant:    "name: watch-session-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/api/breakglassSessions", r.URL.Path)
+				requestCount++
+				if requestCount == 1 {
+					w.Header().Set("Content-Type", "application/json")
+					require.NoError(t, json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassSession{session}))
+					return
+				}
+				http.Error(w, "server stopping", http.StatusServiceUnavailable)
+			}))
+			defer server.Close()
+
+			buf := &bytes.Buffer{}
+			root := NewRootCommand(Config{OutputWriter: buf})
+			args := []string{"--server", server.URL, "--token", "test-token"}
+			if tt.outputFlag != "" {
+				args = append(args, "--output", tt.outputFlag)
+			}
+			args = append(args, "session", "watch", "--show-full", "--interval", "1ms")
+			root.SetArgs(args)
+
+			err := root.Execute()
+
+			require.Error(t, err)
+			out := buf.String()
+			require.NotEmpty(t, out)
+			require.Contains(t, out, tt.want)
+			require.NotContains(t, out, tt.notWant)
+		})
+	}
+}
+
+func TestSessionWatchCommand_ReturnsWriterErrors(t *testing.T) {
+	writerErr := errors.New("writer failed")
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "watch-session-1"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster: "cluster-a",
+			User:    "user@example.com",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "show-full explicit structured output",
+			args: []string{"--output", "json", "session", "watch", "--show-full"},
+		},
+		{
+			name: "show-full default output",
+			args: []string{"session", "watch", "--show-full"},
+		},
+		{
+			name: "tabular output",
+			args: []string{"session", "watch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/api/breakglassSessions", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode([]breakglassv1alpha1.BreakglassSession{session}))
+			}))
+			defer server.Close()
+
+			args := append([]string{
+				"--server", server.URL,
+				"--token", "test-token",
+			}, tt.args...)
+			root := NewRootCommand(Config{OutputWriter: errorWriter{err: writerErr}})
+			root.SetArgs(args)
+
+			err := root.Execute()
+
+			require.ErrorIs(t, err, writerErr)
+		})
+	}
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestSessionWatchCommand_ShowFullRejectsUnsupportedOutputFormat(t *testing.T) {
+	root := NewRootCommand(Config{OutputWriter: &bytes.Buffer{}})
+	root.SetArgs([]string{
+		"--server", "https://breakglass.example.com",
+		"--token", "test-token",
+		"--output", "xml",
+		"session", "watch",
+		"--show-full",
+	})
+
+	err := root.Execute()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unsupported output format: "xml"`)
 }


### PR DESCRIPTION
Summary: session watch --show-full honors explicit json/yaml while preserving default JSON for table/wide/default; structured and tabular watch output return writer errors; add focused CLI tests.

Tests: go test ./pkg/bgctl/...; go test ./cmd/bgctl/...; git diff --check