### PR TITLE
fix(audit): preserve Kafka requiredAcks zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
+- **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/pkg/audit/kafka_sink.go
+++ b/pkg/audit/kafka_sink.go
@@ -72,6 +72,10 @@ type KafkaSinkConfig struct {
 	// Default: -1 (all replicas)
 	RequiredAcks int
 
+	// RequiredAcksSet distinguishes an explicit zero value from an omitted
+	// runtime config value.
+	RequiredAcksSet bool
+
 	// Async enables asynchronous writes (fire-and-forget).
 	// Default: false
 	Async bool
@@ -186,7 +190,7 @@ func NewKafkaSink(cfg KafkaSinkConfig, logger *zap.Logger) (*KafkaSink, error) {
 	}
 
 	requiredAcks := cfg.RequiredAcks
-	if requiredAcks == 0 {
+	if requiredAcks == 0 && !cfg.RequiredAcksSet {
 		requiredAcks = -1 // Default to all replicas
 	}
 

--- a/pkg/audit/kafka_sink_test.go
+++ b/pkg/audit/kafka_sink_test.go
@@ -548,6 +548,61 @@ func TestKafkaSink_DefaultValues(t *testing.T) {
 	// Verify sink was created with defaults
 	assert.Equal(t, "kafka", sink.Name()) // Default name
 	assert.True(t, sink.IsConnected())    // Optimistic initial state
+	assert.Equal(t, -1, int(sink.writer.RequiredAcks))
+}
+
+func TestKafkaSink_RequiredAcks(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	tests := []struct {
+		name            string
+		requiredAcks    int
+		requiredAcksSet bool
+		want            int
+	}{
+		{
+			name: "omitted runtime config defaults to all replicas",
+			want: -1,
+		},
+		{
+			name:            "explicit all replicas",
+			requiredAcks:    -1,
+			requiredAcksSet: true,
+			want:            -1,
+		},
+		{
+			name:            "explicit no acks",
+			requiredAcks:    0,
+			requiredAcksSet: true,
+			want:            0,
+		},
+		{
+			name:            "explicit leader only",
+			requiredAcks:    1,
+			requiredAcksSet: true,
+			want:            1,
+		},
+		{
+			name:         "non-zero value without set flag is honored",
+			requiredAcks: 1,
+			want:         1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink, err := NewKafkaSink(KafkaSinkConfig{
+				Brokers:         []string{"localhost:9092"},
+				Topic:           "test",
+				RequiredAcks:    tt.requiredAcks,
+				RequiredAcksSet: tt.requiredAcksSet,
+			}, logger)
+			require.NoError(t, err)
+			defer func() { _ = sink.Close() }()
+
+			assert.Equal(t, tt.want, int(sink.writer.RequiredAcks))
+		})
+	}
 }
 
 func TestKafkaSink_CustomName(t *testing.T) {

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -522,6 +522,7 @@ func (s *Service) buildKafkaSink(ctx context.Context, sinkCfg breakglassv1alpha1
 		BatchSize:        sinkCfg.Kafka.BatchSize,
 		BatchTimeout:     time.Duration(sinkCfg.Kafka.BatchTimeoutSeconds) * time.Second,
 		RequiredAcks:     sinkCfg.Kafka.RequiredAcks,
+		RequiredAcksSet:  true,
 		CompressionCodec: sinkCfg.Kafka.Compression,
 		Async:            sinkCfg.Kafka.Async,
 	}

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -24,11 +24,19 @@ import (
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
 
+func newServiceTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	return scheme
+}
+
 func TestNewService(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -38,9 +46,7 @@ func TestNewService(t *testing.T) {
 
 func TestService_ReloadDisablesOnNilConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -52,9 +58,7 @@ func TestService_ReloadDisablesOnNilConfig(t *testing.T) {
 
 func TestService_ReloadDisablesOnDisabledConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -73,9 +77,7 @@ func TestService_ReloadDisablesOnDisabledConfig(t *testing.T) {
 
 func TestService_ReloadWithLogSink(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -109,9 +111,7 @@ func TestService_ReloadWithLogSink(t *testing.T) {
 
 func TestService_ReloadWithQueueConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -144,9 +144,7 @@ func TestService_ReloadWithQueueConfig(t *testing.T) {
 
 func TestService_ReloadWithSampling(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -189,9 +187,7 @@ func TestService_ReloadWithSampling(t *testing.T) {
 
 func TestService_ReloadNoSinks(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -212,9 +208,7 @@ func TestService_ReloadNoSinks(t *testing.T) {
 
 func TestService_EmitWhenDisabled(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -237,9 +231,7 @@ func TestService_EmitWhenDisabled(t *testing.T) {
 
 func TestService_EmitWhenEnabled(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -281,9 +273,7 @@ func TestService_EmitWhenEnabled(t *testing.T) {
 
 func TestService_CloseWhenNotInitialized(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -295,9 +285,7 @@ func TestService_CloseWhenNotInitialized(t *testing.T) {
 
 func TestService_ReloadMultipleTimes(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -344,9 +332,7 @@ func TestService_ReloadMultipleTimes(t *testing.T) {
 
 func TestService_BuildWebhookSink(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -713,9 +699,7 @@ func TestService_BuildWebhookSinkRejectsNonControllerSecretNamespaces(t *testing
 
 func TestService_BuildKubernetesSink(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -743,9 +727,7 @@ func TestService_BuildKubernetesSink(t *testing.T) {
 
 func TestService_SkipsInvalidSinkType(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -778,9 +760,7 @@ func TestService_SkipsInvalidSinkType(t *testing.T) {
 
 func TestService_KafkaSinkMissingConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -805,11 +785,46 @@ func TestService_KafkaSinkMissingConfig(t *testing.T) {
 	assert.False(t, svc.IsEnabled())
 }
 
+func TestService_BuildKafkaSinkRequiredAcks(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := newServiceTestScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	svc := NewService(client, nil, logger, "test-namespace")
+
+	tests := []struct {
+		name        string
+		requiredAck int
+	}{
+		{name: "all replicas", requiredAck: -1},
+		{name: "no acks", requiredAck: 0},
+		{name: "leader only", requiredAck: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink, err := svc.buildKafkaSink(context.Background(), breakglassv1alpha1.AuditSinkConfig{
+				Name: "kafka-sink",
+				Type: breakglassv1alpha1.AuditSinkTypeKafka,
+				Kafka: &breakglassv1alpha1.KafkaSinkSpec{
+					Brokers:      []string{"localhost:9092"},
+					Topic:        "audit-events",
+					RequiredAcks: tt.requiredAck,
+				},
+			})
+			require.NoError(t, err)
+			defer func() { _ = sink.Close() }()
+
+			kafkaSink, ok := sink.(*KafkaSink)
+			require.True(t, ok)
+			assert.Equal(t, tt.requiredAck, int(kafkaSink.writer.RequiredAcks))
+		})
+	}
+}
+
 func TestService_WebhookSinkMissingConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -836,9 +851,7 @@ func TestService_WebhookSinkMissingConfig(t *testing.T) {
 
 func TestService_GetSecretKey(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -886,9 +899,7 @@ func TestDefaultQueuedSinkConfig(t *testing.T) {
 
 func TestService_GetSinkHealth_NoSinks(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -899,9 +910,7 @@ func TestService_GetSinkHealth_NoSinks(t *testing.T) {
 
 func TestService_GetSinkHealth_WithLogSink(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -935,9 +944,7 @@ func TestService_GetSinkHealth_WithLogSink(t *testing.T) {
 
 func TestService_GetQueuedSinkHealth_NoSinks(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -948,9 +955,7 @@ func TestService_GetQueuedSinkHealth_NoSinks(t *testing.T) {
 
 func TestService_GetQueuedSinkHealth_WithSink(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -986,9 +991,7 @@ func TestService_GetQueuedSinkHealth_WithSink(t *testing.T) {
 
 func TestService_BuildKafkaTLSConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1112,9 +1115,7 @@ func TestService_BuildKafkaTLSConfig(t *testing.T) {
 
 func TestService_BuildKafkaSASLConfig(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 
 	saslSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1237,9 +1238,7 @@ func TestService_BuildKafkaSASLConfig(t *testing.T) {
 
 func TestService_GetStats_NoManager(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -1251,9 +1250,7 @@ func TestService_GetStats_NoManager(t *testing.T) {
 
 func TestService_GetStats_WithManager(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -1288,9 +1285,7 @@ func TestService_GetStats_WithManager(t *testing.T) {
 
 func TestService_Manager_NilBeforeReload(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")
@@ -1299,9 +1294,7 @@ func TestService_Manager_NilBeforeReload(t *testing.T) {
 
 func TestService_Manager_NonNilAfterSuccessfulReload(t *testing.T) {
 	logger := zap.NewNop()
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = breakglassv1alpha1.AddToScheme(scheme)
+	scheme := newServiceTestScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	svc := NewService(client, nil, logger, "test-namespace")


### PR DESCRIPTION
## Summary
- distinguish omitted runtime Kafka requiredAcks from explicit zero
- preserve AuditConfig requiredAcks values -1, 0, and 1 through service sink construction
- add regression tests for runtime defaults and service wiring

## Validation
- GOCACHE=/private/tmp/k8s-audit-kafka-go-cache GOMODCACHE=/private/tmp/k8s-audit-kafka-go-mod-cache go test -timeout=4m ./pkg/audit
- golangci-lint run --timeout=5m ./pkg/audit
- git -c core.fsmonitor=false diff --check origin/main..HEAD

Duplicate check: gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "audit Kafka requiredAcks zero" returned no matching PR.