### PR TITLE
test: keep unit test targets check-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,11 @@ npm run lint
 npm run typecheck
 ```
 
+`make test` and `make test-controller` are check-only targets: they run vet and
+tests, but do not regenerate manifests, regenerate code, or format Go files. Run
+the mutating targets explicitly when you intend to update generated or formatted
+files, for example `make generate manifests fmt` or `make prepare-test`.
+
 ### 4. Update Documentation
 - Update relevant docs in `docs/`
 - Add changelog entry in [CHANGELOG.md](CHANGELOG.md)

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,19 @@ E2E_EXCLUDE := grep -vE '/e2e($$|/)'
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: prepare-test
+prepare-test: ## Regenerate code/manifests, format Go files, and run vet before testing.
+	$(MAKE) generate
+	$(MAKE) manifests
+	$(MAKE) fmt
+	$(MAKE) vet
+
 .PHONY: test
-test: manifests generate fmt vet ## Run all unit tests (controller + CLI).
+test: vet ## Run all unit tests (controller + CLI) without mutating generated or formatted files.
 	go test $(GO_TEST_FLAGS) $$(go list ./... | $(E2E_EXCLUDE)) -coverprofile cover.out
 
 .PHONY: test-controller
-test-controller: manifests generate fmt vet ## Run controller unit tests (excludes bgctl and e2e).
+test-controller: vet ## Run controller unit tests (excludes bgctl and e2e) without mutating generated or formatted files.
 	go test $(GO_TEST_FLAGS) $$(go list ./... | $(E2E_EXCLUDE) | grep -v bgctl) -coverprofile cover-controller.out
 
 .PHONY: validate-samples


### PR DESCRIPTION
Summary
- Make `make test` and `make test-controller` depend only on `vet` before running unit tests, so they no longer regenerate manifests/code or format files.
- Add `make prepare-test` as the explicit opt-in target for the old mutating preparation flow.
- Document the check-only behavior and explicit mutating targets in CONTRIBUTING.md.

Tests
- git -c core.fsmonitor=false diff --check
- make -n test
- make -n test-controller
- make -n prepare-test

Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "check-only test targets prepare-test Makefile test-controller generate fmt" returned no matches.
- PR #1135 adds generated drift verification but does not change the mutating `test` / `test-controller` prerequisites.