### PR TITLE
perf(api): push session list filters into indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
 - **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
+- **BreakglassSession list filters**: Session status listing now pushes exact state filters through the cache index and deduplicates multi-state results before applying cluster, user, or group filters.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -501,6 +501,23 @@ func copyDebugSessionMatchingFields(in ctrlclient.MatchingFields) ctrlclient.Mat
 	return out
 }
 
+func filterDebugSessionsForIndexedFallback(sessions []breakglassv1alpha1.DebugSession, cluster string, states []breakglassv1alpha1.DebugSessionState) []breakglassv1alpha1.DebugSession {
+	if cluster == "" && len(states) == 0 {
+		return sessions
+	}
+	filtered := make([]breakglassv1alpha1.DebugSession, 0, len(sessions))
+	for _, session := range sessions {
+		if cluster != "" && session.Spec.Cluster != cluster {
+			continue
+		}
+		if !debugSessionStateMatches(session.Status.State, states) {
+			continue
+		}
+		filtered = append(filtered, session)
+	}
+	return filtered
+}
+
 func (c *DebugSessionAPIController) listDebugSessionsForFilters(ctx context.Context, cluster string, states []breakglassv1alpha1.DebugSessionState) ([]breakglassv1alpha1.DebugSession, error) {
 	baseFields := ctrlclient.MatchingFields{}
 	if cluster != "" {
@@ -508,7 +525,10 @@ func (c *DebugSessionAPIController) listDebugSessionsForFilters(ctx context.Cont
 	}
 
 	if len(states) == 0 {
-		sessions, _, err := c.listDebugSessionsWithFields(ctx, baseFields)
+		sessions, fellBack, err := c.listDebugSessionsWithFields(ctx, baseFields)
+		if fellBack {
+			return filterDebugSessionsForIndexedFallback(sessions, cluster, nil), err
+		}
 		return sessions, err
 	}
 
@@ -522,7 +542,7 @@ func (c *DebugSessionAPIController) listDebugSessionsForFilters(ctx context.Cont
 			return nil, err
 		}
 		if fellBack {
-			return stateSessions, nil
+			return filterDebugSessionsForIndexedFallback(stateSessions, cluster, states), nil
 		}
 		for _, session := range stateSessions {
 			key := session.Namespace + "/" + session.Name

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -476,12 +476,15 @@ func debugSessionStateMatches(state breakglassv1alpha1.DebugSessionState, filter
 
 func (c *DebugSessionAPIController) listDebugSessionsWithFields(ctx context.Context, matchingFields ctrlclient.MatchingFields) ([]breakglassv1alpha1.DebugSession, bool, error) {
 	sessionList := &breakglassv1alpha1.DebugSessionList{}
-	listOpts := []ctrlclient.ListOption{}
-	if len(matchingFields) > 0 {
-		listOpts = append(listOpts, matchingFields)
+	if len(matchingFields) == 0 {
+		if err := c.reader().List(ctx, sessionList); err != nil {
+			return nil, false, err
+		}
+		return sessionList.Items, false, nil
 	}
-	if err := c.reader().List(ctx, sessionList, listOpts...); err != nil {
-		if len(matchingFields) > 0 && breakglass.IsFieldIndexError(err) {
+
+	if err := c.client.List(ctx, sessionList, matchingFields); err != nil {
+		if breakglass.IsFieldIndexError(err) {
 			fallbackList := &breakglassv1alpha1.DebugSessionList{}
 			if fallbackErr := c.reader().List(ctx, fallbackList); fallbackErr != nil {
 				return nil, false, fmt.Errorf("failed to list debug sessions after field-index fallback: %w", fallbackErr)

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -429,6 +429,113 @@ func debugSessionIdentityMatches(identity debugSessionReadIdentity, values ...st
 	return false
 }
 
+func parseDebugSessionStateFilters(ctx *gin.Context) ([]breakglassv1alpha1.DebugSessionState, string, bool) {
+	rawStates := ctx.QueryArray("state")
+	states := make([]breakglassv1alpha1.DebugSessionState, 0, len(rawStates))
+	seen := map[breakglassv1alpha1.DebugSessionState]struct{}{}
+	for _, value := range rawStates {
+		for _, rawState := range strings.Split(value, ",") {
+			rawState = strings.TrimSpace(rawState)
+			if rawState == "" {
+				continue
+			}
+			state, ok := canonicalDebugSessionState(rawState)
+			if !ok {
+				return nil, rawState, false
+			}
+			if _, exists := seen[state]; exists {
+				continue
+			}
+			seen[state] = struct{}{}
+			states = append(states, state)
+		}
+	}
+	return states, "", true
+}
+
+func canonicalDebugSessionState(value string) (breakglassv1alpha1.DebugSessionState, bool) {
+	for state := range validDebugSessionStates {
+		if strings.EqualFold(state, value) {
+			return breakglassv1alpha1.DebugSessionState(state), true
+		}
+	}
+	return "", false
+}
+
+func debugSessionStateMatches(state breakglassv1alpha1.DebugSessionState, filters []breakglassv1alpha1.DebugSessionState) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, filter := range filters {
+		if state == filter {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *DebugSessionAPIController) listDebugSessionsWithFields(ctx context.Context, matchingFields ctrlclient.MatchingFields) ([]breakglassv1alpha1.DebugSession, bool, error) {
+	sessionList := &breakglassv1alpha1.DebugSessionList{}
+	listOpts := []ctrlclient.ListOption{}
+	if len(matchingFields) > 0 {
+		listOpts = append(listOpts, matchingFields)
+	}
+	if err := c.reader().List(ctx, sessionList, listOpts...); err != nil {
+		if len(matchingFields) > 0 && breakglass.IsFieldIndexError(err) {
+			fallbackList := &breakglassv1alpha1.DebugSessionList{}
+			if fallbackErr := c.reader().List(ctx, fallbackList); fallbackErr != nil {
+				return nil, false, fmt.Errorf("failed to list debug sessions after field-index fallback: %w", fallbackErr)
+			}
+			return fallbackList.Items, true, nil
+		}
+		return nil, false, err
+	}
+	return sessionList.Items, false, nil
+}
+
+func copyDebugSessionMatchingFields(in ctrlclient.MatchingFields) ctrlclient.MatchingFields {
+	out := make(ctrlclient.MatchingFields, len(in)+1)
+	for field, value := range in {
+		out[field] = value
+	}
+	return out
+}
+
+func (c *DebugSessionAPIController) listDebugSessionsForFilters(ctx context.Context, cluster string, states []breakglassv1alpha1.DebugSessionState) ([]breakglassv1alpha1.DebugSession, error) {
+	baseFields := ctrlclient.MatchingFields{}
+	if cluster != "" {
+		baseFields["spec.cluster"] = cluster
+	}
+
+	if len(states) == 0 {
+		sessions, _, err := c.listDebugSessionsWithFields(ctx, baseFields)
+		return sessions, err
+	}
+
+	sessions := make([]breakglassv1alpha1.DebugSession, 0)
+	seen := map[string]struct{}{}
+	for _, state := range states {
+		matchingFields := copyDebugSessionMatchingFields(baseFields)
+		matchingFields["status.state"] = string(state)
+		stateSessions, fellBack, err := c.listDebugSessionsWithFields(ctx, matchingFields)
+		if err != nil {
+			return nil, err
+		}
+		if fellBack {
+			return stateSessions, nil
+		}
+		for _, session := range stateSessions {
+			key := session.Namespace + "/" + session.Name
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			sessions = append(sessions, session)
+		}
+	}
+	return sessions, nil
+}
+
 // handleListDebugSessions returns a list of debug sessions
 func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 	reqLog := system.GetReqLogger(ctx, c.log)
@@ -444,34 +551,19 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 	// Accept repeated ?state= params (e.g. ?state=Active&state=Pending) as well as
 	// a legacy single comma-separated value (e.g. ?state=Active,Pending).
 	// Comparison is case-insensitive so both "Active" and "active" match.
-	var states []string
-	for _, v := range ctx.QueryArray("state") {
-		for _, s := range strings.Split(v, ",") {
-			if s = strings.TrimSpace(s); s != "" {
-				states = append(states, s)
-			}
-		}
-	}
-	// Validate each requested state value against the canonical set.
-	for _, st := range states {
-		if !isValidDebugSessionState(st) {
-			apiresponses.RespondBadRequest(ctx, fmt.Sprintf("invalid state value: '%s'", st))
-			return
-		}
+	states, invalidState, ok := parseDebugSessionStateFilters(ctx)
+	if !ok {
+		apiresponses.RespondBadRequest(ctx, fmt.Sprintf("invalid state value: '%s'", invalidState))
+		return
 	}
 	user := ctx.Query("user")
 	mine := ctx.Query("mine") == "true"
 
-	sessionList := &breakglassv1alpha1.DebugSessionList{}
-	listOpts := []ctrlclient.ListOption{}
-
-	// Note: cluster/state/user filters are applied client-side after fetching
-	// Field selectors would require additional indexer setup
-
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
 
-	if err := c.reader().List(apiCtx, sessionList, listOpts...); err != nil {
+	sessions, err := c.listDebugSessionsForFilters(apiCtx, cluster, states)
+	if err != nil {
 		reqLog.Errorw("Failed to list debug sessions", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to list debug sessions")
 		return
@@ -480,8 +572,8 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 	// Apply filters
 	var filtered []breakglassv1alpha1.DebugSession
 	readAuthorizer := c.newDebugSessionReadAuthorizer(identity)
-	for i := range sessionList.Items {
-		s := &sessionList.Items[i]
+	for i := range sessions {
+		s := &sessions[i]
 		canRead, err := readAuthorizer.canRead(apiCtx, s)
 		if err != nil {
 			reqLog.Errorw("Failed to evaluate debug session read authorization",
@@ -499,17 +591,8 @@ func (c *DebugSessionAPIController) handleListDebugSessions(ctx *gin.Context) {
 			continue
 		}
 		// State filter
-		if len(states) > 0 {
-			matched := false
-			for _, st := range states {
-				if strings.EqualFold(string(s.Status.State), st) {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				continue
-			}
+		if !debugSessionStateMatches(s.Status.State, states) {
+			continue
 		}
 		// User filter
 		if user != "" && !debugSessionIdentityMatches(debugSessionReadIdentity{username: user, email: user}, s.Spec.RequestedBy, s.Spec.RequestedByEmail) {
@@ -1285,17 +1368,6 @@ var validDebugSessionStates = map[string]struct{}{
 	string(breakglassv1alpha1.DebugSessionStateExpired):         {},
 	string(breakglassv1alpha1.DebugSessionStateTerminated):      {},
 	string(breakglassv1alpha1.DebugSessionStateFailed):          {},
-}
-
-// isValidDebugSessionState returns true when val (case-insensitive) matches
-// one of the canonical DebugSessionState values.
-func isValidDebugSessionState(val string) bool {
-	for k := range validDebugSessionStates {
-		if strings.EqualFold(k, val) {
-			return true
-		}
-	}
-	return false
 }
 
 func parseDebugSessionBindingRef(bindingRef string) (string, string, bool) {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -2295,7 +2295,8 @@ func TestHandleListDebugSessionsFieldIndexFallbackPreservesFilters(t *testing.T)
 		WithStatusSubresource(activeProd, pendingProd, activeDev, failedProd, unauthorizedActiveProd).
 		Build()
 	missingIndexClient := &debugSessionMissingIndexClient{Client: baseClient}
-	ctrl := NewDebugSessionAPIController(logger, missingIndexClient, nil, nil)
+	apiReader := &debugSessionRecordingListClient{Client: baseClient}
+	ctrl := NewDebugSessionAPIController(logger, missingIndexClient, nil, nil).WithAPIReader(apiReader)
 	router := debugSessionAPITestRouter(t, ctrl, "admin@example.com", "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions?cluster=prod&state=Active&state=Pending", nil)
@@ -2310,9 +2311,10 @@ func TestHandleListDebugSessionsFieldIndexFallbackPreservesFilters(t *testing.T)
 		gotNames = append(gotNames, session.Name)
 	}
 	assert.ElementsMatch(t, []string{"active-prod", "pending-prod"}, gotNames)
-	require.Len(t, missingIndexClient.calls, 2, "expected one indexed attempt and one full-list fallback")
+	require.Len(t, missingIndexClient.calls, 1, "expected one cached indexed attempt")
 	assert.NotNil(t, missingIndexClient.calls[0].FieldSelector)
-	assert.Nil(t, missingIndexClient.calls[1].FieldSelector)
+	require.Len(t, apiReader.calls, 1, "expected one uncached full-list fallback")
+	assert.Nil(t, apiReader.calls[0].FieldSelector)
 }
 
 // TestDebugSessionAPIController_HandleGetDebugSession tests the handleGetDebugSession handler

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -68,6 +68,34 @@ func debugSessionAPITestRouter(t *testing.T, ctrl *DebugSessionAPIController, us
 	return router
 }
 
+type debugSessionRecordingListClient struct {
+	client.Client
+	calls []client.ListOptions
+}
+
+func (c *debugSessionRecordingListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&listOpts)
+	}
+	c.calls = append(c.calls, listOpts)
+	return c.Client.List(ctx, list, opts...)
+}
+
+func debugSessionRecordedFieldValues(calls []client.ListOptions, field string) []string {
+	values := make([]string, 0, len(calls))
+	for _, call := range calls {
+		if call.FieldSelector == nil {
+			continue
+		}
+		value, ok := call.FieldSelector.RequiresExactMatch(field)
+		if ok {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
 func TestBuildDebugSessionNameUsesCompactSubsecondEntropy(t *testing.T) {
 	base := time.Unix(1782420779, 1)
 	first := buildDebugSessionName("debug-session-requester", "tenant-a", base)
@@ -2123,6 +2151,86 @@ func TestDebugSessionAPIController_HandleListDebugSessions(t *testing.T) {
 		require.Equal(t, 1, response3.Total)
 		assert.False(t, response3.Sessions[0].IsParticipant, "charlie left the session, should not be isParticipant")
 	})
+}
+
+func TestHandleListDebugSessionsPushesIndexedFiltersAndPreservesAuthorization(t *testing.T) {
+	scheme := testScheme()
+	logger := zap.NewNop().Sugar()
+
+	approverTemplate := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+			Users: []string{"admin@example.com"},
+		},
+	}
+	otherApproverTemplate := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+			Users: []string{"other-admin@example.com"},
+		},
+	}
+	makeSession := func(name, cluster, requester string, state breakglassv1alpha1.DebugSessionState, template *breakglassv1alpha1.DebugSessionTemplateSpec) *breakglassv1alpha1.DebugSession {
+		return &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster:     cluster,
+				TemplateRef: "standard-debug",
+				RequestedBy: requester,
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State:            state,
+				ResolvedTemplate: template,
+			},
+		}
+	}
+
+	activeProd := makeSession("active-prod", "prod", "alice@example.com", breakglassv1alpha1.DebugSessionStateActive, approverTemplate)
+	pendingProd := makeSession("pending-prod", "prod", "bob@example.com", breakglassv1alpha1.DebugSessionStatePending, approverTemplate)
+	activeDev := makeSession("active-dev", "dev", "carol@example.com", breakglassv1alpha1.DebugSessionStateActive, approverTemplate)
+	failedProd := makeSession("failed-prod", "prod", "dave@example.com", breakglassv1alpha1.DebugSessionStateFailed, approverTemplate)
+	unauthorizedActiveProd := makeSession("unauthorized-active-prod", "prod", "mallory@example.com", breakglassv1alpha1.DebugSessionStateActive, otherApproverTemplate)
+
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.DebugSession{}, "spec.cluster", func(obj client.Object) []string {
+			session, ok := obj.(*breakglassv1alpha1.DebugSession)
+			if !ok || session.Spec.Cluster == "" {
+				return nil
+			}
+			return []string{session.Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.DebugSession{}, "status.state", func(obj client.Object) []string {
+			session, ok := obj.(*breakglassv1alpha1.DebugSession)
+			if !ok || session.Status.State == "" {
+				return nil
+			}
+			return []string{string(session.Status.State)}
+		}).
+		WithObjects(activeProd, pendingProd, activeDev, failedProd, unauthorizedActiveProd).
+		WithStatusSubresource(activeProd, pendingProd, activeDev, failedProd, unauthorizedActiveProd).
+		Build()
+	recordingClient := &debugSessionRecordingListClient{Client: baseClient}
+	ctrl := NewDebugSessionAPIController(logger, recordingClient, nil, nil)
+	router := debugSessionAPITestRouter(t, ctrl, "admin@example.com", "", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions?cluster=prod&state=Active&state=Pending", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response DebugSessionListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	gotNames := make([]string, 0, len(response.Sessions))
+	for _, session := range response.Sessions {
+		gotNames = append(gotNames, session.Name)
+	}
+	assert.ElementsMatch(t, []string{"active-prod", "pending-prod"}, gotNames)
+	assert.ElementsMatch(t, []string{"prod", "prod"}, debugSessionRecordedFieldValues(recordingClient.calls, "spec.cluster"))
+	assert.ElementsMatch(t, []string{
+		string(breakglassv1alpha1.DebugSessionStateActive),
+		string(breakglassv1alpha1.DebugSessionStatePending),
+	}, debugSessionRecordedFieldValues(recordingClient.calls, "status.state"))
 }
 
 // TestDebugSessionAPIController_HandleGetDebugSession tests the handleGetDebugSession handler

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -94,6 +95,23 @@ func debugSessionRecordedFieldValues(calls []client.ListOptions, field string) [
 		}
 	}
 	return values
+}
+
+type debugSessionMissingIndexClient struct {
+	client.Client
+	calls []client.ListOptions
+}
+
+func (c *debugSessionMissingIndexClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&listOpts)
+	}
+	c.calls = append(c.calls, listOpts)
+	if listOpts.FieldSelector != nil {
+		return errors.New(`no index with name "spec.cluster" has been registered`)
+	}
+	return c.Client.List(ctx, list, opts...)
 }
 
 func TestBuildDebugSessionNameUsesCompactSubsecondEntropy(t *testing.T) {
@@ -2231,6 +2249,70 @@ func TestHandleListDebugSessionsPushesIndexedFiltersAndPreservesAuthorization(t 
 		string(breakglassv1alpha1.DebugSessionStateActive),
 		string(breakglassv1alpha1.DebugSessionStatePending),
 	}, debugSessionRecordedFieldValues(recordingClient.calls, "status.state"))
+}
+
+func TestHandleListDebugSessionsFieldIndexFallbackPreservesFilters(t *testing.T) {
+	scheme := testScheme()
+	logger := zap.NewNop().Sugar()
+
+	approverTemplate := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+			Users: []string{"admin@example.com"},
+		},
+	}
+	otherApproverTemplate := &breakglassv1alpha1.DebugSessionTemplateSpec{
+		Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+			Users: []string{"other-admin@example.com"},
+		},
+	}
+	makeSession := func(name, cluster, requester string, state breakglassv1alpha1.DebugSessionState, template *breakglassv1alpha1.DebugSessionTemplateSpec) *breakglassv1alpha1.DebugSession {
+		return &breakglassv1alpha1.DebugSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "breakglass",
+			},
+			Spec: breakglassv1alpha1.DebugSessionSpec{
+				Cluster:     cluster,
+				TemplateRef: "standard-debug",
+				RequestedBy: requester,
+			},
+			Status: breakglassv1alpha1.DebugSessionStatus{
+				State:            state,
+				ResolvedTemplate: template,
+			},
+		}
+	}
+
+	activeProd := makeSession("active-prod", "prod", "alice@example.com", breakglassv1alpha1.DebugSessionStateActive, approverTemplate)
+	pendingProd := makeSession("pending-prod", "prod", "bob@example.com", breakglassv1alpha1.DebugSessionStatePending, approverTemplate)
+	activeDev := makeSession("active-dev", "dev", "carol@example.com", breakglassv1alpha1.DebugSessionStateActive, approverTemplate)
+	failedProd := makeSession("failed-prod", "prod", "dave@example.com", breakglassv1alpha1.DebugSessionStateFailed, approverTemplate)
+	unauthorizedActiveProd := makeSession("unauthorized-active-prod", "prod", "mallory@example.com", breakglassv1alpha1.DebugSessionStateActive, otherApproverTemplate)
+
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(activeProd, pendingProd, activeDev, failedProd, unauthorizedActiveProd).
+		WithStatusSubresource(activeProd, pendingProd, activeDev, failedProd, unauthorizedActiveProd).
+		Build()
+	missingIndexClient := &debugSessionMissingIndexClient{Client: baseClient}
+	ctrl := NewDebugSessionAPIController(logger, missingIndexClient, nil, nil)
+	router := debugSessionAPITestRouter(t, ctrl, "admin@example.com", "", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debugSessions?cluster=prod&state=Active&state=Pending", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response DebugSessionListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	gotNames := make([]string, 0, len(response.Sessions))
+	for _, session := range response.Sessions {
+		gotNames = append(gotNames, session.Name)
+	}
+	assert.ElementsMatch(t, []string{"active-prod", "pending-prod"}, gotNames)
+	require.Len(t, missingIndexClient.calls, 2, "expected one indexed attempt and one full-list fallback")
+	assert.NotNil(t, missingIndexClient.calls[0].FieldSelector)
+	assert.Nil(t, missingIndexClient.calls[1].FieldSelector)
 }
 
 // TestDebugSessionAPIController_HandleGetDebugSession tests the handleGetDebugSession handler

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -646,7 +646,10 @@ func exactSessionStateFilters(tokens []string) ([]breakglassv1alpha1.BreakglassS
 	return states, len(states) > 0
 }
 
-func sessionMatchesListFilters(session breakglassv1alpha1.BreakglassSession, cluster, user, group string) bool {
+func sessionMatchesListFilters(session *breakglassv1alpha1.BreakglassSession, cluster, user, group string) bool {
+	if session == nil {
+		return false
+	}
 	if cluster != "" && session.Spec.Cluster != cluster {
 		return false
 	}
@@ -667,11 +670,12 @@ func (wc *BreakglassSessionController) listBreakglassSessionsForStatus(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		for _, session := range stateSessions {
+		for i := range stateSessions {
+			session := &stateSessions[i]
 			if !sessionMatchesListFilters(session, cluster, user, group) {
 				continue
 			}
-			sessions = append(sessions, session)
+			sessions = append(sessions, *session)
 		}
 		return sessions, nil
 	}

--- a/pkg/breakglass/session_controller_status.go
+++ b/pkg/breakglass/session_controller_status.go
@@ -613,6 +613,88 @@ func (wc *BreakglassSessionController) handleRejectBreakglassSession(c *gin.Cont
 	wc.setSessionStatus(c, breakglassv1alpha1.SessionConditionTypeRejected)
 }
 
+var exactSessionStateFilterValues = map[string]breakglassv1alpha1.BreakglassSessionState{
+	"pending":                 breakglassv1alpha1.SessionStatePending,
+	"approved":                breakglassv1alpha1.SessionStateApproved,
+	"waiting":                 breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+	"waitingforscheduledtime": breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+	"scheduled":               breakglassv1alpha1.SessionStateWaitingForScheduledTime,
+	"rejected":                breakglassv1alpha1.SessionStateRejected,
+	"withdrawn":               breakglassv1alpha1.SessionStateWithdrawn,
+	"idleexpired":             breakglassv1alpha1.SessionStateIdleExpired,
+	"timeout":                 breakglassv1alpha1.SessionStateTimeout,
+	"approvaltimeout":         breakglassv1alpha1.SessionStateTimeout,
+}
+
+func exactSessionStateFilters(tokens []string) ([]breakglassv1alpha1.BreakglassSessionState, bool) {
+	if len(tokens) == 0 {
+		return nil, false
+	}
+	states := make([]breakglassv1alpha1.BreakglassSessionState, 0, len(tokens))
+	seen := make(map[breakglassv1alpha1.BreakglassSessionState]struct{}, len(tokens))
+	for _, token := range tokens {
+		state, ok := exactSessionStateFilterValues[token]
+		if !ok {
+			return nil, false
+		}
+		if _, exists := seen[state]; exists {
+			continue
+		}
+		seen[state] = struct{}{}
+		states = append(states, state)
+	}
+	return states, len(states) > 0
+}
+
+func sessionMatchesListFilters(session breakglassv1alpha1.BreakglassSession, cluster, user, group string) bool {
+	if cluster != "" && session.Spec.Cluster != cluster {
+		return false
+	}
+	if user != "" && session.Spec.User != user {
+		return false
+	}
+	if group != "" && session.Spec.GrantedGroup != group {
+		return false
+	}
+	return true
+}
+
+func (wc *BreakglassSessionController) listBreakglassSessionsForStatus(ctx context.Context, reqLog *zap.SugaredLogger, cluster, user, group string, stateFilters []string) ([]breakglassv1alpha1.BreakglassSession, error) {
+	if states, ok := exactSessionStateFilters(stateFilters); ok {
+		sessions := make([]breakglassv1alpha1.BreakglassSession, 0)
+		reqLog.Debugw("Using state index for sessions query", "states", states)
+		stateSessions, err := wc.sessionManager.GetSessionsByStates(ctx, states)
+		if err != nil {
+			return nil, err
+		}
+		for _, session := range stateSessions {
+			if !sessionMatchesListFilters(session, cluster, user, group) {
+				continue
+			}
+			sessions = append(sessions, session)
+		}
+		return sessions, nil
+	}
+
+	if cluster != "" || user != "" || group != "" {
+		fs := fields.Set{}
+		if cluster != "" {
+			fs["spec.cluster"] = cluster
+		}
+		if user != "" {
+			fs["spec.user"] = user
+		}
+		if group != "" {
+			fs["spec.grantedGroup"] = group
+		}
+		selector := fields.SelectorFromSet(fs)
+		reqLog.Debugw("Using field selector for sessions query", "selector", selector.String())
+		return wc.sessionManager.GetBreakglassSessionsWithSelector(ctx, selector)
+	}
+
+	return wc.sessionManager.GetAllBreakglassSessions(ctx)
+}
+
 // handleGetBreakglassSessionStatus handles GET /status for breakglass session
 func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.Context) {
 	reqLog := system.GetReqLogger(c, wc.log)
@@ -693,24 +775,7 @@ func (wc *BreakglassSessionController) handleGetBreakglassSessionStatus(c *gin.C
 
 	var sessions []breakglassv1alpha1.BreakglassSession
 	var err error
-	if clusterQ != "" || userQ != "" || groupQ != "" {
-		// Build field selector from provided params
-		fs := fields.Set{}
-		if clusterQ != "" {
-			fs["spec.cluster"] = clusterQ
-		}
-		if userQ != "" {
-			fs["spec.user"] = userQ
-		}
-		if groupQ != "" {
-			fs["spec.grantedGroup"] = groupQ
-		}
-		selector := fields.SelectorFromSet(fs)
-		reqLog.Debugw("Using field selector for sessions query", "selector", selector.String())
-		sessions, err = wc.sessionManager.GetBreakglassSessionsWithSelector(ctx, selector)
-	} else {
-		sessions, err = wc.sessionManager.GetAllBreakglassSessions(ctx)
-	}
+	sessions, err = wc.listBreakglassSessionsForStatus(ctx, reqLog, clusterQ, userQ, groupQ, stateFilters)
 	if err != nil {
 		reqLog.Error("Error getting breakglass sessions", zap.Error(err))
 		apiresponses.RespondInternalError(c, "list sessions", err, reqLog)

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -92,6 +92,34 @@ func (c clusterConfigListErrorClient) List(_ context.Context, _ client.ObjectLis
 	return c.err
 }
 
+type recordingListClient struct {
+	client.Client
+	calls []client.ListOptions
+}
+
+func (c *recordingListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&listOpts)
+	}
+	c.calls = append(c.calls, listOpts)
+	return c.Client.List(ctx, list, opts...)
+}
+
+func recordedFieldSelectorValues(calls []client.ListOptions, field string) []string {
+	values := make([]string, 0, len(calls))
+	for _, call := range calls {
+		if call.FieldSelector == nil {
+			continue
+		}
+		value, ok := call.FieldSelector.RequiresExactMatch(field)
+		if ok {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
 func TestDropK8sInternalFieldsSessionStripsMetadata(t *testing.T) {
 	s := &breakglassv1alpha1.BreakglassSession{
 		ObjectMeta: metav1.ObjectMeta{
@@ -5220,6 +5248,63 @@ func TestFilterBreakglassSessionsByMultipleStates(t *testing.T) {
 	assertInvalidState(t, "/breakglassSessions?state=pending,not-a-state&mine=true", "notastate")
 	assertInvalidState(t, "/breakglassSessions?state=not-a-state&state=still-not-a-state&mine=true", "stillnotastate")
 	assertInvalidState(t, "/breakglassSessions?state=duplicate-invalid&state=duplicate-invalid&mine=true", "duplicateinvalid")
+}
+
+func TestBreakglassSessionStatusListPushesExactStateFiltersAndPreservesAuthorization(t *testing.T) {
+	viewer := "viewer@example.com"
+	makeSession := func(name, user, cluster string, state breakglassv1alpha1.BreakglassSessionState) *breakglassv1alpha1.BreakglassSession {
+		return &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      cluster,
+				User:         user,
+				GrantedGroup: "g",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{State: state},
+		}
+	}
+
+	authorizedPending := makeSession("authorized-pending", viewer, "prod", breakglassv1alpha1.SessionStatePending)
+	authorizedApproved := makeSession("authorized-approved", viewer, "prod", breakglassv1alpha1.SessionStateApproved)
+	otherPending := makeSession("other-pending", "other@example.com", "prod", breakglassv1alpha1.SessionStatePending)
+	otherClusterPending := makeSession("other-cluster-pending", viewer, "dev", breakglassv1alpha1.SessionStatePending)
+
+	builder := fake.NewClientBuilder().WithScheme(Scheme)
+	for index, fn := range sessionIndexFunctions {
+		builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, index, fn)
+	}
+	baseClient := builder.WithObjects(authorizedPending, authorizedApproved, otherPending, otherClusterPending).Build()
+	recordingClient := &recordingListClient{Client: baseClient}
+	sesmanager := SessionManager{Client: recordingClient}
+	escmanager := testEscalationLookup{Client: recordingClient}
+	logger, _ := zap.NewDevelopment()
+	ctrl := NewBreakglassSessionController(logger.Sugar(), config.Config{}, &sesmanager, &escmanager,
+		func(c *gin.Context) {
+			c.Set("email", viewer)
+			c.Set("username", "viewer")
+			c.Next()
+		}, "/config/config.yaml", nil, recordingClient)
+
+	engine := gin.New()
+	_ = ctrl.Register(engine.Group("/breakglassSessions", ctrl.Handlers()...))
+
+	req, err := http.NewRequest(http.MethodGet, "/breakglassSessions?cluster=prod&state=pending&state=approved&mine=true", nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	sessions := decodeBreakglassSessionListEnvelope(t, res.Body)
+	gotNames := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		gotNames = append(gotNames, session.Name)
+	}
+	assert.ElementsMatch(t, []string{"authorized-pending", "authorized-approved"}, gotNames)
+	assert.ElementsMatch(t, []string{
+		string(breakglassv1alpha1.SessionStatePending),
+		string(breakglassv1alpha1.SessionStateApproved),
+	}, recordedFieldSelectorValues(recordingClient.calls, "status.state"))
 }
 
 func TestFilterBreakglassSessionsApprovedByMe(t *testing.T) {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -183,33 +183,70 @@ func (c *SessionManager) GetAllBreakglassSessions(ctx context.Context) ([]breakg
 func (c *SessionManager) GetSessionsByState(ctx context.Context,
 	state breakglassv1alpha1.BreakglassSessionState,
 ) ([]breakglassv1alpha1.BreakglassSession, error) {
+	return c.GetSessionsByStates(ctx, []breakglassv1alpha1.BreakglassSessionState{state})
+}
+
+// GetSessionsByStates returns all sessions matching any of the specified states.
+// It uses the status.state field index for efficient lookup when available. If
+// the index is missing, it falls back to a single full list plus client-side
+// filtering instead of issuing one full-list fallback per requested state.
+func (c *SessionManager) GetSessionsByStates(ctx context.Context,
+	states []breakglassv1alpha1.BreakglassSessionState,
+) ([]breakglassv1alpha1.BreakglassSession, error) {
 	log := c.getLogger()
-	log.Debugw("Fetching BreakglassSessions by state (using field index)", "state", state)
-	bsl := breakglassv1alpha1.BreakglassSessionList{}
-	// Use the cached client (c.Client.List) for indexed queries.
-	// Field indexes are only available in the cache, not via APIReader.
-	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"status.state": string(state)}); err != nil {
-		if !IsFieldIndexError(err) {
-			// Real error (RBAC, network, etc.) — return it directly.
-			log.Errorw("Failed to list BreakglassSessions by state", "state", state, "error", err)
-			return nil, fmt.Errorf("failed to list BreakglassSessions by state: %w", err)
+
+	stateSet := make(map[breakglassv1alpha1.BreakglassSessionState]struct{}, len(states))
+	uniqueStates := make([]breakglassv1alpha1.BreakglassSessionState, 0, len(states))
+	for _, state := range states {
+		if _, exists := stateSet[state]; exists {
+			continue
 		}
-		// Field index not available — fall back to client-side filtering.
-		log.Debugw("Field index not available; falling back to client-side filtering", "state", state, "error", err)
-		all, err := c.GetAllBreakglassSessions(ctx)
-		if err != nil {
-			return nil, err
-		}
-		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(all))
-		for _, s := range all {
-			if s.Status.State == state {
-				filtered = append(filtered, s)
-			}
-		}
-		return filtered, nil
+		stateSet[state] = struct{}{}
+		uniqueStates = append(uniqueStates, state)
 	}
-	log.Infow("Fetched BreakglassSessions by state (indexed)", "count", len(bsl.Items), "state", state)
-	return bsl.Items, nil
+	if len(uniqueStates) == 0 {
+		return nil, nil
+	}
+
+	log.Debugw("Fetching BreakglassSessions by states (using field index)", "states", uniqueStates)
+	sessions := make([]breakglassv1alpha1.BreakglassSession, 0)
+	seen := make(map[string]struct{})
+	for _, state := range uniqueStates {
+		bsl := breakglassv1alpha1.BreakglassSessionList{}
+		// Use the cached client (c.Client.List) for indexed queries.
+		// Field indexes are only available in the cache, not via APIReader.
+		if err := c.Client.List(ctx, &bsl, client.MatchingFields{"status.state": string(state)}); err != nil {
+			if !IsFieldIndexError(err) {
+				// Real error (RBAC, network, etc.) — return it directly.
+				log.Errorw("Failed to list BreakglassSessions by state", "state", state, "error", err)
+				return nil, fmt.Errorf("failed to list BreakglassSessions by state: %w", err)
+			}
+			// Field index not available — fall back to one full list and filter
+			// all requested states in-memory.
+			log.Debugw("Field index not available; falling back to client-side filtering", "states", uniqueStates, "error", err)
+			all, err := c.GetAllBreakglassSessions(ctx)
+			if err != nil {
+				return nil, err
+			}
+			filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(all))
+			for _, s := range all {
+				if _, ok := stateSet[s.Status.State]; ok {
+					filtered = append(filtered, s)
+				}
+			}
+			return filtered, nil
+		}
+		for _, session := range bsl.Items {
+			key := session.Namespace + "/" + session.Name
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			sessions = append(sessions, session)
+		}
+	}
+	log.Infow("Fetched BreakglassSessions by states (indexed)", "count", len(sessions), "states", uniqueStates)
+	return sessions, nil
 }
 
 // Get all stored GetClusterGroupAccess

--- a/pkg/breakglass/session_manager_test.go
+++ b/pkg/breakglass/session_manager_test.go
@@ -439,6 +439,49 @@ func TestSessionManager_GetSessionsByState(t *testing.T) {
 	})
 }
 
+func TestSessionManager_GetSessionsByStatesFallsBackToSingleFullList(t *testing.T) {
+	ctx := context.Background()
+	session1 := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-1", Namespace: "default"},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	session2 := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-2", Namespace: "default"},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+	session3 := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-3", Namespace: "default"},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateRejected,
+		},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(session1, session2, session3).
+		Build()
+	recordingClient := &recordingListClient{Client: baseClient}
+	mgr := NewSessionManagerWithClient(recordingClient)
+
+	sessions, err := mgr.GetSessionsByStates(ctx, []breakglassv1alpha1.BreakglassSessionState{
+		breakglassv1alpha1.SessionStatePending,
+		breakglassv1alpha1.SessionStateApproved,
+	})
+
+	require.NoError(t, err)
+	gotNames := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		gotNames = append(gotNames, session.Name)
+	}
+	assert.ElementsMatch(t, []string{"session-1", "session-2"}, gotNames)
+	assert.Equal(t, []string{string(breakglassv1alpha1.SessionStatePending)}, recordedFieldSelectorValues(recordingClient.calls, "status.state"))
+	require.Len(t, recordingClient.calls, 2, "expected one indexed attempt and one full-list fallback")
+	assert.Nil(t, recordingClient.calls[1].FieldSelector)
+}
+
 func TestSessionManager_UpdateBreakglassSession(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Summary
- Use indexed BreakglassSession state lookups for exact status filters and dedupe multi-state results.
- Push DebugSession cluster and state filters into MatchingFields with fallback for clients without field indexes.
- Keep final read authorization and request-local filters after the indexed list operations.

Tests
- GOCACHE=/private/tmp/k8s-session-filter-go-cache go test -timeout=4m ./pkg/breakglass ./pkg/breakglass/debug
- GOCACHE=/private/tmp/k8s-session-filter-go-cache golangci-lint run --allow-parallel-runners --timeout=5m ./pkg/breakglass ./pkg/breakglass/debug
- git -c core.fsmonitor=false diff --check

Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "GetSessionsByState MatchingFields state filter pushdown list sessions cluster status.state" returned no matches.