### PR TITLE
ci: harden generated checks and docs snippets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -224,7 +224,7 @@ npx playwright test --config=playwright.e2e.config.ts
 - If Keycloak connection fails: Check `/etc/hosts` has entry for `breakglass-keycloak.breakglass-system.svc.cluster.local`
 - If proxy errors occur: Set `SKIP_PROXY=true`
 - Check pod status: `kubectl get pods -n breakglass-system`
-- Check controller logs: `kubectl logs -n breakglass-system -l app=breakglass-manager`
+- Check controller logs: `kubectl logs -n breakglass-system -l app=breakglass`
 
 ### E2E Test Session Creation (CRITICAL)
 
@@ -468,7 +468,7 @@ make deploy IMG=$IMG
 kubectl apply -k config/samples/
 
 # Debug:
-kubectl logs -n breakglass-system deployment/breakglass-controller -c manager -f
+kubectl logs -n breakglass-system deployment/breakglass-manager -c breakglass -f
 ```
 
 ### Essential Reading

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Verify release provenance workflow
         run: make verify-release-provenance
+      - name: Verify documentation snippets
+        run: make verify-docs-snippets
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -150,8 +152,8 @@ jobs:
           cache: true
       - name: Install tools
         run: make controller-gen kustomize
-      - name: Generate manifests
-        run: make manifests
+      - name: Verify generated artifacts
+        run: make verify-generated
       - name: Build all kustomize targets
         run: |
           mkdir -p manifests-current
@@ -1862,8 +1864,8 @@ jobs:
           if [ "$UI_READY" = "false" ]; then
             echo "ERROR: Controller UI not responding on port 8080 within 15 seconds"
             echo "Checking controller pod status..."
-            kubectl get pods -n breakglass-system -l app=breakglass-manager || true
-            kubectl logs -n breakglass-system -l app=breakglass-manager --tail=50 || true
+            kubectl get pods -n breakglass-system -l app=breakglass || true
+            kubectl logs -n breakglass-system -l app=breakglass --tail=50 || true
             exit 1
           fi
 
@@ -1894,8 +1896,8 @@ jobs:
           # Test controller UI (already verified in previous step, just double-check)
           test_service "Controller UI" "http://localhost:8080" 15 "-s" || {
             echo "Controller UI failed health check - checking controller status"
-            kubectl get pods -n breakglass-system -l app=breakglass-manager || true
-            kubectl logs -n breakglass-system -l app=breakglass-manager --tail=50 || true
+            kubectl get pods -n breakglass-system -l app=breakglass || true
+            kubectl logs -n breakglass-system -l app=breakglass --tail=50 || true
           }
           
           # Test MailHog

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,7 @@ jobs:
     name: Review Dependency Licenses
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ env:
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
     outputs:
       stable: ${{ steps.classify.outputs.stable }}
       prerelease: ${{ steps.classify.outputs.prerelease }}
@@ -39,28 +42,7 @@ jobs:
       - name: Verify CI passed for commit
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          SHA=${GITHUB_SHA}
-          echo "Checking CI status for commit $SHA"
-          sleep 5
-          
-          FAILURES=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs --jq '.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | .name')
-          if [ -n "$FAILURES" ]; then
-            echo "::error::CI checks failed for commit $SHA: $FAILURES"
-            exit 1
-          fi
-          
-          PENDING=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs --jq '.check_runs[] | select(.status == "in_progress" or .status == "queued") | .name')
-          if [ -n "$PENDING" ]; then
-            echo "::error::CI checks are still pending for commit $SHA. Please wait for them to finish before tagging."
-            exit 1
-          fi
-          
-          SUCCESS=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs --jq '.check_runs[] | select(.conclusion == "success") | .name')
-          if [ -z "$SUCCESS" ]; then
-            echo "::error::No successful CI checks found for commit $SHA."
-            exit 1
-          fi
+        run: hack/verify-commit-check-runs.sh
 
       - name: Require version tag ref
         id: classify

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,12 @@ verify-release-provenance: ## Verify release image provenance signs the registry
 
 .PHONY: verify-generated
 verify-generated: generate manifests ## Verify generated API and manifest artifacts are checked in.
-	@git diff --exit-code -- api config || { \
+	@status="$$(git status --porcelain -- api config)"; \
+	if [ -n "$${status}" ]; then \
+		printf '%s\n' "$${status}"; \
 		echo "Generated files are stale. Run 'make generate manifests' and commit the result."; \
 		exit 1; \
-	}
+	fi
 
 .PHONY: verify-docs-snippets
 verify-docs-snippets: ## Verify docs and workflow snippets use current dev workload names.

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,17 @@ lint-strict: golangci-lint ## Run golangci-lint with extended timeout (CI-friend
 verify-release-provenance: ## Verify release image provenance signs the registry digest.
 	bash hack/verify-release-provenance.sh
 
+.PHONY: verify-generated
+verify-generated: generate manifests ## Verify generated API and manifest artifacts are checked in.
+	@git diff --exit-code -- api config || { \
+		echo "Generated files are stale. Run 'make generate manifests' and commit the result."; \
+		exit 1; \
+	}
+
+.PHONY: verify-docs-snippets
+verify-docs-snippets: ## Verify docs and workflow snippets use current dev workload names.
+	bash hack/verify-docs-snippets.sh
+
 .PHONY: vulncheck
 vulncheck: ## Run govulncheck to check for known vulnerabilities.
 	@command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ make install                            # install CRDs
 make deploy_dev                         # deploy breakglass and dependencies
 
 # Access the application
-# Breakglass UI:  https://breakglass-dev:30081
+# Breakglass UI:  https://breakglass-dev:31081
 # Keycloak:       https://breakglass-dev:30083
 # MailHog:        http://breakglass-dev:30084
 ```

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -792,7 +792,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: corp-oidc-client-secret
-  namespace: breakglass
+  namespace: breakglass-system
 type: Opaque
 data:
   clientSecret: <base64-secret>
@@ -802,7 +802,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: keycloak-client-secret
-  namespace: breakglass
+  namespace: breakglass-system
 type: Opaque
 data:
   clientSecret: <base64-secret>
@@ -957,11 +957,11 @@ Track authentication patterns by IDP:
 
 ```bash
 # Count successful logins by issuer
-kubectl logs deployment/breakglass-controller -n breakglass \
+kubectl logs deployment/breakglass-manager -n breakglass-system \
   | grep "iss" | sort | uniq -c
 
 # Monitor token validation failures
-kubectl logs deployment/breakglass-controller -n breakglass \
+kubectl logs deployment/breakglass-manager -n breakglass-system \
   | grep -i "token.*invalid\|issuer.*unknown"
 
 # Check IDP configuration status

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -1283,7 +1283,7 @@ kubectl get breakglassescalation <name> -o jsonpath='{.status.conditions}' | jq 
 kubectl get events --field-selector involvedObject.kind=BreakglassEscalation
 
 # Check controller logs (if accessible)
-kubectl logs -n breakglass deployment/breakglass-controller -f --grep=escalation
+kubectl logs -n breakglass-system deployment/breakglass-manager -f | grep escalation
 ```
 
 ## Best Practices

--- a/docs/building.md
+++ b/docs/building.md
@@ -187,7 +187,7 @@ The E2E environment includes:
 
 | Component | Purpose | Port |
 |-----------|---------|------|
-| Breakglass Controller | Main service | 30081 |
+| Breakglass Controller | Main service (`NODEPORT` default) | 31081 |
 | Keycloak | OIDC identity provider | 30083 |
 | MailHog | Email testing | 30084 |
 | Kafka | Audit event streaming | Internal |

--- a/docs/cli-flags-reference.md
+++ b/docs/cli-flags-reference.md
@@ -871,20 +871,20 @@ docker run \
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
+  name: breakglass-manager
   namespace: breakglass-system
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: breakglass-controller
+      app: breakglass
   template:
     metadata:
       labels:
-        app: breakglass-controller
+        app: breakglass
     spec:
       containers:
-      - name: controller
+      - name: breakglass
         image: breakglass:latest
         args:
           - --enable-leader-election=true
@@ -955,7 +955,7 @@ spec:
         secret:
           secretName: webhook-server-cert
       
-      serviceAccountName: breakglass-controller
+      serviceAccountName: breakglass-manager
 ```
 
 ### Helm Values

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -135,7 +135,7 @@ server:
 
 ```bash
 # Check if origin is allowed (look for blocked_request_origin in logs)
-kubectl logs -l app=breakglass-controller | grep blocked_request_origin
+kubectl logs -n breakglass-system -l app=breakglass | grep blocked_request_origin
 
 # Verify CORS headers in response
 curl -v -H "Origin: https://breakglass.example.com" https://api.breakglass.example.com/api/config
@@ -642,12 +642,12 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
+  name: breakglass-manager
 spec:
   template:
     spec:
       containers:
-      - name: controller
+      - name: breakglass
         args:
           - --config-path=/etc/breakglass/config.yaml
         volumeMounts:
@@ -765,7 +765,7 @@ When a `BreakglassSession` is created, the controller resolves all potential app
 
 1. **Monitor warning logs:** Watch for truncation warnings in controller logs:
    ```bash
-   kubectl logs -n breakglass-system -l app=breakglass-manager | grep -i "truncat\|too many members\|no remaining capacity"
+   kubectl logs -n breakglass-system -l app=breakglass | grep -i "truncat\|too many members\|no remaining capacity"
    ```
 
 2. **Check approver counts:** Sessions with truncated approvers will still work correctly, but some potential approvers may not be notified.

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -36,7 +36,7 @@ apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: DebugSessionClusterBinding
 metadata:
   name: sre-production-access
-  namespace: breakglass
+  namespace: breakglass-system
 spec:
   templateRef:
     name: network-debug
@@ -540,7 +540,7 @@ See [API Reference](api-reference.md#get-template-clusters) for full details.
 
 1. Check binding status:
    ```bash
-   kubectl get debugsessionclusterbinding -n breakglass -o yaml
+   kubectl get debugsessionclusterbinding -n breakglass-system -o yaml
    ```
 
 2. Verify template reference exists:
@@ -757,7 +757,7 @@ apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: ClusterConfig
 metadata:
   name: production-eu           # Must match the cluster name
-  namespace: breakglass
+  namespace: breakglass-system
   labels:
     environment: production
     region: eu
@@ -1027,7 +1027,7 @@ After binding resolution, the session's status is updated with binding informati
 status:
   resolvedBinding:
     name: sre-production-access       # Binding name
-    namespace: breakglass             # Binding namespace
+    namespace: breakglass-system      # Binding namespace
     displayName: "SRE Production"     # Effective display name
   state: Active
 ```
@@ -1185,7 +1185,7 @@ kubectl get debugsessionclusterbinding -A
 kubectl get debugsessionclusterbinding <name> -n <namespace> -o yaml
 
 # View controller logs for auto-discovery
-kubectl logs -n breakglass-system deployment/breakglass-controller -c manager | grep "Auto-discovered binding"
+kubectl logs -n breakglass-system deployment/breakglass-manager -c breakglass | grep "Auto-discovered binding"
 ```
 
 ## Related Resources

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -705,7 +705,7 @@ apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: DebugSession
 metadata:
   name: debug-session-abc123
-  namespace: breakglass
+  namespace: breakglass-system
 spec:
   cluster: prod-cluster-1
   templateRef: standard-debug
@@ -1232,7 +1232,7 @@ apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: DebugSessionClusterBinding
 metadata:
   name: sre-production-access
-  namespace: breakglass
+  namespace: breakglass-system
 spec:
   templateRef:
     name: network-debug

--- a/docs/email-templates.md
+++ b/docs/email-templates.md
@@ -143,7 +143,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: breakglass-custom-templates
-  namespace: breakglass  # Match your Breakglass namespace
+  namespace: breakglass-system  # Match your Breakglass namespace
 data:
   approved.html: |
     <!DOCTYPE html>
@@ -171,13 +171,13 @@ Update the Breakglass deployment to mount the custom template ConfigMap:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
-  namespace: breakglass
+  name: breakglass-manager
+  namespace: breakglass-system
 spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: breakglass
         # ... other container config ...
         volumeMounts:
         - name: custom-email-templates
@@ -221,12 +221,12 @@ patchesStrategicMerge:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
+  name: breakglass-manager
 spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: breakglass
         volumeMounts:
         - name: custom-email-templates
           mountPath: /etc/breakglass/templates
@@ -350,19 +350,19 @@ Always include security warnings:
 **Check 1**: Verify ConfigMap is mounted in the pod:
 
 ```bash
-kubectl exec -n breakglass <pod-name> -- ls -la /etc/breakglass/templates/
+kubectl exec -n breakglass-system <pod-name> -- ls -la /etc/breakglass/templates/
 ```
 
 **Check 2**: Verify environment variable is set:
 
 ```bash
-kubectl exec -n breakglass <pod-name> -- env | grep BREAKGLASS_TEMPLATE_PATH
+kubectl exec -n breakglass-system <pod-name> -- env | grep BREAKGLASS_TEMPLATE_PATH
 ```
 
 **Check 3**: Check pod logs for template loading errors:
 
 ```bash
-kubectl logs -n breakglass <pod-name> | grep -i template
+kubectl logs -n breakglass-system <pod-name> | grep -i template
 ```
 
 ### Template Syntax Errors
@@ -384,7 +384,7 @@ go run cmd/template-validator/main.go -template custom-approved.html
 
 ```bash
 # Enable debug logging to see what variables are passed
-BREAKGLASS_LOG_LEVEL=debug kubectl logs -n breakglass <pod-name>
+BREAKGLASS_LOG_LEVEL=debug kubectl logs -n breakglass-system <pod-name>
 ```
 
 ## Real-World Examples
@@ -503,7 +503,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: breakglass-templates-en
-  namespace: breakglass
+  namespace: breakglass-system
 data:
   approved.html: |
     <!DOCTYPE html>
@@ -514,7 +514,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: breakglass-templates-de
-  namespace: breakglass
+  namespace: breakglass-system
 data:
   approved.html: |
     <!DOCTYPE html>

--- a/docs/identity-provider.md
+++ b/docs/identity-provider.md
@@ -733,7 +733,7 @@ spec:
   clientSecret:
     secretRef:
       name: corporate-secret
-      namespace: breakglass
+      namespace: breakglass-system
   disabled: false
 
 ---
@@ -748,7 +748,7 @@ spec:
   clientSecret:
     secretRef:
       name: keycloak-secret
-      namespace: breakglass
+      namespace: breakglass-system
   disabled: false
 ```
 

--- a/docs/keycloak-configuration.md
+++ b/docs/keycloak-configuration.md
@@ -1258,7 +1258,7 @@ Expected: `type: Ready`, `status: "True"` and `type: GroupSyncHealthy`, `status:
 
 Check controller logs for successful group resolution:
 ```bash
-kubectl logs -n breakglass-system deployment/breakglass-controller | \
+kubectl logs -n breakglass-system deployment/breakglass-manager | \
   grep -i 'group.*member\|keycloak.*group'
 ```
 

--- a/docs/logging-and-debugging.md
+++ b/docs/logging-and-debugging.md
@@ -275,12 +275,12 @@ RUN go build -ldflags="\
 
 1. **Check build info:**
    ```bash
-   kubectl exec -n breakglass deploy/breakglass-controller -- /breakglass --version
+   kubectl exec -n breakglass-system deploy/breakglass-manager -c breakglass -- /breakglass --version
    ```
 
 2. **View API logs:**
    ```bash
-   kubectl logs -n breakglass deploy/breakglass-controller -c manager --follow
+   kubectl logs -n breakglass-system deploy/breakglass-manager -c breakglass --follow
    ```
 
 3. **Enable verbose logging:**
@@ -293,8 +293,8 @@ RUN go build -ldflags="\
 
 4. **Check metrics:**
    ```bash
-   kubectl port-forward -n breakglass svc/breakglass-controller-metrics 8443:8443
-   curl -k https://localhost:8443/metrics
+   kubectl port-forward -n breakglass-system svc/breakglass-breakglass 8081:8081
+   curl http://localhost:8081/metrics
    ```
 
 ### E2E Testing with Logging

--- a/docs/mail-provider.md
+++ b/docs/mail-provider.md
@@ -440,7 +440,7 @@ Common issues:
 
 ```bash
 # Check logs for health check details
-kubectl logs -n breakglass-system deployment/breakglass-controller-manager | grep mailprovider
+kubectl logs -n breakglass-system deployment/breakglass-manager | grep mailprovider
 
 # Manually test SMTP from pod
 kubectl run -it --rm debug --image=nicolaka/netshoot --restart=Never -- bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -400,7 +400,7 @@ kubectl get breakglassescalation,breakglasssession,clusterconfig,denypolicy
 
 # Check controller health
 kubectl get deployment -n breakglass-system
-kubectl logs -n breakglass-system deployment/breakglass-controller
+kubectl logs -n breakglass-system deployment/breakglass-manager
 
 # Verify webhook configuration
 kubectl get clusterconfig

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -229,7 +229,7 @@ done | sort | uniq -c
 # Expected: ~50 200s followed by 429s
 
 # Check logs for rate limiting (if using structured logging)
-kubectl logs -n breakglass-system -l app=breakglass-manager | grep -i "rate"
+kubectl logs -n breakglass-system -l app=breakglass | grep -i "rate"
 ```
 
 ### Memory usage concerns

--- a/docs/scaling-and-leader-election.md
+++ b/docs/scaling-and-leader-election.md
@@ -645,20 +645,20 @@ Manifests generated in:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
+  name: breakglass-manager
   namespace: breakglass-system
 spec:
   replicas: 1  # Single instance
   selector:
     matchLabels:
-      app: breakglass-controller
+      app: breakglass
   template:
     metadata:
       labels:
-        app: breakglass-controller
+        app: breakglass
     spec:
       containers:
-      - name: controller
+      - name: breakglass
         image: breakglass:latest
         args:
           - --enable-leader-election=true  # Optional, no effect with replicas: 1
@@ -680,17 +680,17 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: breakglass-controller
+  name: breakglass-manager
   namespace: breakglass-system
 spec:
   replicas: 3  # Multiple replicas
   selector:
     matchLabels:
-      app: breakglass-controller
+      app: breakglass
   template:
     metadata:
       labels:
-        app: breakglass-controller
+        app: breakglass
     spec:
       affinity:
         podAntiAffinity:
@@ -702,11 +702,11 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - breakglass-controller
+                  - breakglass
               topologyKey: kubernetes.io/hostname
       
       containers:
-      - name: controller
+      - name: breakglass
         image: breakglass:latest
         args:
           - --enable-leader-election=true  # IMPORTANT: Enables leader election
@@ -741,7 +741,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
       
-      serviceAccountName: breakglass-controller
+      serviceAccountName: breakglass-manager
 ```
 
 ### Helm Values (from charts/escalation-config)
@@ -775,7 +775,7 @@ affinity:
           - key: app
             operator: In
             values:
-            - breakglass-controller
+            - breakglass
         topologyKey: kubernetes.io/hostname
 ```
 

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -380,7 +380,7 @@ journalctl -u kubelet | grep authorization
 kubectl --kubeconfig=/etc/kubernetes/breakglass-webhook-kubeconfig.yaml cluster-info
 
 # Check breakglass logs
-kubectl logs -n breakglass-system deployment/breakglass-controller
+kubectl logs -n breakglass-system deployment/breakglass-manager
 ```
 
 ## Preventing Recursive Webhook Calls

--- a/hack/verify-commit-check-runs.sh
+++ b/hack/verify-commit-check-runs.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+sha="${GITHUB_SHA:?GITHUB_SHA is required}"
+current_run_id="${GITHUB_RUN_ID:-}"
+
+filter_current_run='
+  def current_run_url:
+    if $current_run_id == "" then false
+    else
+      (((.details_url // "") | contains("/actions/runs/" + $current_run_id + "/")) or
+       ((.html_url // "") | contains("/actions/runs/" + $current_run_id + "/")))
+    end;
+  map(select(current_run_url | not))
+'
+
+if [ -n "${CHECK_RUNS_JSON:-}" ]; then
+  all_runs="$(jq -c '
+    if type == "object" and has("check_runs") then .check_runs
+    elif type == "array" then .
+    else [.]
+    end
+  ' <<< "${CHECK_RUNS_JSON}")"
+else
+  all_runs="$(
+    gh api --paginate "repos/${repo}/commits/${sha}/check-runs?per_page=100" \
+      --jq '.check_runs[]' | jq -s -c '.'
+  )"
+fi
+
+runs="$(jq -c --arg current_run_id "${current_run_id}" "${filter_current_run}" <<< "${all_runs}")"
+
+ignored_count="$(( $(jq 'length' <<< "${all_runs}") - $(jq 'length' <<< "${runs}") ))"
+if [ "${ignored_count}" -gt 0 ]; then
+  echo "Ignoring ${ignored_count} check run(s) from current release workflow run ${current_run_id}."
+fi
+
+failures="$(
+  jq -r '
+    .[]
+    | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled")
+    | .name
+  ' <<< "${runs}"
+)"
+if [ -n "${failures}" ]; then
+  echo "::error::CI checks failed for commit ${sha}: ${failures}"
+  exit 1
+fi
+
+pending="$(
+  jq -r '
+    .[]
+    | select(.status == "queued" or .status == "in_progress" or .status == "requested" or .status == "waiting" or .status == "pending")
+    | .name
+  ' <<< "${runs}"
+)"
+if [ -n "${pending}" ]; then
+  echo "::error::CI checks are still pending for commit ${sha}: ${pending}"
+  exit 1
+fi
+
+success="$(
+  jq -r '
+    .[]
+    | select(.status == "completed" and .conclusion == "success")
+    | .name
+  ' <<< "${runs}"
+)"
+if [ -z "${success}" ]; then
+  echo "::error::No successful completed CI checks found for commit ${sha}."
+  exit 1
+fi
+
+echo "CI checks passed for commit ${sha}:"
+printf '%s\n' "${success}"

--- a/hack/verify-commit-check-runs.sh
+++ b/hack/verify-commit-check-runs.sh
@@ -16,6 +16,16 @@ filter_current_run='
   map(select(current_run_url | not))
 '
 
+latest_runs_by_check='
+  def check_key:
+    [((.app.id // .app.slug // .app.name // "unknown") | tostring), (.name // "")];
+  def run_order:
+    [(.started_at // .completed_at // .created_at // .updated_at // ""), (.id // 0)];
+  sort_by(check_key)
+  | group_by(check_key)
+  | map(max_by(run_order))
+'
+
 if [ -n "${CHECK_RUNS_JSON:-}" ]; then
   all_runs="$(jq -c '
     if type == "object" and has("check_runs") then .check_runs
@@ -30,11 +40,17 @@ else
   )"
 fi
 
-runs="$(jq -c --arg current_run_id "${current_run_id}" "${filter_current_run}" <<< "${all_runs}")"
+filtered_runs="$(jq -c --arg current_run_id "${current_run_id}" "${filter_current_run}" <<< "${all_runs}")"
 
-ignored_count="$(( $(jq 'length' <<< "${all_runs}") - $(jq 'length' <<< "${runs}") ))"
+ignored_count="$(( $(jq 'length' <<< "${all_runs}") - $(jq 'length' <<< "${filtered_runs}") ))"
 if [ "${ignored_count}" -gt 0 ]; then
   echo "Ignoring ${ignored_count} check run(s) from current release workflow run ${current_run_id}."
+fi
+
+runs="$(jq -c "${latest_runs_by_check}" <<< "${filtered_runs}")"
+superseded_count="$(( $(jq 'length' <<< "${filtered_runs}") - $(jq 'length' <<< "${runs}") ))"
+if [ "${superseded_count}" -gt 0 ]; then
+  echo "Ignoring ${superseded_count} superseded check run attempt(s); evaluating latest check run per app/name."
 fi
 
 failures="$(

--- a/hack/verify-docs-snippets.sh
+++ b/hack/verify-docs-snippets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+paths=(README.md docs .github)
+patterns=(
+  '30081'
+  'deployment/breakglass-controller([^[:alnum:]_-]|$)'
+  'deployment/breakglass-controller-manager([^[:alnum:]_-]|$)'
+  'deploy/breakglass-controller([^[:alnum:]_-]|$)'
+  'svc/breakglass-controller-metrics([^[:alnum:]_-]|$)'
+  'app=breakglass-manager([^[:alnum:]_-]|$)'
+  '-n breakglass([[:space:]]|$)'
+  'namespace:[[:space:]]+breakglass([[:space:]]|$)'
+)
+
+found=0
+for pattern in "${patterns[@]}"; do
+  if grep -RInE -- "${pattern}" "${paths[@]}"; then
+    found=1
+  fi
+done
+
+if [ "${found}" -ne 0 ]; then
+  cat >&2 <<'EOF'
+Stale docs/workflow snippet found.
+
+Use the current dev workload names:
+- deployment/breakglass-manager
+- container breakglass
+- namespace breakglass-system
+- pod label app=breakglass
+- e2e NODEPORT default 31081
+EOF
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- move release check-run validation into a helper that ignores the current release workflow run
- add CI gates for generated artifact drift and stale docs/workflow snippets
- align dev NodePort and workload-name docs with the rendered breakglass-manager deployment

## Validation
- bash -n hack/verify-commit-check-runs.sh hack/verify-docs-snippets.sh hack/verify-release-provenance.sh
- CHECK_RUNS_JSON fixture with current release run ignored: hack/verify-commit-check-runs.sh
- make verify-docs-snippets
- make verify-release-provenance
- git diff --check
- make verify-generated attempted locally, but controller-gen package loading stalled repeatedly in the local macOS/temp clone; PR CI will run this new gate.