### PR TITLE
ci: redact e2e secret diagnostics

### DIFF
--- a/.github/scripts/ci-e2e-diagnostics.sh
+++ b/.github/scripts/ci-e2e-diagnostics.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+# Helpers for GitHub Actions E2E diagnostics. Keep sourced credential-bearing
+# values masked and avoid uploading Docker inspect environment fields.
+
+ci_escape_workflow_command_value() {
+  local value="$1"
+  value="${value//%/%25}"
+  value="${value//$'\r'/%0D}"
+  value="${value//$'\n'/%0A}"
+  printf '%s' "$value"
+}
+
+ci_mask_secret_like_e2e_env() {
+  local name value
+
+  while IFS= read -r name; do
+    case "$name" in
+      E2E_* | BREAKGLASS_* | KEYCLOAK_* | MAILHOG_* | PLAYWRIGHT_* | VITE_*)
+        case "$name" in
+          *SECRET* | *PASSWORD* | *PASS* | *TOKEN* | *PRIVATE* | *CREDENTIAL* | *AUTH_HEADER* | *COOKIE*)
+            value="${!name-}"
+            if [ -n "$value" ]; then
+              printf '::add-mask::%s\n' "$(ci_escape_workflow_command_value "$value")"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+  done < <(compgen -e)
+}
+
+ci_print_e2e_env_allowlist() {
+  local name
+  local allowlist=(
+    E2E_TEST
+    E2E_NAMESPACE
+    E2E_CLUSTER_NAME
+    BREAKGLASS_API_URL
+    BREAKGLASS_WEBHOOK_URL
+    BREAKGLASS_METRICS_URL
+    KEYCLOAK_URL
+    KEYCLOAK_HOST
+    KEYCLOAK_PORT
+    KEYCLOAK_REALM
+    KEYCLOAK_CLIENT_ID
+    KEYCLOAK_ISSUER_HOST
+    KEYCLOAK_INTERNAL_URL
+    KEYCLOAK_SERVICE_HOSTNAME
+    MAILHOG_URL
+    MAILHOG_HOST
+    MAILHOG_PORT
+    MAILHOG_UI_PORT
+    PLAYWRIGHT_BASE_URL
+    VITE_API_BASE_URL
+    VITE_KEYCLOAK_URL
+    VITE_KEYCLOAK_REALM
+    VITE_KEYCLOAK_CLIENT_ID
+  )
+
+  for name in "${allowlist[@]}"; do
+    if [ "${!name+x}" = "x" ]; then
+      printf '%s=%s\n' "$name" "${!name}"
+    fi
+  done
+}
+
+ci_redacted_docker_inspect() {
+  local container="$1"
+  local output="$2"
+
+  if command -v jq >/dev/null 2>&1; then
+    docker inspect "$container" \
+      | jq 'walk(if type == "object" and has("Env") then del(.Env) else . end)' \
+      > "$output"
+  else
+    {
+      echo "jq unavailable; full docker inspect omitted to avoid environment disclosure."
+      echo "Container: $container"
+      echo
+      echo "State:"
+      docker inspect "$container" --format '{{json .State}}' 2>&1 || true
+      echo
+      echo "Mounts:"
+      docker inspect "$container" --format '{{json .Mounts}}' 2>&1 || true
+      echo
+      echo "NetworkSettings:"
+      docker inspect "$container" --format '{{json .NetworkSettings}}' 2>&1 || true
+    } > "$output"
+  fi
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,9 +836,8 @@ jobs:
           if [ -f e2e/kind-setup-single-tdir/e2e-env.sh ]; then
             echo "Sourcing E2E environment from setup script..."
             source e2e/kind-setup-single-tdir/e2e-env.sh
-            if [ -n "${KEYCLOAK_GROUP_SYNC_CLIENT_SECRET:-}" ]; then
-              echo "::add-mask::${KEYCLOAK_GROUP_SYNC_CLIENT_SECRET}"
-            fi
+            source .github/scripts/ci-e2e-diagnostics.sh
+            ci_mask_secret_like_e2e_env
 
             # Export to GITHUB_ENV for subsequent steps
             echo "E2E_TEST=true" >> "$GITHUB_ENV"
@@ -859,8 +858,8 @@ jobs:
             echo "KUBERNETES_API_SERVER=${KUBERNETES_API_SERVER:-}" >> "$GITHUB_ENV"
             echo "KUBECONFIG=${KUBECONFIG}" >> "$GITHUB_ENV"
 
-            echo "Environment variables set:"
-            env | grep -E "E2E_|BREAKGLASS_|KEYCLOAK_" | grep -v "KEYCLOAK_GROUP_SYNC_CLIENT_SECRET=" || true
+            echo "Allowlisted E2E environment variables set:"
+            ci_print_e2e_env_allowlist
           else
             echo "ERROR: E2E environment file not found!"
             exit 1
@@ -1115,6 +1114,7 @@ jobs:
         run: |
           DIAG_DIR="e2e-diagnostics"
           mkdir -p "$DIAG_DIR"/{docker,kubernetes,logs,resources,mailhog}
+          source .github/scripts/ci-e2e-diagnostics.sh
           
           echo "Collecting comprehensive E2E diagnostics to $DIAG_DIR..."
           
@@ -1129,7 +1129,7 @@ jobs:
           
           # External Keycloak container
           docker logs e2e-keycloak > "$DIAG_DIR/logs/keycloak-container.log" 2>&1 || echo "No external keycloak container"
-          docker inspect e2e-keycloak > "$DIAG_DIR/docker/keycloak-inspect.json" 2>&1 || true
+          ci_redacted_docker_inspect e2e-keycloak "$DIAG_DIR/docker/keycloak-inspect.json" || true
           
           # Kind cluster containers
           for container in $(docker ps -a --format '{{.Names}}' | grep -E 'e2e-cluster|control-plane'); do
@@ -1401,6 +1401,8 @@ jobs:
           if [ -f e2e/kind-setup-single-tdir/e2e-env.sh ]; then
             echo "Sourcing E2E environment from setup script..."
             source e2e/kind-setup-single-tdir/e2e-env.sh
+            source .github/scripts/ci-e2e-diagnostics.sh
+            ci_mask_secret_like_e2e_env
             echo "E2E_TEST=true" >> $GITHUB_ENV
             echo "E2E_NAMESPACE=${E2E_NAMESPACE}" >> $GITHUB_ENV
             echo "E2E_CLUSTER_NAME=${E2E_CLUSTER_NAME}" >> $GITHUB_ENV
@@ -1418,8 +1420,8 @@ jobs:
             echo "TLS_DIR=${TLS_DIR:-}" >> $GITHUB_ENV
             echo "KUBERNETES_API_SERVER=${KUBERNETES_API_SERVER:-}" >> $GITHUB_ENV
             echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
-            echo "Environment variables set:"
-            env | grep -E "E2E_|BREAKGLASS_|KEYCLOAK_" || true
+            echo "Allowlisted E2E environment variables set:"
+            ci_print_e2e_env_allowlist
           else
             echo "ERROR: E2E environment file not found!"
             exit 1
@@ -1814,9 +1816,11 @@ jobs:
           # Source the environment from setup script
           if [ -f e2e/kind-setup-single-tdir/e2e-env.sh ]; then
             source e2e/kind-setup-single-tdir/e2e-env.sh
+            source .github/scripts/ci-e2e-diagnostics.sh
+            ci_mask_secret_like_e2e_env
             echo "Sourced E2E environment"
-            echo "Environment variables:"
-            env | grep -E "KEYCLOAK|BREAKGLASS|MAILHOG" || true
+            echo "Allowlisted E2E environment variables:"
+            ci_print_e2e_env_allowlist
             
             # Extract API port from BREAKGLASS_API_URL for Vite proxy configuration
             # BREAKGLASS_API_URL format: http://localhost:PORT
@@ -2016,6 +2020,7 @@ jobs:
         run: |
           DIAG_DIR="e2e-diagnostics"
           mkdir -p "$DIAG_DIR"/{docker,kubernetes,logs,resources,mailhog,frontend,network,keycloak}
+          source .github/scripts/ci-e2e-diagnostics.sh
           
           echo "Collecting comprehensive UI E2E diagnostics to $DIAG_DIR..."
           
@@ -2059,7 +2064,7 @@ jobs:
           if docker ps -a --format '{{.Names}}' | grep -q e2e-keycloak; then
             echo "External Keycloak container found"
             docker logs e2e-keycloak > "$DIAG_DIR/keycloak/container.log" 2>&1
-            docker inspect e2e-keycloak > "$DIAG_DIR/keycloak/inspect.json" 2>&1
+            ci_redacted_docker_inspect e2e-keycloak "$DIAG_DIR/keycloak/inspect.json" || true
             docker stats --no-stream e2e-keycloak > "$DIAG_DIR/keycloak/stats.txt" 2>&1 || true
           else
             echo "No external Keycloak container" > "$DIAG_DIR/keycloak/container-status.txt"
@@ -2091,7 +2096,7 @@ jobs:
           
           # External Keycloak container
           docker logs e2e-keycloak > "$DIAG_DIR/logs/keycloak-container.log" 2>&1 || echo "No external keycloak container"
-          docker inspect e2e-keycloak > "$DIAG_DIR/docker/keycloak-inspect.json" 2>&1 || true
+          ci_redacted_docker_inspect e2e-keycloak "$DIAG_DIR/docker/keycloak-inspect.json" || true
           
           # Kind cluster containers
           for container in $(docker ps -a --format '{{.Names}}' | grep -E 'breakglass-hub|control-plane'); do
@@ -2195,7 +2200,7 @@ jobs:
           fi
           
           # Test environment variables
-          env | grep -E "KEYCLOAK|BREAKGLASS|MAILHOG|PLAYWRIGHT|VITE" > "$DIAG_DIR/frontend/test-environment.txt" 2>&1 || true
+          ci_print_e2e_env_allowlist > "$DIAG_DIR/frontend/test-environment.txt" 2>&1 || true
           
           # Homepage check
           curl -s http://localhost:8080 > "$DIAG_DIR/frontend/homepage.html" 2>&1 || echo "Controller UI not responding" > "$DIAG_DIR/frontend/homepage.html"
@@ -2356,6 +2361,7 @@ jobs:
         run: |
           echo "=== Setup failed, capturing immediate diagnostics ==="
           mkdir -p e2e-setup-failure-logs
+          source .github/scripts/ci-e2e-diagnostics.sh
           
           # Save the setup script output
           if [ -f e2e-setup-output.log ]; then
@@ -2366,7 +2372,7 @@ jobs:
           echo "--- Keycloak container logs ---"
           if docker ps -a --filter "name=e2e-keycloak" --format "{{.Names}}" | grep -q e2e-keycloak; then
             docker logs e2e-keycloak > e2e-setup-failure-logs/keycloak-container.log 2>&1
-            docker inspect e2e-keycloak > e2e-setup-failure-logs/keycloak-inspect.json 2>&1
+            ci_redacted_docker_inspect e2e-keycloak e2e-setup-failure-logs/keycloak-inspect.json || true
             echo "Keycloak container found and logs captured"
           else
             echo "No keycloak container found - it was never created or already cleaned up" > e2e-setup-failure-logs/keycloak-container.log
@@ -2414,7 +2420,7 @@ jobs:
             mkdir -p "e2e-setup-failure-logs/node-$container"
             
             # Container inspect for full details
-            docker inspect "$container" > "e2e-setup-failure-logs/node-$container/docker-inspect.json" 2>&1 || true
+            ci_redacted_docker_inspect "$container" "e2e-setup-failure-logs/node-$container/docker-inspect.json" || true
             
             # Get all Kubernetes static pod manifests
             docker exec "$container" ls -la /etc/kubernetes/manifests/ > "e2e-setup-failure-logs/node-$container/manifests-list.txt" 2>&1 || true
@@ -2497,6 +2503,8 @@ jobs:
         run: |
           # Source environment variables from setup script
           source e2e/kind-setup-multi-tdir/env.sh
+          source .github/scripts/ci-e2e-diagnostics.sh
+          ci_mask_secret_like_e2e_env
           
           echo "Hub kubeconfig: $E2E_HUB_KUBECONFIG"
           echo "Spoke A kubeconfig: $E2E_SPOKE_A_KUBECONFIG"
@@ -2777,6 +2785,7 @@ jobs:
         run: |
           DIAG_DIR="e2e-diagnostics"
           mkdir -p "$DIAG_DIR"/{docker,hub,spoke-a,spoke-b,mailhog}
+          source .github/scripts/ci-e2e-diagnostics.sh
           
           echo "Collecting comprehensive multi-cluster E2E diagnostics to $DIAG_DIR..."
           
@@ -2784,6 +2793,7 @@ jobs:
           if [ -f e2e/kind-setup-multi-tdir/env.sh ]; then
             echo "Sourcing environment from e2e/kind-setup-multi-tdir/env.sh"
             source e2e/kind-setup-multi-tdir/env.sh
+            ci_mask_secret_like_e2e_env
           else
             echo "WARNING: env.sh not found, attempting to detect kubeconfig paths from kind"
             # Fallback: try to find kubeconfig files created by kind
@@ -2812,7 +2822,7 @@ jobs:
           
           # External Keycloak container
           docker logs e2e-keycloak > "$DIAG_DIR/docker/keycloak-container.log" 2>&1 || echo "No external keycloak container"
-          docker inspect e2e-keycloak > "$DIAG_DIR/docker/keycloak-inspect.json" 2>&1 || true
+          ci_redacted_docker_inspect e2e-keycloak "$DIAG_DIR/docker/keycloak-inspect.json" || true
           
           # Kind cluster containers
           for container in $(docker ps -a --format '{{.Names}}' | grep -E 'breakglass-hub|spoke-cluster|control-plane'); do
@@ -2835,7 +2845,7 @@ jobs:
             mkdir -p "$DIAG_DIR/docker/node-$container"
             
             # Container inspect for full details
-            timeout 10 docker inspect "$container" > "$DIAG_DIR/docker/node-$container/docker-inspect.json" 2>&1 || true
+            ci_redacted_docker_inspect "$container" "$DIAG_DIR/docker/node-$container/docker-inspect.json" || true
             
             # Get all Kubernetes static pod manifests (run in parallel)
             timeout 5 docker exec "$container" ls -la /etc/kubernetes/manifests/ > "$DIAG_DIR/docker/node-$container/manifests-list.txt" 2>&1 &

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -1008,6 +1008,35 @@ is_keycloak_running() {
   $DOCKER ps --filter "name=$KEYCLOAK_CONTAINER_NAME" --filter "status=running" -q 2>/dev/null | grep -q .
 }
 
+docker_inspect_redacted() {
+  local container_name="$1"
+
+  if command -v jq >/dev/null 2>&1; then
+    $DOCKER inspect "$container_name" \
+      | jq 'walk(if type == "object" and has("Env") then del(.Env) else . end)'
+  else
+    printf '%s\n' "jq unavailable; full docker inspect omitted to avoid environment disclosure."
+    printf '%s\n' "Container: $container_name"
+    printf '\n%s\n' "State:"
+    $DOCKER inspect "$container_name" --format '{{json .State}}' 2>&1 || true
+    printf '\n%s\n' "Mounts:"
+    $DOCKER inspect "$container_name" --format '{{json .Mounts}}' 2>&1 || true
+    printf '\n%s\n' "NetworkSettings:"
+    $DOCKER inspect "$container_name" --format '{{json .NetworkSettings}}' 2>&1 || true
+  fi
+}
+
+docker_inspect_config_redacted() {
+  local container_name="$1"
+
+  if command -v jq >/dev/null 2>&1; then
+    $DOCKER inspect "$container_name" --format '{{json .Config}}' \
+      | jq 'if type == "object" and has("Env") then del(.Env) else . end'
+  else
+    printf '%s\n' "jq unavailable; docker Config omitted to avoid environment disclosure."
+  fi
+}
+
 # Start Keycloak as a standalone Docker container
 start_keycloak_container() {
   local tls_dir="${1:-}"
@@ -1189,12 +1218,12 @@ start_keycloak_container() {
     $DOCKER ps -a --filter "name=$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
     log "=== Container logs (all) ==="
     $DOCKER logs "$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
-    log "=== Docker inspect (full) ==="
-    $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
+    log "=== Docker inspect (environment redacted) ==="
+    docker_inspect_redacted "$KEYCLOAK_CONTAINER_NAME" >&2 || true
     log "=== Docker inspect (mounts) ==="
     { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Mounts}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Mounts}}' 2>&1 || true; } >&2
-    log "=== Docker inspect (config/env) ==="
-    { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Config.Env}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Config.Env}}' 2>&1 || true; } >&2
+    log "=== Docker inspect (config environment redacted) ==="
+    docker_inspect_config_redacted "$KEYCLOAK_CONTAINER_NAME" >&2 || true
     log "=== Docker inspect (state) ==="
     { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .State}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .State}}' 2>&1 || true; } >&2
     log "=== Port check ==="
@@ -1213,13 +1242,13 @@ start_keycloak_container() {
     $DOCKER ps -a --filter "name=$KEYCLOAK_CONTAINER_NAME" --format "{{.Status}}" >&2 2>&1 || true
     log "=== Container logs (all) ==="
     $DOCKER logs "$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
-    log "=== Docker inspect (mounts and env) ==="
+    log "=== Docker inspect (mounts and redacted config) ==="
     { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Mounts}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Mounts}}' 2>&1 || true; } >&2
-    { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Config.Env}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Config.Env}}' 2>&1 || true; } >&2
+    docker_inspect_config_redacted "$KEYCLOAK_CONTAINER_NAME" >&2 || true
     log "=== Docker inspect (state details) ==="
     { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .State}}' 2>&1 | python3 -m json.tool 2>/dev/null || $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .State}}' 2>&1 || true; } >&2
-    log "=== Docker inspect (full for debugging) ==="
-    $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
+    log "=== Docker inspect (environment redacted) ==="
+    docker_inspect_redacted "$KEYCLOAK_CONTAINER_NAME" >&2 || true
     return 1
   fi
   
@@ -1265,9 +1294,9 @@ start_keycloak_container() {
     $DOCKER ps -a --filter "name=$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
     log "=== Keycloak container full logs ==="
     $DOCKER logs "$KEYCLOAK_CONTAINER_NAME" >&2 2>&1 || true
-    log "=== Docker inspect (mounts and config) ==="
+    log "=== Docker inspect (mounts and redacted config) ==="
     { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Mounts}}' 2>&1 | head -50 || true; } >&2
-    { $DOCKER inspect "$KEYCLOAK_CONTAINER_NAME" --format '{{json .Config}}' 2>&1 | head -50 || true; } >&2
+    { docker_inspect_config_redacted "$KEYCLOAK_CONTAINER_NAME" 2>&1 | head -50 || true; } >&2
     log "=== Port bindings on host ==="
     { netstat -tlnp 2>/dev/null | grep -E "8080|8443" || ss -tlnp 2>/dev/null | grep -E "8080|8443" || echo "Could not check ports"; } >&2
     log "=== Testing localhost connectivity ==="


### PR DESCRIPTION
## Summary
- replace raw E2E environment dumps with an allowlisted diagnostic printer
- add secret-like environment masking before sourced E2E variables are exposed to later logs
- redact Docker inspect environment fields before writing CI diagnostic artifacts

## Validation
- yq e '.jobs | keys' .github/workflows/ci.yml
- bash -n .github/scripts/ci-e2e-diagnostics.sh
- bash -n e2e/lib/common.sh
- git -c core.fsmonitor=false diff --check origin/main..HEAD
- rg scan found no remaining raw env grep, .Config.Env, or full Keycloak/container inspect patterns in touched files

Duplicate check: gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "E2E secret diagnostics env docker inspect redaction" returned no existing PRs.

Note: actionlint is not available in this local environment, so validation is YAML parse plus shell syntax checks.