### PR TITLE
fix(audit): wire webhook auth and TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DebugSession operation authorization**: Usernames loaded from request context are trimmed before debug-session read and kubectl-debug authorization checks, and viewer participants now receive `403 Forbidden` for mutating kubectl-debug endpoints.
 - **BreakglassSession state filters**: `GET /api/breakglassSessions` now returns `400 Bad Request` for unknown non-empty `state` filter tokens.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
+- **Audit webhook sink auth and TLS**: Webhook audit sinks now apply `authSecretRef` bearer/basic credentials and `tls.caSecretRef`/`insecureSkipVerify` settings when constructing the outbound HTTP client, while preserving explicitly configured `Authorization` headers. (#1141)
 - **BreakglassSession duplicate cleanup live guard**: Duplicate-session cleanup now revalidates live session state before terminating duplicates, preserving concurrent rejection, withdrawal, expiry, or activity transitions.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 - **Frontend modal dismissal**: Approval, review, and withdraw modals now keep destructive actions mounted while requests are in flight, and support Escape or modal-close dismissal only when closing is safe.

--- a/docs/audit-config.md
+++ b/docs/audit-config.md
@@ -125,12 +125,21 @@ sinks:
         Content-Type: application/json
       authSecretRef:
         name: splunk-hec-token      # Secret with 'token' key for Bearer auth
+        namespace: breakglass-system
       timeoutSeconds: 10
       tls:
         caSecretRef:
           name: splunk-ca
+          namespace: breakglass-system
       batchSize: 50                 # Send events in batches
 ```
+
+`authSecretRef` is optional and supports either a `token` key for `Bearer`
+authentication or `username` and `password` keys for Basic authentication. If
+`headers` already contains an `Authorization` header, that explicit header is
+kept. `tls.caSecretRef` loads a `ca.crt` key into the webhook HTTP client's
+trust store, while `tls.insecureSkipVerify` disables certificate verification
+for private test endpoints and should not be used in production.
 
 ### Log Sink
 
@@ -437,7 +446,22 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-auth
+  namespace: breakglass-system
 type: Opaque
 stringData:
   token: your-bearer-token
+```
+
+For Basic authentication, use `username` and `password` instead of `token`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-basic-auth
+  namespace: breakglass-system
+type: Opaque
+stringData:
+  username: audit-user
+  password: audit-password
 ```

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -52,6 +52,8 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
 )
 
+var systemCertPool = x509.SystemCertPool
+
 // Service manages the audit system lifecycle, including sink creation and event emission.
 // It watches AuditConfig changes and reconfigures the audit manager accordingly.
 type Service struct {
@@ -725,9 +727,10 @@ func (s *Service) buildWebhookTLSConfig(ctx context.Context, tlsCfg *breakglassv
 		return nil, fmt.Errorf("failed to load webhook CA certificate: %w", err)
 	}
 
-	rootCAs, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load system CA pool: %w", err)
+	rootCAs, err := systemCertPool()
+	if err != nil && s.logger != nil {
+		s.logger.Warn("failed to load system CA pool, using custom webhook CA pool only",
+			zap.String("error", err.Error()))
 	}
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -33,8 +33,12 @@ package audit
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -490,7 +494,7 @@ func (s *Service) buildSink(ctx context.Context, sinkCfg breakglassv1alpha1.Audi
 		return s.buildKafkaSink(ctx, sinkCfg)
 
 	case breakglassv1alpha1.AuditSinkTypeWebhook:
-		return s.buildWebhookSink(sinkCfg)
+		return s.buildWebhookSink(ctx, sinkCfg)
 
 	case breakglassv1alpha1.AuditSinkTypeKubernetes:
 		return s.buildKubernetesSink(sinkCfg)
@@ -606,20 +610,134 @@ func (s *Service) buildKafkaSASLConfig(ctx context.Context, saslCfg *breakglassv
 	return cfg, nil
 }
 
-func (s *Service) buildWebhookSink(sinkCfg breakglassv1alpha1.AuditSinkConfig) (Sink, error) {
+func (s *Service) buildWebhookSink(ctx context.Context, sinkCfg breakglassv1alpha1.AuditSinkConfig) (Sink, error) {
 	if sinkCfg.Webhook == nil {
 		return nil, fmt.Errorf("webhook config required for webhook sink")
+	}
+
+	headers := cloneHeaders(sinkCfg.Webhook.Headers)
+	var err error
+	headers, err = s.applyWebhookAuth(ctx, sinkCfg.Webhook, headers)
+	if err != nil {
+		return nil, err
 	}
 
 	webhookCfg := WebhookSinkConfig{
 		Name:     sinkCfg.Name,
 		URL:      sinkCfg.Webhook.URL,
 		BatchURL: sinkCfg.Webhook.BatchURL,
-		Headers:  sinkCfg.Webhook.Headers,
+		Headers:  headers,
 		Timeout:  time.Duration(sinkCfg.Webhook.TimeoutSeconds) * time.Second,
 	}
 
+	if sinkCfg.Webhook.TLS != nil {
+		tlsCfg, err := s.buildWebhookTLSConfig(ctx, sinkCfg.Webhook.TLS)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build webhook TLS config: %w", err)
+		}
+		webhookCfg.TLS = tlsCfg
+	}
+
 	return NewWebhookSink(webhookCfg, s.logger), nil
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(headers))
+	for key, value := range headers {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func (s *Service) applyWebhookAuth(ctx context.Context, webhookCfg *breakglassv1alpha1.WebhookSinkSpec, headers map[string]string) (map[string]string, error) {
+	if webhookCfg.AuthSecretRef == nil || hasAuthorizationHeader(headers) {
+		return headers, nil
+	}
+
+	namespace := webhookCfg.AuthSecretRef.Namespace
+	if err := s.requireControllerNamespace("webhook auth", webhookCfg.AuthSecretRef.Name, namespace); err != nil {
+		return nil, err
+	}
+
+	secret := &corev1.Secret{}
+	if err := s.client.Get(ctx, types.NamespacedName{Name: webhookCfg.AuthSecretRef.Name, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get webhook auth secret %s/%s: %w", namespace, webhookCfg.AuthSecretRef.Name, err)
+	}
+
+	if headers == nil {
+		headers = make(map[string]string, 1)
+	}
+
+	if token, ok := secret.Data["token"]; ok {
+		headers["Authorization"] = "Bearer " + string(token)
+		return headers, nil
+	}
+
+	username, hasUsername := secret.Data["username"]
+	password, hasPassword := secret.Data["password"]
+	if hasUsername && hasPassword {
+		credentials := append(append([]byte{}, username...), ':')
+		credentials = append(credentials, password...)
+		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString(credentials)
+		return headers, nil
+	}
+
+	return nil, fmt.Errorf("webhook auth secret %s/%s must contain either token or username/password", namespace, webhookCfg.AuthSecretRef.Name)
+}
+
+func (s *Service) requireControllerNamespace(refType, name, namespace string) error {
+	if namespace != s.configNS {
+		return fmt.Errorf("%s secret %q namespace must be controller namespace %q, got %q", refType, name, s.configNS, namespace)
+	}
+	return nil
+}
+
+func hasAuthorizationHeader(headers map[string]string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, "Authorization") {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) buildWebhookTLSConfig(ctx context.Context, tlsCfg *breakglassv1alpha1.WebhookTLSSpec) (*tls.Config, error) {
+	cfg := &tls.Config{
+		InsecureSkipVerify: tlsCfg.InsecureSkipVerify, // #nosec G402 -- Explicit AuditConfig option for private webhook endpoints.
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	if tlsCfg.CASecretRef == nil {
+		return cfg, nil
+	}
+
+	namespace := tlsCfg.CASecretRef.Namespace
+	if err := s.requireControllerNamespace("webhook CA", tlsCfg.CASecretRef.Name, namespace); err != nil {
+		return nil, err
+	}
+
+	caData, err := s.getSecretKey(ctx, tlsCfg.CASecretRef.Name, namespace, "ca.crt")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load webhook CA certificate: %w", err)
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system CA pool: %w", err)
+	}
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if ok := rootCAs.AppendCertsFromPEM(caData); !ok {
+		return nil, fmt.Errorf("failed to parse webhook CA certificate from secret %s/%s", namespace, tlsCfg.CASecretRef.Name)
+	}
+	cfg.RootCAs = rootCAs
+
+	return cfg, nil
 }
 
 func (s *Service) buildKubernetesSink(sinkCfg breakglassv1alpha1.AuditSinkConfig) (Sink, error) {

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -588,7 +588,13 @@ func TestService_BuildWebhookTLSConfigUsesCustomCAWhenSystemPoolFails(t *testing
 	})
 	require.NoError(t, err)
 	require.NotNil(t, cfg.RootCAs)
-	assert.NotEmpty(t, cfg.RootCAs.Subjects())
+
+	httpClient := server.Client()
+	httpClient.Transport = &http.Transport{TLSClientConfig: cfg}
+	resp, err := httpClient.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestService_BuildWebhookSinkMissingSecretErrors(t *testing.T) {

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -5,7 +5,9 @@ package audit
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -545,6 +547,48 @@ func TestService_BuildWebhookSinkTLSWithCASecret(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sink.Write(context.Background(), &Event{ID: "tls", Type: EventSessionRequested}))
 	assert.True(t, received)
+}
+
+func TestService_BuildWebhookTLSConfigUsesCustomCAWhenSystemPoolFails(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-ca",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"ca.crt": pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(caSecret).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	oldSystemCertPool := systemCertPool
+	systemCertPool = func() (*x509.CertPool, error) {
+		return nil, errors.New("system roots unavailable")
+	}
+	defer func() {
+		systemCertPool = oldSystemCertPool
+	}()
+
+	cfg, err := svc.buildWebhookTLSConfig(context.Background(), &breakglassv1alpha1.WebhookTLSSpec{
+		CASecretRef: &breakglassv1alpha1.SecretKeySelector{
+			Name:      "webhook-ca",
+			Namespace: "test-namespace",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg.RootCAs)
+	assert.NotEmpty(t, cfg.RootCAs.Subjects())
 }
 
 func TestService_BuildWebhookSinkMissingSecretErrors(t *testing.T) {

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -5,6 +5,9 @@ package audit
 
 import (
 	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -372,6 +375,290 @@ func TestService_BuildWebhookSink(t *testing.T) {
 
 	// Cleanup
 	_ = svc.Close()
+}
+
+func TestService_BuildWebhookSinkAuthSecretBearer(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-auth",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"token": []byte("secret-token"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(authSecret).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: server.URL,
+			AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+				Name:      "webhook-auth",
+				Namespace: "test-namespace",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(context.Background(), &Event{ID: "bearer", Type: EventSessionRequested}))
+	assert.Equal(t, "Bearer secret-token", authHeader)
+}
+
+func TestService_BuildWebhookSinkAuthSecretBasic(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-auth",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"username": []byte("audit-user"),
+			"password": []byte("audit-pass"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(authSecret).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: server.URL,
+			AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+				Name:      "webhook-auth",
+				Namespace: "test-namespace",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(context.Background(), &Event{ID: "basic", Type: EventSessionRequested}))
+	assert.Equal(t, "Basic YXVkaXQtdXNlcjphdWRpdC1wYXNz", authHeader)
+}
+
+func TestService_BuildWebhookSinkAuthorizationHeaderPrecedence(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	authSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-auth",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"token": []byte("secret-token"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(authSecret).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: server.URL,
+			Headers: map[string]string{
+				"Authorization": "Bearer explicit-token",
+			},
+			AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+				Name:      "webhook-auth",
+				Namespace: "test-namespace",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(context.Background(), &Event{ID: "precedence", Type: EventSessionRequested}))
+	assert.Equal(t, "Bearer explicit-token", authHeader)
+}
+
+func TestService_BuildWebhookSinkTLSWithCASecret(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+
+	var received bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "webhook-ca",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"ca.crt": pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(caSecret).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	sink, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: server.URL,
+			TLS: &breakglassv1alpha1.WebhookTLSSpec{
+				CASecretRef: &breakglassv1alpha1.SecretKeySelector{
+					Name:      "webhook-ca",
+					Namespace: "test-namespace",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sink.Write(context.Background(), &Event{ID: "tls", Type: EventSessionRequested}))
+	assert.True(t, received)
+}
+
+func TestService_BuildWebhookSinkMissingSecretErrors(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	_, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: "https://example.com/audit",
+			AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+				Name:      "missing-auth",
+				Namespace: "test-namespace",
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get webhook auth secret")
+
+	_, err = svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+		Name: "webhook-sink",
+		Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+		Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+			URL: "https://example.com/audit",
+			TLS: &breakglassv1alpha1.WebhookTLSSpec{
+				CASecretRef: &breakglassv1alpha1.SecretKeySelector{
+					Name:      "missing-ca",
+					Namespace: "test-namespace",
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load webhook CA certificate")
+}
+
+func TestService_BuildWebhookSinkRejectsNonControllerSecretNamespaces(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	t.Run("auth secret namespace", func(t *testing.T) {
+		_, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+			Name: "webhook-sink",
+			Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+			Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+				URL: "https://example.com/audit",
+				AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+					Name:      "webhook-auth",
+					Namespace: "other-namespace",
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `webhook auth secret "webhook-auth" namespace must be controller namespace "test-namespace", got "other-namespace"`)
+	})
+
+	t.Run("auth secret missing namespace", func(t *testing.T) {
+		_, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+			Name: "webhook-sink",
+			Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+			Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+				URL: "https://example.com/audit",
+				AuthSecretRef: &breakglassv1alpha1.SecretKeySelector{
+					Name: "webhook-auth",
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `webhook auth secret "webhook-auth" namespace must be controller namespace "test-namespace", got ""`)
+	})
+
+	t.Run("CA secret namespace", func(t *testing.T) {
+		_, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+			Name: "webhook-sink",
+			Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+			Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+				URL: "https://example.com/audit",
+				TLS: &breakglassv1alpha1.WebhookTLSSpec{
+					CASecretRef: &breakglassv1alpha1.SecretKeySelector{
+						Name:      "webhook-ca",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `webhook CA secret "webhook-ca" namespace must be controller namespace "test-namespace", got "other-namespace"`)
+	})
+
+	t.Run("CA secret missing namespace", func(t *testing.T) {
+		_, err := svc.buildWebhookSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+			Name: "webhook-sink",
+			Type: breakglassv1alpha1.AuditSinkTypeWebhook,
+			Webhook: &breakglassv1alpha1.WebhookSinkSpec{
+				URL: "https://example.com/audit",
+				TLS: &breakglassv1alpha1.WebhookTLSSpec{
+					CASecretRef: &breakglassv1alpha1.SecretKeySelector{
+						Name: "webhook-ca",
+					},
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `webhook CA secret "webhook-ca" namespace must be controller namespace "test-namespace", got ""`)
+	})
 }
 
 func TestService_BuildKubernetesSink(t *testing.T) {

--- a/pkg/audit/sink.go
+++ b/pkg/audit/sink.go
@@ -19,6 +19,7 @@ package audit
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -134,6 +135,7 @@ type WebhookSinkConfig struct {
 	BatchURL string // Optional: separate endpoint for batch writes (e.g., /events/batch)
 	Headers  map[string]string
 	Timeout  time.Duration
+	TLS      *tls.Config
 }
 
 // NewWebhookSink creates a new WebhookSink.
@@ -148,15 +150,26 @@ func NewWebhookSink(cfg WebhookSinkConfig, logger *zap.Logger) *WebhookSink {
 		batchURL = cfg.URL // Use same URL for batch if not specified
 	}
 
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+	if cfg.TLS != nil {
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			defaultTransport = &http.Transport{}
+		}
+		transport := defaultTransport.Clone()
+		transport.TLSClientConfig = cfg.TLS.Clone()
+		httpClient.Transport = transport
+	}
+
 	sink := &WebhookSink{
-		name:     cfg.Name,
-		url:      cfg.URL,
-		batchURL: batchURL,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
-		headers: cfg.Headers,
-		logger:  logger.Named("webhook-sink"),
+		name:       cfg.Name,
+		url:        cfg.URL,
+		batchURL:   batchURL,
+		httpClient: httpClient,
+		headers:    cfg.Headers,
+		logger:     logger.Named("webhook-sink"),
 	}
 
 	sink.logger.Info("Webhook audit sink created",


### PR DESCRIPTION
## Summary
- load webhook authSecretRef as bearer or basic auth while preserving explicit Authorization header precedence
- wire webhook TLS caSecretRef and insecureSkipVerify into the HTTP transport
- add regression coverage for bearer/basic auth, header precedence, CA-backed HTTPS, and missing secret errors

## Validation
- GOCACHE=/private/tmp/k8s-audit-webhook-go-cache GOMODCACHE=/private/tmp/k8s-audit-webhook-go-mod-cache go test -timeout=4m ./pkg/audit
- golangci-lint run --timeout=5m ./pkg/audit
- git -c core.fsmonitor=false diff --check origin/main..HEAD

Duplicate check: gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "audit webhook auth TLS caSecretRef authSecretRef" returned no matching PR.