### PR TITLE
fix: align binding approver overrides

### DIFF
--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1367,7 +1367,10 @@ func (a *debugSessionReadAuthorizer) isExplicitDebugSessionApprover(ctx context.
 	if err != nil {
 		return false, err
 	}
-	if debugSessionApproversConfigured(approvers) {
+	if approvers != nil {
+		if !debugSessionApproversConfigured(approvers) {
+			return false, nil
+		}
 		return a.approverAuthorizationMatches(approvers), nil
 	}
 	if session.Status.ResolvedTemplate != nil &&

--- a/pkg/breakglass/debug/debug_session_api_authorization_test.go
+++ b/pkg/breakglass/debug/debug_session_api_authorization_test.go
@@ -310,6 +310,63 @@ func TestCanReadDebugSession_BindingApproversAreAuthoritative(t *testing.T) {
 	assert.False(t, result)
 }
 
+func TestCanReadDebugSession_BindingApproversEmptyVsNil(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		bindingApprovers *breakglassv1alpha1.DebugSessionApprovers
+		want             bool
+	}{
+		{
+			name:             "empty binding approvers replace template",
+			bindingApprovers: &breakglassv1alpha1.DebugSessionApprovers{},
+			want:             false,
+		},
+		{
+			name:             "nil binding approvers inherit template",
+			bindingApprovers: nil,
+			want:             true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zaptest.NewLogger(t).Sugar()
+			binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "prod-binding", Namespace: "breakglass"},
+				Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+					Approvers: tt.bindingApprovers,
+				},
+			}
+			template := &breakglassv1alpha1.DebugSessionTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template"},
+				Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+					Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+						Users: []string{"template-approver@example.com"},
+					},
+				},
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(Scheme).
+				WithObjects(binding, template).
+				Build()
+			ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil)
+
+			session := &breakglassv1alpha1.DebugSession{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-session"},
+				Spec: breakglassv1alpha1.DebugSessionSpec{
+					TemplateRef: "test-template",
+					RequestedBy: "alice@example.com",
+					BindingRef:  &breakglassv1alpha1.BindingReference{Name: "prod-binding", Namespace: "breakglass"},
+				},
+			}
+
+			result, err := ctrl.canReadDebugSession(context.Background(), session, debugSessionReadIdentity{
+				username: "template-approver@example.com",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestCanReadDebugSession_ResolvedTemplateApproversAreAuthoritative(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	template := &breakglassv1alpha1.DebugSessionTemplate{

--- a/pkg/breakglass/debug/debug_session_api_email_ops.go
+++ b/pkg/breakglass/debug/debug_session_api_email_ops.go
@@ -33,7 +33,7 @@ func (c *DebugSessionAPIController) sendDebugSessionRequestEmail(ctx context.Con
 	}
 
 	approvers := effectiveDebugSessionApprovers(template, binding)
-	if approvers == nil {
+	if !debugSessionApproversConfigured(approvers) {
 		c.log.Debugw("No approvers configured for debug session template, skipping request email", "session", session.Name, "template", debugSessionTemplateName(template))
 		return
 	}
@@ -977,7 +977,7 @@ func (c *DebugSessionAPIController) isClusterAllowedByTemplateOrBinding(
 
 func isApprovalRequiredForSession(session *breakglassv1alpha1.DebugSession, template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) bool {
 	approvers := effectiveDebugSessionApprovers(template, binding)
-	if approvers == nil {
+	if !debugSessionApproversConfigured(approvers) {
 		return false
 	}
 	if session != nil && debugSessionAutoApproveMatches(approvers.AutoApproveFor, session.Spec.Cluster, session.Spec.UserGroups) {

--- a/pkg/breakglass/debug/debug_session_api_email_test.go
+++ b/pkg/breakglass/debug/debug_session_api_email_test.go
@@ -678,7 +678,7 @@ func TestSendDebugSessionRequestEmail_EmptyApproversList(t *testing.T) {
 	assert.Empty(t, messages, "no email should be sent when approvers list is empty")
 }
 
-func TestSendDebugSessionRequestEmail_EmptyBindingFallsBackToTemplateApprovers(t *testing.T) {
+func TestSendDebugSessionRequestEmail_EmptyBindingApproversSkipTemplateApprovers(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
 	mockMail := NewMockMailEnqueuer(true)
 	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
@@ -715,8 +715,57 @@ func TestSendDebugSessionRequestEmail_EmptyBindingFallsBackToTemplateApprovers(t
 	ctrl.sendDebugSessionRequestEmail(context.Background(), session, template, binding)
 
 	messages := mockMail.GetMessages()
-	require.Len(t, messages, 1)
-	assert.Equal(t, []string{"template-approver@example.com"}, messages[0].Recipients)
+	assert.Empty(t, messages, "empty binding approvers should replace template approvers and skip request email")
+}
+
+func TestSendDebugSessionRequestEmail_EmptyBindingApproversSkipNotificationRecipients(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	mockMail := NewMockMailEnqueuer(true)
+	fakeClient := fake.NewClientBuilder().WithScheme(Scheme).Build()
+
+	ctrl := NewDebugSessionAPIController(logger, fakeClient, nil, nil).
+		WithMailService(mockMail, "Breakglass", "https://breakglass.example.com")
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-session",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:           "production",
+			TemplateRef:       "template",
+			RequestedBy:       "requester@example.com",
+			RequestedDuration: "1h",
+		},
+	}
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+				Users: []string{"template-approver@example.com"},
+			},
+			Notification: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:              true,
+				NotifyOnRequest:      true,
+				AdditionalRecipients: []string{"template-oncall@example.com"},
+			},
+		},
+	}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Approvers: &breakglassv1alpha1.DebugSessionApprovers{},
+			Notification: &breakglassv1alpha1.DebugSessionNotificationConfig{
+				Enabled:              true,
+				NotifyOnRequest:      true,
+				AdditionalRecipients: []string{"binding-oncall@example.com"},
+			},
+		},
+	}
+
+	ctrl.sendDebugSessionRequestEmail(context.Background(), session, template, binding)
+
+	messages := mockMail.GetMessages()
+	assert.Empty(t, messages, "empty binding approvers should suppress request email even with notification recipients")
 }
 
 func TestSendDebugSessionRequestEmail_GroupOnlyApproversUseAdditionalRecipients(t *testing.T) {

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -164,7 +164,7 @@ func (c *DebugSessionAPIController) resolveApproval(template *breakglassv1alpha1
 	info := &ApprovalInfo{}
 
 	approvers := effectiveDebugSessionApprovers(template, binding)
-	if approvers != nil {
+	if debugSessionApproversConfigured(approvers) {
 		info.Required = true
 		info.ApproverGroups = approvers.Groups
 		info.ApproverUsers = approvers.Users
@@ -209,10 +209,10 @@ func debugSessionAutoApproveMatches(autoApprove *breakglassv1alpha1.AutoApproveC
 }
 
 func effectiveDebugSessionApprovers(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) *breakglassv1alpha1.DebugSessionApprovers {
-	if binding != nil && debugSessionApproversConfigured(binding.Spec.Approvers) {
+	if binding != nil && binding.Spec.Approvers != nil {
 		return binding.Spec.Approvers
 	}
-	if template != nil && debugSessionApproversConfigured(template.Spec.Approvers) {
+	if template != nil {
 		return template.Spec.Approvers
 	}
 	return nil
@@ -594,7 +594,7 @@ func (a *debugSessionApprovalAuthorizer) isIdentityAuthorizedToApprove(ctx conte
 				"session", session.Name, "binding", key.String())
 			return false
 		}
-		if debugSessionApproversConfigured(binding.Spec.Approvers) {
+		if binding.Spec.Approvers != nil {
 			return c.checkApproverAuthorizationForIdentity(binding.Spec.Approvers, identity)
 		}
 	}

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -8692,7 +8692,7 @@ func TestDebugSessionAPIController_resolveApproval(t *testing.T) {
 		assert.True(t, result.CanAutoApprove)
 	})
 
-	t.Run("empty binding approvers fall back to template", func(t *testing.T) {
+	t.Run("empty binding approvers disable approval", func(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
@@ -8705,6 +8705,27 @@ func TestDebugSessionAPIController_resolveApproval(t *testing.T) {
 			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
 				Approvers: &breakglassv1alpha1.DebugSessionApprovers{},
 			},
+		}
+
+		result := controller.resolveApproval(template, binding, cc, []string{"dev-team"})
+
+		assert.False(t, result.Required)
+		assert.False(t, result.CanAutoApprove)
+		assert.Empty(t, result.ApproverGroups)
+		assert.Empty(t, result.ApproverUsers)
+	})
+
+	t.Run("nil binding approvers fall back to template", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Groups: []string{"template-approvers"},
+					Users:  []string{"template-approver@example.com"},
+				},
+			},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{},
 		}
 
 		result := controller.resolveApproval(template, binding, cc, []string{"dev-team"})

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -870,35 +870,32 @@ func (c *DebugSessionController) validateSpokeServiceAccount(
 }
 
 // requiresApproval checks if the session requires approval.
-// It checks both the template and the binding for approvers configuration.
-// Approval is required if either the template or binding specifies approvers
-// (unless auto-approve conditions are met).
+// Binding approvers replace template approvers when present; otherwise template
+// approvers are used. Approval is required when the effective approver set has
+// users or groups, unless auto-approve conditions are met.
 func (c *DebugSessionController) requiresApproval(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding, ds *breakglassv1alpha1.DebugSession) bool {
-	// Check if binding has approvers configured (takes precedence)
+	// Binding approvers replace template approvers when the field is present,
+	// even if the binding intentionally sets an empty approver list.
 	if binding != nil && binding.Spec.Approvers != nil {
-		if len(binding.Spec.Approvers.Users) > 0 || len(binding.Spec.Approvers.Groups) > 0 {
-			c.log.Infow("Approval required by binding",
-				"session", ds.Name,
-				"binding", binding.Name,
-				"bindingNamespace", binding.Namespace)
-			// Check binding auto-approve conditions
-			if binding.Spec.Approvers.AutoApproveFor != nil {
-				if c.checkAutoApprove(binding.Spec.Approvers.AutoApproveFor, ds) {
-					return false
-				}
-			}
-			return true
+		if !debugSessionApproversConfigured(binding.Spec.Approvers) {
+			return false
 		}
+		c.log.Infow("Approval required by binding",
+			"session", ds.Name,
+			"binding", binding.Name,
+			"bindingNamespace", binding.Namespace)
+		// Check binding auto-approve conditions
+		if binding.Spec.Approvers.AutoApproveFor != nil {
+			if c.checkAutoApprove(binding.Spec.Approvers.AutoApproveFor, ds) {
+				return false
+			}
+		}
+		return true
 	}
 
 	// Check if template has approvers configured
-	if template.Spec.Approvers == nil {
+	if template == nil || !debugSessionApproversConfigured(template.Spec.Approvers) {
 		return false // No approvers configured = auto-approve
-	}
-
-	// Check if template has actual approvers (not just auto-approve rules)
-	if len(template.Spec.Approvers.Users) == 0 && len(template.Spec.Approvers.Groups) == 0 {
-		return false // No actual approvers configured
 	}
 
 	// Check template auto-approve conditions

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -4490,7 +4490,7 @@ func TestRequiresApproval(t *testing.T) {
 		assert.False(t, result, "Should not require approval when approvers struct exists but has no users/groups")
 	})
 
-	t.Run("binding_with_empty_approvers_struct_falls_through_to_template", func(t *testing.T) {
+	t.Run("binding_with_empty_approvers_struct_replaces_template", func(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
@@ -4507,8 +4507,23 @@ func TestRequiresApproval(t *testing.T) {
 			},
 		}
 		result := controller.requiresApproval(template, binding, baseSession)
-		// Binding approvers is empty, so it falls through to template check
-		assert.True(t, result, "Should fall through to template when binding has empty approvers")
+		assert.False(t, result, "Should not require approval when binding explicitly replaces template approvers with an empty list")
+	})
+
+	t.Run("binding_with_nil_approvers_inherits_template", func(t *testing.T) {
+		template := &breakglassv1alpha1.DebugSessionTemplate{
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+					Groups: []string{"template-approvers"},
+				},
+			},
+		}
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: "default"},
+			Spec:       breakglassv1alpha1.DebugSessionClusterBindingSpec{},
+		}
+		result := controller.requiresApproval(template, binding, baseSession)
+		assert.True(t, result, "Should inherit template approvers when binding approvers are nil")
 	})
 
 	t.Run("wildcard_cluster_pattern_auto_approve", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- align DebugSessionClusterBinding approver semantics with the API/docs replacement model
- treat `spec.approvers: {}` on a binding as an explicit empty override, not a fallback to template approvers
- keep nil/missing binding approvers inheriting template approvers
- update runtime, API, email, read authorization, approval authorization, and focused regressions

## Validation

- `gofmt -w pkg/breakglass/debug/...`
- `git diff --check origin/main..HEAD`
- `GOCACHE=/private/tmp/k8s-approver-go-cache GOMODCACHE=/private/tmp/k8s-approver-go-mod-cache go test -timeout=4m ./pkg/breakglass/debug`

## Duplicate Check

- `gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search 'binding approvers replace template empty approvers approval DebugSessionClusterBinding'`

