### PR TITLE
fix(frontend): include expired my sessions history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
 - **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
 - **BreakglassSession list filters**: Session status listing now pushes exact state filters through the cache index and deduplicates multi-state results before applying cluster, user, or group filters.
+- **Frontend My Sessions history**: My Sessions now includes expired and idle-expired breakglass sessions without duplicating sessions returned by multiple state queries.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/frontend/src/services/breakglass.spec.ts
+++ b/frontend/src/services/breakglass.spec.ts
@@ -462,7 +462,7 @@ describe("BreakglassService", () => {
     await expect(service.dropBreakglass({} as unknown as Breakglass)).rejects.toThrow("Missing session name");
   });
 
-  it("merges approved, timed-out and historical sessions for fetchMySessions", async () => {
+  it("merges approved, timed-out, expired, idle-expired and historical sessions for fetchMySessions", async () => {
     const now = Date.now();
     mockClient.get
       .mockResolvedValueOnce({
@@ -473,6 +473,13 @@ describe("BreakglassService", () => {
       })
       .mockResolvedValueOnce({
         data: [
+          { metadata: { name: "dup" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { state: "Expired" } },
+          { metadata: { name: "expired" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { state: "Expired" } },
+          {
+            metadata: { name: "idle-expired" },
+            spec: { grantedGroup: "ops", cluster: "c1" },
+            status: { state: "IdleExpired" },
+          },
           { metadata: { name: "hist" }, spec: { grantedGroup: "ops", cluster: "c1" }, status: { state: "Rejected" } },
         ],
       });
@@ -480,8 +487,25 @@ describe("BreakglassService", () => {
     const sessions = await service.fetchMySessions();
     const names = sessions.map((s) => s.name);
     expect(names).toContain("dup");
+    expect(names).toContain("expired");
+    expect(names).toContain("idle-expired");
     expect(names).toContain("hist");
+    expect(sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "expired", state: "Expired" }),
+        expect.objectContaining({ name: "idle-expired", state: "IdleExpired" }),
+      ]),
+    );
     expect(new Set(names).size).toBe(names.length);
+    expect(mockClient.get).toHaveBeenNthCalledWith(1, "/breakglassSessions", {
+      params: { mine: true, approver: false, state: "approved" },
+    });
+    expect(mockClient.get).toHaveBeenNthCalledWith(2, "/breakglassSessions", {
+      params: { mine: true, approver: false, state: "timeout" },
+    });
+    expect(mockClient.get).toHaveBeenNthCalledWith(3, "/breakglassSessions", {
+      params: { state: "rejected,withdrawn,expired,idleexpired", mine: true, approver: false },
+    });
   });
 
   it("returns deduplicated sessions approved by the user", async () => {

--- a/frontend/src/services/breakglass.ts
+++ b/frontend/src/services/breakglass.ts
@@ -370,7 +370,7 @@ export default class BreakglassService {
     try {
       debug("BreakglassService.fetchHistoricalSessions", "Fetching historical sessions");
       const response = await this.client.get("/breakglassSessions", {
-        params: { state: "rejected,withdrawn", mine: true, approver: false },
+        params: { state: "rejected,withdrawn,expired,idleexpired", mine: true, approver: false },
       });
       const all = normalizeList<SessionCR>(response.data);
       debug("BreakglassService.fetchHistoricalSessions", "Fetched historical sessions", { count: all.length });


### PR DESCRIPTION
Summary
- Include Expired and IdleExpired sessions in the historical My Sessions query.
- Keep the existing dedupe behavior across active, timeout, and historical queries.
- Add frontend service coverage for the expanded historical-state request.

Tests
- npm --prefix frontend test -- breakglass
- npm --prefix frontend run typecheck
- git -c core.fsmonitor=false diff --check

Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "My Sessions expired idleexpired fetchHistoricalSessions fetchMySessions" returned no matches.