### PR TITLE
fix: thread cleanup cancellation through expiry passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.
 - **Scheduled activation stale-state guard**: Scheduled activation now re-reads each waiting session before granting access and skips sessions that already left `WaitingForScheduledTime`, preserving concurrent terminal transitions.
+- **Cleanup cancellation propagation**: Background cleanup now threads cancellation through scheduled activation and session-expiry passes so shutdown and timeout signals stop the whole pass promptly.
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - **BreakglassSession state filters**: `GET /api/breakglassSessions` now returns `400 Bad Request` for unknown non-empty `state` filter tokens.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.

--- a/pkg/breakglass/cleanup_task.go
+++ b/pkg/breakglass/cleanup_task.go
@@ -118,6 +118,15 @@ func (cr CleanupRoutine) CleanupRoutine(ctx context.Context) {
 
 func (cr CleanupRoutine) clean(ctx context.Context) {
 	cr.Log.Info("Running breakglass session cleanup task")
+	cleanupCtx := ctx
+	if cleanupCtx == nil {
+		cleanupCtx = context.Background()
+	}
+	// Bound all cleanup operations under a single timeout so shutdown is
+	// predictable and we don't accumulate slow API calls.
+	opCtx, cancel := context.WithTimeout(cleanupCtx, DefaultCleanupOperationTimeout)
+	defer cancel()
+
 	// Activate scheduled sessions first (before expiry checks)
 	if cr.Manager != nil {
 		activator := NewScheduledSessionActivator(cr.Log, cr.Manager).
@@ -125,7 +134,7 @@ func (cr CleanupRoutine) clean(ctx context.Context) {
 		if cr.AuditService != nil {
 			activator = activator.WithAuditService(cr.AuditService)
 		}
-		activator.ActivateScheduledSessions()
+		activator.ActivateScheduledSessions(opCtx)
 	}
 
 	// Build session controller once for the expiry operations below.
@@ -138,19 +147,10 @@ func (cr CleanupRoutine) clean(ctx context.Context) {
 			disableEmail:   cr.DisableEmail,
 			config:         config.Config{Frontend: config.Frontend{BrandingName: cr.BrandingName}},
 		}
-		sessionCtrl.ExpirePendingSessions()
+		sessionCtrl.ExpirePendingSessions(opCtx)
 		// Expire approved sessions whose ExpiresAt has passed
-		sessionCtrl.ExpireApprovedSessions()
+		sessionCtrl.ExpireApprovedSessions(opCtx)
 	}
-
-	cleanupCtx := ctx
-	if cleanupCtx == nil {
-		cleanupCtx = context.Background()
-	}
-	// Bound all cleanup operations under a single timeout so shutdown is
-	// predictable and we don't accumulate slow API calls.
-	opCtx, cancel := context.WithTimeout(cleanupCtx, DefaultCleanupOperationTimeout)
-	defer cancel()
 
 	if cr.Manager != nil {
 		// Remove duplicate active sessions (same cluster/user/grantedGroup triple).
@@ -180,6 +180,13 @@ func (cr CleanupRoutine) clean(ctx context.Context) {
 		}
 	}
 	cr.Log.Info("Finished breakglass session cleanup task")
+}
+
+func optionalCleanupContext(ctxs ...context.Context) context.Context {
+	if len(ctxs) > 0 && ctxs[0] != nil {
+		return ctxs[0]
+	}
+	return context.Background()
 }
 
 // pruneActivityTracker builds a set of active (approved) session NamespacedNames

--- a/pkg/breakglass/expire_approved_sessions.go
+++ b/pkg/breakglass/expire_approved_sessions.go
@@ -12,21 +12,30 @@ import (
 )
 
 // ExpireApprovedSessions sets state to Expired for approved sessions that have passed ExpiresAt
-func (wc *BreakglassSessionController) ExpireApprovedSessions() {
+func (wc *BreakglassSessionController) ExpireApprovedSessions(ctxs ...context.Context) {
+	ctx := optionalCleanupContext(ctxs...)
+	if err := ctx.Err(); err != nil {
+		wc.log.Infow("skipping approved session expiry because context is cancelled", "error", err)
+		return
+	}
 	// Use indexed query to fetch only approved sessions
-	sessions, err := wc.sessionManager.GetSessionsByState(context.Background(), breakglassv1alpha1.SessionStateApproved)
+	sessions, err := wc.sessionManager.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateApproved)
 	if err != nil {
 		wc.log.Error("error listing breakglass sessions for approved expiry", err)
 		return
 	}
 	for _, ses := range sessions {
+		if err := ctx.Err(); err != nil {
+			wc.log.Infow("stopping approved session expiry because context is cancelled", "error", err)
+			return
+		}
 		if IsSessionExpired(ses) {
 			// Log intent and timestamps for easier debugging
 			now := time.Now()
 			wc.log.Infow("Expiring approved session due to reached ExpiresAt", "session", ses.Name, "expiresAt", ses.Status.ExpiresAt.Time, "now", now)
 
 			updated, applied, err := wc.updateSessionStatusIfCurrent(
-				context.Background(),
+				ctx,
 				ses,
 				breakglassv1alpha1.SessionStateApproved,
 				IsSessionExpired,
@@ -57,7 +66,14 @@ func (wc *BreakglassSessionController) ExpireApprovedSessions() {
 			}
 
 			metrics.SessionExpired.WithLabelValues(updated.Spec.Cluster).Inc()
-			wc.emitSessionExpiredAuditEvent(context.Background(), &updated, "timeExpired")
+			wc.emitSessionExpiredAuditEvent(ctx, &updated, "timeExpired")
+			if err := ctx.Err(); err != nil {
+				wc.log.Infow("skipping approved session expiry email because context is cancelled",
+					"session", updated.Name,
+					"namespace", updated.Namespace,
+					"error", err)
+				return
+			}
 			wc.sendSessionExpiredEmail(updated, "timeExpired")
 		}
 	}

--- a/pkg/breakglass/expire_approved_sessions_test.go
+++ b/pkg/breakglass/expire_approved_sessions_test.go
@@ -102,6 +102,47 @@ func TestExpireApprovedSessionsDetailed(t *testing.T) {
 		assert.True(t, hasExpiredCondition, "expected Expired condition to be set")
 	})
 
+	t.Run("canceled context skips approved expiry", func(t *testing.T) {
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "approved-canceled",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:         "test@example.com",
+				Cluster:      "test-cluster",
+				GrantedGroup: "admin",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:           breakglassv1alpha1.SessionStateApproved,
+				ApprovedAt:      metav1.NewTime(time.Now().UTC().Add(-2 * time.Hour)),
+				ActualStartTime: metav1.NewTime(time.Now().UTC().Add(-2 * time.Hour)),
+				ExpiresAt:       metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour)),
+			},
+		}
+
+		fakeClient := newFakeApprovedClient(session)
+		mgr := NewSessionManagerWithClient(fakeClient)
+		controller := &BreakglassSessionController{
+			log:            logger,
+			sessionManager: mgr,
+			disableEmail:   true,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		controller.ExpireApprovedSessions(ctx)
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := fakeClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "approved-canceled"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, updated.Status.State)
+		assert.Empty(t, updated.Status.ReasonEnded)
+		assert.True(t, updated.Status.RetainedUntil.IsZero())
+	})
+
 	t.Run("does not expire approved session before ExpiresAt", func(t *testing.T) {
 		session := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/breakglass/expire_pending_sessions.go
+++ b/pkg/breakglass/expire_pending_sessions.go
@@ -10,19 +10,28 @@ import (
 )
 
 // ExpirePendingSessions sets state to Timeout for pending sessions that have expired (approval timeout).
-func (wc *BreakglassSessionController) ExpirePendingSessions() {
+func (wc *BreakglassSessionController) ExpirePendingSessions(ctxs ...context.Context) {
+	ctx := optionalCleanupContext(ctxs...)
+	if err := ctx.Err(); err != nil {
+		wc.log.Infow("skipping pending session expiry because context is cancelled", "error", err)
+		return
+	}
 	// Use indexed query to fetch only pending sessions (matching ExpireApprovedSessions pattern)
-	sessions, err := wc.sessionManager.GetSessionsByState(context.Background(), breakglassv1alpha1.SessionStatePending)
+	sessions, err := wc.sessionManager.GetSessionsByState(ctx, breakglassv1alpha1.SessionStatePending)
 	if err != nil {
 		wc.log.Error("error listing breakglass sessions for pending expiry", err)
 		return
 	}
 	for _, ses := range sessions {
+		if err := ctx.Err(); err != nil {
+			wc.log.Infow("stopping pending session expiry because context is cancelled", "error", err)
+			return
+		}
 		if IsSessionApprovalTimedOut(ses) {
 			wc.log.Infow("Expiring pending session due to approval timeout", "session", ses.Name)
 			now := time.Now()
 			updated, applied, err := wc.updateSessionStatusIfCurrent(
-				context.Background(),
+				ctx,
 				ses,
 				breakglassv1alpha1.SessionStatePending,
 				IsSessionApprovalTimedOut,
@@ -53,7 +62,14 @@ func (wc *BreakglassSessionController) ExpirePendingSessions() {
 			}
 
 			metrics.SessionExpired.WithLabelValues(updated.Spec.Cluster).Inc()
-			wc.emitSessionExpiredAuditEvent(context.Background(), &updated, "approvalTimeout")
+			wc.emitSessionExpiredAuditEvent(ctx, &updated, "approvalTimeout")
+			if err := ctx.Err(); err != nil {
+				wc.log.Infow("skipping pending session expiry email because context is cancelled",
+					"session", updated.Name,
+					"namespace", updated.Namespace,
+					"error", err)
+				return
+			}
 			wc.sendSessionExpiredEmail(updated, "approvalTimeout")
 		}
 	}

--- a/pkg/breakglass/expire_pending_sessions_test.go
+++ b/pkg/breakglass/expire_pending_sessions_test.go
@@ -167,6 +167,48 @@ func TestExpirePendingSessions(t *testing.T) {
 		assert.Equal(t, breakglassv1alpha1.SessionStateApproved, updatedSession.Status.State)
 	})
 
+	t.Run("canceled context skips pending expiry", func(t *testing.T) {
+		pendingSession := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pending-canceled",
+				Namespace:         "breakglass",
+				CreationTimestamp: metav1.NewTime(time.Now().UTC().Add(-2 * time.Hour)),
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:    "test@example.com",
+				Cluster: "test-cluster",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStatePending,
+				TimeoutAt: metav1.NewTime(time.Now().UTC().Add(-1 * time.Hour)),
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pendingSession).
+			WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "metadata.name", metadataNameIndexerExpire).
+			Build()
+		mgr := NewSessionManagerWithClient(fakeClient)
+		controller := &BreakglassSessionController{
+			log:            logger,
+			sessionManager: mgr,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		controller.ExpirePendingSessions(ctx)
+
+		var updatedSession breakglassv1alpha1.BreakglassSession
+		err := fakeClient.Get(context.Background(),
+			client.ObjectKey{Namespace: pendingSession.Namespace, Name: pendingSession.Name},
+			&updatedSession)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStatePending, updatedSession.Status.State)
+		assert.Empty(t, updatedSession.Status.ReasonEnded)
+	})
+
 	t.Run("does not overwrite concurrent terminal transition during retry", func(t *testing.T) {
 		pendingSession := &breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/breakglass/scheduled_activation.go
+++ b/pkg/breakglass/scheduled_activation.go
@@ -81,8 +81,12 @@ func (ssa *ScheduledSessionActivator) WithAuditService(auditService AuditEmitter
 // ActivateScheduledSessions checks sessions in WaitingForScheduledTime state.
 // Sessions whose ScheduledStartTime has arrived transition to Approved so the RBAC group can be applied.
 // Sessions that can no longer be valid are expired instead of being activated late.
-func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
-	ctx := context.Background()
+func (ssa *ScheduledSessionActivator) ActivateScheduledSessions(ctxs ...context.Context) {
+	ctx := optionalCleanupContext(ctxs...)
+	if err := ctx.Err(); err != nil {
+		ssa.log.Infow("skipping scheduled session activation because context is cancelled", "error", err)
+		return
+	}
 
 	// Use indexed query to fetch only sessions waiting for scheduled time
 	sessions, err := ssa.sessionManager.GetSessionsByState(ctx, breakglassv1alpha1.SessionStateWaitingForScheduledTime)
@@ -93,6 +97,10 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 
 	now := time.Now()
 	for _, ses := range sessions {
+		if err := ctx.Err(); err != nil {
+			ssa.log.Infow("stopping scheduled session activation because context is cancelled", "error", err)
+			return
+		}
 		listedMissingScheduledTime := ses.Spec.ScheduledStartTime == nil || ses.Spec.ScheduledStartTime.IsZero()
 		if !listedMissingScheduledTime && now.Before(ses.Spec.ScheduledStartTime.Time) {
 			// Not yet time for this session; avoid a live read until the cached
@@ -177,9 +185,16 @@ func (ssa *ScheduledSessionActivator) ActivateScheduledSessions() {
 		// Record metric for successful activation
 		metrics.SessionActivated.WithLabelValues(ses.Spec.Cluster).Inc()
 
-		ssa.emitSessionActivatedAuditEvent(ses)
+		ssa.emitSessionActivatedAuditEvent(ctx, ses)
 
 		// Send activation notification email
+		if err := ctx.Err(); err != nil {
+			ssa.log.Infow("skipping scheduled session activation email because context is cancelled",
+				"session", ses.Name,
+				"namespace", ses.Namespace,
+				"error", err)
+			return
+		}
 		ssa.sendSessionActivatedEmail(ses)
 
 		// RBAC group will now be applied by the authorization controller
@@ -295,12 +310,12 @@ func (ssa *ScheduledSessionActivator) currentWaitingScheduledSession(
 	return current, true
 }
 
-func (ssa *ScheduledSessionActivator) emitSessionActivatedAuditEvent(session breakglassv1alpha1.BreakglassSession) {
+func (ssa *ScheduledSessionActivator) emitSessionActivatedAuditEvent(ctx context.Context, session breakglassv1alpha1.BreakglassSession) {
 	if ssa.auditService == nil || !ssa.auditService.IsEnabled() {
 		return
 	}
 
-	ssa.auditService.Emit(context.Background(), &audit.Event{
+	ssa.auditService.Emit(ctx, &audit.Event{
 		Type:      audit.EventSessionActivated,
 		Severity:  audit.SeverityInfo,
 		Timestamp: time.Now().UTC(),

--- a/pkg/breakglass/scheduled_activation_test.go
+++ b/pkg/breakglass/scheduled_activation_test.go
@@ -215,6 +215,44 @@ func TestActivateScheduledSessions(t *testing.T) {
 		assert.True(t, hasCondition, "expected ScheduledStartTimeReached condition")
 	})
 
+	t.Run("canceled context skips scheduled activation", func(t *testing.T) {
+		scheduledTime := time.Now().Add(-5 * time.Minute)
+		session := &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduled-canceled",
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				User:               "test@example.com",
+				Cluster:            "test-cluster",
+				GrantedGroup:       "admin",
+				ScheduledStartTime: &metav1.Time{Time: scheduledTime},
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+				ApprovedAt: metav1.NewTime(scheduledTime.Add(-30 * time.Minute)),
+				ExpiresAt:  metav1.NewTime(time.Now().UTC().Add(1 * time.Hour)),
+			},
+		}
+
+		fakeClient := newFakeActivationClient(session)
+		mgr := NewSessionManagerWithClient(fakeClient)
+		activator := NewScheduledSessionActivator(logger, mgr).
+			WithMailService(nil, "TestBranding", true)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		activator.ActivateScheduledSessions(ctx)
+
+		var updated breakglassv1alpha1.BreakglassSession
+		err := fakeClient.Get(context.Background(),
+			client.ObjectKey{Namespace: "breakglass", Name: "scheduled-canceled"},
+			&updated)
+		require.NoError(t, err)
+		assert.Equal(t, breakglassv1alpha1.SessionStateWaitingForScheduledTime, updated.Status.State)
+		assert.True(t, updated.Status.ActualStartTime.IsZero(), "ActualStartTime should not be set")
+	})
+
 	t.Run("leaves scheduled session waiting when activation status update fails", func(t *testing.T) {
 		scheduledTime := time.Now().Add(-5 * time.Minute)
 		session := &breakglassv1alpha1.BreakglassSession{


### PR DESCRIPTION
## Summary
- pass cleanup cancellation/timeout context into scheduled activation and session expiry passes
- use the same context for list, status-update, and audit emission operations
- add cancellation tests for scheduled activation, pending expiry, and approved expiry

## Validation
- `GOCACHE=/private/tmp/k8s-cleanup-go-cache GOMODCACHE=/private/tmp/k8s-cleanup-go-mod-cache go test -timeout=5m ./pkg/breakglass -run 'TestActivateScheduledSessions|TestExpirePendingSessions|TestExpireApprovedSessionsDetailed|TestCleanupRoutine_clean'`
- `golangci-lint run --timeout=5m ./pkg/breakglass`
- `git diff --check origin/main..HEAD`
