### PR TITLE
fix(deps): bump brace-expansion and postcss to clear CI security gates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4127,9 +4127,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6789,9 +6789,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -7185,9 +7185,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7204,7 +7204,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "^5.0.9",
     "shell-quote": "^1.8.5",
     "vitest": "$vitest",
     "@vitest/coverage-v8": "$@vitest/coverage-v8"


### PR DESCRIPTION
## Summary

Two CI jobs fail **repo-wide on `main`**, not because of any feature branch. This is a standalone hygiene PR that fixes the underlying advisories rather than suppressing them.

## Proof the failures are pre-existing on `main`

Both jobs fail on the scheduled `main` run and on an unrelated PR, and both passed on an older PR:

| Where | Frontend Security Audit | Trivy Filesystem Scan |
|---|---|---|
| `main` scheduled run [30973998386](https://github.com/telekom/k8s-breakglass/actions/runs/30973998386) (`1d1ff85`) | — | **failure** |
| PR #1203 (unrelated) | [**fail** (20s)](https://github.com/telekom/k8s-breakglass/actions/runs/30980695491/job/92224267422) | [**fail** (10s)](https://github.com/telekom/k8s-breakglass/actions/runs/30980695474/job/92224267049) |
| PR #1201 (older) | [pass (19s)](https://github.com/telekom/k8s-breakglass/actions/runs/30789956109/job/91611189450) | [pass (12s)](https://github.com/telekom/k8s-breakglass/actions/runs/30789956086/job/91611189260) |

Neither failure touches Go code, so the regression came from a dependency/advisory-database change on `main`.

## Advisories

| Severity | Package | Vulnerable range | Advisory | Job it breaks |
|---|---|---|---|---|
| **HIGH** | `brace-expansion` | `4.0.0 - 5.0.8` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | Frontend Security Audit |
| MODERATE | `postcss` | `<= 8.5.22` | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153 — incomplete fix of GHSA-6g55-p6wh-862q; attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset | Trivy Filesystem Scan |

Both are transitive. Reproduced on `origin/main`:

```
$ cd frontend && npm audit --audit-level=high
brace-expansion  4.0.0 - 5.0.8
Severity: high
...
3 vulnerabilities (1 moderate, 2 high)
exit 1
```

## Root cause 1 — Frontend Security Audit

`frontend/package.json` already carried an `overrides` entry pinning `brace-expansion` to **exactly `"5.0.8"`** — and `5.0.8` is itself the top of the vulnerable range. That exact pin is *why* `npm audit fix` could not resolve the advisory: the override forced the vulnerable version back in regardless of what the dependents (`minimatch` via `eslint`, `@vue/test-utils` → `js-beautify`) asked for.

**Fix:** relax the override to `"^5.0.9"`. The override stays in place (it is still needed to dedupe `minimatch`'s `brace-expansion`), but now resolves to the patched release.

## Root cause 2 — Trivy Filesystem Scan

This one was not a config typo and not a slow scan — the 10s runtime is just Trivy downloading its DB and finding one hit immediately.

The `trivy-fs` job declares `severity: 'CRITICAL,HIGH'`, so a MODERATE `postcss` finding should not have failed it. But `aquasecurity/trivy-action` **discards the `severity` input when `format: sarif`**. The job log says so explicitly:

```
Building SARIF report with all severities
Running Trivy with options: trivy fs .
```

So the effective gate is `--severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --ignore-unfixed --exit-code 1`, and the MEDIUM `postcss` advisory (fixed in 8.5.23) trips it. Confirmed by reproducing locally with the exact Trivy version pinned in CI (0.70.0):

```
$ docker run --rm -v /tmp/bgtrivy:/scan -w /scan aquasec/trivy:0.70.0 fs \
    --format sarif --output /scan/all.sarif \
    --pkg-types os,library --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL \
    --ignore-unfixed --exit-code 1 .
EXIT=1
RESULT: CVE-2026-69153 warning | Package: postcss Installed Version: 8.5.19 Severity: MEDIUM Fixed Version: 8.5.23
```

(The same command with `--severity CRITICAL,HIGH` exits 0 — which is exactly the discrepancy that made this job look mysterious.)

**Fix:** bump `postcss` to 8.5.25 in the lockfile. `vite` and `@vue/compiler-sfc` both accept it, so no direct dependent needed changing — this is a lockfile-only change.

I deliberately did **not** touch the workflow. Adding a `.trivyignore` or narrowing the severity set would hide a fixable finding; the advisory has an upstream fix, so fixing it is the correct action. The `severity`-vs-`sarif` quirk is documented here for reviewers but left as-is since it makes the gate *stricter*, not weaker.

## Changes

Two files, 11 insertions / 11 deletions total:

- `frontend/package.json` — `overrides."brace-expansion"`: `"5.0.8"` → `"^5.0.9"`
- `frontend/package-lock.json` — `brace-expansion` 5.0.8 → 5.0.9, `postcss` 8.5.19 → 8.5.25, `nanoid` 3.3.12 → 3.3.17

`nanoid` is a required dependency of the new `postcss` and moves at patch level only. No other packages changed. `npm audit fix --force` was **not** used — no major-version upgrades, so no risk of silently breaking the Vue build.

## Verification (real output)

```
$ cd frontend && npm ci && npm audit --audit-level=high
found 0 vulnerabilities
AUDIT_EXIT=0

$ npm run build
✓ built in 18.61s
BUILD_EXIT=0

$ npm test
 Test Files  72 passed (72)
      Tests  1066 passed | 1 skipped (1067)
TEST_EXIT=0
```

Trivy against the patched tree, same flags and same pinned version as CI:

```
EXIT_AS_CI_BUILDS_SARIF=0
sarif results: 0
```

Go side untouched and confirmed green:

```
$ make lint-strict test
MAKE_EXIT=0
```

## Not fixed / notes

- One **UNKNOWN**-severity Go advisory is present but does not affect either job: `GO-2026-5932` in `golang.org/x/crypto v0.54.0`, with **no fixed version available upstream**. Trivy's `--ignore-unfixed` filters it out, so it does not gate CI. Nothing to do until upstream ships a fix; no ignore entry added.
- The `trivy` (image scan) job still carries `continue-on-error: true` for CVE-2026-39822 in the golang base image. Pre-existing and out of scope here.
- The `severity` input being ignored under `format: sarif` is an upstream `trivy-action` behaviour. Worth a follow-up decision by maintainers on whether the fs gate should intentionally be all-severities, but changing it either way is a policy call I left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
