### PR TITLE
fix(frontend): scope package metadata

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "breakglass",
+  "name": "@telekom/k8s-breakglass-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "breakglass",
+      "name": "@telekom/k8s-breakglass-frontend",
       "version": "0.0.0",
+      "private": true,
       "dependencies": {
         "@telekom/scale-components": "3.0.0-beta.161",
         "@telekom/scale-components-neutral": "3.0.0-beta.160",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "breakglass",
+  "name": "@telekom/k8s-breakglass-frontend",
   "version": "0.0.0",
+  "private": true,
   "engines": {
     "node": ">=24.11.0"
   },


### PR DESCRIPTION
## Summary

- rename the frontend package metadata from the unscoped `breakglass` name to `@telekom/k8s-breakglass-frontend`
- mark the frontend package as private in `package.json` and the lockfile root package

## Validation

- `jq` package metadata assertions for `package.json` and `package-lock.json`
- `rg` confirmed no remaining unscoped `name: "breakglass"` in the frontend package files
- `git diff --check`
- `npm --prefix frontend run typecheck`

`npm --prefix frontend test` was attempted locally, but the Vitest parent stayed idle after workers exited and was interrupted.
