### PR TITLE
fix: make group sync runtime diagnostics actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Keycloak group sync diagnostics**: Keycloak group-search failures now include the groups endpoint and `view-users` permission hint in returned errors, and IDP group-sync failure events keep a namespace from the affected escalation.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/docs/group-sync-runtime-diagnostics-reproduction.md
+++ b/docs/group-sync-runtime-diagnostics-reproduction.md
@@ -33,6 +33,17 @@ GOCACHE=/tmp/k8s-breakglass-repro-go-cache go test ./pkg/breakglass/escalation \
 
 Expected result on this branch: both tests fail.
 
+## Fixed Behavior
+
+The corresponding fix wraps Keycloak group-search errors with the
+`/admin/realms/{realm}/groups` endpoint and a `view-users` permission hint, so
+the returned sync error is actionable without correlating controller logs.
+
+`GroupFetchFailed` events emitted for IdentityProvider-backed group sync now
+carry the affected `BreakglassEscalation` namespace on the synthetic
+`IdentityProvider` event target, avoiding empty involved-object namespaces in
+runtime diagnostics.
+
 ## Existing Upstream Coverage Not Duplicated
 
 Current `origin/main` already removed stale event text that pointed operators to

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -54,6 +57,24 @@ type noopGroupMemberResolver struct{}
 
 func (noopGroupMemberResolver) Members(context.Context, string) ([]string, error) {
 	return nil, nil
+}
+
+type keycloakGroupSearchError struct {
+	endpoint string
+	status   string
+	cause    error
+}
+
+func (e keycloakGroupSearchError) Error() string {
+	status := e.status
+	if status == "" {
+		status = "request failed"
+	}
+	return fmt.Sprintf("keycloak group search failed at %s: %s; ensure the service account has the realm-management view-users role", e.endpoint, status)
+}
+
+func (e keycloakGroupSearchError) Unwrap() error {
+	return e.cause
 }
 
 type kcCache struct {
@@ -232,6 +253,7 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	}
 
 	// 1. Search for group by name
+	groupsEndpoint := keycloakGroupsEndpoint(k.cfg.BaseURL, k.cfg.Realm)
 	if log != nil {
 		log.Debugw("Starting group search step", "group", system.RedactGroupName(group))
 		log.Debugw("GetGroups API call details",
@@ -239,7 +261,7 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 			"realm", k.cfg.Realm,
 			"searchParamHint", system.RedactGroupName(group),
 			"tokenLen", len(token),
-			"endpoint", fmt.Sprintf("%s/admin/realms/%s/groups", k.cfg.BaseURL, k.cfg.Realm))
+			"endpoint", groupsEndpoint)
 	}
 	params := gocloak.GetGroupsParams{Search: gocloak.StringP(group)}
 	groups, err := k.gocloak.GetGroups(ctx, token, k.cfg.Realm, params)
@@ -250,10 +272,14 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 				"error", err,
 				"errorType", fmt.Sprintf("%T", err),
 				"tokenLen", len(token),
-				"endpoint", fmt.Sprintf("%s/admin/realms/%s/groups", k.cfg.BaseURL, k.cfg.Realm),
+				"endpoint", groupsEndpoint,
 				"params", fmt.Sprintf("search=%s", system.RedactGroupName(group)))
 		}
-		return nil, err
+		return nil, keycloakGroupSearchError{
+			endpoint: groupsEndpoint,
+			status:   keycloakGroupSearchFailureStatus(err),
+			cause:    err,
+		}
 	}
 	if log != nil {
 		log.Debugw("Keycloak groups search completed", "group", system.RedactGroupName(group), "returnedGroupCount", len(groups))
@@ -826,8 +852,7 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 
 			// Emit event on IdentityProvider resource
 			if u.EventRecorder != nil {
-				idp := &breakglassv1alpha1.IdentityProvider{}
-				idp.SetName(idpName)
+				idp := identityProviderEventTarget(idpName, escalation.Namespace)
 				u.EventRecorder.Eventf(idp, nil, "Warning", "GroupSyncConfigLoadFailed", "GroupSyncConfigLoadFailed",
 					"Failed to load IDP config for escalation %s/%s: %v",
 					escalation.Namespace, escalation.Name, err)
@@ -845,8 +870,7 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 
 			// Emit event on IdentityProvider resource
 			if u.EventRecorder != nil {
-				idp := &breakglassv1alpha1.IdentityProvider{}
-				idp.SetName(idpName)
+				idp := identityProviderEventTarget(idpName, escalation.Namespace)
 				u.EventRecorder.Eventf(idp, nil, "Warning", "GroupSyncResolverCreationFailed", "GroupSyncResolverCreationFailed",
 					"Failed to create group sync resolver for escalation %s/%s",
 					escalation.Namespace, escalation.Name)
@@ -868,8 +892,7 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 
 				// Emit event on IdentityProvider resource
 				if u.EventRecorder != nil {
-					idp := &breakglassv1alpha1.IdentityProvider{}
-					idp.SetName(idpName)
+					idp := identityProviderEventTarget(idpName, escalation.Namespace)
 					u.EventRecorder.Eventf(idp, nil, "Warning", "GroupFetchFailed", "GroupFetchFailed",
 						"Failed to fetch group %s for escalation %s/%s: %v",
 						system.RedactGroupName(g), escalation.Namespace, escalation.Name, err)
@@ -931,6 +954,15 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 	}
 
 	return hierarchy, syncStatus, syncErrors
+}
+
+func identityProviderEventTarget(idpName, eventNamespace string) *breakglassv1alpha1.IdentityProvider {
+	idp := &breakglassv1alpha1.IdentityProvider{}
+	idp.SetName(idpName)
+	if eventNamespace != "" {
+		idp.SetNamespace(eventNamespace)
+	}
+	return idp
 }
 
 func updateNoApproverGroupsCondition(escalation *breakglassv1alpha1.BreakglassEscalation) bool {
@@ -1016,6 +1048,35 @@ func legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount int) string {
 		return groupSyncStatusPartialFailure
 	default:
 		return groupSyncStatusFailed
+	}
+}
+
+func keycloakGroupsEndpoint(baseURL, realm string) string {
+	parsed, err := url.Parse(baseURL)
+	if err == nil && parsed.User != nil {
+		parsed.User = nil
+		baseURL = parsed.String()
+	}
+	return fmt.Sprintf("%s/admin/realms/%s/groups", strings.TrimRight(baseURL, "/"), realm)
+}
+
+func keycloakGroupSearchFailureStatus(err error) string {
+	var apiErr *gocloak.APIError
+	if !errors.As(err, &apiErr) {
+		return ""
+	}
+
+	message := strings.TrimSpace(apiErr.Message)
+	switch {
+	case apiErr.Code > 0 && message == "":
+		if status := http.StatusText(apiErr.Code); status != "" {
+			return fmt.Sprintf("%d %s", apiErr.Code, status)
+		}
+		return fmt.Sprintf("%d", apiErr.Code)
+	case apiErr.Code > 0 && !strings.Contains(message, fmt.Sprintf("%d", apiErr.Code)):
+		return fmt.Sprintf("%d %s", apiErr.Code, message)
+	default:
+		return message
 	}
 }
 

--- a/pkg/breakglass/escalation/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_test.go
@@ -19,6 +19,7 @@ package escalation
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -643,6 +644,22 @@ func TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable(t 
 		assert.Contains(t, errText, "/admin/realms/"+realm+"/groups")
 		assert.Contains(t, errText, "view-users")
 	}
+}
+
+func TestKeycloakGroupSearchErrorRedactsCauseTextAndUnwraps(t *testing.T) {
+	cause := fmt.Errorf("Get \"https://client:secret@keycloak.example.test/admin/realms/t-caas/groups?search=dttcaas-platform-poweruser\": dial tcp: connection refused")
+	err := keycloakGroupSearchError{
+		endpoint: keycloakGroupsEndpoint("https://client:secret@keycloak.example.test", "t-caas"),
+		cause:    cause,
+	}
+
+	errText := err.Error()
+	assert.Contains(t, errText, "https://keycloak.example.test/admin/realms/t-caas/groups")
+	assert.Contains(t, errText, "view-users")
+	assert.NotContains(t, errText, "client:secret")
+	assert.NotContains(t, errText, "search=")
+	assert.NotContains(t, errText, "dttcaas-platform-poweruser")
+	assert.True(t, errors.Is(err, cause))
 }
 
 func TestSetupResolverReturnsQuietNoopWhenGroupSyncDisabled(t *testing.T) {


### PR DESCRIPTION
## Scope

Fixes the runtime diagnostics gaps reproduced by #1129 while keeping the fix stacked on `repro/group-sync-runtime-diagnostics`.

## Changes

- Wrap Keycloak group-search failures with a deterministic, redacted error that includes the groups endpoint and `view-users` permission hint while preserving `errors.Unwrap` access to the original cause.
- Give synthetic IdentityProvider event targets the affected BreakglassEscalation namespace for IDP group-sync failure events.
- Add a regression test for redacting URL userinfo and raw group search query text from surfaced errors.
- Update the repro doc and changelog with the fixed behavior.

## Validation

- `GOCACHE=/tmp/k8s-breakglass-repro-go-cache go test ./pkg/breakglass/escalation -run 'TestKeycloakGroupMemberResolver_Members_GroupSearchForbiddenIsActionable|TestFetchGroupMembersFromMultipleIDPs_GroupFetchFailedEventHasNamespace|TestKeycloakGroupSearchErrorRedactsCauseTextAndUnwraps' -count=1 -v`\n- `go test -race -count=1 ./pkg/breakglass/escalation`\n- `make test-controller`\n