### PR TITLE
fix(audit): enforce configured event filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BreakglassSession state filters**: `GET /api/breakglassSessions` now returns `400 Bad Request` for unknown non-empty `state` filter tokens.
 - **DebugSession reconciler audit and failure mail wiring**: Lifecycle audit events and requester failure emails now use the configured audit and mail services, while invalid failure-mail recipients are rejected before enqueueing.
 - **Audit webhook sink auth and TLS**: Webhook audit sinks now apply `authSecretRef` bearer/basic credentials and `tls.caSecretRef`/`insecureSkipVerify` settings when constructing the outbound HTTP client, while preserving explicitly configured `Authorization` headers. (#1141)
+- **Audit filtering enforcement**: Global `AuditConfig.spec.filtering` event-type filters now run before manager queueing and synchronous writes, and configured user, namespace, resource, event-type, and sink severity filters are enforced before events reach audit sinks. (PR #1143)
 - **BreakglassSession duplicate cleanup live guard**: Duplicate-session cleanup now revalidates live session state before terminating duplicates, preserving concurrent rejection, withdrawal, expiry, or activity transitions.
 - Added `maxItems` limit to `PodSecurityScope.Subresources`.
 - **Frontend modal dismissal**: Approval, review, and withdraw modals now keep destructive actions mounted while requests are in flight, and support Escape or modal-close dismissal only when closing is safe.

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 	"text/template"
@@ -561,6 +562,10 @@ func ValidateAuditConfig(ac *AuditConfig) *ValidationResult {
 		result.Errors = append(result.Errors, field.Required(specPath.Child("sinks"), "at least one audit sink must be configured"))
 	}
 
+	if ac.Spec.Filtering != nil {
+		result.Errors = append(result.Errors, validateAuditFiltering(ac.Spec.Filtering, specPath.Child("filtering"))...)
+	}
+
 	// Track sink names for duplicate detection
 	seenNames := make(map[string]bool)
 
@@ -580,6 +585,7 @@ func ValidateAuditConfig(ac *AuditConfig) *ValidationResult {
 			}
 			seenNames[sink.Name] = true
 		}
+		result.Errors = append(result.Errors, validateGlobPatterns(sink.EventTypes, sinkPath.Child("eventTypes"))...)
 
 		// Validate sink-specific configuration based on type
 		switch sink.Type {
@@ -595,6 +601,40 @@ func ValidateAuditConfig(ac *AuditConfig) *ValidationResult {
 	}
 
 	return result
+}
+
+func validateAuditFiltering(filter *AuditFilterConfig, filterPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if filter == nil {
+		return errs
+	}
+
+	errs = append(errs, validateGlobPatterns(filter.IncludeEventTypes, filterPath.Child("includeEventTypes"))...)
+	errs = append(errs, validateGlobPatterns(filter.ExcludeEventTypes, filterPath.Child("excludeEventTypes"))...)
+	errs = append(errs, validateGlobPatterns(filter.IncludeUsers, filterPath.Child("includeUsers"))...)
+	errs = append(errs, validateGlobPatterns(filter.ExcludeUsers, filterPath.Child("excludeUsers"))...)
+	errs = append(errs, validateNamespaceFilterGlobPatterns(filter.IncludeNamespaces, filterPath.Child("includeNamespaces"))...)
+	errs = append(errs, validateNamespaceFilterGlobPatterns(filter.ExcludeNamespaces, filterPath.Child("excludeNamespaces"))...)
+	errs = append(errs, validateGlobPatterns(filter.IncludeResources, filterPath.Child("includeResources"))...)
+	errs = append(errs, validateGlobPatterns(filter.ExcludeResources, filterPath.Child("excludeResources"))...)
+	return errs
+}
+
+func validateNamespaceFilterGlobPatterns(filter *NamespaceFilter, filterPath *field.Path) field.ErrorList {
+	if filter == nil {
+		return nil
+	}
+	return validateGlobPatterns(filter.Patterns, filterPath.Child("patterns"))
+}
+
+func validateGlobPatterns(patterns []string, patternsPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, pattern := range patterns {
+		if _, err := path.Match(pattern, ""); err != nil {
+			errs = append(errs, field.Invalid(patternsPath.Index(i), pattern, fmt.Sprintf("invalid glob pattern: %v", err)))
+		}
+	}
+	return errs
 }
 
 // validateKafkaSink validates Kafka sink configuration

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -933,6 +933,39 @@ func TestValidateAuditConfig(t *testing.T) {
 		assert.False(t, result.IsValid())
 		assert.Contains(t, result.ErrorMessage(), "Duplicate")
 	})
+
+	t.Run("invalid filtering glob pattern", func(t *testing.T) {
+		ac := validAC()
+		ac.Spec.Filtering = &AuditFilterConfig{
+			IncludeUsers: []string{"["},
+		}
+		result := ValidateAuditConfig(ac)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "spec.filtering.includeUsers[0]")
+		assert.Contains(t, result.ErrorMessage(), "invalid glob pattern")
+	})
+
+	t.Run("invalid namespace filtering glob pattern", func(t *testing.T) {
+		ac := validAC()
+		ac.Spec.Filtering = &AuditFilterConfig{
+			IncludeNamespaces: &NamespaceFilter{
+				Patterns: []string{"prod-["},
+			},
+		}
+		result := ValidateAuditConfig(ac)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "spec.filtering.includeNamespaces.patterns[0]")
+		assert.Contains(t, result.ErrorMessage(), "invalid glob pattern")
+	})
+
+	t.Run("invalid sink event type glob pattern", func(t *testing.T) {
+		ac := validAC()
+		ac.Spec.Sinks[0].EventTypes = []string{"session.["}
+		result := ValidateAuditConfig(ac)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "spec.sinks[0].eventTypes[0]")
+		assert.Contains(t, result.ErrorMessage(), "invalid glob pattern")
+	})
 }
 
 func TestValidateAuditConfig_KafkaSink(t *testing.T) {

--- a/docs/audit-config.md
+++ b/docs/audit-config.md
@@ -232,7 +232,12 @@ These capture access to non-API endpoints:
 
 ## Filtering
 
-Control which events are captured:
+Control which events are captured. Configured filters are enforced before
+events reach sinks: global event-type filters run before manager queueing and
+synchronous writes, and global user, namespace, resource, and event-type filters
+are applied at every sink. Sink-local `eventTypes` and `minSeverity` filters
+then further narrow each sink's output. Exclude filters take precedence over
+include filters.
 
 ```yaml
 spec:
@@ -255,8 +260,9 @@ spec:
     
     # Filter by namespace
     excludeNamespaces:
-      - kube-system
-      - kube-public
+      patterns:
+        - kube-system
+        - kube-public
     
     # Filter by resource type
     includeResources:
@@ -294,6 +300,10 @@ This allows dynamic namespace selection based on labels, which is useful when:
 - New namespaces are created frequently
 - Namespace naming conventions vary
 - You want to use Kubernetes-native label selectors
+
+Label selector terms are evaluated only when the audit event includes
+`target.namespaceLabels`; name patterns continue to match on
+`target.namespace`. Events without namespace labels do not match selector terms.
 
 ## Sampling
 

--- a/pkg/audit/filter.go
+++ b/pkg/audit/filter.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
+)
+
+// EventFilterConfig controls which events pass through a sink or manager.
+type EventFilterConfig struct {
+	// IncludeEventTypes allows only matching event types. Empty means all.
+	IncludeEventTypes []string
+
+	// ExcludeEventTypes blocks matching event types and takes precedence.
+	ExcludeEventTypes []string
+
+	// MinSeverity blocks events below this severity. Empty disables severity filtering.
+	MinSeverity Severity
+
+	// IncludeUsers allows only matching actor users. Empty means all.
+	IncludeUsers []string
+
+	// ExcludeUsers blocks matching actor users and takes precedence.
+	ExcludeUsers []string
+
+	// IncludeNamespaces allows only matching target namespaces. Empty means all.
+	IncludeNamespaces *breakglassv1alpha1.NamespaceFilter
+
+	// ExcludeNamespaces blocks matching target namespaces and takes precedence.
+	ExcludeNamespaces *breakglassv1alpha1.NamespaceFilter
+
+	// IncludeResources allows only matching target resource kinds. Empty means all.
+	IncludeResources []string
+
+	// ExcludeResources blocks matching target resource kinds and takes precedence.
+	ExcludeResources []string
+
+	includeNamespaceMatcher *utils.NamespaceMatcher
+	excludeNamespaceMatcher *utils.NamespaceMatcher
+}
+
+// NewFilteredSink wraps a sink with event type and severity filtering.
+func NewFilteredSink(sink Sink, filter EventFilterConfig) Sink {
+	filtered := &filteredSink{
+		sink:   sink,
+		filter: filter.compile(),
+	}
+	if batchSink, ok := sink.(BatchSink); ok {
+		return &filteredBatchSink{
+			filteredSink: filtered,
+			batchSink:    batchSink,
+		}
+	}
+	return filtered
+}
+
+type filteredSink struct {
+	sink   Sink
+	filter EventFilterConfig
+}
+
+func (s *filteredSink) Write(ctx context.Context, event *Event) error {
+	if !s.filter.allows(event) {
+		return nil
+	}
+	return s.sink.Write(ctx, event)
+}
+
+func (s *filteredSink) Close() error {
+	return s.sink.Close()
+}
+
+func (s *filteredSink) Name() string {
+	return s.sink.Name()
+}
+
+type filteredBatchSink struct {
+	*filteredSink
+	batchSink BatchSink
+}
+
+func (s *filteredBatchSink) WriteBatch(ctx context.Context, events []*Event) error {
+	filtered := make([]*Event, 0, len(events))
+	for _, event := range events {
+		if s.filter.allows(event) {
+			filtered = append(filtered, event)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return s.batchSink.WriteBatch(ctx, filtered)
+}
+
+// Allows returns true when an event passes the configured filters.
+func (f EventFilterConfig) Allows(event *Event) bool {
+	return f.compile().allows(event)
+}
+
+func (f EventFilterConfig) compile() EventFilterConfig {
+	if f.IncludeNamespaces != nil && !f.IncludeNamespaces.IsEmpty() {
+		f.includeNamespaceMatcher = utils.NewNamespaceMatcher(f.IncludeNamespaces)
+	}
+	if f.ExcludeNamespaces != nil && !f.ExcludeNamespaces.IsEmpty() {
+		f.excludeNamespaceMatcher = utils.NewNamespaceMatcher(f.ExcludeNamespaces)
+	}
+	return f
+}
+
+func (f EventFilterConfig) allows(event *Event) bool {
+	if event == nil {
+		return false
+	}
+	if !eventTypeAllowed(event.Type, f.IncludeEventTypes, f.ExcludeEventTypes) {
+		return false
+	}
+	if !patternFilterAllowed(event.Actor.User, f.IncludeUsers, f.ExcludeUsers) {
+		return false
+	}
+	if !f.namespaceFilterAllowed(event.Target.Namespace, event.Target.NamespaceLabels) {
+		return false
+	}
+	if !resourceFilterAllowed(event.Target.Kind, f.IncludeResources, f.ExcludeResources) {
+		return false
+	}
+	if f.MinSeverity == "" {
+		return true
+	}
+	return severityRank(eventSeverity(event)) >= severityRank(f.MinSeverity)
+}
+
+func eventTypeAllowed(eventType EventType, includePatterns, excludePatterns []string) bool {
+	if matchesEventType(excludePatterns, eventType) {
+		return false
+	}
+	if len(includePatterns) == 0 {
+		return true
+	}
+	return matchesEventType(includePatterns, eventType)
+}
+
+func matchesEventType(patterns []string, eventType EventType) bool {
+	value := string(eventType)
+	return matchesPattern(patterns, value)
+}
+
+func patternFilterAllowed(value string, includePatterns, excludePatterns []string) bool {
+	if matchesPattern(excludePatterns, value) {
+		return false
+	}
+	if len(includePatterns) == 0 {
+		return true
+	}
+	return matchesPattern(includePatterns, value)
+}
+
+func resourceFilterAllowed(kind string, includePatterns, excludePatterns []string) bool {
+	candidates := resourceFilterCandidates(kind)
+	if matchesAnyPattern(excludePatterns, candidates) {
+		return false
+	}
+	if len(includePatterns) == 0 {
+		return true
+	}
+	return matchesAnyPattern(includePatterns, candidates)
+}
+
+func resourceFilterCandidates(kind string) []string {
+	if kind == "" {
+		return []string{""}
+	}
+	candidates := make([]string, 0, 6)
+	seen := make(map[string]struct{}, 6)
+	add := func(value string) {
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		candidates = append(candidates, value)
+	}
+
+	lower := strings.ToLower(kind)
+	singular := singularResourceName(lower)
+	plural := pluralResourceName(singular)
+
+	add(kind)
+	add(lower)
+	add(singular)
+	add(plural)
+	add(titleResourceName(singular))
+	add(titleResourceName(plural))
+
+	return candidates
+}
+
+func singularResourceName(lower string) string {
+	switch {
+	case strings.HasSuffix(lower, "ies") && len(lower) > len("ies"):
+		return strings.TrimSuffix(lower, "ies") + "y"
+	case strings.HasSuffix(lower, "sses") && len(lower) > len("es"):
+		return strings.TrimSuffix(lower, "es")
+	case strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") && len(lower) > 1:
+		return strings.TrimSuffix(lower, "s")
+	default:
+		return lower
+	}
+}
+
+func pluralResourceName(singular string) string {
+	switch {
+	case strings.HasSuffix(singular, "y") && len(singular) > 1:
+		return strings.TrimSuffix(singular, "y") + "ies"
+	case strings.HasSuffix(singular, "s"):
+		return singular + "es"
+	default:
+		return singular + "s"
+	}
+}
+
+func titleResourceName(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func matchesAnyPattern(patterns []string, values []string) bool {
+	for _, value := range values {
+		if matchesPattern(patterns, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesPattern(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if pattern == value {
+			return true
+		}
+		if matched, err := path.Match(pattern, value); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func (f EventFilterConfig) namespaceFilterAllowed(namespace string, namespaceLabels map[string]string) bool {
+	if namespaceFilterMatches(f.excludeNamespaceMatcher, namespace, namespaceLabels) {
+		return false
+	}
+	if f.includeNamespaceMatcher == nil {
+		return true
+	}
+	return namespaceFilterMatches(f.includeNamespaceMatcher, namespace, namespaceLabels)
+}
+
+func namespaceFilterMatches(matcher *utils.NamespaceMatcher, namespace string, namespaceLabels map[string]string) bool {
+	if matcher == nil {
+		return false
+	}
+	if namespaceLabels != nil {
+		return matcher.MatchesWithLabels(namespace, namespaceLabels)
+	}
+	return matcher.Matches(namespace)
+}
+
+func eventSeverity(event *Event) Severity {
+	if event.Severity != "" {
+		return event.Severity
+	}
+	return SeverityForEventType(event.Type)
+}
+
+func severityRank(severity Severity) int {
+	switch severity {
+	case SeverityCritical:
+		return 2
+	case SeverityWarning:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/audit/filter.go
+++ b/pkg/audit/filter.go
@@ -174,6 +174,9 @@ func patternFilterAllowed(value string, includePatterns, excludePatterns []strin
 }
 
 func resourceFilterAllowed(kind string, includePatterns, excludePatterns []string) bool {
+	if len(includePatterns) == 0 && len(excludePatterns) == 0 {
+		return true
+	}
 	candidates := resourceFilterCandidates(kind)
 	if matchesAnyPattern(excludePatterns, candidates) {
 		return false

--- a/pkg/audit/filter.go
+++ b/pkg/audit/filter.go
@@ -58,7 +58,7 @@ type EventFilterConfig struct {
 	excludeNamespaceMatcher *utils.NamespaceMatcher
 }
 
-// NewFilteredSink wraps a sink with event type and severity filtering.
+// NewFilteredSink wraps a sink with the configured audit event filters.
 func NewFilteredSink(sink Sink, filter EventFilterConfig) Sink {
 	filtered := &filteredSink{
 		sink:   sink,

--- a/pkg/audit/filter_test.go
+++ b/pkg/audit/filter_test.go
@@ -222,6 +222,11 @@ func TestFilteredSinkResourceFilterMatchesSingularPluralAliases(t *testing.T) {
 	}
 }
 
+func TestResourceFilterAllowedSkipsCandidateExpansionWithoutPatterns(t *testing.T) {
+	assert.True(t, resourceFilterAllowed("", nil, nil))
+	assert.True(t, resourceFilterAllowed("pods", nil, nil))
+}
+
 func TestFilteredSinkNamespaceSelectorTermsWhenLabelsArePresent(t *testing.T) {
 	var received []string
 	sink := NewFilteredSink(&testSink{

--- a/pkg/audit/filter_test.go
+++ b/pkg/audit/filter_test.go
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+func TestManager_GlobalEventTypeFiltering(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	var received []EventType
+	sink := &testSink{
+		name: "test",
+		writeFunc: func(event *Event) {
+			received = append(received, event.Type)
+		},
+	}
+	cfg := DefaultManagerConfig()
+	cfg.IncludeEventTypes = []string{"session.*", "access.denied*"}
+	cfg.ExcludeEventTypes = []string{string(EventSessionDenied), string(EventAccessDeniedPolicy)}
+	manager := NewManager(sink, cfg, logger)
+	defer func() { _ = manager.Close() }()
+
+	events := []EventType{
+		EventSessionRequested,
+		EventSessionDenied,
+		EventAccessDenied,
+		EventAccessDeniedPolicy,
+		EventResourceGet,
+	}
+	for _, eventType := range events {
+		err := manager.EmitSync(context.Background(), &Event{Type: eventType})
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, []EventType{EventSessionRequested, EventAccessDenied}, received)
+}
+
+func TestFilteredSinkEventTypes(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	var sessionEvents []EventType
+	var allEvents []EventType
+	sessionSink := NewFilteredSink(&testSink{
+		name: "sessions",
+		writeFunc: func(event *Event) {
+			sessionEvents = append(sessionEvents, event.Type)
+		},
+	}, EventFilterConfig{IncludeEventTypes: []string{"session.*"}})
+	allSink := NewFilteredSink(&testSink{
+		name: "all",
+		writeFunc: func(event *Event) {
+			allEvents = append(allEvents, event.Type)
+		},
+	}, EventFilterConfig{})
+	multi := NewMultiSink([]Sink{sessionSink, allSink}, logger)
+
+	err := multi.Write(context.Background(), &Event{Type: EventSessionApproved})
+	require.NoError(t, err)
+	err = multi.Write(context.Background(), &Event{Type: EventAccessDenied})
+	require.NoError(t, err)
+
+	assert.Equal(t, []EventType{EventSessionApproved}, sessionEvents)
+	assert.Equal(t, []EventType{EventSessionApproved, EventAccessDenied}, allEvents)
+}
+
+func TestFilteredSinkMinSeverity(t *testing.T) {
+	var received []EventType
+	sink := NewFilteredSink(&testSink{
+		name: "warnings",
+		writeFunc: func(event *Event) {
+			received = append(received, event.Type)
+		},
+	}, EventFilterConfig{MinSeverity: SeverityWarning})
+
+	for _, eventType := range []EventType{
+		EventSessionRequested,
+		EventAccessDenied,
+		EventSessionRevoked,
+	} {
+		err := sink.Write(context.Background(), &Event{Type: eventType})
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, []EventType{EventAccessDenied, EventSessionRevoked}, received)
+}
+
+func TestFilteredSinkAuditFilterFields(t *testing.T) {
+	var received []string
+	sink := NewFilteredSink(&testSink{
+		name: "filtered",
+		writeFunc: func(event *Event) {
+			received = append(received, event.Target.Name)
+		},
+	}, EventFilterConfig{
+		IncludeUsers: []string{"*@example.com"},
+		ExcludeUsers: []string{"system:*"},
+		IncludeNamespaces: &breakglassv1alpha1.NamespaceFilter{
+			Patterns: []string{"prod-*"},
+		},
+		ExcludeNamespaces: &breakglassv1alpha1.NamespaceFilter{
+			Patterns: []string{"prod-kube-*"},
+		},
+		IncludeResources: []string{"pods", "secrets"},
+		ExcludeResources: []string{"secrets"},
+	})
+
+	events := []*Event{
+		{
+			Type:  EventAccessAllowed,
+			Actor: Actor{User: "alice@example.com"},
+			Target: Target{
+				Kind:      "Pod",
+				Name:      "allowed",
+				Namespace: "prod-app",
+			},
+		},
+		{
+			Type:  EventAccessAllowed,
+			Actor: Actor{User: "system:serviceaccount:prod-app:controller"},
+			Target: Target{
+				Kind:      "Pod",
+				Name:      "excluded-user",
+				Namespace: "prod-app",
+			},
+		},
+		{
+			Type:  EventAccessAllowed,
+			Actor: Actor{User: "bob@example.com"},
+			Target: Target{
+				Kind:      "Pod",
+				Name:      "excluded-namespace",
+				Namespace: "prod-kube-system",
+			},
+		},
+		{
+			Type:  EventAccessAllowed,
+			Actor: Actor{User: "carol@example.com"},
+			Target: Target{
+				Kind:      "Secret",
+				Name:      "excluded-resource",
+				Namespace: "prod-app",
+			},
+		},
+		{
+			Type:  EventAccessAllowed,
+			Actor: Actor{User: "dan@example.com"},
+			Target: Target{
+				Kind:      "Deployment",
+				Name:      "not-included-resource",
+				Namespace: "prod-app",
+			},
+		},
+	}
+
+	for _, event := range events {
+		err := sink.Write(context.Background(), event)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, []string{"allowed"}, received)
+}
+
+func TestFilteredSinkResourceFilterMatchesSingularPluralAliases(t *testing.T) {
+	tests := []struct {
+		name            string
+		kind            string
+		includeResource string
+	}{
+		{
+			name:            "plural lowercase event resource matches title-case singular config",
+			kind:            "pods",
+			includeResource: "Pod",
+		},
+		{
+			name:            "title-case kind matches lowercase plural config",
+			kind:            "Pod",
+			includeResource: "pods",
+		},
+		{
+			name:            "ies plural matches singular config",
+			kind:            "policies",
+			includeResource: "policy",
+		},
+		{
+			name:            "ses plural matches singular config",
+			kind:            "ingresses",
+			includeResource: "Ingress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var received []string
+			sink := NewFilteredSink(&testSink{
+				name: "resources",
+				writeFunc: func(event *Event) {
+					received = append(received, event.Target.Name)
+				},
+			}, EventFilterConfig{
+				IncludeResources: []string{tt.includeResource},
+			})
+
+			err := sink.Write(context.Background(), &Event{
+				Type: EventAccessAllowed,
+				Target: Target{
+					Kind: tt.kind,
+					Name: "matched",
+				},
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, []string{"matched"}, received)
+		})
+	}
+}
+
+func TestFilteredSinkNamespaceSelectorTermsWhenLabelsArePresent(t *testing.T) {
+	var received []string
+	sink := NewFilteredSink(&testSink{
+		name: "selector",
+		writeFunc: func(event *Event) {
+			received = append(received, event.Target.Name)
+		},
+	}, EventFilterConfig{
+		IncludeNamespaces: &breakglassv1alpha1.NamespaceFilter{
+			SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+				{MatchLabels: map[string]string{"audit-enabled": "true"}},
+			},
+		},
+	})
+
+	events := []*Event{
+		{
+			Type: EventSessionRequested,
+			Target: Target{
+				Name:            "labels-match",
+				Namespace:       "app-a",
+				NamespaceLabels: map[string]string{"audit-enabled": "true"},
+			},
+		},
+		{
+			Type: EventSessionRequested,
+			Target: Target{
+				Name:      "labels-unavailable",
+				Namespace: "app-b",
+			},
+		},
+		{
+			Type: EventSessionRequested,
+			Target: Target{
+				Name:            "labels-do-not-match",
+				Namespace:       "app-c",
+				NamespaceLabels: map[string]string{"audit-enabled": "false"},
+			},
+		},
+	}
+
+	for _, event := range events {
+		err := sink.Write(context.Background(), event)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, []string{"labels-match"}, received)
+}

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -106,6 +106,12 @@ type ManagerConfig struct {
 	// AlwaysCaptureEventTypes are never sampled (always 100%).
 	AlwaysCaptureEventTypes []EventType
 
+	// IncludeEventTypes allows only matching event types. Empty means all.
+	IncludeEventTypes []string
+
+	// ExcludeEventTypes blocks matching event types and takes precedence.
+	ExcludeEventTypes []string
+
 	// WriteTimeout is the timeout for writing to sinks.
 	// Default: 5s
 	WriteTimeout time.Duration
@@ -207,6 +213,10 @@ func NewManager(sink Sink, cfg ManagerConfig, logger *zap.Logger) *Manager {
 // queue is full, which may block up to WriteTimeout.
 func (m *Manager) Emit(ctx context.Context, event *Event) {
 	if m.closed.Load() {
+		return
+	}
+
+	if !eventTypeAllowed(event.Type, m.config.IncludeEventTypes, m.config.ExcludeEventTypes) {
 		return
 	}
 
@@ -322,6 +332,10 @@ func (m *Manager) syncWriteDirect(ctx context.Context, event *Event) error {
 // EmitSync sends an audit event synchronously.
 // Use sparingly - for critical events only.
 func (m *Manager) EmitSync(ctx context.Context, event *Event) error {
+	if !eventTypeAllowed(event.Type, m.config.IncludeEventTypes, m.config.ExcludeEventTypes) {
+		return nil
+	}
+
 	// Assign ID if not set
 	if event.ID == "" {
 		event.ID = uuid.New().String()

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -156,6 +156,8 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 	sampleRateConfigured := false
 	var highVolume []EventType
 	var alwaysCapture []EventType
+	var includeEventTypes []string
+	var excludeEventTypes []string
 
 	// Use the first config's queue settings as baseline
 	if len(enabledConfigs) > 0 {
@@ -184,6 +186,10 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 				alwaysCapture = append(alwaysCapture, EventType(ac))
 			}
 		}
+		if len(enabledConfigs) == 1 && config.Spec.Filtering != nil {
+			includeEventTypes = append(includeEventTypes, config.Spec.Filtering.IncludeEventTypes...)
+			excludeEventTypes = append(excludeEventTypes, config.Spec.Filtering.ExcludeEventTypes...)
+		}
 	}
 
 	// Create isolated multi-sink: each sink gets its own queue for isolation
@@ -209,6 +215,8 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 		sampleRateConfigured:    sampleRateConfigured,
 		HighVolumeEventTypes:    highVolume,
 		AlwaysCaptureEventTypes: alwaysCapture,
+		IncludeEventTypes:       includeEventTypes,
+		ExcludeEventTypes:       excludeEventTypes,
 		WriteTimeout:            5 * time.Second,
 		// DirectSinks references the same sink instances stored in s.sinks.
 		// On the next ReloadMultiple call, the Manager is closed (draining all
@@ -459,6 +467,23 @@ func (s *Service) buildSinks(ctx context.Context, config *breakglassv1alpha1.Aud
 				zap.String("type", string(sinkCfg.Type)),
 				zap.Int("failure_threshold", cbCfg.FailureThreshold),
 				zap.Duration("open_timeout", cbCfg.OpenTimeout))
+		}
+
+		sink = NewFilteredSink(sink, EventFilterConfig{
+			IncludeEventTypes: sinkCfg.EventTypes,
+			MinSeverity:       Severity(sinkCfg.MinSeverity),
+		})
+		if config.Spec.Filtering != nil {
+			sink = NewFilteredSink(sink, EventFilterConfig{
+				IncludeEventTypes: config.Spec.Filtering.IncludeEventTypes,
+				ExcludeEventTypes: config.Spec.Filtering.ExcludeEventTypes,
+				IncludeUsers:      config.Spec.Filtering.IncludeUsers,
+				ExcludeUsers:      config.Spec.Filtering.ExcludeUsers,
+				IncludeNamespaces: config.Spec.Filtering.IncludeNamespaces,
+				ExcludeNamespaces: config.Spec.Filtering.ExcludeNamespaces,
+				IncludeResources:  config.Spec.Filtering.IncludeResources,
+				ExcludeResources:  config.Spec.Filtering.ExcludeResources,
+			})
 		}
 
 		sinks = append(sinks, sink)

--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -37,6 +37,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -156,8 +157,6 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 	sampleRateConfigured := false
 	var highVolume []EventType
 	var alwaysCapture []EventType
-	var includeEventTypes []string
-	var excludeEventTypes []string
 
 	// Use the first config's queue settings as baseline
 	if len(enabledConfigs) > 0 {
@@ -186,10 +185,10 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 				alwaysCapture = append(alwaysCapture, EventType(ac))
 			}
 		}
-		if len(enabledConfigs) == 1 && config.Spec.Filtering != nil {
-			includeEventTypes = append(includeEventTypes, config.Spec.Filtering.IncludeEventTypes...)
-			excludeEventTypes = append(excludeEventTypes, config.Spec.Filtering.ExcludeEventTypes...)
-		}
+	}
+	includeEventTypes, excludeEventTypes, sharedEventTypeFilters := managerEventTypeFilters(enabledConfigs)
+	if !sharedEventTypeFilters {
+		s.logger.Debug("manager event-type pre-filter disabled because enabled AuditConfigs use different event-type filters")
 	}
 
 	// Create isolated multi-sink: each sink gets its own queue for isolation
@@ -276,6 +275,33 @@ func (s *Service) ReloadMultiple(ctx context.Context, configs []*breakglassv1alp
 
 	metrics.AuditConfigReloads.WithLabelValues("success").Inc()
 	return nil
+}
+
+func managerEventTypeFilters(configs []*breakglassv1alpha1.AuditConfig) ([]string, []string, bool) {
+	if len(configs) == 0 {
+		return nil, nil, true
+	}
+
+	var include []string
+	var exclude []string
+	for i, config := range configs {
+		var currentInclude []string
+		var currentExclude []string
+		if config != nil && config.Spec.Filtering != nil {
+			currentInclude = config.Spec.Filtering.IncludeEventTypes
+			currentExclude = config.Spec.Filtering.ExcludeEventTypes
+		}
+		if i == 0 {
+			include = append([]string(nil), currentInclude...)
+			exclude = append([]string(nil), currentExclude...)
+			continue
+		}
+		if !slices.Equal(include, currentInclude) || !slices.Equal(exclude, currentExclude) {
+			return nil, nil, false
+		}
+	}
+
+	return include, exclude, true
 }
 
 // Emit sends an audit event asynchronously.

--- a/pkg/audit/service_test.go
+++ b/pkg/audit/service_test.go
@@ -185,6 +185,76 @@ func TestService_ReloadWithSampling(t *testing.T) {
 	_ = svc.Close()
 }
 
+func TestService_ReloadMultipleUsesSharedEventTypeFilters(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	svc := NewService(client, nil, logger, "test-namespace")
+	configs := []*breakglassv1alpha1.AuditConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "config-a"},
+			Spec: breakglassv1alpha1.AuditConfigSpec{
+				Enabled:   true,
+				Filtering: &breakglassv1alpha1.AuditFilterConfig{IncludeEventTypes: []string{"session.*"}, ExcludeEventTypes: []string{"session.denied"}},
+				Sinks:     []breakglassv1alpha1.AuditSinkConfig{{Name: "log-a", Type: breakglassv1alpha1.AuditSinkTypeLog}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "config-b"},
+			Spec: breakglassv1alpha1.AuditConfigSpec{
+				Enabled:   true,
+				Filtering: &breakglassv1alpha1.AuditFilterConfig{IncludeEventTypes: []string{"session.*"}, ExcludeEventTypes: []string{"session.denied"}},
+				Sinks:     []breakglassv1alpha1.AuditSinkConfig{{Name: "log-b", Type: breakglassv1alpha1.AuditSinkTypeLog}},
+			},
+		},
+	}
+
+	err := svc.ReloadMultiple(context.Background(), configs)
+	require.NoError(t, err)
+	require.NotNil(t, svc.manager)
+	assert.Equal(t, []string{"session.*"}, svc.manager.config.IncludeEventTypes)
+	assert.Equal(t, []string{"session.denied"}, svc.manager.config.ExcludeEventTypes)
+	_ = svc.Close()
+}
+
+func TestService_ReloadMultipleDisablesManagerEventFilterForDifferentConfigs(t *testing.T) {
+	logger := zap.NewNop()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = breakglassv1alpha1.AddToScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	svc := NewService(client, nil, logger, "test-namespace")
+	configs := []*breakglassv1alpha1.AuditConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "config-a"},
+			Spec: breakglassv1alpha1.AuditConfigSpec{
+				Enabled:   true,
+				Filtering: &breakglassv1alpha1.AuditFilterConfig{IncludeEventTypes: []string{"session.*"}},
+				Sinks:     []breakglassv1alpha1.AuditSinkConfig{{Name: "log-a", Type: breakglassv1alpha1.AuditSinkTypeLog}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "config-b"},
+			Spec: breakglassv1alpha1.AuditConfigSpec{
+				Enabled:   true,
+				Filtering: &breakglassv1alpha1.AuditFilterConfig{IncludeEventTypes: []string{"access.*"}},
+				Sinks:     []breakglassv1alpha1.AuditSinkConfig{{Name: "log-b", Type: breakglassv1alpha1.AuditSinkTypeLog}},
+			},
+		},
+	}
+
+	err := svc.ReloadMultiple(context.Background(), configs)
+	require.NoError(t, err)
+	require.NotNil(t, svc.manager)
+	assert.Empty(t, svc.manager.config.IncludeEventTypes)
+	assert.Empty(t, svc.manager.config.ExcludeEventTypes)
+	_ = svc.Close()
+}
+
 func TestService_ReloadNoSinks(t *testing.T) {
 	logger := zap.NewNop()
 	scheme := newServiceTestScheme(t)

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -293,6 +293,9 @@ type Target struct {
 
 	// APIGroup is the API group of the resource
 	APIGroup string `json:"apiGroup,omitempty"`
+
+	// NamespaceLabels contains labels for namespace selector filtering when known.
+	NamespaceLabels map[string]string `json:"namespaceLabels,omitempty"`
 }
 
 // RequestContext contains correlation and context information

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -36,6 +36,8 @@ const denyReasonMessage = "Access denied. To request temporary access via Breakg
 
 const maxSARBodySize = 1 << 20 // 1 MiB
 
+const auditNamespaceLabelLookupTimeout = 500 * time.Millisecond
+
 // buildReason appends a helpful link to the breakglass frontend for a given cluster.
 func (wc *WebhookController) buildBreakglassLink(cluster string) string {
 	base := strings.TrimRight(wc.config.Frontend.BaseURL, "/")
@@ -624,7 +626,9 @@ func (wc *WebhookController) auditNamespaceLabels(ctx context.Context, cluster, 
 	if namespace == "" || (wc.namespaceLabelsFetchFn == nil && wc.ccProvider == nil) {
 		return nil
 	}
-	labels, err := wc.fetchNamespaceLabels(ctx, cluster, namespace)
+	lookupCtx, cancel := context.WithTimeout(ctx, auditNamespaceLabelLookupTimeout)
+	defer cancel()
+	labels, err := wc.fetchNamespaceLabels(lookupCtx, cluster, namespace)
 	if err != nil {
 		if wc.log != nil {
 			wc.log.Debugw("failed to fetch namespace labels for audit event filtering",

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -489,22 +489,7 @@ func (wc *WebhookController) emitAccessDecisionAudit(ctx context.Context, userna
 		severity = audit.SeverityWarning
 	}
 
-	// Build target information from SAR
-	var resource, name, namespace, verb, subresource, apiGroup string
-	if sar.Spec.ResourceAttributes != nil {
-		ra := sar.Spec.ResourceAttributes
-		resource = ra.Resource
-		name = ra.Name
-		namespace = ra.Namespace
-		verb = ra.Verb
-		subresource = ra.Subresource
-		apiGroup = ra.Group
-	} else if sar.Spec.NonResourceAttributes != nil {
-		nra := sar.Spec.NonResourceAttributes
-		resource = "nonresource"
-		name = nra.Path
-		verb = nra.Verb
-	}
+	target, verb, subresource, apiGroup := wc.auditTargetFromSAR(ctx, cluster, sar)
 
 	// Build details map
 	details := map[string]interface{}{
@@ -525,12 +510,7 @@ func (wc *WebhookController) emitAccessDecisionAudit(ctx context.Context, userna
 			User:   username,
 			Groups: groups,
 		},
-		Target: audit.Target{
-			Kind:      resource,
-			Name:      name,
-			Namespace: namespace,
-			Cluster:   cluster,
-		},
+		Target:  target,
 		Details: details,
 	}
 
@@ -543,22 +523,7 @@ func (wc *WebhookController) emitPolicyDenialAudit(ctx context.Context, username
 		return
 	}
 
-	// Build target information from SAR
-	var resource, name, namespace, verb, subresource, apiGroup string
-	if sar.Spec.ResourceAttributes != nil {
-		ra := sar.Spec.ResourceAttributes
-		resource = ra.Resource
-		name = ra.Name
-		namespace = ra.Namespace
-		verb = ra.Verb
-		subresource = ra.Subresource
-		apiGroup = ra.Group
-	} else if sar.Spec.NonResourceAttributes != nil {
-		nra := sar.Spec.NonResourceAttributes
-		resource = "nonresource"
-		name = nra.Path
-		verb = nra.Verb
-	}
+	target, verb, subresource, apiGroup := wc.auditTargetFromSAR(ctx, cluster, sar)
 
 	event := &audit.Event{
 		Type:     audit.EventAccessDeniedPolicy,
@@ -567,12 +532,7 @@ func (wc *WebhookController) emitPolicyDenialAudit(ctx context.Context, username
 			User:   username,
 			Groups: groups,
 		},
-		Target: audit.Target{
-			Kind:      resource,
-			Name:      name,
-			Namespace: namespace,
-			Cluster:   cluster,
-		},
+		Target: target,
 		Details: map[string]interface{}{
 			"policyName":  policyName,
 			"policyScope": scope,
@@ -610,17 +570,7 @@ func (wc *WebhookController) emitPodSecurityAudit(ctx context.Context, username 
 		severity = audit.SeverityInfo
 	}
 
-	// Build target information from SAR
-	var resource, name, namespace, verb, subresource, apiGroup string
-	if sar.Spec.ResourceAttributes != nil {
-		ra := sar.Spec.ResourceAttributes
-		resource = ra.Resource
-		name = ra.Name
-		namespace = ra.Namespace
-		verb = ra.Verb
-		subresource = ra.Subresource
-		apiGroup = ra.Group
-	}
+	target, verb, subresource, apiGroup := wc.auditTargetFromSAR(ctx, cluster, sar)
 
 	event := &audit.Event{
 		Type:     eventType,
@@ -629,12 +579,7 @@ func (wc *WebhookController) emitPodSecurityAudit(ctx context.Context, username 
 			User:   username,
 			Groups: groups,
 		},
-		Target: audit.Target{
-			Kind:      resource,
-			Name:      name,
-			Namespace: namespace,
-			Cluster:   cluster,
-		},
+		Target: target,
 		Details: map[string]interface{}{
 			"policyName":      policyName,
 			"action":          result.Action,
@@ -649,6 +594,48 @@ func (wc *WebhookController) emitPodSecurityAudit(ctx context.Context, username 
 	}
 
 	wc.auditService.Emit(ctx, event)
+}
+
+func (wc *WebhookController) auditTargetFromSAR(ctx context.Context, cluster string, sar *authorizationv1.SubjectAccessReview) (audit.Target, string, string, string) {
+	target := audit.Target{Cluster: cluster}
+	var verb, subresource, apiGroup string
+	if sar == nil {
+		return target, verb, subresource, apiGroup
+	}
+	if sar.Spec.ResourceAttributes != nil {
+		ra := sar.Spec.ResourceAttributes
+		target.Kind = ra.Resource
+		target.Name = ra.Name
+		target.Namespace = ra.Namespace
+		target.NamespaceLabels = wc.auditNamespaceLabels(ctx, cluster, ra.Namespace)
+		verb = ra.Verb
+		subresource = ra.Subresource
+		apiGroup = ra.Group
+	} else if sar.Spec.NonResourceAttributes != nil {
+		nra := sar.Spec.NonResourceAttributes
+		target.Kind = "nonresource"
+		target.Name = nra.Path
+		verb = nra.Verb
+	}
+	return target, verb, subresource, apiGroup
+}
+
+func (wc *WebhookController) auditNamespaceLabels(ctx context.Context, cluster, namespace string) map[string]string {
+	if namespace == "" || (wc.namespaceLabelsFetchFn == nil && wc.ccProvider == nil) {
+		return nil
+	}
+	labels, err := wc.fetchNamespaceLabels(ctx, cluster, namespace)
+	if err != nil {
+		if wc.log != nil {
+			wc.log.Debugw("failed to fetch namespace labels for audit event filtering",
+				"error", err.Error(), "cluster", cluster, "namespace", namespace)
+		}
+		return nil
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	return labels
 }
 
 // getUserGroupsForCluster removed (unused)

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -3652,4 +3653,71 @@ func TestAuditEmitWithDifferentEventSeverities(t *testing.T) {
 			wc.emitPodSecurityAudit(ctx, "test@example.com", []string{"group1"}, "cluster1", sar, "policy1", tc.result)
 		})
 	}
+}
+
+func TestAuditTargetFromSARIncludesNamespaceLabels(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	ctx := context.Background()
+	wc := NewWebhookController(logger.Sugar(), config.Config{}, nil, nil, nil, nil,
+		WithNamespaceLabelsFetchFunc(func(_ context.Context, clusterName, namespace string) (map[string]string, error) {
+			if clusterName != "cluster1" || namespace != "production" {
+				return nil, fmt.Errorf("unexpected namespace lookup %s/%s", clusterName, namespace)
+			}
+			return map[string]string{"audit-enabled": "true"}, nil
+		}),
+	)
+
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "production",
+				Verb:      "get",
+				Resource:  "pods",
+				Name:      "pod-a",
+			},
+		},
+	}
+
+	target, verb, subresource, apiGroup := wc.auditTargetFromSAR(ctx, "cluster1", sar)
+
+	assert.Equal(t, "pods", target.Kind)
+	assert.Equal(t, "pod-a", target.Name)
+	assert.Equal(t, "production", target.Namespace)
+	assert.Equal(t, "cluster1", target.Cluster)
+	assert.Equal(t, map[string]string{"audit-enabled": "true"}, target.NamespaceLabels)
+	assert.Equal(t, "get", verb)
+	assert.Empty(t, subresource)
+	assert.Empty(t, apiGroup)
+}
+
+func TestAuditTargetFromSARSkipsNamespaceLabelsForNonResource(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	ctx := context.Background()
+	called := false
+	wc := NewWebhookController(logger.Sugar(), config.Config{}, nil, nil, nil, nil,
+		WithNamespaceLabelsFetchFunc(func(context.Context, string, string) (map[string]string, error) {
+			called = true
+			return nil, nil
+		}),
+	)
+
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			NonResourceAttributes: &authorizationv1.NonResourceAttributes{
+				Path: "/metrics",
+				Verb: "get",
+			},
+		},
+	}
+
+	target, verb, subresource, apiGroup := wc.auditTargetFromSAR(ctx, "cluster1", sar)
+
+	assert.False(t, called)
+	assert.Equal(t, "nonresource", target.Kind)
+	assert.Equal(t, "/metrics", target.Name)
+	assert.Equal(t, "cluster1", target.Cluster)
+	assert.Nil(t, target.NamespaceLabels)
+	assert.Equal(t, "get", verb)
+	assert.Empty(t, subresource)
+	assert.Empty(t, apiGroup)
 }

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -3690,6 +3690,37 @@ func TestAuditTargetFromSARIncludesNamespaceLabels(t *testing.T) {
 	assert.Empty(t, apiGroup)
 }
 
+func TestAuditTargetFromSARBoundsNamespaceLabelLookup(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	ctx := context.Background()
+	var sawDeadline bool
+	wc := NewWebhookController(logger.Sugar(), config.Config{}, nil, nil, nil, nil,
+		WithNamespaceLabelsFetchFunc(func(ctx context.Context, _, _ string) (map[string]string, error) {
+			deadline, ok := ctx.Deadline()
+			sawDeadline = ok
+			if ok {
+				assert.LessOrEqual(t, time.Until(deadline), auditNamespaceLabelLookupTimeout)
+			}
+			return map[string]string{"audit-enabled": "true"}, nil
+		}),
+	)
+
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "production",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+
+	target, _, _, _ := wc.auditTargetFromSAR(ctx, "cluster1", sar)
+
+	assert.True(t, sawDeadline)
+	assert.Equal(t, map[string]string{"audit-enabled": "true"}, target.NamespaceLabels)
+}
+
 func TestAuditTargetFromSARSkipsNamespaceLabelsForNonResource(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- enforce AuditConfig event type filters before audit manager queueing
- wrap sinks with configured event type, user, namespace, resource, and severity filters
- support namespace selector matching when audit events carry namespace labels, with pattern-only fallback otherwise

## Validation
- GOCACHE=/private/tmp/k8s-audit-filter-go-cache GOMODCACHE=/private/tmp/k8s-audit-filter-go-mod-cache go test -timeout=4m ./pkg/audit
- golangci-lint run --timeout=5m ./pkg/audit
- git diff --check

## Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "AuditConfig filtering event types users namespaces resources minSeverity" returned no matches
