### PR TITLE
fix(bgctl): require update checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **DebugSession denial and HTTP log redaction**: Frontend HTTP error logging and unauthorized DebugSession cluster-denial responses now avoid exposing bearer tokens or template cluster patterns.
+- **bgctl self-update checksum enforcement**: `bgctl update` now refuses to install
+  release archives when the matching `.sha256` asset is missing or cannot be
+  downloaded, instead of proceeding without verification.
 - **BreakglassEscalation admission validation**: Escalation duration fields now reject non-positive or malformed values consistently, `idleTimeout` and `approvalTimeout` are checked against the effective `maxValidFor`, and invalid cluster glob patterns are rejected before they can affect session admission.
 - **OIDC upstream response handling**: OIDC discovery, JWKS, userinfo, token, and Keycloak API reads now enforce bounded response bodies, preventing oversized identity-provider responses from exhausting controller memory. (#1131)
 - **BreakglassSession approver IDP enforcement**: Approval and rejection requests now enforce `BreakglassEscalation.spec.allowedIdentityProvidersForApprovers`, denying approvers whose authenticated IdentityProvider is missing or not allowed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -306,6 +306,10 @@ bgctl update --version v1.2.0
 bgctl update rollback
 ```
 
+`bgctl update` fails closed when the matching `.sha256` checksum asset is missing
+or cannot be downloaded. Download the release archive and checksum manually if a
+release needs to be installed before its checksum asset is available.
+
 ## Exit Codes
 
 - `0` - Success

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -159,7 +159,7 @@ func runUpdate(cmd *cobra.Command, versionTag string) error {
 		return err
 	}
 
-	if err := verifyChecksumIfAvailable(ctx, release.Assets, assetName, archivePath); err != nil {
+	if err := verifyChecksum(ctx, release.Assets, assetName, archivePath); err != nil {
 		return err
 	}
 
@@ -332,11 +332,11 @@ func formatBytes(b int64) string {
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
-func verifyChecksumIfAvailable(ctx context.Context, assets []githubAsset, name, filePath string) error {
+func verifyChecksum(ctx context.Context, assets []githubAsset, name, filePath string) error {
 	checksumName := name + ".sha256"
 	url := findAssetURL(assets, checksumName)
 	if url == "" {
-		return nil
+		return fmt.Errorf("refusing update without checksum verification: checksum asset not found for %s", checksumName)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -350,7 +350,11 @@ func verifyChecksumIfAvailable(ctx context.Context, assets []githubAsset, name, 
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		return nil
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 0 {
+			return fmt.Errorf("refusing update without checksum verification: checksum download failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		}
+		return fmt.Errorf("refusing update without checksum verification: checksum download failed: %s", resp.Status)
 	}
 	checksumBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -29,6 +29,8 @@ const (
 	// maxBinarySize is the maximum allowed size for extracted binaries (500 MB).
 	maxBinarySize = 500 << 20
 
+	maxUpdateErrorBodyBytes = 4 << 10
+
 	defaultUpdateAPIHTTPTimeout      = 30 * time.Second
 	defaultUpdateDownloadHTTPTimeout = 5 * time.Minute
 )
@@ -194,8 +196,7 @@ func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to fetch release: %s", string(body))
+		return nil, fmt.Errorf("failed to fetch release: %s", readUpdateErrorBody(resp.Body))
 	}
 	var release githubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
@@ -218,8 +219,7 @@ func fetchReleaseByTag(ctx context.Context, tag string) (*githubRelease, error) 
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to fetch release: %s", string(body))
+		return nil, fmt.Errorf("failed to fetch release: %s", readUpdateErrorBody(resp.Body))
 	}
 	var release githubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
@@ -259,8 +259,7 @@ func downloadFile(ctx context.Context, url, path string) error {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("download failed: %s", string(body))
+		return fmt.Errorf("download failed: %s", readUpdateErrorBody(resp.Body))
 	}
 	out, err := os.Create(path)
 	if err != nil {
@@ -332,6 +331,19 @@ func formatBytes(b int64) string {
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
+func readUpdateErrorBody(r io.Reader) string {
+	body, _ := io.ReadAll(io.LimitReader(r, maxUpdateErrorBodyBytes+1))
+	truncated := len(body) > maxUpdateErrorBodyBytes
+	if truncated {
+		body = body[:maxUpdateErrorBodyBytes]
+	}
+	text := strings.TrimSpace(string(body))
+	if truncated {
+		text += "... (truncated)"
+	}
+	return text
+}
+
 func verifyChecksum(ctx context.Context, assets []githubAsset, name, filePath string) error {
 	checksumName := name + ".sha256"
 	url := findAssetURL(assets, checksumName)
@@ -350,9 +362,9 @@ func verifyChecksum(ctx context.Context, assets []githubAsset, name, filePath st
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		if len(body) > 0 {
-			return fmt.Errorf("refusing update without checksum verification: checksum download failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		body := readUpdateErrorBody(resp.Body)
+		if body != "" {
+			return fmt.Errorf("refusing update without checksum verification: checksum download failed: %s: %s", resp.Status, body)
 		}
 		return fmt.Errorf("refusing update without checksum verification: checksum download failed: %s", resp.Status)
 	}

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -233,6 +233,25 @@ func TestVerifyChecksumDownloadFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "404")
 }
 
+func TestVerifyChecksumDownloadFailureBoundsErrorBody(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
+
+	body := strings.Repeat("x", maxUpdateErrorBodyBytes+1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	assets := []githubAsset{{Name: "bgctl.bin.sha256", URL: server.URL}}
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum download failed")
+	assert.Contains(t, err.Error(), "(truncated)")
+	assert.NotContains(t, err.Error(), strings.Repeat("x", maxUpdateErrorBodyBytes+1))
+}
+
 func TestExtractTarGz(t *testing.T) {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "bgctl.tar.gz")

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -156,7 +156,7 @@ func TestFetchReleaseByTagEscapesPathSegment(t *testing.T) {
 	assert.True(t, strings.HasSuffix(escapedPath, "/releases/tags/1.0.0%2F..%2Fx"), "unexpected escaped path: %s", escapedPath)
 }
 
-func TestVerifyChecksumIfAvailable(t *testing.T) {
+func TestVerifyChecksum(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
 	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
 
@@ -170,11 +170,11 @@ func TestVerifyChecksumIfAvailable(t *testing.T) {
 	defer server.Close()
 
 	assets := []githubAsset{{Name: "bgctl.bin.sha256", URL: server.URL}}
-	err := verifyChecksumIfAvailable(context.Background(), assets, "bgctl.bin", filePath)
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
 	require.NoError(t, err)
 }
 
-func TestVerifyChecksumIfAvailableMismatch(t *testing.T) {
+func TestVerifyChecksumMismatch(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
 	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
 
@@ -185,12 +185,12 @@ func TestVerifyChecksumIfAvailableMismatch(t *testing.T) {
 	defer server.Close()
 
 	assets := []githubAsset{{Name: "bgctl.bin.sha256", URL: server.URL}}
-	err := verifyChecksumIfAvailable(context.Background(), assets, "bgctl.bin", filePath)
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum mismatch")
 }
 
-func TestVerifyChecksumIfAvailableEmptyFile(t *testing.T) {
+func TestVerifyChecksumEmptyFile(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
 	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
 
@@ -200,18 +200,37 @@ func TestVerifyChecksumIfAvailableEmptyFile(t *testing.T) {
 	defer server.Close()
 
 	assets := []githubAsset{{Name: "bgctl.bin.sha256", URL: server.URL}}
-	err := verifyChecksumIfAvailable(context.Background(), assets, "bgctl.bin", filePath)
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty checksum")
 }
 
-func TestVerifyChecksumIfAvailableMissingAsset(t *testing.T) {
+func TestVerifyChecksumMissingAsset(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
 	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
 
 	assets := []githubAsset{}
-	err := verifyChecksumIfAvailable(context.Background(), assets, "bgctl.bin", filePath)
-	require.NoError(t, err)
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing update without checksum verification")
+	assert.Contains(t, err.Error(), "checksum asset not found")
+}
+
+func TestVerifyChecksumDownloadFailure(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "bgctl.bin")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	assets := []githubAsset{{Name: "bgctl.bin.sha256", URL: server.URL}}
+	err := verifyChecksum(context.Background(), assets, "bgctl.bin", filePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing update without checksum verification")
+	assert.Contains(t, err.Error(), "checksum download failed")
+	assert.Contains(t, err.Error(), "404")
 }
 
 func TestExtractTarGz(t *testing.T) {


### PR DESCRIPTION
## Summary

- make `bgctl update` fail closed when the release archive has no matching `.sha256` asset
- treat checksum download HTTP failures as update failures instead of silently skipping verification
- update checksum tests for success, mismatch, empty file, missing asset, and download failure

## Validation

- `gofmt -w pkg/bgctl/cmd/update.go pkg/bgctl/cmd/update_test.go`
- `git diff --check origin/main..HEAD`
- `GOCACHE=/private/tmp/k8s-breakglass-checksum-go-cache GOMODCACHE=/private/tmp/k8s-breakglass-checksum-go-mod-cache go test -timeout=4m ./pkg/bgctl/cmd`

## Duplicate Check

- `gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search 'bgctl checksum update sha256'`
- `gh search prs --repo telekom/k8s-breakglass 'verifyChecksumIfAvailable OR verifyChecksum OR bgctl update checksum'`

