### PR TITLE
fix(auth): require IdentityProvider audience validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Required IdentityProvider JWT audience validation**: `IdentityProvider.spec.oidc.expectedAudience` is now required and CRD-backed auth refuses providers without it. Existing IdentityProvider resources must be updated with an expected audience and the OIDC provider must issue tokens whose `aud` claim contains that value before upgrading.
 - **DebugSession denial and HTTP log redaction**: Frontend HTTP error logging and unauthorized DebugSession cluster-denial responses now avoid exposing bearer tokens or template cluster patterns.
 - **bgctl self-update checksum enforcement**: `bgctl update` now refuses to install
   release archives when the matching `.sha256` asset is missing or cannot be
@@ -158,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OIDC discovery JWKS URI origin validation (SEC-003)** ([#472](https://github.com/telekom/k8s-breakglass/issues/472)): Discovered `jwks_uri` origin (hostname and port) must match the configured authority to prevent SSRF if a compromised IDP discovery endpoint returns a malicious JWKS URI pointing to an internal, unrelated, or different-port host
 - **Audience refresh singleflight deduplication** ([#472](https://github.com/telekom/k8s-breakglass/issues/472)): Periodic audience refresh from IdentityProvider now uses singleflight to prevent thundering herd when many requests arrive simultaneously after the refresh interval elapses
 - **Issuer trailing slash normalization** ([#472](https://github.com/telekom/k8s-breakglass/issues/472)): `LoadIdentityProviderByIssuer` now normalizes trailing slashes in both the incoming issuer and `IdentityProvider.spec.issuer` for the primary match, consistent with the auth layer's canonicalization
-- **JWT audience claim validation (SEC-005a)** ([#472](https://github.com/telekom/k8s-breakglass/issues/472)): Conditional JWT `aud` claim validation when `IdentityProvider.spec.oidc.expectedAudience` is configured. Prevents cross-service token confusion from other OIDC clients at the same provider. Requires a matching audience protocol mapper in the IDP. When unconfigured (default), audience validation is skipped for backwards compatibility
+- **JWT audience claim validation (SEC-005a)** ([#472](https://github.com/telekom/k8s-breakglass/issues/472)): JWT `aud` claim validation now uses `IdentityProvider.spec.oidc.expectedAudience` to prevent cross-service token confusion from other OIDC clients at the same provider. Requires a matching audience protocol mapper in the IDP.
 - **JWT expiration required (SEC-005b)** ([#459](https://github.com/telekom/k8s-breakglass/issues/459)): JWT parser now rejects tokens without an `exp` claim via `jwt.WithExpirationRequired()`
 - **TLS minimum version (SEC-003)** ([#459](https://github.com/telekom/k8s-breakglass/issues/459)): Set `tls.VersionTLS12` as minimum on the API server and all OIDC proxy / JWKS HTTP clients
 - **X-Request-ID sanitization (SEC-004)** ([#459](https://github.com/telekom/k8s-breakglass/issues/459)): Validate `X-Request-ID` header (alphanumeric + `-_.:`; max 128 chars) and replace invalid values with a generated UUID to prevent log injection

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/oidcconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/oidcconfig.go
@@ -22,13 +22,12 @@ type OIDCConfigApplyConfiguration struct {
 	JWKSEndpoint *string `json:"jwksEndpoint,omitempty"`
 	// ClientID is the OIDC client ID for user authentication (frontend/UI)
 	ClientID *string `json:"clientID,omitempty"`
-	// ExpectedAudience is the expected JWT audience (aud) claim value.
-	// When set, the API server validates that incoming JWTs contain this value
-	// in their aud claim. This prevents cross-service token confusion from other
-	// OIDC clients at the same identity provider.
+	// ExpectedAudience is the required JWT audience (aud) claim value.
+	// The API server validates that incoming JWTs contain this value in their
+	// aud claim. This prevents cross-service token confusion from other OIDC
+	// clients at the same identity provider.
 	// Requires a matching audience protocol mapper in the identity provider
 	// that adds this value to the aud claim in issued tokens.
-	// If empty, audience validation is skipped.
 	ExpectedAudience *string `json:"expectedAudience,omitempty"`
 	// InsecureSkipVerify is deprecated for IdentityProvider OIDC/JWKS authentication.
 	// Admission and runtime auth/OIDC proxy paths reject this setting; configure

--- a/api/v1alpha1/identity_provider_types.go
+++ b/api/v1alpha1/identity_provider_types.go
@@ -76,17 +76,17 @@ type OIDCConfig struct {
 	// +kubebuilder:validation:Pattern=`^\S+$`
 	ClientID string `json:"clientID"`
 
-	// ExpectedAudience is the expected JWT audience (aud) claim value.
-	// When set, the API server validates that incoming JWTs contain this value
-	// in their aud claim. This prevents cross-service token confusion from other
-	// OIDC clients at the same identity provider.
+	// ExpectedAudience is the required JWT audience (aud) claim value.
+	// The API server validates that incoming JWTs contain this value in their
+	// aud claim. This prevents cross-service token confusion from other OIDC
+	// clients at the same identity provider.
 	// Requires a matching audience protocol mapper in the identity provider
 	// that adds this value to the aud claim in issued tokens.
-	// If empty, audience validation is skipped.
-	// +optional
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^\S+$`
-	ExpectedAudience string `json:"expectedAudience,omitempty"`
+	ExpectedAudience string `json:"expectedAudience"`
 
 	// InsecureSkipVerify is deprecated for IdentityProvider OIDC/JWKS authentication.
 	// Admission and runtime auth/OIDC proxy paths reject this setting; configure

--- a/api/v1alpha1/identity_provider_types_test.go
+++ b/api/v1alpha1/identity_provider_types_test.go
@@ -90,8 +90,9 @@ func TestKeycloakGroupSyncWithTLS(t *testing.T) {
 func TestIdentityProviderSpecBasic(t *testing.T) {
 	spec := IdentityProviderSpec{
 		OIDC: OIDCConfig{
-			Authority: "https://auth.example.com",
-			ClientID:  "frontend-app",
+			Authority:        "https://auth.example.com",
+			ClientID:         "frontend-app",
+			ExpectedAudience: "frontend-app",
 		},
 		Issuer:      "https://auth.example.com",
 		DisplayName: "Corporate Identity",
@@ -106,8 +107,9 @@ func TestIdentityProviderSpecBasic(t *testing.T) {
 func TestIdentityProviderSpecWithGroupSync(t *testing.T) {
 	spec := IdentityProviderSpec{
 		OIDC: OIDCConfig{
-			Authority: "https://auth.example.com",
-			ClientID:  "frontend-app",
+			Authority:        "https://auth.example.com",
+			ClientID:         "frontend-app",
+			ExpectedAudience: "frontend-app",
 		},
 		GroupSyncProvider: GroupSyncProviderKeycloak,
 		Keycloak: &KeycloakGroupSync{
@@ -126,8 +128,9 @@ func TestIdentityProviderSpecWithGroupSync(t *testing.T) {
 func TestIdentityProviderSpecPrimary(t *testing.T) {
 	spec := IdentityProviderSpec{
 		OIDC: OIDCConfig{
-			Authority: "https://auth.example.com",
-			ClientID:  "frontend-app",
+			Authority:        "https://auth.example.com",
+			ClientID:         "frontend-app",
+			ExpectedAudience: "frontend-app",
 		},
 		Primary: true,
 	}
@@ -139,8 +142,9 @@ func TestIdentityProviderSpecPrimary(t *testing.T) {
 func TestIdentityProviderSpecDisabled(t *testing.T) {
 	spec := IdentityProviderSpec{
 		OIDC: OIDCConfig{
-			Authority: "https://auth.example.com",
-			ClientID:  "frontend-app",
+			Authority:        "https://auth.example.com",
+			ClientID:         "frontend-app",
+			ExpectedAudience: "frontend-app",
 		},
 		Disabled: true,
 	}
@@ -236,8 +240,9 @@ func TestIdentityProvider(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.corp.com",
-				ClientID:  "frontend-web",
+				Authority:        "https://auth.corp.com",
+				ClientID:         "frontend-web",
+				ExpectedAudience: "frontend-web",
 			},
 			Issuer:      "https://auth.corp.com",
 			DisplayName: "Corporate OIDC Provider",
@@ -410,8 +415,9 @@ func TestIdentityProviderValidateCreateValidSpec(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}
@@ -431,8 +437,9 @@ func TestIdentityProviderValidateCreateRejectsNonHTTPSURLs(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "http://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "http://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://issuer.example.com",
 		},
@@ -450,8 +457,9 @@ func TestIdentityProviderValidateCreateRejectsInvalidKeycloakDurations(t *testin
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer:            "https://issuer.example.com",
 			GroupSyncProvider: GroupSyncProviderKeycloak,
@@ -481,8 +489,9 @@ func TestIdentityProviderValidateCreateRejectsInvalidRequestTimeout(t *testing.T
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer:            "https://issuer.example.com",
 			GroupSyncProvider: GroupSyncProviderKeycloak,
@@ -513,8 +522,9 @@ func TestIdentityProviderValidateUpdateValidSpec(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}
@@ -525,8 +535,9 @@ func TestIdentityProviderValidateUpdateValidSpec(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "updated-client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "updated-client-id",
+				ExpectedAudience: "updated-client-id",
 			},
 		},
 	}
@@ -610,9 +621,10 @@ func TestIdentityProviderIntegration(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority:    "https://auth.example.com",
-				ClientID:     "test-client",
-				JWKSEndpoint: "https://auth.example.com/.well-known/jwks.json",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
+				JWKSEndpoint:     "https://auth.example.com/.well-known/jwks.json",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -657,7 +669,8 @@ func TestIdentityProvider_ValidateCreate_MissingAuthority(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-no-authority"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				ClientID: "client-id",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}
@@ -685,9 +698,10 @@ func TestIdentityProvider_ValidateCreate_InvalidJWKSEndpoint(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-bad-jwks"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority:    "https://auth.example.com",
-				ClientID:     "client-id",
-				JWKSEndpoint: "not-a-valid-url",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
+				JWKSEndpoint:     "not-a-valid-url",
 			},
 		},
 	}
@@ -701,8 +715,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakMissingConfig(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-cfg"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			// Keycloak config is nil
@@ -718,8 +733,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakMissingBaseURL(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-url"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -746,8 +762,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakMissingRealm(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-realm"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -766,8 +783,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakMissingClientID(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-clientid"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -786,8 +804,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakMissingSecretRef(t *testing.T) 
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-secretref"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -807,8 +826,9 @@ func TestIdentityProvider_ValidateCreate_ValidKeycloak(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-valid"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			GroupSyncProvider: GroupSyncProviderKeycloak,
 			Keycloak: &KeycloakGroupSync{
@@ -831,8 +851,9 @@ func TestIdentityProvider_ValidateCreate_KeycloakWithoutGroupSyncProvider(t *tes
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-keycloak-no-gsp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			// GroupSyncProvider not set but Keycloak config provided
 			Keycloak: &KeycloakGroupSync{

--- a/api/v1alpha1/multi_idp_test.go
+++ b/api/v1alpha1/multi_idp_test.go
@@ -31,8 +31,9 @@ func TestIdentityProviderIssuerField(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 			Issuer:      "https://auth.example.com",
 			DisplayName: "Test IDP",
@@ -110,8 +111,9 @@ func TestBackwardCompatibilityPrimaryField(t *testing.T) {
 		},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "legacy-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "legacy-client",
+				ExpectedAudience: "legacy-client",
 			},
 			Primary: true, // Backward compatibility
 		},

--- a/api/v1alpha1/multi_idp_validation_test.go
+++ b/api/v1alpha1/multi_idp_validation_test.go
@@ -38,8 +38,9 @@ func TestIdentityProviderIssuerValidationUnique(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-1"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client1",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client1",
+				ExpectedAudience: "client1",
 			},
 			Issuer: "https://auth.example.com",
 		},
@@ -53,8 +54,9 @@ func TestIdentityProviderIssuerValidationUnique(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-2"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "client2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "client2",
+				ExpectedAudience: "client2",
 			},
 			Issuer: "https://auth.example.com", // Same issuer as idp1
 		},
@@ -78,8 +80,9 @@ func TestIdentityProviderIssuerValidationURL(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-invalid"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Issuer: ":", // Will fail url.Parse
 		},
@@ -99,8 +102,9 @@ func TestClusterConfigIdentityProviderRefsValidation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "enabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Disabled: false,
 		},
@@ -135,8 +139,9 @@ func TestClusterConfigIdentityProviderRefsValidationDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Disabled: true,
 		},
@@ -197,8 +202,9 @@ func TestBreakglassEscalationAllowedIdentityProvidersValidation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "tenant-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Disabled: false,
 		},
@@ -277,8 +283,9 @@ func TestBreakglassSessionIdentityProviderFieldsValidation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "tenant-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Issuer:   "https://auth.example.com",
 			Disabled: false,
@@ -317,8 +324,9 @@ func TestBreakglassSessionIdentityProviderIssuerMismatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "tenant-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Issuer:   "https://auth.example.com",
 			Disabled: false,
@@ -384,8 +392,9 @@ func TestValidateIdentityProviderRefsHelper(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "enabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Disabled: false,
 		},
@@ -395,8 +404,9 @@ func TestValidateIdentityProviderRefsHelper(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "client2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "client2",
+				ExpectedAudience: "client2",
 			},
 			Disabled: true,
 		},
@@ -477,8 +487,9 @@ func TestValidateIdentityProviderFieldsHelper(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "tenant-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Issuer:   "https://auth.example.com",
 			Disabled: false,
@@ -489,8 +500,9 @@ func TestValidateIdentityProviderFieldsHelper(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "client2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "client2",
+				ExpectedAudience: "client2",
 			},
 			Issuer:   "https://auth2.example.com",
 			Disabled: true,

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -339,6 +339,12 @@ func ValidateIdentityProvider(idp *IdentityProvider) *ValidationResult {
 		result.Errors = append(result.Errors, validateIdentifierFormat(idp.Spec.OIDC.ClientID, oidcPath.Child("clientID"))...)
 	}
 
+	if idp.Spec.OIDC.ExpectedAudience == "" {
+		result.Errors = append(result.Errors, field.Required(oidcPath.Child("expectedAudience"), "OIDC expectedAudience is required"))
+	} else {
+		result.Errors = append(result.Errors, validateIdentifierFormat(idp.Spec.OIDC.ExpectedAudience, oidcPath.Child("expectedAudience"))...)
+	}
+
 	if idp.Spec.OIDC.InsecureSkipVerify {
 		result.Errors = append(result.Errors, field.Forbidden(oidcPath.Child("insecureSkipVerify"),
 			"insecureSkipVerify is not supported for IdentityProvider OIDC/JWKS authentication; configure certificateAuthority"))

--- a/api/v1alpha1/validation_helpers_test.go
+++ b/api/v1alpha1/validation_helpers_test.go
@@ -1252,8 +1252,9 @@ func TestEnsureClusterWideUniqueIssuer_WithConflict(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "existing-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://auth.example.com", // same issuer
 		},
@@ -1277,8 +1278,9 @@ func TestEnsureClusterWideUniqueIssuer_SameName(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://auth.example.com",
 		},
@@ -1369,8 +1371,9 @@ func TestValidateIdentityProviderFields_NilContext(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://issuer.com",
 		},
@@ -1417,8 +1420,9 @@ func TestValidateIdentityProviderFields_IDPDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Disabled: true,
 		},
@@ -1446,8 +1450,9 @@ func TestValidateIdentityProviderFields_IssuerMismatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://auth.example.com",
 		},
@@ -1475,8 +1480,9 @@ func TestValidateIdentityProviderFields_ValidMatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Issuer: "https://auth.example.com",
 		},
@@ -1507,8 +1513,9 @@ func TestValidateIdentityProviderFields_AuthorityFallback(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			// Issuer intentionally NOT set
 		},
@@ -1538,8 +1545,9 @@ func TestValidateIdentityProviderFields_AuthorityFallbackWithTrailingSlash(t *te
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com/", // with trailing slash
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com/", // with trailing slash
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}
@@ -1700,8 +1708,9 @@ func TestValidateIdentityProviderRefs_ValidExisting(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "existing-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}
@@ -1723,8 +1732,9 @@ func TestValidateIdentityProviderRefs_DisabledIDP(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 			Disabled: true,
 		},
@@ -1747,8 +1757,9 @@ func TestValidateIdentityProviderRefs_NilContext(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: IdentityProviderSpec{
 			OIDC: OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client-id",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client-id",
+				ExpectedAudience: "client-id",
 			},
 		},
 	}

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -490,8 +490,9 @@ func TestValidateIdentityProvider(t *testing.T) {
 			},
 			Spec: IdentityProviderSpec{
 				OIDC: OIDCConfig{
-					Authority: "https://auth.example.com",
-					ClientID:  "breakglass-client",
+					Authority:        "https://auth.example.com",
+					ClientID:         "breakglass-client",
+					ExpectedAudience: "breakglass-client",
 				},
 			},
 		}
@@ -522,6 +523,14 @@ func TestValidateIdentityProvider(t *testing.T) {
 		result := ValidateIdentityProvider(idp)
 		assert.False(t, result.IsValid())
 		assert.Contains(t, result.ErrorMessage(), "clientID")
+	})
+
+	t.Run("missing OIDC expectedAudience", func(t *testing.T) {
+		idp := validIDP()
+		idp.Spec.OIDC.ExpectedAudience = ""
+		result := ValidateIdentityProvider(idp)
+		assert.False(t, result.IsValid())
+		assert.Contains(t, result.ErrorMessage(), "expectedAudience")
 	})
 
 	t.Run("invalid OIDC authority URL", func(t *testing.T) {
@@ -1530,8 +1539,9 @@ func TestValidateIdentityProvider_MalformedResources(t *testing.T) {
 			},
 			Spec: IdentityProviderSpec{
 				OIDC: OIDCConfig{
-					Authority: "://not-a-valid-url",
-					ClientID:  "client",
+					Authority:        "://not-a-valid-url",
+					ClientID:         "client",
+					ExpectedAudience: "client",
 				},
 			},
 		}
@@ -1547,8 +1557,9 @@ func TestValidateIdentityProvider_MalformedResources(t *testing.T) {
 			},
 			Spec: IdentityProviderSpec{
 				OIDC: OIDCConfig{
-					Authority: "https://auth.example.com",
-					ClientID:  "client",
+					Authority:        "https://auth.example.com",
+					ClientID:         "client",
+					ExpectedAudience: "client",
 				},
 				GroupSyncProvider: GroupSyncProviderKeycloak,
 				Keycloak:          &KeycloakGroupSync{}, // Empty config

--- a/config/crd/bases/breakglass.t-caas.telekom.com_identityproviders.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_identityproviders.yaml
@@ -181,14 +181,14 @@ spec:
                     type: string
                   expectedAudience:
                     description: |-
-                      ExpectedAudience is the expected JWT audience (aud) claim value.
-                      When set, the API server validates that incoming JWTs contain this value
-                      in their aud claim. This prevents cross-service token confusion from other
-                      OIDC clients at the same identity provider.
+                      ExpectedAudience is the required JWT audience (aud) claim value.
+                      The API server validates that incoming JWTs contain this value in their
+                      aud claim. This prevents cross-service token confusion from other OIDC
+                      clients at the same identity provider.
                       Requires a matching audience protocol mapper in the identity provider
                       that adds this value to the aud claim in issued tokens.
-                      If empty, audience validation is skipped.
                     maxLength: 253
+                    minLength: 1
                     pattern: ^\S+$
                     type: string
                   insecureSkipVerify:
@@ -207,6 +207,7 @@ spec:
                 required:
                 - authority
                 - clientID
+                - expectedAudience
                 type: object
               primary:
                 description: |-

--- a/config/dev/resources/breakglass-e2e-contractors-realm.json
+++ b/config/dev/resources/breakglass-e2e-contractors-realm.json
@@ -59,6 +59,17 @@
             "id.token.claim": "true",
             "access.token.claim": "true"
           }
+        },
+        {
+          "name": "audience-breakglass-contractors",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "breakglass-contractors",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
         }
       ]
     }

--- a/config/dev/resources/breakglass-e2e-realm.json
+++ b/config/dev/resources/breakglass-e2e-realm.json
@@ -63,6 +63,17 @@
             "id.token.claim": "true",
             "access.token.claim": "true"
           }
+        },
+        {
+          "name": "audience-breakglass-ui",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "breakglass-ui",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
         }
       ]
     },

--- a/config/dev/resources/idp.yaml
+++ b/config/dev/resources/idp.yaml
@@ -10,6 +10,7 @@ spec:
   oidc:
     authority: "https://breakglass-keycloak.breakglass-system.svc.cluster.local:8443/realms/breakglass-e2e"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
     # The E2E/dev setup injects the generated Keycloak CA as certificateAuthority.
   # Keycloak group sync enables resolving group members for group-based approvers
   # This is required for notification emails to be sent to group members

--- a/config/samples/breakglass_v1alpha1_clusterconfig_oidc_from_idp.yaml
+++ b/config/samples/breakglass_v1alpha1_clusterconfig_oidc_from_idp.yaml
@@ -15,9 +15,9 @@ spec:
   oidc:
     authority: https://keycloak.example.com/realms/kubernetes
     clientID: breakglass-ui
-    # Optional: Enable JWT audience validation. Requires a matching audience
-    # protocol mapper in Keycloak that adds this value to the "aud" claim.
-    # expectedAudience: breakglass-ui
+    # Required: JWT audience accepted by the Breakglass API. Requires a matching
+    # audience protocol mapper in Keycloak that adds this value to the "aud" claim.
+    expectedAudience: breakglass-ui
   
   # Keycloak configuration - provides service account for cluster auth
   keycloak:

--- a/config/samples/breakglass_v1alpha1_identityprovider_keycloak.yaml
+++ b/config/samples/breakglass_v1alpha1_identityprovider_keycloak.yaml
@@ -18,6 +18,7 @@ spec:
     # Authority is typically the Keycloak server base URL
     authority: "https://auth.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
     
     # Optional: jwksEndpoint for custom JWKS endpoint
     # If not specified, defaults to Authority/.well-known/openid-configuration
@@ -119,6 +120,7 @@ spec:
   oidc:
     authority: "https://backup-auth.example.com"
     clientID: "breakglass-ui-fallback"
+    expectedAudience: "breakglass-ui-fallback"
 
   # IMPORTANT: Different issuer URL to distinguish this provider
   issuer: "https://backup-auth.example.com"

--- a/config/samples/breakglass_v1alpha1_identityprovider_oidc.yaml
+++ b/config/samples/breakglass_v1alpha1_identityprovider_oidc.yaml
@@ -8,6 +8,7 @@
 #   This is critical for multi-IDP mode and is used by the SAR webhook to identify which provider
 #   authenticated a user based on their JWT token issuer claim.
 # - ClientID: The OIDC client identifier configured in your OIDC provider
+# - ExpectedAudience: The JWT aud claim required by the Breakglass API
 #
 apiVersion: breakglass.t-caas.telekom.com/v1alpha1
 kind: IdentityProvider
@@ -23,6 +24,10 @@ spec:
 
     # ClientID is the OIDC client ID for user authentication (frontend/UI)
     clientID: "breakglass-ui"
+
+    # ExpectedAudience is the required JWT aud claim for the Breakglass API.
+    # Configure your OIDC provider to include this audience in issued access tokens.
+    expectedAudience: "breakglass-ui"
 
     # JWKSEndpoint (optional) specifies a custom endpoint for fetching JSON Web Key Sets
     # If empty, defaults to Authority/.well-known/openid-configuration
@@ -71,6 +76,7 @@ spec:
     # Different OIDC provider authority
     authority: "https://backup-auth.example.com"
     clientID: "breakglass-ui-backup"
+    expectedAudience: "breakglass-ui-backup"
 
   # IMPORTANT: Each IdentityProvider in multi-IDP mode must have a UNIQUE issuer
   # This is how the system knows which provider authenticated a user (via JWT iss claim)

--- a/docs/identity-provider.md
+++ b/docs/identity-provider.md
@@ -31,6 +31,7 @@ spec:
   oidc:
     authority: "https://auth.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
     # Optional: CA certificate for TLS validation
     certificateAuthority: |
       -----BEGIN CERTIFICATE-----
@@ -84,6 +85,7 @@ spec:
   oidc:
     authority: "https://auth-corp.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   issuer: "https://auth-corp.example.com"  # ← Unique issuer
   displayName: "Corporate OIDC"
 
@@ -97,6 +99,7 @@ spec:
   oidc:
     authority: "https://keycloak.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   issuer: "https://keycloak.example.com/realms/master"  # ← Different issuer
   displayName: "Keycloak Provider"
 ```
@@ -119,6 +122,7 @@ spec:
   oidc:
     authority: "https://auth.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   
   # Enable Keycloak group synchronization
   groupSyncProvider: Keycloak
@@ -214,6 +218,7 @@ spec:
   oidc:
     authority: "https://auth-primary.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
 
 ---
 # Fallback provider
@@ -226,6 +231,7 @@ spec:
   oidc:
     authority: "https://auth-secondary.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
 ```
 
 **Load Priority:**
@@ -259,6 +265,7 @@ spec:
   oidc:
     authority: "https://auth.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   
   # Session limits for users from this IDP
   sessionLimits:
@@ -360,7 +367,8 @@ metadata:
 spec:
   oidc:
     authority: "https://auth.enterprise.com"
-    clientID: "breakglass"
+    clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   
   sessionLimits:
     # Most users: 2 concurrent sessions
@@ -493,6 +501,7 @@ spec:
   oidc:
     authority: "https://auth.example.com"
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   groupSyncProvider: Keycloak
   keycloak:
     baseURL: "https://keycloak.example.com"

--- a/docs/identity-provider.md
+++ b/docs/identity-provider.md
@@ -44,7 +44,7 @@ spec:
 |-------|------|----------|-------------|
 | `authority` | string | ✅ Yes | OIDC provider authority endpoint (e.g., `https://auth.example.com`). The frontend redirects users to this endpoint for authentication. |
 | `clientID` | string | ✅ Yes | OIDC client ID for the Breakglass UI (frontend). Configured in your OIDC provider. |
-| `expectedAudience` | string | ❌ No | Expected JWT `aud` claim value. When set, tokens must contain this audience. Requires a matching audience protocol mapper in your IDP. If empty, audience validation is skipped. |
+| `expectedAudience` | string | ✅ Yes | Expected JWT `aud` claim value. Tokens must contain this audience. Requires a matching audience protocol mapper in your IDP. |
 | `jwksEndpoint` | string | ❌ No | JWKS endpoint for key sets. Defaults to `{authority}/.well-known/openid-configuration` |
 | `insecureSkipVerify` | boolean | ❌ No | Deprecated for OIDC/JWKS authentication. Admission and runtime auth/OIDC proxy/group sync paths reject this setting. Leave unset/`false` and use `certificateAuthority` for private CAs. |
 | `certificateAuthority` | string | ❌ No | PEM-encoded CA certificate for OIDC issuer TLS validation |

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -174,7 +174,7 @@ These protections are in addition to the existing LRU cache for JWKS key sets.
 
 ### Audience Validation (SEC-005)
 
-When an `IdentityProvider` CRD has the `expectedAudience` field configured, the middleware validates the JWT `aud` claim against that value. This prevents token reuse from other services that share the same OIDC provider — a common cross-service token confusion attack.
+Every `IdentityProvider` CRD must set `spec.oidc.expectedAudience`. The middleware validates the JWT `aud` claim against that value. This prevents token reuse from other services that share the same OIDC provider — a common cross-service token confusion attack.
 
 ```yaml
 apiVersion: breakglass.t-caas.telekom.com/v1alpha1
@@ -182,12 +182,10 @@ kind: IdentityProvider
 spec:
   oidc:
     clientID: "breakglass-ui"
-    expectedAudience: "breakglass-ui"  # optional: enables JWT aud validation
+    expectedAudience: "breakglass-ui"
 ```
 
-This requires a matching audience protocol mapper in your identity provider (e.g., Keycloak) that adds the expected value to the `aud` claim in issued tokens.
-
-If `expectedAudience` is empty (default), audience validation is skipped for backwards compatibility.
+This requires a matching audience protocol mapper in your identity provider (e.g., Keycloak) that adds the expected value to the `aud` claim in issued tokens. Existing `IdentityProvider` resources created before this requirement must be updated with `spec.oidc.expectedAudience` before applying the new CRD or rolling out the new controller.
 
 ### Token Storage in the Browser
 

--- a/e2e/api/cluster_config_oidc_test.go
+++ b/e2e/api/cluster_config_oidc_test.go
@@ -255,8 +255,9 @@ func TestClusterConfigOIDCAuthentication(t *testing.T) {
 				DisplayName: "Test OIDC Provider",
 				Primary:     true,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: keycloakIssuer,
-					ClientID:  "breakglass-ui",
+					Authority:        keycloakIssuer,
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 			},
 		}

--- a/e2e/api/config_hot_reload_test.go
+++ b/e2e/api/config_hot_reload_test.go
@@ -54,8 +54,9 @@ func TestIdentityProviderHotReload(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://original-issuer.example.com",
-					ClientID:  "original-client-id",
+					Authority:        "https://original-issuer.example.com",
+					ClientID:         "original-client-id",
+					ExpectedAudience: "original-client-id",
 				},
 				Issuer: "https://original-issuer.example.com",
 			},
@@ -75,6 +76,7 @@ func TestIdentityProviderHotReload(t *testing.T) {
 		err = helpers.UpdateWithRetry(ctx, cli, &initial, func(idp *breakglassv1alpha1.IdentityProvider) error {
 			idp.Spec.OIDC.Authority = "https://updated-issuer.example.com"
 			idp.Spec.OIDC.ClientID = "updated-client-id"
+			idp.Spec.OIDC.ExpectedAudience = "updated-client-id"
 			idp.Spec.Issuer = "https://updated-issuer.example.com"
 			return nil
 		})
@@ -103,8 +105,9 @@ func TestIdentityProviderHotReload(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://disabled-test.example.com",
-					ClientID:  "disabled-client",
+					Authority:        "https://disabled-test.example.com",
+					ClientID:         "disabled-client",
+					ExpectedAudience: "disabled-client",
 				},
 				Issuer:   "https://disabled-test.example.com",
 				Disabled: false,
@@ -419,18 +422,22 @@ func TestAPIReloadsDuringLiveTraffic(t *testing.T) {
 		}
 
 		originalClientID := testIDP.Spec.OIDC.ClientID
+		originalExpectedAudience := testIDP.Spec.OIDC.ExpectedAudience
 
 		// Ensure we restore the original client ID at the end
 		defer func() {
 			// Re-fetch to get latest version to avoid conflict
 			_ = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
 				idp.Spec.OIDC.ClientID = originalClientID
+				idp.Spec.OIDC.ExpectedAudience = originalExpectedAudience
 				return nil
 			})
 		}()
 
 		err = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
-			idp.Spec.OIDC.ClientID = "temporary-client-id-" + helpers.GenerateUniqueName("")
+			temporaryClientID := "temporary-client-id-" + helpers.GenerateUniqueName("")
+			idp.Spec.OIDC.ClientID = temporaryClientID
+			idp.Spec.OIDC.ExpectedAudience = temporaryClientID
 			return nil
 		})
 		require.NoError(t, err, "Failed to update test IDP")
@@ -448,6 +455,7 @@ func TestAPIReloadsDuringLiveTraffic(t *testing.T) {
 		// Explicitly restore (defer will handle it if this fails, but good to be explicit for the test flow)
 		err = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
 			idp.Spec.OIDC.ClientID = originalClientID
+			idp.Spec.OIDC.ExpectedAudience = originalExpectedAudience
 			return nil
 		})
 		require.NoError(t, err, "Failed to restore test IDP")

--- a/e2e/api/feature_coverage_test.go
+++ b/e2e/api/feature_coverage_test.go
@@ -632,8 +632,9 @@ func TestMultipleIdentityProvidersFeature(t *testing.T) {
 				DisplayName: "Primary Corporate OIDC",
 				Issuer:      "https://auth-corp.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://auth-corp.example.com",
-					ClientID:  "breakglass-ui",
+					Authority:        "https://auth-corp.example.com",
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 			},
 		}
@@ -660,8 +661,9 @@ func TestMultipleIdentityProvidersFeature(t *testing.T) {
 				DisplayName: "Keycloak Provider",
 				Issuer:      "https://keycloak.example.com/realms/master",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://keycloak.example.com",
-					ClientID:  "breakglass-ui-keycloak",
+					Authority:        "https://keycloak.example.com",
+					ClientID:         "breakglass-ui-keycloak",
+					ExpectedAudience: "breakglass-ui-keycloak",
 				},
 			},
 		}

--- a/e2e/api/identity_provider_groupsync_test.go
+++ b/e2e/api/identity_provider_groupsync_test.go
@@ -38,8 +38,9 @@ func TestIdentityProviderGroupSync(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://keycloak.example.com/realms/test",
-					ClientID:  "breakglass-ui",
+					Authority:        "https://keycloak.example.com/realms/test",
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 				GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -73,8 +74,9 @@ func TestIdentityProviderGroupSync(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://keycloak.example.com/realms/timeout-test",
-					ClientID:  "breakglass-ui",
+					Authority:        "https://keycloak.example.com/realms/timeout-test",
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 				GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -105,8 +107,9 @@ func TestIdentityProviderGroupSync(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://keycloak.example.com/realms/ca-test",
-					ClientID:  "breakglass-ui",
+					Authority:        "https://keycloak.example.com/realms/ca-test",
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 				GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -138,6 +141,7 @@ func TestIdentityProviderOIDCConfig(t *testing.T) {
 		oidcConfig := breakglassv1alpha1.OIDCConfig{
 			Authority:            "https://auth.example.com",
 			ClientID:             "breakglass-ui",
+			ExpectedAudience:     "breakglass-ui",
 			JWKSEndpoint:         "https://auth.example.com/.well-known/jwks.json",
 			InsecureSkipVerify:   false,
 			CertificateAuthority: "-----BEGIN CERTIFICATE-----\n...",

--- a/e2e/api/identity_provider_test.go
+++ b/e2e/api/identity_provider_test.go
@@ -90,8 +90,9 @@ func TestIdentityProviderMultipleSelection(t *testing.T) {
 				DisplayName: "Corporate OIDC",
 				Issuer:      "https://corp-auth.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://corp-auth.example.com",
-					ClientID:  "breakglass-ui",
+					Authority:        "https://corp-auth.example.com",
+					ClientID:         "breakglass-ui",
+					ExpectedAudience: "breakglass-ui",
 				},
 			},
 		}
@@ -110,8 +111,9 @@ func TestIdentityProviderMultipleSelection(t *testing.T) {
 				DisplayName: "Partner SSO",
 				Issuer:      "https://partner-sso.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://partner-sso.example.com",
-					ClientID:  "breakglass-partner",
+					Authority:        "https://partner-sso.example.com",
+					ClientID:         "breakglass-partner",
+					ExpectedAudience: "breakglass-partner",
 				},
 			},
 		}
@@ -146,8 +148,9 @@ func TestIdentityProviderMultipleSelection(t *testing.T) {
 				DisplayName: "Duplicate",
 				Issuer:      "https://corp-auth.example.com", // Same as idp1
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://corp-auth.example.com",
-					ClientID:  "duplicate-client",
+					Authority:        "https://corp-auth.example.com",
+					ClientID:         "duplicate-client",
+					ExpectedAudience: "duplicate-client",
 				},
 			},
 		}
@@ -195,6 +198,7 @@ func TestIdentityProviderStatusHealth(t *testing.T) {
 				OIDC: breakglassv1alpha1.OIDCConfig{
 					Authority:            keycloakURL,
 					ClientID:             "breakglass-ui",
+					ExpectedAudience:     "breakglass-ui",
 					CertificateAuthority: keycloakCA,
 				},
 			},
@@ -248,8 +252,9 @@ func TestIdentityProviderInvalidIssuer(t *testing.T) {
 				DisplayName: "Invalid Issuer IDP",
 				Issuer:      "https://nonexistent.invalid.local",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://nonexistent.invalid.local",
-					ClientID:  "test-client",
+					Authority:        "https://nonexistent.invalid.local",
+					ClientID:         "test-client",
+					ExpectedAudience: "test-client",
 				},
 			},
 		}
@@ -293,8 +298,9 @@ func TestIdentityProviderDisabled(t *testing.T) {
 				Issuer:      "https://disabled-idp.example.com",
 				Disabled:    true,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://disabled-idp.example.com",
-					ClientID:  "disabled-client",
+					Authority:        "https://disabled-idp.example.com",
+					ClientID:         "disabled-client",
+					ExpectedAudience: "disabled-client",
 				},
 			},
 		}
@@ -355,6 +361,7 @@ func TestIdentityProviderKeycloakGroupSync(t *testing.T) {
 				OIDC: breakglassv1alpha1.OIDCConfig{
 					Authority:            keycloakURL,
 					ClientID:             "breakglass-ui",
+					ExpectedAudience:     "breakglass-ui",
 					CertificateAuthority: keycloakCA,
 				},
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{

--- a/e2e/api/idp_restriction_test.go
+++ b/e2e/api/idp_restriction_test.go
@@ -52,8 +52,9 @@ func TestIdentityProviderCRUD(t *testing.T) {
 				DisplayName: "E2E Test IDP",
 				Issuer:      issuer,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: issuer,
-					ClientID:  "test-client-id",
+					Authority:        issuer,
+					ClientID:         "test-client-id",
+					ExpectedAudience: "test-client-id",
 				},
 			},
 		}
@@ -82,8 +83,9 @@ func TestIdentityProviderCRUD(t *testing.T) {
 				DisplayName: "Original Name",
 				Issuer:      issuer,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: issuer,
-					ClientID:  "original-client-id",
+					Authority:        issuer,
+					ClientID:         "original-client-id",
+					ExpectedAudience: "original-client-id",
 				},
 			},
 		}
@@ -123,8 +125,9 @@ func TestIdentityProviderCRUD(t *testing.T) {
 				DisplayName: "To Be Deleted",
 				Issuer:      issuer,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: issuer,
-					ClientID:  "delete-client",
+					Authority:        issuer,
+					ClientID:         "delete-client",
+					ExpectedAudience: "delete-client",
 				},
 			},
 		}
@@ -162,8 +165,9 @@ func TestIdentityProviderRestrictions(t *testing.T) {
 				DisplayName: "Allowed IDP",
 				Issuer:      "https://allowed.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://allowed.example.com",
-					ClientID:  "allowed-client",
+					Authority:        "https://allowed.example.com",
+					ClientID:         "allowed-client",
+					ExpectedAudience: "allowed-client",
 				},
 			},
 		}
@@ -200,8 +204,9 @@ func TestIdentityProviderRestrictions(t *testing.T) {
 				DisplayName: "Approver IDP",
 				Issuer:      "https://approver.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://approver.example.com",
-					ClientID:  "approver-client",
+					Authority:        "https://approver.example.com",
+					ClientID:         "approver-client",
+					ExpectedAudience: "approver-client",
 				},
 			},
 		}
@@ -248,8 +253,9 @@ func TestIdentityProviderStatus(t *testing.T) {
 				DisplayName: "Status Test IDP",
 				Issuer:      "https://status.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://status.example.com",
-					ClientID:  "status-client",
+					Authority:        "https://status.example.com",
+					ClientID:         "status-client",
+					ExpectedAudience: "status-client",
 				},
 			},
 		}
@@ -291,8 +297,9 @@ func TestMultipleIDPSelection(t *testing.T) {
 				DisplayName: "Corporate SSO",
 				Issuer:      "https://corp.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://corp.example.com",
-					ClientID:  "corp-sso",
+					Authority:        "https://corp.example.com",
+					ClientID:         "corp-sso",
+					ExpectedAudience: "corp-sso",
 				},
 			},
 		}
@@ -309,8 +316,9 @@ func TestMultipleIDPSelection(t *testing.T) {
 				DisplayName: "Partner SSO",
 				Issuer:      "https://partner.example.com",
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://partner.example.com",
-					ClientID:  "partner-sso",
+					Authority:        "https://partner.example.com",
+					ClientID:         "partner-sso",
+					ExpectedAudience: "partner-sso",
 				},
 			},
 		}

--- a/e2e/api/multi_cluster_test.go
+++ b/e2e/api/multi_cluster_test.go
@@ -147,8 +147,9 @@ users:
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://auth.example.com",
-					ClientID:  "primary-client",
+					Authority:        "https://auth.example.com",
+					ClientID:         "primary-client",
+					ExpectedAudience: "primary-client",
 				},
 				DisplayName: "Primary IDP",
 				Primary:     true,
@@ -169,8 +170,9 @@ users:
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://backup-auth.example.com",
-					ClientID:  "backup-client",
+					Authority:        "https://backup-auth.example.com",
+					ClientID:         "backup-client",
+					ExpectedAudience: "backup-client",
 				},
 				DisplayName: "Backup IDP",
 			},

--- a/e2e/api/security_mechanisms_test.go
+++ b/e2e/api/security_mechanisms_test.go
@@ -484,6 +484,7 @@ func TestSecurityGroupSyncSecretRequired(t *testing.T) {
 				OIDC: breakglassv1alpha1.OIDCConfig{
 					Authority:            "https://auth.example.com",
 					ClientID:             "test-client",
+					ExpectedAudience:     "test-client",
 					CertificateAuthority: keycloakCA,
 				},
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{

--- a/e2e/api/validation_test.go
+++ b/e2e/api/validation_test.go
@@ -407,7 +407,8 @@ func TestInvalidIdentityProviderConfigs(t *testing.T) {
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
 					// Authority intentionally missing
-					ClientID: "some-client",
+					ClientID:         "some-client",
+					ExpectedAudience: "some-client",
 				},
 			},
 		}
@@ -430,7 +431,8 @@ func TestInvalidIdentityProviderConfigs(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://example.com",
+					Authority:        "https://example.com",
+					ExpectedAudience: "some-client",
 					// ClientID intentionally missing
 				},
 			},
@@ -454,8 +456,9 @@ func TestInvalidIdentityProviderConfigs(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "not-a-valid-url",
-					ClientID:  "some-client",
+					Authority:        "not-a-valid-url",
+					ClientID:         "some-client",
+					ExpectedAudience: "some-client",
 				},
 			},
 		}
@@ -478,8 +481,9 @@ func TestInvalidIdentityProviderConfigs(t *testing.T) {
 			},
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://example.com",
-					ClientID:  "some-client",
+					Authority:        "https://example.com",
+					ClientID:         "some-client",
+					ExpectedAudience: "some-client",
 				},
 				GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 				Keycloak: &breakglassv1alpha1.KeycloakGroupSync{

--- a/e2e/fixtures/multi-cluster/identity-providers.yaml
+++ b/e2e/fixtures/multi-cluster/identity-providers.yaml
@@ -8,6 +8,7 @@ spec:
   oidc:
     authority: "https://auth.example.com"
     clientID: "breakglass"
+    expectedAudience: "breakglass"
   # Issuer URL for token validation
   issuer: "https://auth.example.com"
   primary: true
@@ -22,4 +23,5 @@ spec:
   oidc:
     authority: "https://contractors-auth.example.com"
     clientID: "breakglass-contractors"
+    expectedAudience: "breakglass-contractors"
   issuer: "https://contractors-auth.example.com"

--- a/e2e/fixtures/multi-cluster/identity-providers.yaml
+++ b/e2e/fixtures/multi-cluster/identity-providers.yaml
@@ -7,8 +7,8 @@ spec:
   displayName: "Main IDP (Employees)"
   oidc:
     authority: "https://auth.example.com"
-    clientID: "breakglass"
-    expectedAudience: "breakglass"
+    clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
   # Issuer URL for token validation
   issuer: "https://auth.example.com"
   primary: true

--- a/e2e/kind-setup-multi.sh
+++ b/e2e/kind-setup-multi.sh
@@ -1142,8 +1142,8 @@ spec:
   displayName: "Main IDP (Employees)"
   oidc:
     authority: "${main_issuer_url}"
-    clientID: "breakglass"
-    expectedAudience: "breakglass"
+    clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
     certificateAuthority: |
 $(printf '%s\n' "$keycloak_ca_pem" | sed 's/^/      /')
   issuer: "${main_issuer_url}"

--- a/e2e/kind-setup-multi.sh
+++ b/e2e/kind-setup-multi.sh
@@ -1143,6 +1143,7 @@ spec:
   oidc:
     authority: "${main_issuer_url}"
     clientID: "breakglass"
+    expectedAudience: "breakglass"
     certificateAuthority: |
 $(printf '%s\n' "$keycloak_ca_pem" | sed 's/^/      /')
   issuer: "${main_issuer_url}"
@@ -1168,6 +1169,7 @@ spec:
   oidc:
     authority: "${contractors_issuer_url}"
     clientID: "breakglass-contractors"
+    expectedAudience: "breakglass-contractors"
     certificateAuthority: |
 $(printf '%s\n' "$keycloak_ca_pem" | sed 's/^/      /')
   issuer: "${contractors_issuer_url}"

--- a/e2e/kind-setup-single.sh
+++ b/e2e/kind-setup-single.sh
@@ -1856,6 +1856,7 @@ spec:
     authority: "https://${KEYCLOAK_SERVICE_HOSTNAME}:8443/realms/${KEYCLOAK_REALM}"
     # OIDC client ID (must match realm configuration)
     clientID: "breakglass-ui"
+    expectedAudience: "breakglass-ui"
     # Trust the generated Keycloak CA for self-signed E2E certificates.
     certificateAuthority: |
 $KEYCLOAK_CA_INLINE

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -1563,7 +1563,8 @@ spec:
   issuer: \"$issuer_url\"
   oidc:
     authority: \"$issuer_url\"
-    clientID: \"breakglass\""
+    clientID: \"breakglass\"
+    expectedAudience: \"breakglass\""
   
   # Add CA if provided
   if [ -n "$ca_pem" ] && [ -f "$ca_pem" ]; then

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -1563,8 +1563,8 @@ spec:
   issuer: \"$issuer_url\"
   oidc:
     authority: \"$issuer_url\"
-    clientID: \"breakglass\"
-    expectedAudience: \"breakglass\""
+    clientID: \"breakglass-ui\"
+    expectedAudience: \"breakglass-ui\""
   
   # Add CA if provided
   if [ -n "$ca_pem" ] && [ -f "$ca_pem" ]; then

--- a/pkg/api/api_oidc_proxy_test.go
+++ b/pkg/api/api_oidc_proxy_test.go
@@ -904,6 +904,7 @@ func TestHandleOIDCProxyUsesSelectedIdentityProviderCA(t *testing.T) {
 			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority:            upstream.URL,
 				ClientID:             "breakglass-ui",
+				ExpectedAudience:     "breakglass-ui",
 				CertificateAuthority: certificatePEMForTLSServer(t, upstream),
 			},
 		},

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -80,7 +80,7 @@ func (e *jwksFetchRateLimitedError) Unwrap() error { return errJWKSFetchRateLimi
 type jwksCacheEntry struct {
 	issuer              string
 	idpName             string // resolved IDP name, cached to avoid redundant K8s API calls
-	expectedAudience    string // from IDP config; when non-empty, JWT aud claim is validated
+	expectedAudience    string // from IDP config; JWT aud claim is validated
 	audienceRefreshedAt time.Time
 	audienceAttemptedAt time.Time
 	jwks                keyfunc.Keyfunc
@@ -134,6 +134,12 @@ func (a *AuthHandler) validateJWKSIdentityProviderConfig(idpCfg *config.Identity
 	if idpCfg.InsecureSkipVerify || (idpCfg.Keycloak != nil && idpCfg.Keycloak.InsecureSkipVerify) {
 		if a.log != nil {
 			a.log.Warnw("refusing insecure TLS verification for IDP", "idp", idpCfg.Name)
+		}
+		return errUnknownIdentityProvider
+	}
+	if idpCfg.ExpectedAudience == "" {
+		if a.log != nil {
+			a.log.Warnw("refusing IDP without expected audience", "idp", idpCfg.Name)
 		}
 		return errUnknownIdentityProvider
 	}
@@ -657,10 +663,10 @@ func (a *AuthHandler) authenticate(c *gin.Context) bool {
 		jwt.WithExpirationRequired(), // SEC-005: reject tokens without exp claim
 	}
 
-	// SEC-005: Audience validation when expectedAudience is configured.
+	// SEC-005: Audience validation for CRD-backed identity providers.
 	// Prevents cross-service token confusion from other OIDC clients at the
-	// same IDP. Only applied when the admin explicitly sets expectedAudience
-	// and configures a matching audience protocol mapper in their IDP.
+	// same IDP. IdentityProvider CRDs require expectedAudience and a matching
+	// audience protocol mapper in the IDP.
 	if expectedAudience != "" {
 		parserOpts = append(parserOpts, jwt.WithAudience(expectedAudience))
 	}

--- a/pkg/api/auth_jwt_negative_test.go
+++ b/pkg/api/auth_jwt_negative_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"container/list"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -16,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
+	"github.com/telekom/k8s-breakglass/pkg/config"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -525,11 +527,9 @@ func TestAuthMiddleware_JWTTimingEdgeCases(t *testing.T) {
 	}
 }
 
-// TestAuthMiddleware_AudienceNotValidated verifies that JWT audience (aud) claim
-// is NOT validated — Keycloak does not include the requesting client_id in the
-// aud claim by default, so audience validation would break environments without
-// audience protocol mappers. A dedicated CRD field is needed before this can be enabled.
-func TestAuthMiddleware_AudienceNotValidated(t *testing.T) {
+// TestAuthMiddleware_IdentityProviderRequiresAudience verifies that CRD-backed
+// identity providers fail closed when expectedAudience is missing.
+func TestAuthMiddleware_IdentityProviderRequiresAudience(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	srv, priv, kid := setupTestJWKSServer(t)
@@ -539,50 +539,51 @@ func TestAuthMiddleware_AudienceNotValidated(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := zaptest.NewLogger(t).Sugar()
-
-	tests := []struct {
-		name          string
-		tokenAudience interface{} // aud claim in token (nil = omitted)
-	}{
-		{name: "no audience claim", tokenAudience: nil},
-		{name: "audience present", tokenAudience: "some-audience"},
-		{name: "array audience", tokenAudience: []string{"aud1", "aud2"}},
-		{name: "mismatched audience", tokenAudience: "wrong-client"},
+	auth := &AuthHandler{
+		jwksCache:   make(map[string]*list.Element),
+		jwksLRUList: list.New(),
+		log:         logger,
+		idpLoader: staticIdentityProviderByIssuerLoader{cfg: &config.IdentityProviderConfig{
+			Name:      "missing-audience",
+			Issuer:    "https://idp.example.com",
+			Authority: "https://idp.example.com",
+			ClientID:  "breakglass-ui",
+		}},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Use the simple single-IDP path — no need for cache internals
-			// since audience validation is disabled regardless.
-			auth := &AuthHandler{jwks: jwks, log: logger}
-
-			router := gin.New()
-			router.Use(auth.Middleware())
-			router.GET("/test", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
-
-			claims := jwt.MapClaims{
-				"sub": "test-user",
-				"exp": time.Now().Add(time.Hour).Unix(),
-			}
-			if tt.tokenAudience != nil {
-				claims["aud"] = tt.tokenAudience
-			}
-
-			tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-			tok.Header["kid"] = kid
-			tokStr, err := tok.SignedString(priv)
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set("Authorization", "Bearer "+tokStr)
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
-
-			// All cases should succeed since audience is not validated
-			require.Equal(t, http.StatusOK, w.Code,
-				"audience validation is disabled; all audience values should be accepted")
-		})
+	entry := &jwksCacheEntry{
+		issuer:              "https://idp.example.com",
+		idpName:             "missing-audience",
+		expectedAudience:    "",
+		jwks:                jwks,
+		audienceRefreshedAt: time.Now().Add(-audienceRefreshInterval - time.Second),
+		audienceAttemptedAt: time.Now().Add(-audienceRefreshFailureBackoff - time.Second),
 	}
+	elem := auth.jwksLRUList.PushFront(entry)
+	auth.jwksCache[entry.issuer] = elem
+
+	router := gin.New()
+	router.Use(auth.Middleware())
+	router.GET("/test", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	claims := jwt.MapClaims{
+		"iss": "https://idp.example.com",
+		"sub": "test-user",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"aud": "wrong-client",
+	}
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	tokStr, err := tok.SignedString(priv)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+tokStr)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 // TestAuthMiddleware_ExpirationRequired verifies SEC-005: tokens without exp claim are rejected.

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -729,6 +729,7 @@ func TestGetJWKSForIssuerRejectsInsecureSkipVerifyBeforeCA(t *testing.T) {
 					OIDC: breakglassv1alpha1.OIDCConfig{
 						Authority:            "https://oidc.example.com",
 						ClientID:             "breakglass-ui",
+						ExpectedAudience:     "breakglass-ui",
 						CertificateAuthority: testCertificatePEM(t),
 						InsecureSkipVerify:   true,
 					},
@@ -745,6 +746,7 @@ func TestGetJWKSForIssuerRejectsInsecureSkipVerifyBeforeCA(t *testing.T) {
 					OIDC: breakglassv1alpha1.OIDCConfig{
 						Authority:            "https://keycloak.example.com/realms/test",
 						ClientID:             "breakglass-ui",
+						ExpectedAudience:     "breakglass-ui",
 						CertificateAuthority: testCertificatePEM(t),
 					},
 					Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -936,6 +938,7 @@ func TestGetJWKSForIssuer_EvictsCachedJWKSWhenLiveIDPBecomesInsecure(t *testing.
 			Issuer:               issuer,
 			Authority:            issuer,
 			ClientID:             "breakglass-ui",
+			ExpectedAudience:     "breakglass-ui",
 			CertificateAuthority: caPEM,
 		},
 	}
@@ -953,7 +956,7 @@ func TestGetJWKSForIssuer_EvictsCachedJWKSWhenLiveIDPBecomesInsecure(t *testing.
 	_, audience, idpName, cacheHit, err := auth.getJWKSForIssuer(t.Context(), issuer)
 	require.NoError(t, err)
 	assert.False(t, cacheHit)
-	assert.Empty(t, audience)
+	assert.Equal(t, "breakglass-ui", audience)
 	assert.Equal(t, "secure-idp", idpName)
 
 	auth.jwksMutex.Lock()
@@ -969,6 +972,7 @@ func TestGetJWKSForIssuer_EvictsCachedJWKSWhenLiveIDPBecomesInsecure(t *testing.
 		Issuer:             issuer,
 		Authority:          issuer,
 		ClientID:           "breakglass-ui",
+		ExpectedAudience:   "breakglass-ui",
 		InsecureSkipVerify: true,
 	})
 
@@ -995,8 +999,9 @@ func TestGetJWKSForIssuer_InvalidAuthorityRejected(t *testing.T) {
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Issuer: "https://auth.example.com",
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "http://insecure.example.com",
-				ClientID:  "test-client",
+				Authority:        "http://insecure.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,8 +109,8 @@ type IdentityProviderConfig struct {
 	ClientID string
 
 	// ExpectedAudience is the expected JWT audience claim value.
-	// When set, the auth middleware validates the aud claim against this value.
-	// When empty, audience validation is skipped.
+	// The auth middleware validates the aud claim against this value for
+	// CRD-backed identity providers.
 	ExpectedAudience string
 
 	// ClientSecret for Keycloak (loaded from secret reference)

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -565,8 +565,9 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			Spec: breakglassv1alpha1.IdentityProviderSpec{
 				Disabled: true,
 				OIDC: breakglassv1alpha1.OIDCConfig{
-					Authority: "https://example.com",
-					ClientID:  "test",
+					Authority:        "https://example.com",
+					ClientID:         "test",
+					ExpectedAudience: "test",
 				},
 			},
 		}
@@ -986,8 +987,9 @@ func TestEscalationReconciler_ValidateIDPRefs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "enabled-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://example.com",
-				ClientID:  "test",
+				Authority:        "https://example.com",
+				ClientID:         "test",
+				ExpectedAudience: "test",
 			},
 		},
 	}
@@ -997,8 +999,9 @@ func TestEscalationReconciler_ValidateIDPRefs(t *testing.T) {
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Disabled: true,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://example.com",
-				ClientID:  "test",
+				Authority:        "https://example.com",
+				ClientID:         "test",
+				ExpectedAudience: "test",
 			},
 		},
 	}

--- a/pkg/config/identity_provider_loader_test.go
+++ b/pkg/config/identity_provider_loader_test.go
@@ -36,8 +36,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Primary: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test-client",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test-client",
+							ExpectedAudience: "test-client",
 						},
 					},
 				},
@@ -60,8 +61,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Primary: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test-client",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test-client",
+							ExpectedAudience: "test-client",
 						},
 						GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 						Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -109,8 +111,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 						Primary:  true,
 						Disabled: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://disabled.example.com",
-							ClientID:  "disabled",
+							Authority:        "https://disabled.example.com",
+							ClientID:         "disabled",
+							ExpectedAudience: "disabled",
 						},
 					},
 				},
@@ -121,8 +124,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Primary: false,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://fallback.example.com",
-							ClientID:  "fallback",
+							Authority:        "https://fallback.example.com",
+							ClientID:         "fallback",
+							ExpectedAudience: "fallback",
 						},
 					},
 				},
@@ -148,8 +152,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Disabled: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test",
+							ExpectedAudience: "test",
 						},
 					},
 				},
@@ -166,8 +171,9 @@ func TestIdentityProviderLoader_LoadIdentityProvider(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Primary: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test",
+							ExpectedAudience: "test",
 						},
 						GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 						Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -245,8 +251,9 @@ func TestIdentityProviderLoader_LoadIdentityProviderByName(t *testing.T) {
 					},
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://specific.example.com",
-							ClientID:  "specific",
+							Authority:        "https://specific.example.com",
+							ClientID:         "specific",
+							ExpectedAudience: "specific",
 						},
 					},
 				},
@@ -311,6 +318,7 @@ func TestIdentityProviderLoader_RejectsInsecureSkipVerify(t *testing.T) {
 					OIDC: breakglassv1alpha1.OIDCConfig{
 						Authority:          "https://auth.example.com",
 						ClientID:           "breakglass-ui",
+						ExpectedAudience:   "breakglass-ui",
 						InsecureSkipVerify: true,
 					},
 				},
@@ -322,8 +330,9 @@ func TestIdentityProviderLoader_RejectsInsecureSkipVerify(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "insecure-keycloak"},
 				Spec: breakglassv1alpha1.IdentityProviderSpec{
 					OIDC: breakglassv1alpha1.OIDCConfig{
-						Authority: "https://auth.example.com",
-						ClientID:  "breakglass-ui",
+						Authority:        "https://auth.example.com",
+						ClientID:         "breakglass-ui",
+						ExpectedAudience: "breakglass-ui",
 					},
 					GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 					Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -378,8 +387,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Primary: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test",
+							ExpectedAudience: "test",
 						},
 					},
 				},
@@ -393,8 +403,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "fallback"},
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test",
+							ExpectedAudience: "test",
 						},
 					},
 				},
@@ -415,8 +426,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Disabled: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth.example.com",
-							ClientID:  "test",
+							Authority:        "https://auth.example.com",
+							ClientID:         "test",
+							ExpectedAudience: "test",
 						},
 					},
 				},
@@ -425,8 +437,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists(t *testing.T) {
 					Spec: breakglassv1alpha1.IdentityProviderSpec{
 						Disabled: true,
 						OIDC: breakglassv1alpha1.OIDCConfig{
-							Authority: "https://auth2.example.com",
-							ClientID:  "test2",
+							Authority:        "https://auth2.example.com",
+							ClientID:         "test2",
+							ExpectedAudience: "test2",
 						},
 					},
 				},
@@ -472,8 +485,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists_ManagerCacheNotSt
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Primary: true,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "demo",
+				Authority:        "https://auth.example.com",
+				ClientID:         "demo",
+				ExpectedAudience: "demo",
 			},
 		},
 	}
@@ -494,8 +508,9 @@ func TestIdentityProviderLoader_ValidateIdentityProviderExists_ManagerCacheStart
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Primary: true,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "demo",
+				Authority:        "https://auth.example.com",
+				ClientID:         "demo",
+				ExpectedAudience: "demo",
 			},
 		},
 	}
@@ -587,8 +602,9 @@ func TestIdentityProviderLoader_CrossNamespaceSecrets(t *testing.T) {
 				Spec: breakglassv1alpha1.IdentityProviderSpec{
 					Primary: true,
 					OIDC: breakglassv1alpha1.OIDCConfig{
-						Authority: "https://auth.example.com",
-						ClientID:  "test",
+						Authority:        "https://auth.example.com",
+						ClientID:         "test",
+						ExpectedAudience: "test",
 					},
 					GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
 					Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
@@ -765,8 +781,9 @@ func TestIdentityProviderLoader_updateConversionFailureStatus(t *testing.T) {
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Primary: true,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://authority",
-				ClientID:  "client",
+				Authority:        "https://authority",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 		},
 	}
@@ -878,8 +895,9 @@ func TestLoadAllIdentityProviders_MultipleProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-alpha"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://alpha.example.com",
-				ClientID:  "alpha-client",
+				Authority:        "https://alpha.example.com",
+				ClientID:         "alpha-client",
+				ExpectedAudience: "alpha-client",
 			},
 			Issuer:   "https://alpha.example.com",
 			Disabled: false,
@@ -890,8 +908,9 @@ func TestLoadAllIdentityProviders_MultipleProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-beta"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://beta.example.com",
-				ClientID:  "beta-client",
+				Authority:        "https://beta.example.com",
+				ClientID:         "beta-client",
+				ExpectedAudience: "beta-client",
 			},
 			Issuer:   "https://beta.example.com",
 			Disabled: false,
@@ -902,8 +921,9 @@ func TestLoadAllIdentityProviders_MultipleProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-gamma"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://gamma.example.com",
-				ClientID:  "gamma-client",
+				Authority:        "https://gamma.example.com",
+				ClientID:         "gamma-client",
+				ExpectedAudience: "gamma-client",
 			},
 			Issuer:   "https://gamma.example.com",
 			Disabled: false,
@@ -943,8 +963,9 @@ func TestLoadAllIdentityProviders_WithDisabledProvider(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "enabled-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://enabled.example.com",
-				ClientID:  "enabled",
+				Authority:        "https://enabled.example.com",
+				ClientID:         "enabled",
+				ExpectedAudience: "enabled",
 			},
 			Issuer:   "https://enabled.example.com",
 			Disabled: false,
@@ -955,8 +976,9 @@ func TestLoadAllIdentityProviders_WithDisabledProvider(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://disabled.example.com",
-				ClientID:  "disabled",
+				Authority:        "https://disabled.example.com",
+				ClientID:         "disabled",
+				ExpectedAudience: "disabled",
 			},
 			Issuer:   "https://disabled.example.com",
 			Disabled: true,
@@ -994,8 +1016,9 @@ func TestLoadAllIdentityProviders_WithConversionError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "valid-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://valid.example.com",
-				ClientID:  "valid",
+				Authority:        "https://valid.example.com",
+				ClientID:         "valid",
+				ExpectedAudience: "valid",
 			},
 			Issuer:   "https://valid.example.com",
 			Disabled: false,
@@ -1007,8 +1030,9 @@ func TestLoadAllIdentityProviders_WithConversionError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "broken-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://broken.example.com",
-				ClientID:  "broken",
+				Authority:        "https://broken.example.com",
+				ClientID:         "broken",
+				ExpectedAudience: "broken",
 			},
 			Issuer:            "https://broken.example.com",
 			Disabled:          false,
@@ -1060,8 +1084,9 @@ func TestLoadAllIdentityProviders_SkipsInsecureSkipVerify(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "valid-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://valid.example.com",
-				ClientID:  "valid",
+				Authority:        "https://valid.example.com",
+				ClientID:         "valid",
+				ExpectedAudience: "valid",
 			},
 			Issuer: "https://valid.example.com",
 		},
@@ -1072,6 +1097,7 @@ func TestLoadAllIdentityProviders_SkipsInsecureSkipVerify(t *testing.T) {
 			OIDC: breakglassv1alpha1.OIDCConfig{
 				Authority:          "https://insecure.example.com",
 				ClientID:           "insecure",
+				ExpectedAudience:   "insecure",
 				InsecureSkipVerify: true,
 			},
 			Issuer: "https://insecure.example.com",
@@ -1122,8 +1148,9 @@ func TestLoadAllIdentityProviders_AllDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-1"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://disabled1.example.com",
-				ClientID:  "disabled1",
+				Authority:        "https://disabled1.example.com",
+				ClientID:         "disabled1",
+				ExpectedAudience: "disabled1",
 			},
 			Disabled: true,
 		},
@@ -1133,8 +1160,9 @@ func TestLoadAllIdentityProviders_AllDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled-2"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://disabled2.example.com",
-				ClientID:  "disabled2",
+				Authority:        "https://disabled2.example.com",
+				ClientID:         "disabled2",
+				ExpectedAudience: "disabled2",
 			},
 			Disabled: true,
 		},
@@ -1183,8 +1211,9 @@ func TestLoadAllIdentityProviders_MetricsRecorder(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "broken-idp-metrics"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://broken.example.com",
-				ClientID:  "broken",
+				Authority:        "https://broken.example.com",
+				ClientID:         "broken",
+				ExpectedAudience: "broken",
 			},
 			Disabled:          false,
 			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
@@ -1233,8 +1262,9 @@ func TestLoadIdentityProviderByIssuer_TrailingSlashNormalization(t *testing.T) {
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Issuer: "https://auth.example.com/",
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com/realms/test",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com/realms/test",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -1289,8 +1319,9 @@ func TestLoadIdentityProviderByIssuer_AuthorityFallbackNormalization(t *testing.
 		ObjectMeta: metav1.ObjectMeta{Name: "authority-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com/realms/test/",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com/realms/test/",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}

--- a/pkg/config/identity_provider_reconciler_test.go
+++ b/pkg/config/identity_provider_reconciler_test.go
@@ -93,8 +93,9 @@ func TestIdentityProviderReconciler_ReconcileSuccess(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -160,8 +161,9 @@ func TestIdentityProviderReconciler_ReconcileReloadError(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -204,8 +206,9 @@ func TestIdentityProviderReconciler_ReconcileWithMultipleIDPs(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 			Primary: true,
 		},
@@ -217,8 +220,9 @@ func TestIdentityProviderReconciler_ReconcileWithMultipleIDPs(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 			Primary: false,
 		},
@@ -669,8 +673,9 @@ func TestIdentityProviderReconciler_GetCachedIdentityProviders(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -704,8 +709,9 @@ func TestIdentityProviderReconciler_GetEnabledIdentityProviders(t *testing.T) {
 		},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -735,8 +741,9 @@ func TestIdentityProviderReconciler_DisabledIDPsFilteredFromCache(t *testing.T) 
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Disabled: false,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 		},
 	}
@@ -748,8 +755,9 @@ func TestIdentityProviderReconciler_DisabledIDPsFilteredFromCache(t *testing.T) 
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			Disabled: true,
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "test-client-2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "test-client-2",
+				ExpectedAudience: "test-client-2",
 			},
 		},
 	}

--- a/pkg/config/multi_idp_loader_test.go
+++ b/pkg/config/multi_idp_loader_test.go
@@ -36,8 +36,9 @@ func TestLoadAllIdentityProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-1"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth1.example.com",
-				ClientID:  "client-1",
+				Authority:        "https://auth1.example.com",
+				ClientID:         "client-1",
+				ExpectedAudience: "client-1",
 			},
 			Issuer:   "https://auth1.example.com",
 			Disabled: false,
@@ -48,8 +49,9 @@ func TestLoadAllIdentityProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-2"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "client-2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "client-2",
+				ExpectedAudience: "client-2",
 			},
 			Issuer:   "https://auth2.example.com",
 			Disabled: false,
@@ -60,8 +62,9 @@ func TestLoadAllIdentityProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-3-disabled"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth3.example.com",
-				ClientID:  "client-3",
+				Authority:        "https://auth3.example.com",
+				ClientID:         "client-3",
+				ExpectedAudience: "client-3",
 			},
 			Issuer:   "https://auth3.example.com",
 			Disabled: true, // Disabled, should not be included
@@ -94,8 +97,9 @@ func TestLoadIdentityProviderByIssuer(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "tenant-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.tenant.com",
-				ClientID:  "tenant-client",
+				Authority:        "https://auth.tenant.com",
+				ClientID:         "tenant-client",
+				ExpectedAudience: "tenant-client",
 			},
 			Issuer:   "https://auth.tenant.com",
 			Disabled: false,
@@ -127,8 +131,9 @@ func TestValidateIdentityProviderRefs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-1"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth1.example.com",
-				ClientID:  "client-1",
+				Authority:        "https://auth1.example.com",
+				ClientID:         "client-1",
+				ExpectedAudience: "client-1",
 			},
 			Issuer:   "https://auth1.example.com",
 			Disabled: false,
@@ -139,8 +144,9 @@ func TestValidateIdentityProviderRefs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "idp-2-disabled"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth2.example.com",
-				ClientID:  "client-2",
+				Authority:        "https://auth2.example.com",
+				ClientID:         "client-2",
+				ExpectedAudience: "client-2",
 			},
 			Issuer:   "https://auth2.example.com",
 			Disabled: true,
@@ -182,8 +188,9 @@ func TestGetIDPNameByIssuer(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "client",
+				ExpectedAudience: "client",
 			},
 			Issuer:   "https://auth.example.com",
 			Disabled: false,
@@ -210,8 +217,9 @@ func TestIdentityProviderConfigIncludesIssuerAndName(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-idp"},
 		Spec: breakglassv1alpha1.IdentityProviderSpec{
 			OIDC: breakglassv1alpha1.OIDCConfig{
-				Authority: "https://auth.example.com",
-				ClientID:  "test-client",
+				Authority:        "https://auth.example.com",
+				ClientID:         "test-client",
+				ExpectedAudience: "test-client",
 			},
 			Issuer:      "https://auth.example.com",
 			DisplayName: "Test IDP",


### PR DESCRIPTION
## Summary

- require `IdentityProvider.spec.oidc.expectedAudience` in the CRD schema and shared webhook/reconciler validation
- reject CRD-backed identity providers without an expected audience at JWT/JWKS runtime, including cached audience refreshes
- update generated CRD/applyconfiguration output, samples, docs, changelog, and valid IdentityProvider fixtures

## Security impact

This fixes the default-empty audience validation gap behind `GHSA-hrm9-fc9r-x899`. CRD-backed OIDC authentication now fails closed unless the IdentityProvider declares the audience that Breakglass expects in JWT `aud` claims.

## Breaking change / migration

Before upgrading, update every existing `IdentityProvider` resource with:

```yaml
spec:
  oidc:
    expectedAudience: <breakglass-api-audience>
```

Also configure the OIDC provider, for example Keycloak, with an audience protocol mapper so access tokens issued for Breakglass include that value in the `aud` claim. Existing IdentityProviders without the field will be rejected by the new CRD validation and by runtime auth if they are already cached or bypass admission.

## Validation

- `make generate && make manifests`
- `go test ./api/v1alpha1 ./pkg/api -run 'TestValidateIdentityProvider|TestIdentityProvider_ValidateCreate|TestAuthMiddleware_Audience|TestAuthMiddleware_IdentityProviderRequiresAudience|TestGetJWKSForIssuerRejects|TestGetJWKSForIssuer_Audience'`
- `go test ./api/v1alpha1 ./pkg/api ./pkg/config`
