### PR TITLE
perf(breakglass): narrow escalation lookups with indexes

### DIFF
--- a/pkg/breakglass/escalation/escalation_manager.go
+++ b/pkg/breakglass/escalation/escalation_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -117,6 +118,63 @@ func (em *EscalationManager) GetBreakglassEscalationsWithSelector(ctx context.Co
 	return ess.Items, nil
 }
 
+func escalationGroupIndexLookupValues(groups, oidcPrefixes []string) []string {
+	seen := make(map[string]struct{}, len(groups)*(len(oidcPrefixes)+1))
+	values := make([]string, 0, len(groups)*(len(oidcPrefixes)+1))
+	add := func(value string) {
+		if value == "" {
+			return
+		}
+		if _, exists := seen[value]; exists {
+			return
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+
+	for _, group := range groups {
+		add(group)
+		for _, prefix := range oidcPrefixes {
+			if prefix == "" {
+				continue
+			}
+			if strings.HasPrefix(group, prefix) {
+				add(strings.TrimPrefix(group, prefix))
+				continue
+			}
+			add(prefix + group)
+		}
+	}
+	return values
+}
+
+func (em *EscalationManager) collectEscalationsByFieldIndex(ctx context.Context, field string, values []string) ([]breakglassv1alpha1.BreakglassEscalation, bool, error) {
+	if len(values) == 0 {
+		return nil, true, nil
+	}
+
+	collected := make([]breakglassv1alpha1.BreakglassEscalation, 0)
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		list := breakglassv1alpha1.BreakglassEscalationList{}
+		if err := em.List(ctx, &list, client.MatchingFields{field: value}); err != nil {
+			if breakglass.IsFieldIndexError(err) {
+				return nil, false, nil
+			}
+			return nil, false, fmt.Errorf("failed to list BreakglassEscalation by %s: %w", field, err)
+		}
+		for _, item := range list.Items {
+			key := item.Namespace + "/" + item.Name
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			collected = append(collected, item)
+		}
+	}
+	return collected, true, nil
+}
+
 // GetBreakglassEscalation retrieves a single BreakglassEscalation by namespace/name using the cached controller-runtime client.
 // Prefer this over filter-based scans when the owner reference is known to minimize cache iterations.
 func (em *EscalationManager) GetBreakglassEscalation(ctx context.Context, namespace, name string) (*breakglassv1alpha1.BreakglassEscalation, error) {
@@ -142,40 +200,24 @@ func (em *EscalationManager) GetGroupBreakglassEscalations(ctx context.Context,
 	log := em.getLogger()
 	log.Debugw("Fetching group BreakglassEscalations", "groupCount", len(groups))
 	metrics.APIEndpointRequests.WithLabelValues("GetGroupBreakglassEscalations").Inc()
-	// First try index-based lookup for each group and collect results (deduped)
-	collectedMap := map[string]breakglassv1alpha1.BreakglassEscalation{}
-	for _, g := range groups {
-		list := breakglassv1alpha1.BreakglassEscalationList{}
-		if err := em.List(ctx, &list, client.MatchingFields{"spec.allowed.group": g}); err == nil {
-			log.Debugw("Index lookup for group returned items", "group", system.RedactGroupName(g), "count", len(list.Items))
-			for _, it := range list.Items {
-				// apply group normalization check to be safe (fake client may ignore MatchingFields)
-				allowed := it.Spec.Allowed.Groups
-				// normalize OIDC prefixes for comparison
-				normAllowed := allowed
-				if cfg, err := em.getConfig(); err == nil && len(cfg.Kubernetes.OIDCPrefixes) > 0 {
-					normAllowed = breakglass.StripOIDCPrefixes(allowed, cfg.Kubernetes.OIDCPrefixes)
-				}
-				if slices.Contains(normAllowed, g) {
-					collectedMap[it.Namespace+"/"+it.Name] = it
-				}
+
+	oidcPrefixes := em.getOIDCPrefixes()
+	collected, indexed, err := em.collectEscalationsByFieldIndex(ctx, "spec.allowed.group", escalationGroupIndexLookupValues(groups, oidcPrefixes))
+	if err != nil {
+		return nil, err
+	}
+	if indexed {
+		output := make([]breakglassv1alpha1.BreakglassEscalation, 0, len(collected))
+		for _, item := range collected {
+			if groupsMatch(groups, item.Spec.Allowed.Groups, oidcPrefixes) {
+				output = append(output, item)
 			}
 		}
-	}
-	if len(collectedMap) > 0 {
-		collected := make([]breakglassv1alpha1.BreakglassEscalation, 0, len(collectedMap))
-		for _, v := range collectedMap {
-			collected = append(collected, v)
-		}
-		return collected, nil
+		log.Debugw("Fetched group escalation candidates with group index", "candidateCount", len(collected), "matched", len(output))
+		return output, nil
 	}
 
-	// Fallback to full filter if indices not available or returned nothing
-	var oidcPrefixes []string
-	if cfg, err := em.getConfig(); err == nil && len(cfg.Kubernetes.OIDCPrefixes) > 0 {
-		oidcPrefixes = cfg.Kubernetes.OIDCPrefixes
-		log.Debugw("Loaded OIDC prefixes for group normalization", "prefixes", oidcPrefixes)
-	}
+	// Fallback to full filter if the group index is unavailable or unsupported.
 	return em.GetBreakglassEscalationsWithFilter(ctx, func(be breakglassv1alpha1.BreakglassEscalation) bool {
 		allowedGroups := be.Spec.Allowed.Groups
 		if len(oidcPrefixes) > 0 {
@@ -260,15 +302,23 @@ func (em *EscalationManager) GetClusterGroupBreakglassEscalations(ctx context.Co
 	log.Debugw("Fetching cluster-group BreakglassEscalations", "cluster", cluster, "groupCount", len(groups))
 	metrics.APIEndpointRequests.WithLabelValues("GetClusterGroupBreakglassEscalations").Inc()
 
-	all, err := em.GetAllBreakglassEscalations(ctx)
+	oidcPrefixes := em.getOIDCPrefixes()
+	collected, indexed, err := em.collectEscalationsByFieldIndex(ctx, "spec.allowed.group", escalationGroupIndexLookupValues(groups, oidcPrefixes))
 	if err != nil {
 		return nil, err
 	}
-	collected := all
-	log.Debugw("Fetched full escalation scan", "cluster", cluster, "totalEscalations", len(collected))
+	if !indexed {
+		all, err := em.GetAllBreakglassEscalations(ctx)
+		if err != nil {
+			return nil, err
+		}
+		collected = all
+		log.Debugw("Fell back to full escalation scan", "cluster", cluster, "totalEscalations", len(collected))
+	} else {
+		log.Debugw("Fetched escalation candidates with group index", "cluster", cluster, "candidateCount", len(collected))
+	}
 
 	// Filter collected by cluster matching and groups using shared helpers
-	oidcPrefixes := em.getOIDCPrefixes()
 	out := make([]breakglassv1alpha1.BreakglassEscalation, 0)
 	for _, be := range collected {
 		if !escalationMatchesCluster(be, cluster) {
@@ -294,14 +344,29 @@ func (em *EscalationManager) GetClusterGroupBreakglassEscalations(ctx context.Co
 
 // GetClusterGroupTargetBreakglassEscalation returns escalations for specific cluster, user groups, and target group
 func (em *EscalationManager) GetClusterGroupTargetBreakglassEscalation(ctx context.Context, cluster string, userGroups []string, targetGroup string) ([]breakglassv1alpha1.BreakglassEscalation, error) {
-	em.getLogger().Debugw("Fetching cluster-group-target BreakglassEscalations", "cluster", cluster, "userGroupCount", len(userGroups), "targetGroupHint", system.RedactGroupName(targetGroup))
+	log := em.getLogger()
+	log.Debugw("Fetching cluster-group-target BreakglassEscalations", "cluster", cluster, "userGroupCount", len(userGroups), "targetGroupHint", system.RedactGroupName(targetGroup))
 	metrics.APIEndpointRequests.WithLabelValues("GetClusterGroupTargetBreakglassEscalation").Inc()
 
-	all, err := em.GetAllBreakglassEscalations(ctx)
-	if err != nil {
-		return nil, err
+	var collected []breakglassv1alpha1.BreakglassEscalation
+	indexed := false
+	if targetGroup != "" {
+		var err error
+		collected, indexed, err = em.collectEscalationsByFieldIndex(ctx, "spec.escalatedGroup", []string{targetGroup})
+		if err != nil {
+			return nil, err
+		}
 	}
-	collected := all
+	if !indexed {
+		all, err := em.GetAllBreakglassEscalations(ctx)
+		if err != nil {
+			return nil, err
+		}
+		collected = all
+		log.Debugw("Fell back to full target escalation scan", "cluster", cluster, "targetGroupHint", system.RedactGroupName(targetGroup), "totalEscalations", len(collected))
+	} else {
+		log.Debugw("Fetched escalation candidates with target-group index", "cluster", cluster, "targetGroupHint", system.RedactGroupName(targetGroup), "candidateCount", len(collected))
+	}
 
 	// Filter collected by cluster and allowed groups using shared helpers
 	oidcPrefixes := em.getOIDCPrefixes()

--- a/pkg/breakglass/escalation/escalation_manager_test.go
+++ b/pkg/breakglass/escalation/escalation_manager_test.go
@@ -3,6 +3,7 @@ package escalation_test
 import (
 	"context"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -16,6 +17,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+type escalationRecordingListClient struct {
+	client.Client
+	calls []client.ListOptions
+}
+
+func (c *escalationRecordingListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&listOpts)
+	}
+	c.calls = append(c.calls, listOpts)
+	return c.Client.List(ctx, list, opts...)
+}
+
+func recordedExactFieldValues(calls []client.ListOptions, field string) []string {
+	values := make([]string, 0, len(calls))
+	for _, call := range calls {
+		if call.FieldSelector == nil {
+			continue
+		}
+		value, ok := call.FieldSelector.RequiresExactMatch(field)
+		if ok {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func hasUnfilteredListCall(calls []client.ListOptions) bool {
+	for _, call := range calls {
+		if call.FieldSelector == nil {
+			return true
+		}
+	}
+	return false
+}
 
 func TestEscalationManager_GetAllBreakglassEscalations(t *testing.T) {
 	// TestEscalationManager_GetAllBreakglassEscalations
@@ -501,6 +539,117 @@ func TestEscalationManager_GetClusterGroupBreakglassEscalations(t *testing.T) {
 				t.Errorf("GetClusterGroupBreakglassEscalations() count = %v, want %v", len(result), tt.expectedCount)
 			}
 		})
+	}
+}
+
+func TestEscalationManager_GetClusterGroupBreakglassEscalationsUsesGroupIndexCandidates(t *testing.T) {
+	scheme := breakglass.Scheme
+	matchingGlobCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-glob-cluster", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-*"},
+				Groups:   []string{"admin"},
+			},
+		},
+	}
+	wrongGroup := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-group", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"guest"},
+			},
+		},
+	}
+	wrongCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-cluster", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"dev-*"},
+				Groups:   []string{"admin"},
+			},
+		},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.BreakglassEscalation{}, "spec.allowed.group", func(o client.Object) []string {
+			be, ok := o.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil {
+				return nil
+			}
+			return be.Spec.Allowed.Groups
+		}).
+		WithObjects(matchingGlobCluster, wrongGroup, wrongCluster).
+		Build()
+	recordingClient := &escalationRecordingListClient{Client: baseClient}
+	em := escalation.EscalationManager{Client: recordingClient}
+
+	result, err := em.GetClusterGroupBreakglassEscalations(context.Background(), "prod-eu", []string{"admin"})
+	if err != nil {
+		t.Fatalf("GetClusterGroupBreakglassEscalations() unexpected error: %v", err)
+	}
+	if len(result) != 1 || result[0].Name != "matching-glob-cluster" {
+		t.Fatalf("GetClusterGroupBreakglassEscalations() = %v, want only matching-glob-cluster", result)
+	}
+	values := recordedExactFieldValues(recordingClient.calls, "spec.allowed.group")
+	if !slices.Contains(values, "admin") {
+		t.Fatalf("expected spec.allowed.group index lookup for admin, got %v", values)
+	}
+	if hasUnfilteredListCall(recordingClient.calls) {
+		t.Fatalf("expected indexed candidate lookup without an unfiltered escalation list, got calls %#v", recordingClient.calls)
+	}
+}
+
+func TestEscalationManager_GetClusterGroupBreakglassEscalationsFallsBackWithoutGroupIndex(t *testing.T) {
+	scheme := breakglass.Scheme
+	matchingGlobCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-glob-cluster", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-*"},
+				Groups:   []string{"admin"},
+			},
+		},
+	}
+	wrongGroup := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-group", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"guest"},
+			},
+		},
+	}
+	wrongCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-cluster", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"dev-*"},
+				Groups:   []string{"admin"},
+			},
+		},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(matchingGlobCluster, wrongGroup, wrongCluster).
+		Build()
+	recordingClient := &escalationRecordingListClient{Client: baseClient}
+	em := escalation.EscalationManager{Client: recordingClient}
+
+	result, err := em.GetClusterGroupBreakglassEscalations(context.Background(), "prod-eu", []string{"admin"})
+	if err != nil {
+		t.Fatalf("GetClusterGroupBreakglassEscalations() unexpected error: %v", err)
+	}
+	if len(result) != 1 || result[0].Name != "matching-glob-cluster" {
+		t.Fatalf("GetClusterGroupBreakglassEscalations() = %v, want only matching-glob-cluster", result)
+	}
+	values := recordedExactFieldValues(recordingClient.calls, "spec.allowed.group")
+	if !slices.Contains(values, "admin") {
+		t.Fatalf("expected attempted spec.allowed.group index lookup for admin, got %v", values)
+	}
+	if !hasUnfilteredListCall(recordingClient.calls) {
+		t.Fatalf("expected fallback to an unfiltered escalation list when group index is missing, got calls %#v", recordingClient.calls)
 	}
 }
 
@@ -1245,5 +1394,122 @@ func TestEscalationManager_GetClusterGroupTargetBreakglassEscalation(t *testing.
 				t.Errorf("GetClusterGroupTargetBreakglassEscalation() count = %v, want %v", len(result), tt.expectedCount)
 			}
 		})
+	}
+}
+
+func TestEscalationManager_GetClusterGroupTargetBreakglassEscalationUsesTargetIndexCandidates(t *testing.T) {
+	scheme := breakglass.Scheme
+	matchingGlobCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-target", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-*"},
+				Groups:   []string{"admin"},
+			},
+			EscalatedGroup: "apps",
+		},
+	}
+	wrongTarget := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-target", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"admin"},
+			},
+			EscalatedGroup: "database",
+		},
+	}
+	wrongGroup := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-group", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"guest"},
+			},
+			EscalatedGroup: "apps",
+		},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.BreakglassEscalation{}, "spec.escalatedGroup", func(o client.Object) []string {
+			be, ok := o.(*breakglassv1alpha1.BreakglassEscalation)
+			if !ok || be == nil || be.Spec.EscalatedGroup == "" {
+				return nil
+			}
+			return []string{be.Spec.EscalatedGroup}
+		}).
+		WithObjects(matchingGlobCluster, wrongTarget, wrongGroup).
+		Build()
+	recordingClient := &escalationRecordingListClient{Client: baseClient}
+	em := escalation.EscalationManager{Client: recordingClient}
+
+	result, err := em.GetClusterGroupTargetBreakglassEscalation(context.Background(), "prod-eu", []string{"admin"}, "apps")
+	if err != nil {
+		t.Fatalf("GetClusterGroupTargetBreakglassEscalation() unexpected error: %v", err)
+	}
+	if len(result) != 1 || result[0].Name != "matching-target" {
+		t.Fatalf("GetClusterGroupTargetBreakglassEscalation() = %v, want only matching-target", result)
+	}
+	values := recordedExactFieldValues(recordingClient.calls, "spec.escalatedGroup")
+	if len(values) != 1 || values[0] != "apps" {
+		t.Fatalf("expected one spec.escalatedGroup index lookup for apps, got %v", values)
+	}
+	if hasUnfilteredListCall(recordingClient.calls) {
+		t.Fatalf("expected target-index candidate lookup without an unfiltered escalation list, got calls %#v", recordingClient.calls)
+	}
+}
+
+func TestEscalationManager_GetClusterGroupTargetBreakglassEscalationFallsBackWithoutTargetIndex(t *testing.T) {
+	scheme := breakglass.Scheme
+	matchingGlobCluster := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-target", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-*"},
+				Groups:   []string{"admin"},
+			},
+			EscalatedGroup: "apps",
+		},
+	}
+	wrongTarget := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-target", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"admin"},
+			},
+			EscalatedGroup: "database",
+		},
+	}
+	wrongGroup := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-group", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"prod-eu"},
+				Groups:   []string{"guest"},
+			},
+			EscalatedGroup: "apps",
+		},
+	}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(matchingGlobCluster, wrongTarget, wrongGroup).
+		Build()
+	recordingClient := &escalationRecordingListClient{Client: baseClient}
+	em := escalation.EscalationManager{Client: recordingClient}
+
+	result, err := em.GetClusterGroupTargetBreakglassEscalation(context.Background(), "prod-eu", []string{"admin"}, "apps")
+	if err != nil {
+		t.Fatalf("GetClusterGroupTargetBreakglassEscalation() unexpected error: %v", err)
+	}
+	if len(result) != 1 || result[0].Name != "matching-target" {
+		t.Fatalf("GetClusterGroupTargetBreakglassEscalation() = %v, want only matching-target", result)
+	}
+	values := recordedExactFieldValues(recordingClient.calls, "spec.escalatedGroup")
+	if len(values) != 1 || values[0] != "apps" {
+		t.Fatalf("expected attempted spec.escalatedGroup index lookup for apps, got %v", values)
+	}
+	if !hasUnfilteredListCall(recordingClient.calls) {
+		t.Fatalf("expected fallback to an unfiltered escalation list when target index is missing, got calls %#v", recordingClient.calls)
 	}
 }

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -119,7 +119,7 @@ func (c *SessionManager) list(ctx context.Context, list client.ObjectList, opts 
 	return c.Client.List(ctx, list, opts...)
 }
 
-// isFieldIndexError returns true if the error indicates a missing field index
+// IsFieldIndexError returns true if the error indicates a missing field index
 // or unsupported field selector—i.e. it is safe to fall back to a full list +
 // client-side filter.  All other errors (RBAC, network, etcd) are real failures.
 //
@@ -128,7 +128,7 @@ func (c *SessionManager) list(ctx context.Context, list client.ObjectList, opts 
 // against known error messages. If controller-runtime changes wording in a
 // future release, the regression tests in session_manager_test.go
 // (TestIsFieldIndexError*) will catch the change.
-func isFieldIndexError(err error) bool {
+func IsFieldIndexError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -189,7 +189,7 @@ func (c *SessionManager) GetSessionsByState(ctx context.Context,
 	// Use the cached client (c.Client.List) for indexed queries.
 	// Field indexes are only available in the cache, not via APIReader.
 	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"status.state": string(state)}); err != nil {
-		if !isFieldIndexError(err) {
+		if !IsFieldIndexError(err) {
 			// Real error (RBAC, network, etc.) — return it directly.
 			log.Errorw("Failed to list BreakglassSessions by state", "state", state, "error", err)
 			return nil, fmt.Errorf("failed to list BreakglassSessions by state: %w", err)
@@ -300,7 +300,7 @@ func (c *SessionManager) GetUserBreakglassSessions(ctx context.Context,
 	// Use the cached client (c.Client.List) for indexed queries.
 	// Field indexes are only available in the cache, not via APIReader.
 	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"spec.user": user}); err != nil {
-		if !isFieldIndexError(err) {
+		if !IsFieldIndexError(err) {
 			log.Errorw("Failed to list BreakglassSessions for user", "user", user, "error", err)
 			return nil, fmt.Errorf("failed to list BreakglassSessions for user: %w", err)
 		}
@@ -335,7 +335,7 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 	// Use the cached client (c.Client.List) for indexed queries.
 	// Field indexes are only available in the cache, not via APIReader.
 	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"spec.cluster": cluster, "spec.user": user}); err != nil {
-		if !isFieldIndexError(err) {
+		if !IsFieldIndexError(err) {
 			log.Errorw("Failed to list BreakglassSessions for cluster/user", "cluster", cluster, "user", user, "error", err)
 			return nil, fmt.Errorf("failed to list BreakglassSessions for cluster/user: %w", err)
 		}

--- a/pkg/breakglass/session_manager_test.go
+++ b/pkg/breakglass/session_manager_test.go
@@ -123,7 +123,7 @@ func TestNewSessionManagerWithClientAndReader(t *testing.T) {
 // TestIsFieldIndexError_KnownMessages is a regression test that pins the
 // expected error strings from controller-runtime v0.23.x. If a future upgrade
 // changes the wording, this test will fail, alerting maintainers to update
-// isFieldIndexError accordingly.
+// IsFieldIndexError accordingly.
 func TestIsFieldIndexError_KnownMessages(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -143,7 +143,7 @@ func TestIsFieldIndexError_KnownMessages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isFieldIndexError(tt.err)
+			got := IsFieldIndexError(tt.err)
 			assert.Equal(t, tt.expected, got)
 		})
 	}


### PR DESCRIPTION
Summary
- Use `spec.allowed.group` index candidates for group and cluster+group escalation lookups, with a full-list fallback only when indexes are unavailable.
- Use the `spec.escalatedGroup` index for cluster+group+target lookups, while preserving the final cluster/group filters and glob matching semantics from #1034.
- Query OIDC-prefixed group variants when prefixes are configured, then keep the existing normalized in-memory group check as the final source of truth.
- Add tests proving indexed candidate lookup avoids unfiltered lists while still matching glob-cluster escalations.

Tests
- GOCACHE=/private/tmp/k8s-escalation-go-cache go test -timeout=4m ./pkg/breakglass/escalation
- GOCACHE=/private/tmp/k8s-escalation-go-cache golangci-lint run --allow-parallel-runners --timeout=5m ./pkg/breakglass/escalation
- git -c core.fsmonitor=false diff --check

Duplicate check
- gh pr list --repo telekom/k8s-breakglass --state all --limit 100 --search "GetClusterGroupBreakglassEscalations GetClusterGroupTargetBreakglassEscalation escalation index lookup" found only merged #1034, which is the glob-correctness constraint this PR preserves.