### PR TITLE
Harden HTTP and DebugSession denial logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **DebugSession denial and HTTP log redaction**: Frontend HTTP error logging and unauthorized DebugSession cluster-denial responses now avoid exposing bearer tokens or template cluster patterns.
 - **BreakglassEscalation admission validation**: Escalation duration fields now reject non-positive or malformed values consistently, `idleTimeout` and `approvalTimeout` are checked against the effective `maxValidFor`, and invalid cluster glob patterns are rejected before they can affect session admission.
 - **BreakglassSession approver IDP enforcement**: Approval and rejection requests now enforce `BreakglassEscalation.spec.allowedIdentityProvidersForApprovers`, denying approvers whose authenticated IdentityProvider is missing or not allowed.
 - **Frontend debug logging hardening**: Production builds no longer enable verbose debug logging from URL or localStorage flags, group and claim refresh diagnostics log only counts and claim keys instead of sensitive group memberships or full profile claims, and stale OIDC refresh tokens are removed from browser session state before silent renew.

--- a/frontend/src/services/httpClient.spec.ts
+++ b/frontend/src/services/httpClient.spec.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import { createAuthenticatedApiClient } from "./httpClient";
 import type AuthService from "@/services/auth";
-import { AxiosError, type InternalAxiosRequestConfig } from "axios";
+import { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from "axios";
 
 function createResolvedAdapter() {
   return async (config: InternalAxiosRequestConfig) => ({
@@ -14,6 +14,15 @@ function createResolvedAdapter() {
     headers: {},
     config,
   });
+}
+
+function stringifyLogArg(arg: unknown): string {
+  if (typeof arg === "string") return arg;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
 }
 
 describe("createAuthenticatedApiClient", () => {
@@ -92,18 +101,37 @@ describe("createAuthenticatedApiClient", () => {
     const authHeaderCalls = debugSpy.mock.calls.filter((call) =>
       call.some((arg) => typeof arg === "string" && arg.includes("Authorization header set")),
     );
-    const authHeaderCallsStringified = authHeaderCalls
-      .flat()
-      .map((arg) => {
-        if (typeof arg === "string") return arg;
-        try {
-          return JSON.stringify(arg);
-        } catch {
-          return String(arg);
-        }
-      })
-      .join(" ");
+    const authHeaderCallsStringified = authHeaderCalls.flat().map(stringifyLogArg).join(" ");
     expect(authHeaderCallsStringified).not.toContain("dev-token");
+  });
+
+  it("does not log Authorization headers or bearer tokens for failed authenticated requests", async () => {
+    const auth = {
+      getAccessToken: vi.fn().mockResolvedValue("sensitive-token"),
+      trySilentRenew: vi.fn().mockResolvedValue(false),
+    } as unknown as AuthService;
+
+    const client = createAuthenticatedApiClient(auth, { retryOn401: false });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    client.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+      const response = {
+        data: { error: "denied" },
+        status: 403,
+        statusText: "Forbidden",
+        headers: {},
+        config,
+      } satisfies AxiosResponse;
+      throw new AxiosError("Request failed with status code 403", "ERR_BAD_REQUEST", config, {}, response);
+    };
+
+    await expect(client.get("/restricted")).rejects.toThrow("Request failed with status code 403");
+
+    const logged = errorSpy.mock.calls.flat().map(stringifyLogArg).join(" ");
+    expect(logged).toContain("HTTP 403 error");
+    expect(logged).not.toContain("Authorization");
+    expect(logged).not.toContain("Bearer sensitive-token");
+    expect(logged).not.toContain("sensitive-token");
   });
 });
 

--- a/frontend/src/services/httpClient.ts
+++ b/frontend/src/services/httpClient.ts
@@ -17,6 +17,53 @@ const DEFAULT_TIMEOUT_MS = 30000;
 // Track if we're currently retrying to avoid infinite loops
 const RETRY_FLAG = "__authRetried";
 
+interface SafeHttpClientErrorDetails {
+  message?: string;
+  code?: string;
+  method?: string;
+  url?: string;
+  status?: number;
+  timeout?: number;
+}
+
+interface AxiosErrorLike {
+  message?: unknown;
+  code?: unknown;
+  config?: {
+    method?: unknown;
+    url?: unknown;
+  };
+  response?: {
+    status?: unknown;
+  };
+}
+
+function safeHttpClientErrorDetails(
+  error: unknown,
+  extra: SafeHttpClientErrorDetails = {},
+): SafeHttpClientErrorDetails {
+  const axiosError = error as AxiosErrorLike | undefined;
+  const details: SafeHttpClientErrorDetails = { ...extra };
+
+  if (typeof axiosError?.message === "string") {
+    details.message = axiosError.message;
+  }
+  if (typeof axiosError?.code === "string") {
+    details.code = axiosError.code;
+  }
+  if (typeof axiosError?.config?.method === "string") {
+    details.method = axiosError.config.method.toUpperCase();
+  }
+  if (typeof axiosError?.config?.url === "string") {
+    details.url = axiosError.config.url;
+  }
+  if (typeof axiosError?.response?.status === "number") {
+    details.status = axiosError.response.status;
+  }
+
+  return details;
+}
+
 export function createAuthenticatedApiClient(auth: AuthService, options?: ApiClientOptions): AxiosInstance {
   const client = axios.create({
     baseURL: options?.baseURL ?? "/api",
@@ -52,7 +99,7 @@ export function createAuthenticatedApiClient(auth: AuthService, options?: ApiCli
       return config;
     },
     (error) => {
-      logger.error("HttpClient", "Request interceptor error", error);
+      logger.error("HttpClient", "Request interceptor error", safeHttpClientErrorDetails(error));
       return Promise.reject(error);
     },
   );
@@ -92,29 +139,25 @@ export function createAuthenticatedApiClient(auth: AuthService, options?: ApiCli
             logger.warn("HttpClient", "Silent renew failed, not retrying request");
           }
         } catch (renewError) {
-          logger.error("HttpClient", "Error during silent renew attempt", renewError);
+          logger.error("HttpClient", "Error during silent renew attempt", safeHttpClientErrorDetails(renewError));
         }
       }
 
       if (error.response) {
-        logger.error("HttpClient", `HTTP ${error.response.status} error`, error, {
-          method: error.config?.method?.toUpperCase(),
-          url: error.config?.url,
+        logger.error("HttpClient", `HTTP ${error.response.status} error`, {
+          ...safeHttpClientErrorDetails(error),
           status: error.response.status,
-          data: error.response.data,
         });
       } else if (error.request) {
         // Check if this is a timeout error (axios uses ECONNABORTED for timeouts)
         const isTimeout = error.code === "ECONNABORTED";
         const errorType = isTimeout ? "Request timeout" : "No response received";
-        logger.error("HttpClient", errorType, error, {
-          method: error.config?.method?.toUpperCase(),
-          url: error.config?.url,
-          code: error.code,
+        logger.error("HttpClient", errorType, {
+          ...safeHttpClientErrorDetails(error),
           timeout: isTimeout ? (options?.timeout ?? DEFAULT_TIMEOUT_MS) : undefined,
         });
       } else {
-        logger.error("HttpClient", "Request setup error", error);
+        logger.error("HttpClient", "Request setup error", safeHttpClientErrorDetails(error));
       }
       return Promise.reject(error);
     },

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -705,12 +705,23 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	// ClusterConfig readiness and existence errors are returned only after template/binding
 	// and requester authorization succeeds, so unauthorized callers cannot probe cluster state.
 	var bindingList breakglassv1alpha1.DebugSessionClusterBindingList
-	var clusterConfigList breakglassv1alpha1.ClusterConfigList
 	if err := authorizationReader.List(apiCtx, &bindingList); err != nil {
 		reqLog.Errorw("Failed to list bindings for cluster validation", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to validate cluster access")
 		return
 	}
+	if req.BindingRef == "" &&
+		!c.isDebugSessionRequesterAllowedForTemplateOrBindings(template, bindingList.Items, currentUserStr, userEmail, userGroups) {
+		reqLog.Warnw("User is not allowed to request debug session",
+			"templateRef", req.TemplateRef,
+			"user", currentUserStr,
+			"groupCount", len(userGroups),
+		)
+		apiresponses.RespondForbidden(ctx, "user is not allowed to request this debug session")
+		return
+	}
+
+	var clusterConfigList breakglassv1alpha1.ClusterConfigList
 	if err := authorizationReader.List(apiCtx, &clusterConfigList); err != nil {
 		reqLog.Errorw("Failed to list cluster configs for cluster validation", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to validate cluster access")
@@ -836,6 +847,15 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		}
 	}
 	if !allowedResult.Allowed {
+		if !isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), currentUserStr, userEmail, userGroups) {
+			reqLog.Warnw("User is not allowed to request debug session",
+				"templateRef", req.TemplateRef,
+				"user", currentUserStr,
+				"groupCount", len(userGroups),
+			)
+			apiresponses.RespondForbidden(ctx, "user is not allowed to request this debug session")
+			return
+		}
 		var errDetails string
 		if template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
 			errDetails = fmt.Sprintf("cluster '%s' is not allowed by template '%s'. Template cluster patterns: %v. No bindings grant access to this cluster.",
@@ -1299,6 +1319,26 @@ func effectiveDebugSessionAllowed(template *breakglassv1alpha1.DebugSessionTempl
 		return nil
 	}
 	return template.Spec.Allowed
+}
+
+func (c *DebugSessionAPIController) isDebugSessionRequesterAllowedForTemplateOrBindings(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	bindings []breakglassv1alpha1.DebugSessionClusterBinding,
+	username, email string,
+	userGroups []string,
+) bool {
+	if isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), username, email, userGroups) {
+		return true
+	}
+
+	applicableBindings := c.findBindingsForTemplate(template, bindings)
+	for i := range applicableBindings {
+		if isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, &applicableBindings[i]), username, email, userGroups) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isDebugSessionRequesterAllowed(allowed *breakglassv1alpha1.DebugSessionAllowed, username, email string, userGroups []string) bool {

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -860,15 +860,6 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		}
 	}
 	if !allowedResult.Allowed {
-		if !requesterAllowedForTemplateOrBinding {
-			reqLog.Warnw("User is not allowed to request debug session",
-				"templateRef", req.TemplateRef,
-				"user", currentUserStr,
-				"groupCount", len(userGroups),
-			)
-			apiresponses.RespondForbidden(ctx, "user is not allowed to request this debug session")
-			return
-		}
 		var errDetails string
 		if template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
 			if templateRequesterAllowed {

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -710,15 +710,28 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to validate cluster access")
 		return
 	}
-	if req.BindingRef == "" &&
-		!c.isDebugSessionRequesterAllowedForTemplateOrBindings(template, bindingList.Items, currentUserStr, userEmail, userGroups) {
-		reqLog.Warnw("User is not allowed to request debug session",
-			"templateRef", req.TemplateRef,
-			"user", currentUserStr,
-			"groupCount", len(userGroups),
-		)
-		apiresponses.RespondForbidden(ctx, "user is not allowed to request this debug session")
-		return
+	templateRequesterAllowed := isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), currentUserStr, userEmail, userGroups)
+	requesterAllowedForTemplateOrBinding := templateRequesterAllowed
+	var applicableTemplateBindings []breakglassv1alpha1.DebugSessionClusterBinding
+	if req.BindingRef == "" {
+		applicableTemplateBindings = c.findBindingsForTemplate(template, bindingList.Items)
+		if !requesterAllowedForTemplateOrBinding {
+			for i := range applicableTemplateBindings {
+				if isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, &applicableTemplateBindings[i]), currentUserStr, userEmail, userGroups) {
+					requesterAllowedForTemplateOrBinding = true
+					break
+				}
+			}
+		}
+		if !requesterAllowedForTemplateOrBinding {
+			reqLog.Warnw("User is not allowed to request debug session",
+				"templateRef", req.TemplateRef,
+				"user", currentUserStr,
+				"groupCount", len(userGroups),
+			)
+			apiresponses.RespondForbidden(ctx, "user is not allowed to request this debug session")
+			return
+		}
 	}
 
 	var clusterConfigList breakglassv1alpha1.ClusterConfigList
@@ -840,15 +853,14 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		}
 	} else {
 		for _, authorizationCluster := range authorizationClusters {
-			allowedResult = c.isClusterAllowedByTemplateOrBinding(template, authorizationCluster, bindingList.Items, clusterMap, clusterConfigList.Items)
+			allowedResult = c.isClusterAllowedByTemplateOrApplicableBindings(template, authorizationCluster, applicableTemplateBindings, clusterMap, clusterConfigList.Items)
 			if allowedResult.Allowed {
 				break
 			}
 		}
 	}
 	if !allowedResult.Allowed {
-		templateRequesterAllowed := isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), currentUserStr, userEmail, userGroups)
-		if !templateRequesterAllowed && !c.isDebugSessionRequesterAllowedForTemplateOrBindings(template, bindingList.Items, currentUserStr, userEmail, userGroups) {
+		if !requesterAllowedForTemplateOrBinding {
 			reqLog.Warnw("User is not allowed to request debug session",
 				"templateRef", req.TemplateRef,
 				"user", currentUserStr,

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1339,26 +1339,6 @@ func effectiveDebugSessionAllowed(template *breakglassv1alpha1.DebugSessionTempl
 	return template.Spec.Allowed
 }
 
-func (c *DebugSessionAPIController) isDebugSessionRequesterAllowedForTemplateOrBindings(
-	template *breakglassv1alpha1.DebugSessionTemplate,
-	bindings []breakglassv1alpha1.DebugSessionClusterBinding,
-	username, email string,
-	userGroups []string,
-) bool {
-	if isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), username, email, userGroups) {
-		return true
-	}
-
-	applicableBindings := c.findBindingsForTemplate(template, bindings)
-	for i := range applicableBindings {
-		if isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, &applicableBindings[i]), username, email, userGroups) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isDebugSessionRequesterAllowed(allowed *breakglassv1alpha1.DebugSessionAllowed, username, email string, userGroups []string) bool {
 	if allowed == nil || (len(allowed.Users) == 0 && len(allowed.Groups) == 0) {
 		return true

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -847,7 +847,8 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		}
 	}
 	if !allowedResult.Allowed {
-		if !isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), currentUserStr, userEmail, userGroups) {
+		templateRequesterAllowed := isDebugSessionRequesterAllowed(effectiveDebugSessionAllowed(template, nil), currentUserStr, userEmail, userGroups)
+		if !templateRequesterAllowed && !c.isDebugSessionRequesterAllowedForTemplateOrBindings(template, bindingList.Items, currentUserStr, userEmail, userGroups) {
 			reqLog.Warnw("User is not allowed to request debug session",
 				"templateRef", req.TemplateRef,
 				"user", currentUserStr,
@@ -858,8 +859,13 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		}
 		var errDetails string
 		if template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0 {
-			errDetails = fmt.Sprintf("cluster '%s' is not allowed by template '%s'. Template cluster patterns: %v. No bindings grant access to this cluster.",
-				req.Cluster, req.TemplateRef, template.Spec.Allowed.Clusters)
+			if templateRequesterAllowed {
+				errDetails = fmt.Sprintf("cluster '%s' is not allowed by template '%s'. Template cluster patterns: %v. No bindings grant access to this cluster.",
+					req.Cluster, req.TemplateRef, template.Spec.Allowed.Clusters)
+			} else {
+				errDetails = fmt.Sprintf("cluster '%s' is not allowed by template '%s'. No bindings grant access to this cluster.",
+					req.Cluster, req.TemplateRef)
+			}
 		} else {
 			errDetails = fmt.Sprintf("cluster '%s' is not allowed. Template '%s' has no allowed cluster patterns and no bindings grant access to this cluster.",
 				req.Cluster, req.TemplateRef)

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -861,6 +861,17 @@ func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrBinding(
 	clusterConfigs map[string]*breakglassv1alpha1.ClusterConfig,
 	clusterConfigItems []breakglassv1alpha1.ClusterConfig,
 ) ClusterAllowedResult {
+	applicableBindings := c.findBindingsForTemplate(template, bindings)
+	return c.isClusterAllowedByTemplateOrApplicableBindings(template, clusterName, applicableBindings, clusterConfigs, clusterConfigItems)
+}
+
+func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrApplicableBindings(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	clusterName string,
+	applicableBindings []breakglassv1alpha1.DebugSessionClusterBinding,
+	clusterConfigs map[string]*breakglassv1alpha1.ClusterConfig,
+	clusterConfigItems []breakglassv1alpha1.ClusterConfig,
+) ClusterAllowedResult {
 	result := ClusterAllowedResult{}
 
 	hasTemplateClusterRestriction := template.Spec.Allowed != nil && len(template.Spec.Allowed.Clusters) > 0
@@ -869,7 +880,7 @@ func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrBinding(
 		"template", template.Name,
 		"cluster", clusterName,
 		"hasTemplateClusterRestriction", hasTemplateClusterRestriction,
-		"totalBindingsProvided", len(bindings),
+		"applicableBindingsProvided", len(applicableBindings),
 		"totalClusterConfigs", len(clusterConfigs),
 	)
 
@@ -909,7 +920,6 @@ func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrBinding(
 	}
 
 	// 2. Check if allowed by any binding that references this template
-	applicableBindings := c.findBindingsForTemplate(template, bindings)
 	sortDebugSessionClusterBindings(applicableBindings)
 	c.log.Debugw("Found bindings for template",
 		"template", template.Name,

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -4336,6 +4336,56 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.Equal(t, 403, w.Code)
 	})
 
+	t.Run("create session hides template cluster patterns from unauthorized requester", func(t *testing.T) {
+		restrictedTemplate := template.DeepCopy()
+		restrictedTemplate.Name = "cluster-pattern-restricted-debug"
+		restrictedTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Users:    []string{"alice@example.com"},
+			Clusters: []string{"prod-*", "stage-a"},
+		}
+		devCluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "dev-a", Namespace: "breakglass"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionTrue,
+						Reason: "Verified",
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(restrictedTemplate, devCluster).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "bob@example.com")
+			c.Set("email", "bob@example.com")
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"cluster-pattern-restricted-debug","cluster":"dev-a","reason":"debugging issue"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), "user is not allowed to request this debug session")
+		assert.NotContains(t, w.Body.String(), "Template cluster patterns")
+		assert.NotContains(t, w.Body.String(), "prod-*")
+		assert.NotContains(t, w.Body.String(), "stage-a")
+	})
+
 	t.Run("create session accepts requester allowed by binding", func(t *testing.T) {
 		templateViaBinding := template.DeepCopy()
 		templateViaBinding.Name = "binding-debug"

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -4386,6 +4386,69 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		assert.NotContains(t, w.Body.String(), "stage-a")
 	})
 
+	t.Run("create session returns redacted cluster denial for binding-authorized requester", func(t *testing.T) {
+		restrictedTemplate := template.DeepCopy()
+		restrictedTemplate.Name = "cluster-pattern-binding-debug"
+		restrictedTemplate.Spec.Allowed = &breakglassv1alpha1.DebugSessionAllowed{
+			Users:    []string{"alice@example.com"},
+			Clusters: []string{"prod-*", "stage-a"},
+		}
+		devCluster := &breakglassv1alpha1.ClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "dev-a", Namespace: "breakglass"},
+			Status: breakglassv1alpha1.ClusterConfigStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(breakglassv1alpha1.ClusterConfigConditionReady),
+						Status: metav1.ConditionTrue,
+						Reason: "Verified",
+					},
+				},
+			},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "sre-binding", Namespace: "breakglass"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				TemplateRef: &breakglassv1alpha1.TemplateReference{Name: "cluster-pattern-binding-debug"},
+				Clusters:    []string{"stage-b"},
+				Allowed: &breakglassv1alpha1.DebugSessionAllowed{
+					Groups: []string{"sre"},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(restrictedTemplate, devCluster, binding).
+			Build()
+
+		ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("username", "bob@example.com")
+			c.Set("email", "bob@example.com")
+			c.Set("groups", []string{"sre"})
+			c.Next()
+		})
+		rg := router.Group("/api/v1/" + ctrl.BasePath())
+		err := ctrl.Register(rg)
+		require.NoError(t, err)
+
+		body := `{"templateRef":"cluster-pattern-binding-debug","cluster":"dev-a","reason":"debugging issue"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/debugSessions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), "cluster 'dev-a' is not allowed")
+		assert.Contains(t, w.Body.String(), "No bindings grant access to this cluster")
+		assert.NotContains(t, w.Body.String(), "user is not allowed to request this debug session")
+		assert.NotContains(t, w.Body.String(), "Template cluster patterns")
+		assert.NotContains(t, w.Body.String(), "prod-*")
+		assert.NotContains(t, w.Body.String(), "stage-a")
+	})
+
 	t.Run("create session accepts requester allowed by binding", func(t *testing.T) {
 		templateViaBinding := template.DeepCopy()
 		templateViaBinding.Name = "binding-debug"


### PR DESCRIPTION
## Finding

- `httpClient` logged raw Axios error objects, which can carry `config.headers.Authorization`.
- No-`bindingRef` DebugSession create denials could disclose template cluster patterns before requester authorization completed.

## Fix

- Log only sanitized HTTP error metadata from the frontend interceptor.
- Gate no-`bindingRef` DebugSession create requests before cluster diagnostics and keep detailed cluster-denial diagnostics for authorized template requesters.
- Add regression coverage for token-bearing HTTP failures and unauthorized DebugSession cluster probes.

## Tests

- `go test -timeout=4m ./pkg/breakglass/debug`
- `npm --prefix frontend run typecheck`
- `./node_modules/.bin/vitest run --config vitest.httpclient.config.ts httpClient --pool=forks --maxWorkers=1` (temporary local config, 8 passed)
- `npm --prefix frontend test -- httpClient` (local Vitest fork worker startup timeout before tests imported)
