### PR TITLE
chart: bump escalation-config for RC release

### DIFF
--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:


### PR DESCRIPTION
## Summary

- Bump `charts/escalation-config` from `0.3.1` to `0.3.2` so the next k8s-breakglass RC can publish a fresh immutable Helm chart package.
- Fixes the `v0.1.0-rc.1` release failure where GHCR already had `escalation-config:0.3.1` with `appVersion v0.1.0-beta.31`.

## Validation

- `helm lint charts/escalation-config --set cluster.clusterID=release-check --set cluster.environment=prod --set cluster.tenant=platform`
- Verified `ghcr.io/telekom/k8s-breakglass/charts/escalation-config:0.3.2` is not published yet.
