### PR TITLE
fix(bgctl): bound device login polling and responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Frontend My Sessions history**: My Sessions now includes expired and idle-expired breakglass sessions without duplicating sessions returned by multiple state queries.
 - **bgctl update archive downloads**: Release archive downloads are now capped before extraction, with bounded error-body reads for failed download responses.
 - **Frontend auto-logout warning**: Session-expiry warnings now read OIDC users from session storage, tolerate blocked browser storage, and hide when stored user data disappears.
+- **bgctl OIDC device login bounds**: Device-code login polling now honors context cancellation promptly and bounds OIDC response body reads.
 - **Frontend direct approval route refresh**: Direct approval pages now reload session details when navigating between `/session/{name}/approve` links within the same mounted view.
 - **Frontend debug refresh accessibility**: The Debug Sessions refresh icon button now exposes a screen-reader label through Scale's `inner-aria-label`.
 - **BreakglassSession ownership filters**: `mine=true` and `approvedByMe=true` no longer implicitly include sessions where the caller is only an approver unless `approver=true` is also requested.

--- a/pkg/bgctl/auth/device.go
+++ b/pkg/bgctl/auth/device.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,11 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+)
+
+const (
+	oidcErrorBodyLimit = 4 * 1024
+	oidcJSONBodyLimit  = 1 * 1024 * 1024
 )
 
 type oidcDiscovery struct {
@@ -86,12 +92,16 @@ func DeviceCodeLogin(ctx context.Context, cfg OIDCConfig) (*LoginResult, error) 
 		tokenResp, err := pollDeviceToken(ctx, client, endpoints.TokenEndpoint, cfg, deviceResp.DeviceCode)
 		if err != nil {
 			if errors.Is(err, errAuthorizationPending) {
-				time.Sleep(interval)
+				if err := waitForDevicePoll(ctx, interval); err != nil {
+					return nil, err
+				}
 				continue
 			}
 			if errors.Is(err, errSlowDown) {
 				interval += 5 * time.Second
-				time.Sleep(interval)
+				if err := waitForDevicePoll(ctx, interval); err != nil {
+					return nil, err
+				}
 				continue
 			}
 			return nil, err
@@ -126,11 +136,10 @@ func discoverOIDCEndpoints(ctx context.Context, client *http.Client, authority s
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("discovery failed: %s", string(body))
+		return nil, fmt.Errorf("discovery failed: %s", readOIDCErrorBody(resp.Body))
 	}
 	var discovery oidcDiscovery
-	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+	if err := decodeLimitedJSON(resp.Body, &discovery); err != nil {
 		return nil, err
 	}
 	return &discovery, nil
@@ -142,7 +151,7 @@ func requestDeviceCode(ctx context.Context, client *http.Client, endpoint string
 	if len(cfg.Scopes) > 0 {
 		values.Set("scope", strings.Join(cfg.Scopes, " "))
 	}
-	resp, err := client.PostForm(endpoint, values)
+	resp, err := postFormWithContext(ctx, client, endpoint, values)
 	if err != nil {
 		return nil, err
 	}
@@ -150,11 +159,10 @@ func requestDeviceCode(ctx context.Context, client *http.Client, endpoint string
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("device authorization failed: %s", string(body))
+		return nil, fmt.Errorf("device authorization failed: %s", readOIDCErrorBody(resp.Body))
 	}
 	var payload deviceCodeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := decodeLimitedJSON(resp.Body, &payload); err != nil {
 		return nil, err
 	}
 	return &payload, nil
@@ -165,7 +173,7 @@ func pollDeviceToken(ctx context.Context, client *http.Client, endpoint string, 
 	values.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
 	values.Set("device_code", deviceCode)
 	values.Set("client_id", cfg.ClientID)
-	resp, err := client.PostForm(endpoint, values)
+	resp, err := postFormWithContext(ctx, client, endpoint, values)
 	if err != nil {
 		return nil, err
 	}
@@ -173,18 +181,106 @@ func pollDeviceToken(ctx context.Context, client *http.Client, endpoint string, 
 		_ = resp.Body.Close()
 	}()
 	var payload tokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if resp.StatusCode >= 400 {
+		body, truncated, err := readLimitedBody(resp.Body, oidcErrorBodyLimit)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("device token failed: HTTP %d: %s", resp.StatusCode, formatLimitedBody(body, truncated, oidcErrorBodyLimit))
+		}
+		if err := deviceTokenPayloadError(payload); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("device token failed: HTTP %d: %s", resp.StatusCode, formatLimitedBody(body, truncated, oidcErrorBodyLimit))
+	}
+	if err := decodeLimitedJSON(resp.Body, &payload); err != nil {
 		return nil, err
 	}
+	if err := deviceTokenPayloadError(payload); err != nil {
+		return nil, err
+	}
+	return &payload, nil
+}
+
+func deviceTokenPayloadError(payload tokenResponse) error {
 	if payload.Error != "" {
 		switch payload.Error {
 		case "authorization_pending":
-			return nil, errAuthorizationPending
+			return errAuthorizationPending
 		case "slow_down":
-			return nil, errSlowDown
+			return errSlowDown
 		default:
-			return nil, fmt.Errorf("device token error: %s", payload.Error)
+			if description := strings.TrimSpace(payload.ErrorDesc); description != "" {
+				return fmt.Errorf("device token error: %s: %s", payload.Error, description)
+			}
+			return fmt.Errorf("device token error: %s", payload.Error)
 		}
 	}
-	return &payload, nil
+	return nil
+}
+
+func postFormWithContext(ctx context.Context, client *http.Client, endpoint string, values url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return client.Do(req)
+}
+
+func waitForDevicePoll(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func readOIDCErrorBody(body io.Reader) string {
+	data, truncated, err := readLimitedBody(body, oidcErrorBodyLimit)
+	if err != nil {
+		return fmt.Sprintf("failed to read response body: %v", err)
+	}
+	return formatLimitedBody(data, truncated, oidcErrorBodyLimit)
+}
+
+func decodeLimitedJSON(body io.Reader, target interface{}) error {
+	return decodeLimitedJSONWithLimit(body, target, oidcJSONBodyLimit)
+}
+
+func decodeLimitedJSONWithLimit(body io.Reader, target interface{}, limit int64) error {
+	data, truncated, err := readLimitedBody(body, limit)
+	if err != nil {
+		return err
+	}
+	if truncated {
+		return fmt.Errorf("oidc json response exceeds %d bytes", limit)
+	}
+	return json.NewDecoder(bytes.NewReader(data)).Decode(target)
+}
+
+func readLimitedBody(body io.Reader, limit int64) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > limit {
+		return data[:limit], true, nil
+	}
+	return data, false, nil
+}
+
+func formatLimitedBody(data []byte, truncated bool, limit int64) string {
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		text = "<empty response body>"
+	}
+	if truncated {
+		return fmt.Sprintf("%s... (truncated after %d bytes)", text, limit)
+	}
+	return text
 }

--- a/pkg/bgctl/auth/device.go
+++ b/pkg/bgctl/auth/device.go
@@ -140,7 +140,7 @@ func discoverOIDCEndpoints(ctx context.Context, client *http.Client, authority s
 	}
 	var discovery oidcDiscovery
 	if err := decodeLimitedJSON(resp.Body, &discovery); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode OIDC discovery response from %s: %w", url, err)
 	}
 	return &discovery, nil
 }
@@ -163,7 +163,7 @@ func requestDeviceCode(ctx context.Context, client *http.Client, endpoint string
 	}
 	var payload deviceCodeResponse
 	if err := decodeLimitedJSON(resp.Body, &payload); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode device authorization response from %s: %w", endpoint, err)
 	}
 	return &payload, nil
 }
@@ -184,10 +184,10 @@ func pollDeviceToken(ctx context.Context, client *http.Client, endpoint string, 
 	if resp.StatusCode >= 400 {
 		body, truncated, err := readLimitedBody(resp.Body, oidcErrorBodyLimit)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read device token error response from %s: %w", endpoint, err)
 		}
 		if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
-			return nil, fmt.Errorf("device token failed: HTTP %d: %s", resp.StatusCode, formatLimitedBody(body, truncated, oidcErrorBodyLimit))
+			return nil, fmt.Errorf("decode device token error response from %s: %w (HTTP %d: %s)", endpoint, err, resp.StatusCode, formatLimitedBody(body, truncated, oidcErrorBodyLimit))
 		}
 		if err := deviceTokenPayloadError(payload); err != nil {
 			return nil, err
@@ -195,7 +195,7 @@ func pollDeviceToken(ctx context.Context, client *http.Client, endpoint string, 
 		return nil, fmt.Errorf("device token failed: HTTP %d: %s", resp.StatusCode, formatLimitedBody(body, truncated, oidcErrorBodyLimit))
 	}
 	if err := decodeLimitedJSON(resp.Body, &payload); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode device token response from %s: %w", endpoint, err)
 	}
 	if err := deviceTokenPayloadError(payload); err != nil {
 		return nil, err

--- a/pkg/bgctl/auth/device_test.go
+++ b/pkg/bgctl/auth/device_test.go
@@ -179,6 +179,32 @@ func TestRequestDeviceCodeTruncatesOversizedErrorBody(t *testing.T) {
 	require.NotContains(t, err.Error(), "TAIL")
 }
 
+func TestDiscoverOIDCEndpointsWrapsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"token_endpoint":"` + strings.Repeat("a", oidcJSONBodyLimit) + `"}`))
+	}))
+	defer server.Close()
+
+	_, err := discoverOIDCEndpoints(context.Background(), server.Client(), server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode OIDC discovery response")
+	require.Contains(t, err.Error(), server.URL+"/.well-known/openid-configuration")
+	require.Contains(t, err.Error(), "oidc json response exceeds 1048576 bytes")
+}
+
+func TestRequestDeviceCodeWrapsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"device_code":"` + strings.Repeat("a", oidcJSONBodyLimit) + `"}`))
+	}))
+	defer server.Close()
+
+	_, err := requestDeviceCode(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode device authorization response")
+	require.Contains(t, err.Error(), server.URL)
+	require.Contains(t, err.Error(), "oidc json response exceeds 1048576 bytes")
+}
+
 func TestPollDeviceTokenRejectsOversizedSuccessBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"access_token":"` + strings.Repeat("a", oidcJSONBodyLimit) + `"}`))
@@ -187,7 +213,23 @@ func TestPollDeviceTokenRejectsOversizedSuccessBody(t *testing.T) {
 
 	_, err := pollDeviceToken(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"}, "abc")
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode device token response")
+	require.Contains(t, err.Error(), server.URL)
 	require.Contains(t, err.Error(), "oidc json response exceeds 1048576 bytes")
+}
+
+func TestPollDeviceTokenWrapsInvalidErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("{not-json"))
+	}))
+	defer server.Close()
+
+	_, err := pollDeviceToken(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"}, "abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode device token error response")
+	require.Contains(t, err.Error(), server.URL)
+	require.Contains(t, err.Error(), "HTTP 400")
 }
 
 func TestPollDeviceTokenIncludesErrorDescription(t *testing.T) {

--- a/pkg/bgctl/auth/device_test.go
+++ b/pkg/bgctl/auth/device_test.go
@@ -3,15 +3,23 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestDeviceCodeLogin(t *testing.T) {
 	var tokenCalls int32
@@ -49,12 +57,150 @@ func TestDeviceCodeLogin(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_ = os.Setenv("BGCTL_NO_BROWSER", "true")
-	t.Cleanup(func() { _ = os.Unsetenv("BGCTL_NO_BROWSER") })
+	t.Setenv("BGCTL_NO_BROWSER", "true")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	res, err := DeviceCodeLogin(ctx, OIDCConfig{Authority: server.URL, ClientID: "bgctl", GrantType: "device-code"})
 	require.NoError(t, err)
 	require.Equal(t, "token", res.Token.AccessToken)
+}
+
+func TestDeviceCodeLoginCancelsDuringPollingWait(t *testing.T) {
+	var tokenCalls int32
+	var closeTokenResponded sync.Once
+	tokenResponded := make(chan struct{})
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"token_endpoint":                server.URL + "/token",
+				"device_authorization_endpoint": server.URL + "/device",
+			})
+		case "/device":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"device_code":      "abc",
+				"user_code":        "XYZ",
+				"verification_uri": "https://example.com",
+				"expires_in":       60,
+				"interval":         1,
+			})
+		case "/token":
+			atomic.AddInt32(&tokenCalls, 1)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			closeTokenResponded.Do(func() { close(tokenResponded) })
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("BGCTL_NO_BROWSER", "true")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := DeviceCodeLogin(ctx, OIDCConfig{Authority: server.URL, ClientID: "bgctl", GrantType: "device-code"})
+		done <- err
+	}()
+
+	select {
+	case <-tokenResponded:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial authorization_pending response")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	start := time.Now()
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+		require.Less(t, time.Since(start), 500*time.Millisecond)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("device login did not stop promptly after context cancellation")
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&tokenCalls))
+}
+
+func TestRequestDeviceCodeUsesRequestContext(t *testing.T) {
+	requestStarted := make(chan struct{})
+	contentTypeSeen := make(chan string, 1)
+	var closeRequestStarted sync.Once
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			contentTypeSeen <- req.Header.Get("Content-Type")
+			closeRequestStarted.Do(func() { close(requestStarted) })
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestDeviceCode(ctx, client, "https://oidc.example/device", OIDCConfig{ClientID: "bgctl"})
+		done <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for device authorization request")
+	}
+	require.Equal(t, "application/x-www-form-urlencoded", <-contentTypeSeen)
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context canceled"), "expected context cancellation, got %v", err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("device authorization request did not stop promptly after context cancellation")
+	}
+}
+
+func TestRequestDeviceCodeTruncatesOversizedErrorBody(t *testing.T) {
+	body := strings.Repeat("a", oidcErrorBodyLimit) + "TAIL"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	_, err := requestDeviceCode(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device authorization failed")
+	require.Contains(t, err.Error(), "truncated after 4096 bytes")
+	require.NotContains(t, err.Error(), "TAIL")
+}
+
+func TestPollDeviceTokenRejectsOversizedSuccessBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"` + strings.Repeat("a", oidcJSONBodyLimit) + `"}`))
+	}))
+	defer server.Close()
+
+	_, err := pollDeviceToken(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"}, "abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oidc json response exceeds 1048576 bytes")
+}
+
+func TestPollDeviceTokenIncludesErrorDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "access_denied",
+			"error_description": "device login was denied",
+		})
+	}))
+	defer server.Close()
+
+	_, err := pollDeviceToken(context.Background(), server.Client(), server.URL, OIDCConfig{ClientID: "bgctl"}, "abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device token error: access_denied: device login was denied")
 }

--- a/pkg/bgctl/auth/device_test.go
+++ b/pkg/bgctl/auth/device_test.go
@@ -113,7 +113,6 @@ func TestDeviceCodeLoginCancelsDuringPollingWait(t *testing.T) {
 		t.Fatal("timed out waiting for initial authorization_pending response")
 	}
 
-	time.Sleep(20 * time.Millisecond)
 	start := time.Now()
 	cancel()
 


### PR DESCRIPTION
Summary
- Bind OIDC device-code POST requests and polling waits to the caller context.
- Cap OIDC error bodies and JSON response bodies before decoding or formatting diagnostics.
- Add bgctl auth tests for cancellation and bounded response handling.

Tests
- GOCACHE=/private/tmp/k8s-bgctl-device-go-cache go test -timeout=4m ./pkg/bgctl/auth
- GOCACHE=/private/tmp/k8s-bgctl-device-go-cache golangci-lint run --allow-parallel-runners --timeout=5m ./pkg/bgctl/auth
- git -c core.fsmonitor=false diff --check

Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "DeviceCodeLogin context cancellation OIDC body limit PostForm bgctl" returned no matches.