### PR TITLE
fix(bgctl): cap update archive downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
 - **BreakglassSession list filters**: Session status listing now pushes exact state filters through the cache index and deduplicates multi-state results before applying cluster, user, or group filters.
 - **Frontend My Sessions history**: My Sessions now includes expired and idle-expired breakglass sessions without duplicating sessions returned by multiple state queries.
+- **bgctl update archive downloads**: Release archive downloads are now capped before extraction, with bounded error-body reads for failed download responses.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -314,14 +314,22 @@ func limitedDownloadCopy(dst io.Writer, src io.Reader, maxBytes int64) error {
 	}
 
 	var probe [1]byte
-	extra, probeErr := src.Read(probe[:])
-	if probeErr != nil && !errors.Is(probeErr, io.EOF) {
-		return probeErr
+	const maxEmptyProbeReads = 100
+	for emptyReads := 0; ; emptyReads++ {
+		extra, probeErr := src.Read(probe[:])
+		if probeErr != nil && !errors.Is(probeErr, io.EOF) {
+			return probeErr
+		}
+		if extra > 0 {
+			return fmt.Errorf("download exceeds maximum allowed size of %d bytes", maxBytes)
+		}
+		if errors.Is(probeErr, io.EOF) {
+			return nil
+		}
+		if emptyReads >= maxEmptyProbeReads {
+			return fmt.Errorf("download size probe made no progress after %d reads", maxEmptyProbeReads+1)
+		}
 	}
-	if extra > 0 {
-		return fmt.Errorf("download exceeds maximum allowed size of %d bytes", maxBytes)
-	}
-	return nil
 }
 
 // progressReader wraps an io.Reader and prints download progress to stderr.

--- a/pkg/bgctl/cmd/update.go
+++ b/pkg/bgctl/cmd/update.go
@@ -29,6 +29,9 @@ const (
 	// maxBinarySize is the maximum allowed size for extracted binaries (500 MB).
 	maxBinarySize = 500 << 20
 
+	// maxArchiveDownloadSize is the maximum allowed size for downloaded release archives (600 MB).
+	maxArchiveDownloadSize = 600 << 20
+
 	maxUpdateErrorBodyBytes = 4 << 10
 
 	defaultUpdateAPIHTTPTimeout      = 30 * time.Second
@@ -247,6 +250,10 @@ func findAssetURL(assets []githubAsset, name string) string {
 }
 
 func downloadFile(ctx context.Context, url, path string) error {
+	return downloadFileWithLimit(ctx, url, path, maxArchiveDownloadSize)
+}
+
+func downloadFileWithLimit(ctx context.Context, url, path string, maxBytes int64) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -261,28 +268,60 @@ func downloadFile(ctx context.Context, url, path string) error {
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("download failed: %s", readUpdateErrorBody(resp.Body))
 	}
+	if maxBytes > 0 && resp.ContentLength > maxBytes {
+		return fmt.Errorf("download exceeds maximum allowed size of %d bytes", maxBytes)
+	}
+
 	out, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = out.Close()
-	}()
 
-	// Use progress writer if content length is known
+	var reader io.Reader = resp.Body
 	if resp.ContentLength > 0 {
-		_, err = io.Copy(out, &progressReader{
+		reader = &progressReader{
 			reader: resp.Body,
 			total:  resp.ContentLength,
-		})
-	} else {
-		_, err = io.Copy(out, resp.Body)
+		}
 	}
+
+	if maxBytes > 0 {
+		err = limitedDownloadCopy(out, reader, maxBytes)
+	} else {
+		_, err = io.Copy(out, reader)
+	}
+	closeErr := out.Close()
+
 	// Clear the progress line
 	if resp.ContentLength > 0 {
 		_, _ = fmt.Fprint(os.Stderr, "\r                                                  \r")
 	}
-	return err
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return closeErr
+	}
+	return nil
+}
+
+func limitedDownloadCopy(dst io.Writer, src io.Reader, maxBytes int64) error {
+	_, err := io.Copy(dst, io.LimitReader(src, maxBytes))
+	if err != nil {
+		return err
+	}
+
+	var probe [1]byte
+	extra, probeErr := src.Read(probe[:])
+	if probeErr != nil && !errors.Is(probeErr, io.EOF) {
+		return probeErr
+	}
+	if extra > 0 {
+		return fmt.Errorf("download exceeds maximum allowed size of %d bytes", maxBytes)
+	}
+	return nil
 }
 
 // progressReader wraps an io.Reader and prints download progress to stderr.

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -27,6 +27,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func useUpdateDownloadClient(t *testing.T, client *http.Client) {
+	t.Helper()
+
+	oldClient := updateDownloadHTTPClient
+	updateDownloadHTTPClient = client
+	t.Cleanup(func() {
+		updateDownloadHTTPClient = oldClient
+	})
+}
+
 func TestAssetFileName_CurrentPlatform(t *testing.T) {
 	name := assetFileName()
 	if runtime.GOOS == "windows" {
@@ -93,6 +103,27 @@ func TestDownloadFileErrorStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "download failed")
 }
 
+func TestDownloadFileErrorStatusCapsResponseBody(t *testing.T) {
+	largeBody := strings.Repeat("x", maxUpdateErrorBodyBytes) + "tail"
+	useUpdateDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader("  " + largeBody + "  "))
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})})
+
+	path := filepath.Join(t.TempDir(), "download.bin")
+	err := downloadFile(context.Background(), "https://example.com/archive.tar.gz", path)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "download failed")
+	assert.Contains(t, err.Error(), strings.Repeat("x", 32))
+	assert.NotContains(t, err.Error(), "tail")
+	assert.LessOrEqual(t, len(err.Error()), maxUpdateErrorBodyBytes+len("download failed: ... (truncated)"))
+}
+
 func TestDownloadFileHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -134,6 +165,101 @@ func TestDownloadFileUsesDedicatedDownloadClient(t *testing.T) {
 	assert.Equal(t, "payload", string(content))
 	assert.Equal(t, 0, apiCalls, "metadata client must not be used for binary download")
 	assert.Equal(t, 1, downloadCalls, "download client should be used exactly once")
+}
+
+func TestDownloadFileRejectsDeclaredOversizedDownloadBeforeCreatingDestination(t *testing.T) {
+	const limit = int64(5)
+	useUpdateDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(""))
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: limit + 1,
+			Body:          body,
+			Header:        make(http.Header),
+		}, nil
+	})})
+
+	path := filepath.Join(t.TempDir(), "download.bin")
+	err := downloadFileWithLimit(context.Background(), "https://example.com/archive.tar.gz", path, limit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download exceeds maximum allowed size")
+
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestDownloadFileRejectsUnknownLengthOversizedDownloadAndRemovesPartialFile(t *testing.T) {
+	const limit = int64(5)
+	useUpdateDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader("123456"))
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Body:          body,
+			Header:        make(http.Header),
+		}, nil
+	})})
+
+	path := filepath.Join(t.TempDir(), "download.bin")
+	err := downloadFileWithLimit(context.Background(), "https://example.com/archive.tar.gz", path, limit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download exceeds maximum allowed size")
+
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestDownloadFileWithNoLimitCopiesCompleteDownload(t *testing.T) {
+	useUpdateDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader("123456"))
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Body:          body,
+			Header:        make(http.Header),
+		}, nil
+	})})
+
+	path := filepath.Join(t.TempDir(), "download.bin")
+	err := downloadFileWithLimit(context.Background(), "https://example.com/archive.tar.gz", path, 0)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "123456", string(content))
+}
+
+func TestDownloadFileAllowsExactAndUnderLimitDownloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		limit   int64
+	}{
+		{name: "under limit", payload: "1234", limit: 5},
+		{name: "exact limit", payload: "12345", limit: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useUpdateDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				body := io.NopCloser(strings.NewReader(tt.payload))
+				return &http.Response{
+					StatusCode:    http.StatusOK,
+					ContentLength: int64(len(tt.payload)),
+					Body:          body,
+					Header:        make(http.Header),
+				}, nil
+			})})
+
+			path := filepath.Join(t.TempDir(), "download.bin")
+			err := downloadFileWithLimit(context.Background(), "https://example.com/archive.tar.gz", path, tt.limit)
+			require.NoError(t, err)
+
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.payload, string(content))
+		})
+	}
 }
 
 func TestFetchReleaseByTagEscapesPathSegment(t *testing.T) {

--- a/pkg/bgctl/cmd/update_test.go
+++ b/pkg/bgctl/cmd/update_test.go
@@ -537,6 +537,26 @@ func (r *errAfterDataReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+type emptyReadAfterDataReader struct {
+	data          []byte
+	emptyAfter    int
+	returnedEmpty bool
+	pos           int
+}
+
+func (r *emptyReadAfterDataReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.pos >= r.emptyAfter && !r.returnedEmpty {
+		r.returnedEmpty = true
+		return 0, nil
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
 func TestLimitedCopyReturnsProbeReadError(t *testing.T) {
 	limit := int64(4)
 	src := &errAfterDataReader{data: []byte("test"), err: io.ErrUnexpectedEOF}
@@ -544,6 +564,17 @@ func TestLimitedCopyReturnsProbeReadError(t *testing.T) {
 	var dst bytes.Buffer
 	err := limitedCopy(&dst, src, limit)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestLimitedDownloadCopyRejectsOversizedAfterEmptyProbeRead(t *testing.T) {
+	limit := int64(4)
+	src := &emptyReadAfterDataReader{data: []byte("extra"), emptyAfter: int(limit)}
+
+	var dst bytes.Buffer
+	err := limitedDownloadCopy(&dst, src, limit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download exceeds maximum allowed size")
+	assert.Equal(t, "extr", dst.String())
 }
 
 func TestExtractTarGzAllowsValidArchive(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a separate maximum size for bgctl update archive downloads
- reject declared oversized downloads before creating the destination file
- reject unknown-length oversized responses with a limit-plus-probe copy and remove partial files

## Validation
- GOCACHE=/private/tmp/k8s-bgctl-archive-go-cache GOMODCACHE=/private/tmp/k8s-bgctl-archive-go-mod-cache go test -timeout=4m ./pkg/bgctl/cmd
- golangci-lint run --allow-parallel-runners --timeout=5m ./pkg/bgctl/cmd
- git -c core.fsmonitor=false diff --check

## Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "bgctl update archive download size limit maxArchiveDownloadSize" returned no matches
