### PR TITLE
fix: shared cached rest.Config impersonation leak, approval fail-open, DenyPolicy ephemeral-container blind spot, non-deterministic spoke selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spoke cluster across calls — and this path is reached from the authorization webhook. It now
   errors on ambiguity, matching the semantics its unexported `getAcrossAllNamespacesLocked` twin
   already had. Single-match and not-found behaviour are unchanged. `ensureClusterWideUniqueName`
-  admission validation already prevented duplicates, so this is defence in depth.
+  admission validation already prevented duplicates, so this is defence in depth. The fail-closed
+  path is observable: the cache-hit ambiguity branch now still counts the lookup in
+  `breakglass_cluster_cache_hits_total` and both branches increment the new
+  `breakglass_cluster_cache_ambiguous_total{cluster,source}`, so repeated ambiguity errors are
+  visible in monitoring instead of only in logs.
 - **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
 - **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
 - **BreakglassSession list filters**: Session status listing now pushes exact state filters through the cache index and deduplicates multi-state results before applying cluster, user, or group filters.
@@ -71,10 +75,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`breakglass_cluster_cache_ambiguous_total{cluster,source}` metric**, incremented when a
+  cluster-name lookup is rejected because the name resolved to multiple `ClusterConfig` objects
+  (`source` is `cache` or `list`). Alert on any non-zero value: cluster-wide name uniqueness has
+  been violated and name-based lookups — including the authorization webhook path — are failing
+  closed.
 - **`debug_session.binding_unresolved` audit event** (severity `warning`, classified sensitive so it
   is never sampled or dropped) and **`breakglass_debug_session_binding_unresolved_total{cluster,reason}`
   metric**, emitted when a `DebugSession` names an explicit `spec.bindingRef` that cannot be
-  resolved. `reason` is `binding not found` or `binding lookup failed`.
+  resolved. `reason` is `binding_not_found` or `binding_lookup_failed`.
 
 ### Upgrade impact: DenyPolicy ephemeral containers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Impersonation no longer leaks onto the shared cached spoke REST config**: `createImpersonatedClient`
+  wrote `Impersonate` directly onto the `*rest.Config` returned by `ClientProvider.GetRESTConfig`,
+  which is the shared cached pointer for that spoke. The impersonated ServiceAccount identity
+  persisted on the cache entry, so subsequent unrelated consumers of the same spoke config (the
+  authorization webhook's SAR checks, session cleanup, workload deployment, cached clientsets)
+  silently acted as that ServiceAccount until the TTL expired, and concurrent reconciles raced on
+  one struct. The config is now copied with `rest.CopyConfig` before any mutation, matching the
+  existing pattern in `group_checker.go` and `session_controller_approval_utils.go`. `GetRESTConfig`
+  now documents the read-only ownership contract for its return value.
+- **DebugSession no longer activates without approval when an explicit `bindingRef` is unresolvable**:
+  a failed `DebugSessionClusterBinding` lookup was only logged as a warning before falling through
+  to auto-discovery. Since the binding carries the approver configuration, a transient API error
+  made `requiresApproval` see no approvers and the session activated with no approval at all. An
+  unresolvable explicit `spec.bindingRef` is now treated as *indeterminate*: the session state is
+  left untouched (no access granted, nothing terminally failed), the reconcile is requeued with
+  backoff, and the condition is surfaced via an Error log, the new
+  `debug_session.binding_unresolved` audit event and the new
+  `breakglass_debug_session_binding_unresolved_total` metric. Sessions without a `bindingRef` still
+  auto-discover exactly as before.
+- **DenyPolicy risk scoring now inspects ephemeral containers**: `detectRiskFactors`,
+  `calculateRiskScore` and `isHostPathWritable` each built their container list from
+  `spec.containers` plus `spec.initContainers` only, so `spec.ephemeralContainers` — the primary
+  debug primitive this operator injects — was exempt from the guardrail meant to police it. All
+  three now evaluate ephemeral containers as well. **This tightens enforcement:** see
+  [Upgrade impact](#upgrade-impact-denypolicy-ephemeral-containers) below.
+- **`ClientProvider.GetAcrossAllNamespaces` is deterministic and fails closed on ambiguity**: it
+  returned the first Go map-iteration / list match on cluster name, so when two namespaces held a
+  `ClusterConfig` with the same `metadata.name` the same cluster name could resolve to a different
+  spoke cluster across calls — and this path is reached from the authorization webhook. It now
+  errors on ambiguity, matching the semantics its unexported `getAcrossAllNamespacesLocked` twin
+  already had. Single-match and not-found behaviour are unchanged. `ensureClusterWideUniqueName`
+  admission validation already prevented duplicates, so this is defence in depth.
 - **OIDC proxy CORS header**: API CORS preflight responses now allow `X-OIDC-Authority` for browser-based multi-IDP OIDC proxy flows. (#1130)
 - **Audit Kafka requiredAcks**: Kafka audit sinks now preserve an explicit `requiredAcks: 0` no-ack configuration instead of treating it as unset and defaulting to all replicas.
 - **BreakglassSession list filters**: Session status listing now pushes exact state filters through the cache index and deduplicates multi-state results before applying cluster, user, or group filters.
@@ -36,6 +68,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed single resource table formatting in `bgctl` commands.
 
 - Fixed duplicate session error when status initialization fails.
+
+### Added
+
+- **`debug_session.binding_unresolved` audit event** (severity `warning`, classified sensitive so it
+  is never sampled or dropped) and **`breakglass_debug_session_binding_unresolved_total{cluster,reason}`
+  metric**, emitted when a `DebugSession` names an explicit `spec.bindingRef` that cannot be
+  resolved. `reason` is `binding not found` or `binding lookup failed`.
+
+### Upgrade impact: DenyPolicy ephemeral containers
+
+<a id="upgrade-impact-denypolicy-ephemeral-containers"></a>
+
+DenyPolicy risk scoring now evaluates `spec.ephemeralContainers` in addition to `spec.containers`
+and `spec.initContainers`. This **tightens** enforcement and is a behaviour change.
+
+**Config shape whose meaning changes** — any `DenyPolicy` with `spec.podSecurityRules`:
+
+```yaml
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DenyPolicy
+spec:
+  podSecurityRules:
+    riskFactors:            # <- these weights now also apply to ephemeral containers
+      privilegedContainer: 50
+      runAsRoot: 20
+      hostPathWritable: 25
+      capabilities:
+        SYS_ADMIN: 40
+    thresholds:             # <- an unchanged threshold may now be crossed
+      - maxScore: 40
+        action: allow
+      - maxScore: 100
+        action: deny
+```
+
+No field was added, removed or renamed, and no field's syntax changed. What changes is the computed
+`score`: a pod whose only risky container is an *ephemeral* one previously scored 0 for that
+container and could fall in an `allow` band; it now scores the configured weights and may cross a
+`warn` or `deny` threshold.
+
+- **Who is affected:** clusters that run a `DenyPolicy` with `podSecurityRules` **and** whose debug
+  sessions inject privileged / root / capability-granting / writable-`hostPath` ephemeral containers.
+  If your DenyPolicy has no `podSecurityRules`, or your debug templates inject only unprivileged
+  ephemeral containers, nothing changes.
+- **Direction of change:** allow → warn/deny only. Nothing that was previously denied becomes
+  allowed.
+- **Before upgrading:** review `breakglass_pod_security_risk_score` and your `thresholds`. If you
+  had (unknowingly) relied on the under-scoring, raise the relevant `maxScore` bands, or add the
+  affected factors to `podSecurityOverrides.exemptFactors` for the escalations that legitimately
+  need them.
+- **Detection after upgrade:** a step change in `breakglass_pod_security_denied_total` or
+  `breakglass_pod_security_warnings_total` for a given `policy` label.
+
+The other three fixes in this release are pure correctness fixes with no behaviour change in the
+non-buggy case:
+
+- The impersonation copy and the `GetAcrossAllNamespaces` determinism fix are behaviour-identical
+  whenever the buggy condition is absent (no impersonation configured; exactly one `ClusterConfig`
+  per cluster name — which admission validation already enforces).
+- The `bindingRef` fix is scoped strictly to "explicit `spec.bindingRef` that failed to resolve".
+  Sessions without a `bindingRef`, and sessions whose `bindingRef` resolves, behave exactly as
+  before. It introduces **no new lockout path**: the session state is left untouched rather than
+  being set to the terminal `Failed` state, so a transient error resolves on the next reconcile and
+  no operator is locked out mid-incident.
 
 ### Security
 

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -659,6 +659,27 @@ for _, binding := range allBindings {
 }
 ```
 
+### Explicit `bindingRef` failures are indeterminate, not "no binding"
+
+Auto-discovery above only runs when the `DebugSession` does **not** carry an explicit
+`spec.bindingRef`. When a session *does* name a `bindingRef` and that object cannot be read, the
+reconciler does **not** fall back to auto-discovery. The binding carries the approver
+configuration, so treating an unreadable ref as "no binding" would let a session that was meant to
+require approval activate with none.
+
+Instead the reconciler:
+
+1. logs at **Error** with the session, cluster, state and binding coordinates,
+2. emits the `debug_session.binding_unresolved` audit event,
+3. increments `breakglass_debug_session_binding_unresolved_total{cluster,reason}`, and
+4. returns the error so the session is **requeued with exponential backoff**.
+
+The session's state is left untouched — it stays `Pending` or `PendingApproval`, so no access is
+granted and nothing is terminally failed. A transient apiserver error resolves itself on the next
+reconcile; a mistyped or deleted `bindingRef` keeps requeueing and stays visible in the log, the
+audit trail and the metric until an operator corrects it. Sessions without a `bindingRef` are
+unaffected and still auto-discover exactly as documented above.
+
 ### Template Matching Options
 
 Bindings can match templates using two methods. At least one must be specified:

--- a/docs/deny-policy.md
+++ b/docs/deny-policy.md
@@ -501,9 +501,26 @@ kubectl get pod <pod-name> -o yaml | grep -A20 securityContext
 
 #### Score Calculation Seems Wrong
 
-1. **Check all containers**: Both init containers and regular containers are evaluated.
+1. **Check all containers**: Regular containers, init containers **and ephemeral containers** are
+   all evaluated.
 2. **Capabilities are cumulative**: Multiple capabilities in one container add up.
 3. **Privileged counted once**: Multiple privileged containers only add the score once.
+
+#### Ephemeral containers are in scope
+
+Risk scoring inspects `spec.ephemeralContainers` alongside `spec.containers` and
+`spec.initContainers`. This matters because injecting an ephemeral container is the primary
+debug primitive this operator exposes: a privileged, root, capability-carrying or
+writable-`hostPath`-mounting ephemeral container contributes to the risk score exactly as the
+equivalent regular container would.
+
+> **Upgrade note.** Releases before this fix scored only `containers` and `initContainers`.
+> A `DenyPolicy` with `podSecurityRules` whose thresholds previously *allowed* a pod because the
+> risk lived exclusively in an ephemeral container will now score higher and may cross a `deny`
+> threshold. No configuration field changed meaning; the same policy is simply enforced against
+> the containers it always intended to cover. Review your thresholds if you relied on the
+> previous under-scoring — `breakglass_pod_security_risk_score` and
+> `breakglass_pod_security_denied_total` will show the shift.
 
 #### Override Not Working
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -625,11 +625,12 @@ Track debug session lifecycle and resource usage.
 | `breakglass_debug_session_approval_required_total` | Counter | `cluster`, `template` | Debug sessions requiring approval |
 | `breakglass_debug_session_approved_total` | Counter | `cluster`, `approver_type` | Debug sessions approved |
 | `breakglass_debug_session_rejected_total` | Counter | `cluster`, `reason` | Debug sessions rejected |
-| `breakglass_debug_session_binding_unresolved_total` | Counter | `cluster`, `reason` | Reconciles where an explicit `spec.bindingRef` could not be resolved (`reason`: `binding not found` or `binding lookup failed`). The session is requeued, not activated. |
+| `breakglass_debug_session_binding_unresolved_total` | Counter | `cluster`, `reason` | Reconciles where an explicit `spec.bindingRef` could not be resolved (`reason`: `binding_not_found` or `binding_lookup_failed`). The session is requeued, not activated. |
 
 > Alert on `breakglass_debug_session_binding_unresolved_total`. A sustained non-zero rate means
-> debug sessions are stalled waiting on a binding: either the `bindingRef` is wrong (`binding not
-> found`) or the hub cannot read `DebugSessionClusterBinding` objects (`binding lookup failed`).
+> debug sessions are stalled waiting on a binding: either the `bindingRef` is wrong
+> (`binding_not_found`) or the hub cannot read `DebugSessionClusterBinding` objects
+> (`binding_lookup_failed`).
 > Because the binding carries the approver configuration, the reconciler treats an unresolvable
 > ref as *indeterminate* and refuses to activate rather than guessing that no approval is needed.
 > The matching audit event is `debug_session.binding_unresolved`.
@@ -650,6 +651,7 @@ Track cluster client caching and rest config loading.
 |--------|------|--------|-------------|
 | `breakglass_cluster_cache_hits_total` | Counter | `cluster` | Cluster client cache hits |
 | `breakglass_cluster_cache_misses_total` | Counter | `cluster` | Cluster client cache misses |
+| `breakglass_cluster_cache_ambiguous_total` | Counter | `cluster`, `source` | Cluster-name lookups rejected because the name resolved to multiple `ClusterConfig` objects (`source`: `cache` or `list`). Any non-zero value means cluster-wide name uniqueness was violated and name-based lookups are failing closed. |
 | `breakglass_cluster_rest_config_loaded_total` | Counter | `cluster` | REST configs loaded |
 | `breakglass_cluster_rest_config_errors_total` | Counter | `cluster` | REST config load errors |
 | `breakglass_cluster_cache_invalidations_total` | Counter | `cluster` | Cache invalidations |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -625,6 +625,14 @@ Track debug session lifecycle and resource usage.
 | `breakglass_debug_session_approval_required_total` | Counter | `cluster`, `template` | Debug sessions requiring approval |
 | `breakglass_debug_session_approved_total` | Counter | `cluster`, `approver_type` | Debug sessions approved |
 | `breakglass_debug_session_rejected_total` | Counter | `cluster`, `reason` | Debug sessions rejected |
+| `breakglass_debug_session_binding_unresolved_total` | Counter | `cluster`, `reason` | Reconciles where an explicit `spec.bindingRef` could not be resolved (`reason`: `binding not found` or `binding lookup failed`). The session is requeued, not activated. |
+
+> Alert on `breakglass_debug_session_binding_unresolved_total`. A sustained non-zero rate means
+> debug sessions are stalled waiting on a binding: either the `bindingRef` is wrong (`binding not
+> found`) or the hub cannot read `DebugSessionClusterBinding` objects (`binding lookup failed`).
+> Because the binding carries the approver configuration, the reconciler treats an unresolvable
+> ref as *indeterminate* and refuses to activate rather than guessing that no approval is needed.
+> The matching audit event is `debug_session.binding_unresolved`.
 
 ## Field Index Metrics
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4127,9 +4127,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6789,9 +6789,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -7185,9 +7185,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7204,7 +7204,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "^5.0.9",
     "shell-quote": "^1.8.5",
     "vitest": "$vitest",
     "@vitest/coverage-v8": "$@vitest/coverage-v8"

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -783,6 +783,33 @@ func (m *Manager) DebugSessionApprovalTimeout(ctx context.Context, sessionName, 
 	})
 }
 
+// DebugSessionBindingUnresolved emits an audit event when a DebugSession names an
+// explicit BindingRef that could not be resolved. Because the binding carries the
+// approver configuration, this leaves the approval requirement indeterminate and the
+// session is NOT activated — it is requeued until the ref resolves or the reference
+// is corrected.
+func (m *Manager) DebugSessionBindingUnresolved(ctx context.Context, sessionName, namespace, cluster, bindingName, bindingNamespace, reason string) {
+	m.Emit(ctx, &Event{
+		Type:     EventDebugSessionBindingUnresolved,
+		Severity: SeverityWarning,
+		Actor:    Actor{User: "system"},
+		Target: Target{
+			Kind:      "DebugSession",
+			Name:      sessionName,
+			Namespace: namespace,
+		},
+		Details: map[string]interface{}{
+			"cluster":          cluster,
+			"bindingName":      bindingName,
+			"bindingNamespace": bindingNamespace,
+			"reason":           reason,
+		},
+		RequestContext: &RequestContext{
+			DebugSessionName: sessionName,
+		},
+	})
+}
+
 // DebugSessionPodFailed emits an audit event when a debug session pod fails.
 func (m *Manager) DebugSessionPodFailed(ctx context.Context, sessionName, namespace, podName, podNamespace, reason, message string) {
 	m.Emit(ctx, &Event{

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -120,6 +120,11 @@ const (
 	EventDebugSessionPodRestarted    EventType = "debug_session.pod_restarted"
 	EventDebugSessionResourceDeploy  EventType = "debug_session.resource_deployed"
 	EventDebugSessionResourceCleanup EventType = "debug_session.resource_cleanup"
+	// EventDebugSessionBindingUnresolved is emitted when a DebugSession names an
+	// explicit BindingRef that cannot be resolved. The binding carries the approver
+	// configuration, so an unresolvable ref means the approval requirement is
+	// INDETERMINATE and the session must not be activated on a guess.
+	EventDebugSessionBindingUnresolved EventType = "debug_session.binding_unresolved"
 
 	// === Pod and container events ===
 	EventPodCreated     EventType = "pod.created"
@@ -328,7 +333,8 @@ func SeverityForEventType(eventType EventType) Severity {
 		EventEscalationRejected, EventPolicyViolation, EventAdmissionDenied,
 		EventSecretAccessed, EventSecretUpdated, EventResourceExec, EventResourceDelete,
 		EventPodExec, EventPodAttach, EventResourceImpersonate, EventWebhookTimeout,
-		EventDebugSessionCommand, EventAuditBackpressure, EventPodSecurityWarning:
+		EventDebugSessionCommand, EventAuditBackpressure, EventPodSecurityWarning,
+		EventDebugSessionBindingUnresolved:
 		return SeverityWarning
 
 	// Info events - normal operation
@@ -468,6 +474,7 @@ func IsSensitiveEvent(eventType EventType) bool {
 		EventDebugSessionCreated, EventDebugSessionStarted,
 		EventDebugSessionTerminated, EventDebugSessionFailed,
 		EventDebugSessionExpired, EventDebugSessionApprovalTimeout,
+		EventDebugSessionBindingUnresolved,
 		EventClusterRoleBindingCreated, EventClusterRoleBindingDeleted,
 		EventResourceImpersonate, EventPolicyBypassed,
 		EventPodSecurityDenied, EventPodSecurityWarning, EventPodSecurityOverride:

--- a/pkg/breakglass/debug/debug_session_impersonation_isolation_test.go
+++ b/pkg/breakglass/debug/debug_session_impersonation_isolation_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/cluster"
+)
+
+// impersonationTestClusterName is the namespaced cluster key used by the fixtures below.
+const impersonationTestClusterName = "default/spoke-a"
+
+// newImpersonationTestController wires a DebugSessionController onto a real
+// cluster.ClientProvider backed by a fake hub client holding a valid kubeconfig
+// Secret. Using the real provider (rather than a stub) is deliberate: the defect
+// under test is that GetRESTConfig hands back the *shared cached pointer*, and only
+// the real provider reproduces that caching behaviour.
+func newImpersonationTestController(t *testing.T) *DebugSessionController {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		Clusters:       map[string]*clientcmdapi.Cluster{"spoke": {Server: "https://spoke-a.example.com:6443"}},
+		AuthInfos:      map[string]*clientcmdapi.AuthInfo{"admin": {Token: "hub-controller-token"}},
+		Contexts:       map[string]*clientcmdapi.Context{"ctx": {Cluster: "spoke", AuthInfo: "admin"}},
+		CurrentContext: "ctx",
+	})
+	require.NoError(t, err)
+
+	cc := &breakglassv1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke-a", Namespace: "default"},
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
+			KubeconfigSecretRef: &breakglassv1alpha1.SecretKeyReference{
+				Name: "spoke-a-kubeconfig", Namespace: "default",
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke-a-kubeconfig", Namespace: "default"},
+		Data:       map[string][]byte{"value": kubeconfig},
+	}
+
+	hub := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cc, secret).Build()
+
+	return &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     hub,
+		ccProvider: cluster.NewClientProvider(hub, zap.NewNop().Sugar()),
+	}
+}
+
+func saImpersonation(namespace, name string) *breakglassv1alpha1.ImpersonationConfig {
+	return &breakglassv1alpha1.ImpersonationConfig{
+		ServiceAccountRef: &breakglassv1alpha1.ServiceAccountReference{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+// TestCreateImpersonatedClient_DoesNotPoisonSharedCachedRESTConfig pins the defect.
+//
+// createImpersonatedClient obtains the spoke REST config from
+// ClientProvider.GetRESTConfig, which returns the SHARED cached *rest.Config pointer.
+// Before the fix it wrote Impersonate directly onto that shared object, so the
+// impersonation identity of one DebugSession leaked onto the cache entry and every
+// later consumer of the same spoke config silently acted as that ServiceAccount until
+// the TTL expired.
+//
+// Assertion: after impersonating on a client built for session A, a fresh
+// GetRESTConfig for the same cluster must still be un-impersonated.
+func TestCreateImpersonatedClient_DoesNotPoisonSharedCachedRESTConfig(t *testing.T) {
+	c := newImpersonationTestController(t)
+	ctx := context.Background()
+
+	// Warm the cache and record the pristine state of the shared entry.
+	shared, err := c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+	require.NoError(t, err)
+	require.Empty(t, shared.Impersonate.UserName, "precondition: cached config must start un-impersonated")
+
+	// Session A impersonates a ServiceAccount on the spoke.
+	_, err = c.createImpersonatedClient(ctx, impersonationTestClusterName,
+		saImpersonation("kube-system", "debug-sa"))
+	require.NoError(t, err)
+
+	// The shared cached object must be untouched.
+	assert.Empty(t, shared.Impersonate.UserName,
+		"impersonation leaked onto the SHARED cached rest.Config; every other consumer "+
+			"of this spoke's config would now act as the impersonated ServiceAccount")
+
+	// And an independent consumer obtaining the config again must see no impersonation.
+	again, err := c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+	require.NoError(t, err)
+	assert.Same(t, shared, again, "provider is expected to hand back the same cached pointer")
+	assert.Empty(t, again.Impersonate.UserName,
+		"a subsequent unrelated consumer inherited impersonation from an earlier DebugSession")
+}
+
+// TestCreateImpersonatedClient_SessionsDoNotSeeEachOthersIdentity asserts the
+// per-session isolation that the shared-pointer mutation destroyed: two sessions
+// impersonating different ServiceAccounts against the same spoke must not observe
+// each other's identity, and neither may reach the cache entry.
+func TestCreateImpersonatedClient_SessionsDoNotSeeEachOthersIdentity(t *testing.T) {
+	c := newImpersonationTestController(t)
+	ctx := context.Background()
+
+	shared, err := c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+	require.NoError(t, err)
+
+	_, err = c.createImpersonatedClient(ctx, impersonationTestClusterName,
+		saImpersonation("team-a", "sa-a"))
+	require.NoError(t, err)
+	assert.Empty(t, shared.Impersonate.UserName, "session A poisoned the cache")
+
+	_, err = c.createImpersonatedClient(ctx, impersonationTestClusterName,
+		saImpersonation("team-b", "sa-b"))
+	require.NoError(t, err)
+	assert.Empty(t, shared.Impersonate.UserName, "session B poisoned the cache")
+}
+
+// TestCreateImpersonatedClient_NoImpersonationConfigIsUnchanged proves the
+// non-buggy path is behaviour-identical: with no impersonation configured, nothing
+// is written and the client is built from an un-impersonated config.
+func TestCreateImpersonatedClient_NoImpersonationConfigIsUnchanged(t *testing.T) {
+	c := newImpersonationTestController(t)
+	ctx := context.Background()
+
+	shared, err := c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+	require.NoError(t, err)
+
+	for name, impConfig := range map[string]*breakglassv1alpha1.ImpersonationConfig{
+		"nil config":                    nil,
+		"config without serviceAccount": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := c.createImpersonatedClient(ctx, impersonationTestClusterName, impConfig)
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+			assert.Empty(t, shared.Impersonate.UserName)
+		})
+	}
+
+	// Non-impersonation fields of the shared config must survive untouched.
+	assert.Equal(t, "https://spoke-a.example.com:6443", shared.Host)
+	assert.Equal(t, "hub-controller-token", shared.BearerToken)
+}
+
+// TestCreateImpersonatedClient_ConcurrentSessionsAreRaceFree exercises the data-race
+// half of the defect. Run under `go test -race`: concurrent reconciles writing
+// Impersonate onto one shared struct is an unsynchronised write, which the race
+// detector reports. Copying first removes the shared write entirely.
+func TestCreateImpersonatedClient_ConcurrentSessionsAreRaceFree(t *testing.T) {
+	c := newImpersonationTestController(t)
+	ctx := context.Background()
+
+	// Warm the cache so every goroutine takes the cache-hit path that returns the
+	// shared pointer.
+	shared, err := c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+	require.NoError(t, err)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			// Half impersonate, half just read the config concurrently — the mix of
+			// concurrent read and write on the shared object is what races.
+			if idx%2 == 0 {
+				_, errs[idx] = c.createImpersonatedClient(ctx, impersonationTestClusterName,
+					saImpersonation("team", "sa"))
+				return
+			}
+			_, errs[idx] = c.ccProvider.GetRESTConfig(ctx, impersonationTestClusterName)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d", i)
+	}
+	assert.Empty(t, shared.Impersonate.UserName,
+		"concurrent sessions mutated the shared cached rest.Config")
+}

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -207,7 +207,14 @@ func (c *DebugSessionController) handlePending(ctx context.Context, ds *breakgla
 	}
 
 	// Find binding early so we can check its approvers for the approval decision
-	// This ensures bindings with approvers properly trigger approval workflow
+	// This ensures bindings with approvers properly trigger approval workflow.
+	//
+	// An explicit BindingRef that cannot be resolved is INDETERMINATE, not "absent".
+	// The binding is what carries the approver configuration, so silently falling
+	// through to auto-discovery here would let requiresApproval() see no approvers
+	// and activate the session with no approval at all — a fail-OPEN on a transient
+	// API/cache error. We requeue instead: the session stays Pending (nothing is
+	// granted, nothing is denied) until the ref resolves or an operator corrects it.
 	var binding *breakglassv1alpha1.DebugSessionClusterBinding
 	if ds.Spec.BindingRef != nil {
 		binding, err = c.getBinding(ctx, ds.Spec.BindingRef.Name, ds.Spec.BindingRef.Namespace)
@@ -823,11 +830,20 @@ func (c *DebugSessionController) createImpersonatedClient(
 	clusterName string,
 	impConfig *breakglassv1alpha1.ImpersonationConfig,
 ) (ctrlclient.Client, error) {
-	// Get base REST config for spoke cluster
-	restCfg, err := c.ccProvider.GetRESTConfig(ctx, clusterName)
+	// Get base REST config for spoke cluster.
+	//
+	// GetRESTConfig returns the *shared* cached *rest.Config pointer held in the
+	// ClientProvider cache for this spoke. It MUST NOT be mutated in place: every
+	// other consumer of that cluster's cached config (webhook SAR checks, cleanup,
+	// workload deployment, clientsets) would inherit whatever we wrote until the
+	// cache entry expires, and concurrent reconciles would race on the same struct.
+	// Always copy before touching any field. See group_checker.go and
+	// session_controller_approval_utils.go for the same pattern.
+	sharedCfg, err := c.ccProvider.GetRESTConfig(ctx, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST config for cluster %s: %w", clusterName, err)
 	}
+	restCfg := rest.CopyConfig(sharedCfg)
 
 	// If impersonation is configured, set up impersonation
 	if impConfig != nil && impConfig.ServiceAccountRef != nil {

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -754,9 +754,9 @@ func (c *DebugSessionController) deferOnUnresolvedBinding(
 		bindingNamespace = ds.Spec.BindingRef.Namespace
 	}
 
-	reason := "binding lookup failed"
+	reason := "binding_lookup_failed"
 	if apierrors.IsNotFound(cause) {
-		reason = "binding not found"
+		reason = "binding_not_found"
 	}
 
 	c.log.Errorw("Refusing to evaluate debug session: explicit bindingRef is unresolvable, "+

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -219,10 +219,7 @@ func (c *DebugSessionController) handlePending(ctx context.Context, ds *breakgla
 	if ds.Spec.BindingRef != nil {
 		binding, err = c.getBinding(ctx, ds.Spec.BindingRef.Name, ds.Spec.BindingRef.Namespace)
 		if err != nil {
-			log.Warnw("Failed to get binding by ref, will try auto-discovery",
-				"binding", ds.Spec.BindingRef.Name,
-				"namespace", ds.Spec.BindingRef.Namespace,
-				"error", err)
+			return c.deferOnUnresolvedBinding(ctx, ds, err)
 		}
 	}
 	if binding == nil {
@@ -267,10 +264,17 @@ func (c *DebugSessionController) handlePendingApproval(ctx context.Context, ds *
 		if err != nil {
 			return c.failSession(ctx, ds, fmt.Sprintf("template not found: %s", ds.Spec.TemplateRef))
 		}
-		// Find binding for merging allowed pod operations
+		// Find binding for merging allowed pod operations.
+		// Same indeterminate-vs-absent reasoning as handlePending: the binding can only
+		// narrow AllowedPodOperations, so activating without it would grant a strictly
+		// wider set than the approver saw. Requeue instead of guessing.
 		var binding *breakglassv1alpha1.DebugSessionClusterBinding
 		if ds.Spec.BindingRef != nil {
-			binding, _ = c.getBinding(ctx, ds.Spec.BindingRef.Name, ds.Spec.BindingRef.Namespace)
+			var bErr error
+			binding, bErr = c.getBinding(ctx, ds.Spec.BindingRef.Name, ds.Spec.BindingRef.Namespace)
+			if bErr != nil {
+				return c.deferOnUnresolvedBinding(ctx, ds, bErr)
+			}
 		}
 		if binding == nil {
 			binding, _ = c.findBindingForSession(ctx, template, ds.Spec.Cluster)
@@ -718,6 +722,67 @@ func (c *DebugSessionController) getBinding(ctx context.Context, name, namespace
 		return nil, err
 	}
 	return binding, nil
+}
+
+// deferOnUnresolvedBinding handles the case where a DebugSession names an explicit
+// BindingRef that cannot be resolved.
+//
+// Failure modes here are asymmetric, so the design is deliberately "indeterminate",
+// not "deny":
+//
+//   - Silently auto-discovering (the previous behaviour) fails OPEN: the binding
+//     carries the approver set, so losing it makes requiresApproval() return false and
+//     the session activates with no approval on a transient API error.
+//   - Failing the session outright would fail CLOSED but destructively: DebugSessionStateFailed
+//     is terminal and never requeues, so a two-second apiserver blip during an incident
+//     would permanently kill an operator's emergency session and force a manual re-request.
+//
+// So we do neither. The session stays in its current state (Pending / PendingApproval —
+// no access granted, nothing terminal) and we requeue. A NotFound on a mistyped ref will
+// keep requeueing and remain visible via the audit event, the Error log and the
+// breakglass_debug_session_binding_unresolved_total metric; the existing approval-timeout
+// path still bounds how long a PendingApproval session can linger. No NEW lockout path is
+// introduced: every state that previously activated either still activates or is retried.
+func (c *DebugSessionController) deferOnUnresolvedBinding(
+	ctx context.Context,
+	ds *breakglassv1alpha1.DebugSession,
+	cause error,
+) (ctrl.Result, error) {
+	bindingName, bindingNamespace := "", ""
+	if ds.Spec.BindingRef != nil {
+		bindingName = ds.Spec.BindingRef.Name
+		bindingNamespace = ds.Spec.BindingRef.Namespace
+	}
+
+	reason := "binding lookup failed"
+	if apierrors.IsNotFound(cause) {
+		reason = "binding not found"
+	}
+
+	c.log.Errorw("Refusing to evaluate debug session: explicit bindingRef is unresolvable, "+
+		"approval requirement is indeterminate; not falling back to auto-discovery",
+		"debugSession", ds.Name,
+		"namespace", ds.Namespace,
+		"cluster", ds.Spec.Cluster,
+		"state", string(ds.Status.State),
+		"binding", bindingName,
+		"bindingNamespace", bindingNamespace,
+		"reason", reason,
+		"error", cause)
+
+	metrics.DebugSessionBindingUnresolved.WithLabelValues(ds.Spec.Cluster, reason).Inc()
+
+	if c.shouldEmitAudit(ds) {
+		if auditManager := c.currentAuditManager(); auditManager != nil {
+			auditManager.DebugSessionBindingUnresolved(ctx, ds.Name, ds.Namespace,
+				ds.Spec.Cluster, bindingName, bindingNamespace, reason)
+		}
+	}
+
+	// Return the error so controller-runtime applies its exponential backoff rather
+	// than our fixed requeue interval; the session state is left untouched.
+	return ctrl.Result{}, fmt.Errorf("resolve bindingRef %s/%s for debug session %s/%s: %w",
+		bindingNamespace, bindingName, ds.Namespace, ds.Name, cause)
 }
 
 // findBindingForSession finds a DebugSessionClusterBinding that matches the session's template and cluster.

--- a/pkg/breakglass/debug/debug_session_unresolved_binding_test.go
+++ b/pkg/breakglass/debug/debug_session_unresolved_binding_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -35,6 +36,7 @@ import (
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/cluster"
+	"github.com/telekom/k8s-breakglass/pkg/metrics"
 )
 
 const unresolvedBindingNamespace = "breakglass"
@@ -316,18 +318,36 @@ func TestDeferOnUnresolvedBinding_ClassifiesReason(t *testing.T) {
 		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
 	}
 
-	ds := sessionWithBindingRef("classify", "tmpl", "spoke-a", "b")
+	ds := sessionWithBindingRef("classify", "tmpl", "spoke-classify", "b")
+
+	// The reason label values must be stable snake_case, matching every other
+	// label value in this codebase (e.g. "user_rejected", "policy_violation").
+	// Human phrases with spaces are awkward in PromQL and invite drift.
+	const (
+		reasonNotFound     = "binding_not_found"
+		reasonLookupFailed = "binding_lookup_failed"
+	)
+	notFoundBefore := testutil.ToFloat64(
+		metrics.DebugSessionBindingUnresolved.WithLabelValues("spoke-classify", reasonNotFound))
+	lookupFailedBefore := testutil.ToFloat64(
+		metrics.DebugSessionBindingUnresolved.WithLabelValues("spoke-classify", reasonLookupFailed))
 
 	notFound := apierrors.NewNotFound(
 		schema.GroupResource{Group: breakglassv1alpha1.GroupVersion.Group, Resource: "debugsessionclusterbindings"}, "b")
 	_, err := c.deferOnUnresolvedBinding(context.Background(), ds, notFound)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, notFound)
+	assert.Equal(t, notFoundBefore+1, testutil.ToFloat64(
+		metrics.DebugSessionBindingUnresolved.WithLabelValues("spoke-classify", reasonNotFound)),
+		"a NotFound cause must be reported as %q", reasonNotFound)
 
 	transient := apierrors.NewServiceUnavailable("apiserver is restarting")
 	_, err = c.deferOnUnresolvedBinding(context.Background(), ds, transient)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, transient)
+	assert.Equal(t, lookupFailedBefore+1, testutil.ToFloat64(
+		metrics.DebugSessionBindingUnresolved.WithLabelValues("spoke-classify", reasonLookupFailed)),
+		"a transient cause must be reported as %q", reasonLookupFailed)
 
 	// A nil BindingRef must not panic (defensive: the helper is only called when the
 	// ref is set, but it must stay safe if that ever changes).

--- a/pkg/breakglass/debug/debug_session_unresolved_binding_test.go
+++ b/pkg/breakglass/debug/debug_session_unresolved_binding_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/cluster"
+)
+
+const unresolvedBindingNamespace = "breakglass"
+
+func unresolvedBindingScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(s))
+	return s
+}
+
+// approvalRequiredTemplate has approvers configured, so a session created against it
+// MUST NOT activate without approval.
+func approvalRequiredTemplate(name string) *breakglassv1alpha1.DebugSessionTemplate {
+	return &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+				Groups: []string{"sre-leads"},
+			},
+		},
+	}
+}
+
+// noApproverTemplate has no approvers at all: this is the template shape that makes
+// the fail-open reachable, because losing the binding leaves nothing requiring approval.
+func noApproverTemplate(name string) *breakglassv1alpha1.DebugSessionTemplate {
+	return &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       breakglassv1alpha1.DebugSessionTemplateSpec{},
+	}
+}
+
+func sessionWithBindingRef(name, templateRef, clusterName, bindingName string) *breakglassv1alpha1.DebugSession {
+	ds := newTestDebugSession(name, templateRef, clusterName, "oncall@example.com")
+	ds.Spec.BindingRef = &breakglassv1alpha1.BindingReference{
+		Name:      bindingName,
+		Namespace: unresolvedBindingNamespace,
+	}
+	return ds
+}
+
+// TestHandlePending_UnresolvableBindingRefDoesNotActivateWithoutApproval pins the
+// fail-open defect.
+//
+// Setup reproduces the exact dangerous combination:
+//   - the DebugSession names an explicit bindingRef
+//   - the template has NO approvers, so approval can only come from the binding
+//   - the binding lookup fails with a TRANSIENT error (not NotFound)
+//
+// Before the fix the error was only log.Warnw'd, flow fell through to
+// findBindingForSession (which returns nil,nil when nothing matches), requiresApproval
+// then saw a nil binding and an approver-less template and returned false — and the
+// session was ACTIVATED with no approval at all.
+func TestHandlePending_UnresolvableBindingRefDoesNotActivateWithoutApproval(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	template := noApproverTemplate("no-approver-template")
+	ds := sessionWithBindingRef("fail-open-probe", template.Name, "spoke-a", "gated-binding")
+
+	// The binding EXISTS and requires approval, but the API read fails transiently.
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "gated-binding", Namespace: unresolvedBindingNamespace},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Clusters: []string{"spoke-a"},
+			Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+				Groups: []string{"sre-leads"},
+			},
+		},
+	}
+
+	transient := apierrors.NewInternalError(errors.New("etcdserver: request timed out"))
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ds, template, binding).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c ctrlclient.WithWatch, key ctrlclient.ObjectKey,
+				obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+				if _, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding); ok {
+					return transient
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	res, err := c.handlePending(context.Background(), ds)
+
+	// The reconcile must surface the error so controller-runtime retries with backoff.
+	require.Error(t, err, "an unresolvable bindingRef must not be silently ignored")
+	assert.Contains(t, err.Error(), "resolve bindingRef")
+	assert.Contains(t, err.Error(), "gated-binding")
+	assert.ErrorIs(t, err, transient, "the underlying cause must be wrapped, not swallowed")
+	assert.Zero(t, res.RequeueAfter, "returning an error defers requeue timing to controller-runtime")
+
+	// Crucially: the session must NOT have been activated.
+	assert.NotEqual(t, breakglassv1alpha1.DebugSessionStateActive, ds.Status.State,
+		"session activated despite an unresolvable approval-carrying binding (fail-open)")
+
+	// And it must NOT have been driven into the terminal Failed state either — that would
+	// be a new lockout path for what may be a two-second apiserver blip.
+	assert.NotEqual(t, breakglassv1alpha1.DebugSessionStateFailed, ds.Status.State,
+		"a transient lookup error must not terminally fail an emergency-access session")
+
+	// Nothing was persisted, so the object on the API server is untouched and the next
+	// reconcile re-evaluates from scratch.
+	var stored breakglassv1alpha1.DebugSession
+	require.NoError(t, fakeClient.Get(context.Background(),
+		ctrlclient.ObjectKeyFromObject(ds), &stored))
+	assert.Empty(t, stored.Status.State)
+	assert.Nil(t, stored.Status.Approval)
+}
+
+// TestHandlePending_NotFoundBindingRefIsAlsoIndeterminate covers a mistyped or deleted
+// ref. It is still indeterminate rather than "no binding": we cannot know whether the
+// binding that was supposed to gate this session required approval.
+func TestHandlePending_NotFoundBindingRefIsAlsoIndeterminate(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	template := noApproverTemplate("no-approver-template")
+	ds := sessionWithBindingRef("missing-ref", template.Name, "spoke-a", "typo-binding")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ds, template).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	_, err := c.handlePending(context.Background(), ds)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(errors.Unwrap(err)) || apierrors.IsNotFound(err),
+		"NotFound cause must be preserved for callers and logs")
+	assert.NotEqual(t, breakglassv1alpha1.DebugSessionStateActive, ds.Status.State)
+	assert.NotEqual(t, breakglassv1alpha1.DebugSessionStateFailed, ds.Status.State)
+}
+
+// TestHandlePendingApproval_UnresolvableBindingRefDoesNotActivate covers the second
+// site. Approval has already been granted here, but the binding can only NARROW
+// AllowedPodOperations, so activating without it would grant a strictly wider set of
+// pod operations than the approver actually saw.
+func TestHandlePendingApproval_UnresolvableBindingRefDoesNotActivate(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	template := approvalRequiredTemplate("gated-template")
+	ds := sessionWithBindingRef("approved-session", template.Name, "spoke-a", "narrowing-binding")
+	ds.Status.State = breakglassv1alpha1.DebugSessionStatePendingApproval
+	approvedAt := metav1.Now()
+	ds.Status.Approval = &breakglassv1alpha1.DebugSessionApproval{
+		Required:   true,
+		ApprovedAt: &approvedAt,
+		ApprovedBy: "sre-lead@example.com",
+	}
+
+	transient := apierrors.NewTooManyRequests("client rate limiter", 1)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ds, template).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c ctrlclient.WithWatch, key ctrlclient.ObjectKey,
+				obj ctrlclient.Object, opts ...ctrlclient.GetOption) error {
+				if _, ok := obj.(*breakglassv1alpha1.DebugSessionClusterBinding); ok {
+					return transient
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	_, err := c.handlePendingApproval(context.Background(), ds)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve bindingRef")
+	assert.ErrorIs(t, err, transient)
+
+	// State is left as PendingApproval — retryable, non-terminal, no access granted.
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, ds.Status.State,
+		"an unresolvable binding must leave the session retryable, not activate or fail it")
+	// The approval itself is preserved, so no re-approval is needed once the ref resolves.
+	require.NotNil(t, ds.Status.Approval)
+	assert.NotNil(t, ds.Status.Approval.ApprovedAt)
+}
+
+// TestHandlePending_NoBindingRefStillAutoDiscovers is the backwards-compatibility
+// guarantee: sessions with NO bindingRef are completely unaffected — auto-discovery
+// still runs, and an approver-less template still auto-approves exactly as before.
+// The new behaviour is scoped strictly to "explicit bindingRef that failed to resolve".
+func TestHandlePending_NoBindingRefStillAutoDiscovers(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	template := noApproverTemplate("no-approver-template")
+	// No BindingRef at all.
+	ds := newTestDebugSession("no-ref-session", template.Name, "spoke-a", "oncall@example.com")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ds, template).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	_, err := c.handlePending(context.Background(), ds)
+	// Activation may still fail later for unrelated reasons (no ClusterConfig in this
+	// fixture); what matters is that we did NOT stop at binding resolution.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "resolve bindingRef",
+			"a session without a bindingRef must never hit the unresolved-binding path")
+	}
+	require.NotNil(t, ds.Status.Approval)
+	assert.False(t, ds.Status.Approval.Required,
+		"approver-less template must still auto-approve, exactly as before")
+}
+
+// TestHandlePending_ResolvableBindingRefUnchanged proves the happy path is untouched:
+// a bindingRef that resolves and carries approvers still routes to PendingApproval.
+func TestHandlePending_ResolvableBindingRefUnchanged(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	template := noApproverTemplate("no-approver-template")
+	ds := sessionWithBindingRef("resolvable", template.Name, "spoke-a", "gated-binding")
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "gated-binding", Namespace: unresolvedBindingNamespace},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			Clusters: []string{"spoke-a"},
+			Approvers: &breakglassv1alpha1.DebugSessionApprovers{
+				Groups: []string{"sre-leads"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ds, template, binding).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		Build()
+
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	res, err := c.handlePending(context.Background(), ds)
+	require.NoError(t, err)
+	assert.Equal(t, breakglassv1alpha1.DebugSessionStatePendingApproval, ds.Status.State)
+	require.NotNil(t, ds.Status.Approval)
+	assert.True(t, ds.Status.Approval.Required)
+	assert.Equal(t, DefaultDebugSessionRequeue, res.RequeueAfter)
+}
+
+// TestDeferOnUnresolvedBinding_ClassifiesReason checks the reason label that feeds both
+// the audit event and the Prometheus metric, so the two failure classes stay
+// distinguishable in dashboards.
+func TestDeferOnUnresolvedBinding_ClassifiesReason(t *testing.T) {
+	scheme := unresolvedBindingScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &DebugSessionController{
+		log:        zap.NewNop().Sugar(),
+		client:     fakeClient,
+		ccProvider: cluster.NewClientProvider(fakeClient, zap.NewNop().Sugar()),
+	}
+
+	ds := sessionWithBindingRef("classify", "tmpl", "spoke-a", "b")
+
+	notFound := apierrors.NewNotFound(
+		schema.GroupResource{Group: breakglassv1alpha1.GroupVersion.Group, Resource: "debugsessionclusterbindings"}, "b")
+	_, err := c.deferOnUnresolvedBinding(context.Background(), ds, notFound)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, notFound)
+
+	transient := apierrors.NewServiceUnavailable("apiserver is restarting")
+	_, err = c.deferOnUnresolvedBinding(context.Background(), ds, transient)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transient)
+
+	// A nil BindingRef must not panic (defensive: the helper is only called when the
+	// ref is set, but it must stay safe if that ever changes).
+	ds.Spec.BindingRef = nil
+	_, err = c.deferOnUnresolvedBinding(context.Background(), ds, transient)
+	require.Error(t, err)
+}

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -143,20 +143,36 @@ func splitNamespacedName(value string) (string, string, bool) {
 //
 // Note: This method performs an O(n) scan of cached entries. For high-throughput scenarios
 // with many cached ClusterConfigs, consider using GetInNamespace with a known namespace.
+//
+// Ambiguity fails closed. If two namespaces hold a ClusterConfig with the same
+// metadata.name, this returns an error rather than an arbitrary one of them. Go map
+// iteration order is randomised, so returning "the first match" would resolve the same
+// cluster name to different spoke clusters across calls — and this function is reached
+// from the authorization webhook. `ClusterConfig.ValidateCreate` enforces
+// `ensureClusterWideUniqueName`, so duplicates should not exist; this is defence in depth
+// for the case where they do (pre-existing objects, webhook bypass, direct etcd writes).
+// Semantics match the unexported getAcrossAllNamespacesLocked twin.
 func (p *ClientProvider) GetAcrossAllNamespaces(ctx context.Context, name string) (*breakglassv1alpha1.ClusterConfig, error) {
 	// Try exact namespace/name lookup first if we have cached entries
 	p.mu.RLock()
 	// First, try to find a cached entry by scanning for any namespace with this name
 	// We match by the ClusterConfig's Name field to ensure exact match (avoids
 	// issues with similar cluster names like "prod" vs "my-prod").
+	var cachedFound *breakglassv1alpha1.ClusterConfig
 	for _, cfg := range p.data {
 		if cfg != nil && cfg.Name == name {
-			p.mu.RUnlock()
-			metrics.ClusterCacheHits.WithLabelValues(name).Inc()
-			return cfg, nil
+			if cachedFound != nil {
+				p.mu.RUnlock()
+				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q in cache", name)
+			}
+			cachedFound = cfg
 		}
 	}
 	p.mu.RUnlock()
+	if cachedFound != nil {
+		metrics.ClusterCacheHits.WithLabelValues(name).Inc()
+		return cachedFound, nil
+	}
 	metrics.ClusterCacheMisses.WithLabelValues(name).Inc()
 
 	// Namespace not provided: preserve legacy behavior and list across namespaces
@@ -164,15 +180,22 @@ func (p *ClientProvider) GetAcrossAllNamespaces(ctx context.Context, name string
 	if err := p.k8s.List(ctx, &list); err != nil {
 		return nil, fmt.Errorf("list clusterconfigs: %w", err)
 	}
+	var found *breakglassv1alpha1.ClusterConfig
 	for _, item := range list.Items {
 		if item.Name == name {
+			if found != nil {
+				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q across namespaces", name)
+			}
 			// copy loop variable before taking address
 			cp := item
-			p.mu.Lock()
-			p.data[cacheKey(cp.Namespace, cp.Name)] = &cp
-			p.mu.Unlock()
-			return &cp, nil
+			found = &cp
 		}
+	}
+	if found != nil {
+		p.mu.Lock()
+		p.data[cacheKey(found.Namespace, found.Name)] = found
+		p.mu.Unlock()
+		return found, nil
 	}
 	return nil, fmt.Errorf("%w: %s", ErrClusterConfigNotFound, name)
 }

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -268,6 +268,27 @@ func (p *ClientProvider) getInNamespaceLocked(ctx context.Context, namespace, na
 // without attempting any network call. When the breaker is in half-open state, a single probe
 // request is allowed through to test cluster reachability; all other callers still receive
 // ErrCircuitOpen until the probe succeeds.
+//
+// OWNERSHIP CONTRACT — the returned *rest.Config is the SHARED cached pointer.
+// Callers MUST treat it as read-only. Any caller that needs to change a field
+// (Impersonate, QPS/Burst, Timeout, WrapTransport, TLS settings, …) MUST take a
+// copy first:
+//
+//	cfg := rest.CopyConfig(shared)
+//	cfg.Impersonate = rest.ImpersonationConfig{...}
+//
+// Mutating the returned value in place poisons the cache entry for that spoke:
+// every subsequent consumer — the authorization webhook's SAR checks, session
+// cleanup, workload deployment, and any Clientset built from it — silently
+// inherits the mutation until the TTL expires, and concurrent reconciles race on
+// the same struct.
+//
+// The shared pointer is deliberately NOT copied here: the pointer-identity
+// caching contract is depended on by GetClientset (which reuses the config to
+// avoid duplicate clientsets) and by the TTL/invalidation tests, and copying on
+// every call would allocate on a hot webhook path where the overwhelming
+// majority of callers are read-only. The three call sites that do mutate all
+// copy explicitly.
 func (p *ClientProvider) GetRESTConfig(ctx context.Context, name string) (*rest.Config, error) {
 	now := time.Now()
 

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -163,6 +163,12 @@ func (p *ClientProvider) GetAcrossAllNamespaces(ctx context.Context, name string
 		if cfg != nil && cfg.Name == name {
 			if cachedFound != nil {
 				p.mu.RUnlock()
+				// The lookup was served entirely from cache, so it is a cache hit even
+				// though it fails closed. Counting it keeps hits+misses equal to the
+				// number of lookups, and the dedicated ambiguity counter makes the
+				// failure itself alertable instead of invisible.
+				metrics.ClusterCacheHits.WithLabelValues(name).Inc()
+				metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache").Inc()
 				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q in cache", name)
 			}
 			cachedFound = cfg
@@ -184,6 +190,9 @@ func (p *ClientProvider) GetAcrossAllNamespaces(ctx context.Context, name string
 	for _, item := range list.Items {
 		if item.Name == name {
 			if found != nil {
+				// The miss was already counted above; record the ambiguity so the
+				// fail-closed path is visible in monitoring rather than only in logs.
+				metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list").Inc()
 				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q across namespaces", name)
 			}
 			// copy loop variable before taking address
@@ -234,6 +243,9 @@ func (p *ClientProvider) getAcrossAllNamespacesLocked(ctx context.Context, name 
 	for _, cfg := range p.data {
 		if cfg != nil && cfg.Name == name {
 			if found != nil {
+				// Callers of the locked variant have already accounted the
+				// hit/miss for this lookup, so only the ambiguity is recorded here.
+				metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache").Inc()
 				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q in cache", name)
 			}
 			found = cfg
@@ -251,6 +263,7 @@ func (p *ClientProvider) getAcrossAllNamespacesLocked(ctx context.Context, name 
 	for _, item := range list.Items {
 		if item.Name == name {
 			if found != nil {
+				metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list").Inc()
 				return nil, fmt.Errorf("multiple ClusterConfigs found for name %q across namespaces", name)
 			}
 			cp := item

--- a/pkg/cluster/cache_ambiguous_cluster_name_test.go
+++ b/pkg/cluster/cache_ambiguous_cluster_name_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+func newAmbiguityTestProvider(t *testing.T, ccs ...*breakglassv1alpha1.ClusterConfig) *ClientProvider {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, cc := range ccs {
+		builder = builder.WithObjects(cc)
+	}
+	return NewClientProvider(builder.Build(), zaptest.NewLogger(t).Sugar())
+}
+
+func clusterConfig(namespace, name string) *breakglassv1alpha1.ClusterConfig {
+	return &breakglassv1alpha1.ClusterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: breakglassv1alpha1.ClusterConfigSpec{
+			KubeconfigSecretRef: &breakglassv1alpha1.SecretKeyReference{
+				Name: name + "-kubeconfig", Namespace: namespace,
+			},
+		},
+	}
+}
+
+// TestGetAcrossAllNamespaces_ErrorsOnAmbiguousListResult pins the defect.
+//
+// GetAcrossAllNamespaces is reached from the authorization webhook. When two
+// namespaces hold a ClusterConfig with the same metadata.name it previously returned
+// the FIRST list/map-iteration match, which is non-deterministic — the same cluster
+// name could resolve to a different spoke cluster on different calls. The unexported
+// twin getAcrossAllNamespacesLocked already errors on ambiguity; this aligns the two.
+func TestGetAcrossAllNamespaces_ErrorsOnAmbiguousListResult(t *testing.T) {
+	p := newAmbiguityTestProvider(t,
+		clusterConfig("team-a", "shared-name"),
+		clusterConfig("team-b", "shared-name"),
+	)
+
+	// Cache is cold, so this exercises the List path.
+	cfg, err := p.GetAcrossAllNamespaces(context.Background(), "shared-name")
+
+	require.Error(t, err, "ambiguous cluster name must not resolve to an arbitrary spoke")
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "multiple ClusterConfigs found")
+	assert.Contains(t, err.Error(), "shared-name")
+	assert.Contains(t, err.Error(), "across namespaces")
+}
+
+// TestGetAcrossAllNamespaces_ErrorsOnAmbiguousCacheContents covers the cache-hit
+// branch, which is the hot path for the webhook: once both namespaces' configs have
+// been pulled into p.data (e.g. by two GetInNamespace calls), the scan over the Go map
+// is order-randomised, so "first match wins" is genuinely non-deterministic here.
+func TestGetAcrossAllNamespaces_ErrorsOnAmbiguousCacheContents(t *testing.T) {
+	p := newAmbiguityTestProvider(t,
+		clusterConfig("team-a", "shared-name"),
+		clusterConfig("team-b", "shared-name"),
+	)
+	ctx := context.Background()
+
+	// Populate the cache for both namespaces via the namespace-explicit accessor.
+	_, err := p.GetInNamespace(ctx, "team-a", "shared-name")
+	require.NoError(t, err)
+	_, err = p.GetInNamespace(ctx, "team-b", "shared-name")
+	require.NoError(t, err)
+
+	cfg, err := p.GetAcrossAllNamespaces(ctx, "shared-name")
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "multiple ClusterConfigs found")
+	assert.Contains(t, err.Error(), "in cache")
+}
+
+// TestGetAcrossAllNamespaces_SingleMatchUnchanged proves the fix is behaviour-identical
+// on the non-buggy path: exactly one match still resolves, is still cached under
+// namespace/name, and the second call still hits the cache and returns the same pointer.
+func TestGetAcrossAllNamespaces_SingleMatchUnchanged(t *testing.T) {
+	p := newAmbiguityTestProvider(t,
+		clusterConfig("team-a", "unique-name"),
+		clusterConfig("team-b", "other-name"),
+	)
+	ctx := context.Background()
+
+	first, err := p.GetAcrossAllNamespaces(ctx, "unique-name")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "unique-name", first.Name)
+	assert.Equal(t, "team-a", first.Namespace)
+
+	// Result must have been cached under the canonical namespace/name key.
+	p.mu.RLock()
+	cached, ok := p.data[cacheKey("team-a", "unique-name")]
+	p.mu.RUnlock()
+	require.True(t, ok, "single match must still populate the cache")
+	assert.Same(t, first, cached)
+
+	// Second call takes the cache-hit path and returns the same pointer.
+	second, err := p.GetAcrossAllNamespaces(ctx, "unique-name")
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+
+	// A name that only exists in the other namespace still resolves independently.
+	other, err := p.GetAcrossAllNamespaces(ctx, "other-name")
+	require.NoError(t, err)
+	assert.Equal(t, "team-b", other.Namespace)
+}
+
+// TestGetAcrossAllNamespaces_NotFoundUnchanged proves the not-found sentinel is
+// preserved — callers match on ErrClusterConfigNotFound.
+func TestGetAcrossAllNamespaces_NotFoundUnchanged(t *testing.T) {
+	p := newAmbiguityTestProvider(t, clusterConfig("team-a", "exists"))
+
+	cfg, err := p.GetAcrossAllNamespaces(context.Background(), "does-not-exist")
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.ErrorIs(t, err, ErrClusterConfigNotFound)
+}
+
+// TestGetAcrossAllNamespaces_MatchesUnexportedTwinSemantics asserts the two variants
+// now agree, which was the point of the fix: the safe implementation had been the
+// private one.
+func TestGetAcrossAllNamespaces_MatchesUnexportedTwinSemantics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ambiguous: both error", func(t *testing.T) {
+		exported := newAmbiguityTestProvider(t,
+			clusterConfig("team-a", "dup"), clusterConfig("team-b", "dup"))
+		unexported := newAmbiguityTestProvider(t,
+			clusterConfig("team-a", "dup"), clusterConfig("team-b", "dup"))
+
+		_, expErr := exported.GetAcrossAllNamespaces(ctx, "dup")
+		unexported.mu.Lock()
+		_, unexpErr := unexported.getAcrossAllNamespacesLocked(ctx, "dup")
+		unexported.mu.Unlock()
+
+		require.Error(t, expErr)
+		require.Error(t, unexpErr)
+		assert.Equal(t, unexpErr.Error(), expErr.Error(),
+			"exported and unexported variants must report ambiguity identically")
+	})
+
+	t.Run("single match: both resolve to the same object", func(t *testing.T) {
+		exported := newAmbiguityTestProvider(t, clusterConfig("team-a", "solo"))
+		unexported := newAmbiguityTestProvider(t, clusterConfig("team-a", "solo"))
+
+		expCfg, expErr := exported.GetAcrossAllNamespaces(ctx, "solo")
+		unexported.mu.Lock()
+		unexpCfg, unexpErr := unexported.getAcrossAllNamespacesLocked(ctx, "solo")
+		unexported.mu.Unlock()
+
+		require.NoError(t, expErr)
+		require.NoError(t, unexpErr)
+		assert.Equal(t, unexpCfg.Namespace, expCfg.Namespace)
+		assert.Equal(t, unexpCfg.Name, expCfg.Name)
+	})
+}

--- a/pkg/cluster/cache_ambiguous_cluster_name_test.go
+++ b/pkg/cluster/cache_ambiguous_cluster_name_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/telekom/k8s-breakglass/pkg/metrics"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,6 +102,88 @@ func TestGetAcrossAllNamespaces_ErrorsOnAmbiguousCacheContents(t *testing.T) {
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "multiple ClusterConfigs found")
 	assert.Contains(t, err.Error(), "in cache")
+}
+
+// TestGetAcrossAllNamespaces_AmbiguityIsVisibleInMetrics pins the observability of
+// the fail-closed path. The cache-hit ambiguity branch used to return before touching
+// either ClusterCacheHits or ClusterCacheMisses, so a lookup that failed on ambiguous
+// cached contents was invisible in cache metrics and repeated ambiguity errors could
+// only be found in logs. The lookup is now counted as a hit (it was served entirely
+// from cache) and the dedicated ambiguity counter makes the failure alertable.
+func TestGetAcrossAllNamespaces_AmbiguityIsVisibleInMetrics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cache-hit ambiguity counts a hit and an ambiguity", func(t *testing.T) {
+		const name = "metrics-cache-dup"
+		p := newAmbiguityTestProvider(t,
+			clusterConfig("team-a", name), clusterConfig("team-b", name))
+
+		// Prime both namespaces. Each GetInNamespace records its own miss, which is
+		// why the deltas below are measured after priming.
+		_, err := p.GetInNamespace(ctx, "team-a", name)
+		require.NoError(t, err)
+		_, err = p.GetInNamespace(ctx, "team-b", name)
+		require.NoError(t, err)
+
+		hitsBefore := testutil.ToFloat64(metrics.ClusterCacheHits.WithLabelValues(name))
+		missesBefore := testutil.ToFloat64(metrics.ClusterCacheMisses.WithLabelValues(name))
+		ambigBefore := testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache"))
+
+		_, err = p.GetAcrossAllNamespaces(ctx, name)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "in cache")
+
+		assert.Equal(t, hitsBefore+1,
+			testutil.ToFloat64(metrics.ClusterCacheHits.WithLabelValues(name)),
+			"a lookup served from cache must be counted even when it fails closed")
+		assert.Equal(t, missesBefore,
+			testutil.ToFloat64(metrics.ClusterCacheMisses.WithLabelValues(name)),
+			"a cache-served lookup must not be counted as a miss")
+		assert.Equal(t, ambigBefore+1,
+			testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache")),
+			"the ambiguity itself must be alertable")
+	})
+
+	t.Run("list ambiguity counts a miss and an ambiguity", func(t *testing.T) {
+		const name = "metrics-list-dup"
+		p := newAmbiguityTestProvider(t,
+			clusterConfig("team-a", name), clusterConfig("team-b", name))
+
+		hitsBefore := testutil.ToFloat64(metrics.ClusterCacheHits.WithLabelValues(name))
+		missesBefore := testutil.ToFloat64(metrics.ClusterCacheMisses.WithLabelValues(name))
+		ambigBefore := testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list"))
+
+		// Cache is cold, so this exercises the List path.
+		_, err := p.GetAcrossAllNamespaces(ctx, name)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "across namespaces")
+
+		assert.Equal(t, missesBefore+1,
+			testutil.ToFloat64(metrics.ClusterCacheMisses.WithLabelValues(name)))
+		assert.Equal(t, hitsBefore,
+			testutil.ToFloat64(metrics.ClusterCacheHits.WithLabelValues(name)))
+		assert.Equal(t, ambigBefore+1,
+			testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list")),
+			"list-path ambiguity must be alertable too")
+	})
+
+	t.Run("unambiguous lookups record no ambiguity", func(t *testing.T) {
+		const name = "metrics-unique"
+		p := newAmbiguityTestProvider(t, clusterConfig("team-a", name))
+
+		ambigCacheBefore := testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache"))
+		ambigListBefore := testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list"))
+
+		_, err := p.GetAcrossAllNamespaces(ctx, name) // list path
+		require.NoError(t, err)
+		_, err = p.GetAcrossAllNamespaces(ctx, name) // cache path
+		require.NoError(t, err)
+
+		assert.Equal(t, ambigCacheBefore,
+			testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "cache")))
+		assert.Equal(t, ambigListBefore,
+			testutil.ToFloat64(metrics.ClusterCacheAmbiguous.WithLabelValues(name, "list")))
+	})
 }
 
 // TestGetAcrossAllNamespaces_SingleMatchUnchanged proves the fix is behaviour-identical

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,6 +30,16 @@ var (
 		Name: "breakglass_cluster_cache_misses_total",
 		Help: "Total number of cluster config cache misses",
 	}, []string{"cluster"})
+	// ClusterCacheAmbiguous counts cluster-name lookups that failed closed because
+	// more than one ClusterConfig carries the requested metadata.name. `source`
+	// distinguishes where the duplicate was seen: "cache" (two cached entries from
+	// different namespaces) or "list" (two live objects returned by the API server).
+	// Any non-zero value means cluster-wide name uniqueness has been violated and
+	// name-based lookups — including the authorization webhook path — are failing.
+	ClusterCacheAmbiguous = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "breakglass_cluster_cache_ambiguous_total",
+		Help: "Total number of cluster config lookups rejected because the name resolved to multiple ClusterConfigs",
+	}, []string{"cluster", "source"})
 	ClusterRESTConfigLoaded = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "breakglass_cluster_rest_config_loaded_total",
 		Help: "Total number of successful REST config loads",
@@ -604,6 +614,7 @@ func init() {
 	ctrlmetrics.Registry.MustRegister(ClusterConfigsDeleted)
 	ctrlmetrics.Registry.MustRegister(ClusterCacheHits)
 	ctrlmetrics.Registry.MustRegister(ClusterCacheMisses)
+	ctrlmetrics.Registry.MustRegister(ClusterCacheAmbiguous)
 	ctrlmetrics.Registry.MustRegister(ClusterRESTConfigLoaded)
 	ctrlmetrics.Registry.MustRegister(ClusterRESTConfigErrors)
 	ctrlmetrics.Registry.MustRegister(ClusterCacheInvalidations)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -467,6 +467,15 @@ var (
 		Name: "breakglass_debug_session_rejected_total",
 		Help: "Total debug sessions rejected",
 	}, []string{"cluster", "reason"})
+	// DebugSessionBindingUnresolved counts DebugSessions whose explicit bindingRef could
+	// not be resolved. The binding carries the approver configuration, so the approval
+	// requirement is indeterminate and activation is deferred (requeued) rather than
+	// falling back to auto-discovery. A non-zero rate means sessions are stalled waiting
+	// on a binding — alert on it.
+	DebugSessionBindingUnresolved = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "breakglass_debug_session_binding_unresolved_total",
+		Help: "Total debug session reconciles where an explicit bindingRef could not be resolved",
+	}, []string{"cluster", "reason"})
 
 	// Auxiliary resource metrics
 	AuxiliaryResourceDeployments = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -715,6 +724,7 @@ func init() {
 	ctrlmetrics.Registry.MustRegister(DebugSessionApprovalRequired)
 	ctrlmetrics.Registry.MustRegister(DebugSessionApproved)
 	ctrlmetrics.Registry.MustRegister(DebugSessionRejected)
+	ctrlmetrics.Registry.MustRegister(DebugSessionBindingUnresolved)
 
 	// Register auxiliary resource metrics
 	ctrlmetrics.Registry.MustRegister(AuxiliaryResourceDeployments)

--- a/pkg/policy/deny.go
+++ b/pkg/policy/deny.go
@@ -410,6 +410,31 @@ func (e *Evaluator) isPodExempt(pod *corev1.Pod, exemptions *breakglassv1alpha1.
 	return false
 }
 
+// allPodContainers flattens every container the pod runs into a single slice:
+// regular containers, init containers AND ephemeral containers.
+//
+// Ephemeral containers matter specifically here: injecting one is the primary
+// debug primitive this operator exposes, so a DenyPolicy that ignored them
+// would exempt exactly the workload it is meant to guard. corev1.EphemeralContainer
+// wraps an EphemeralContainerCommon with a field-for-field identical layout to
+// corev1.Container (it exists only to forbid a few fields at the API level), so
+// the risk-relevant fields — SecurityContext, VolumeMounts, Name — can be
+// projected onto corev1.Container for uniform evaluation.
+func allPodContainers(pod *corev1.Pod) []corev1.Container {
+	if pod == nil {
+		return nil
+	}
+	spec := pod.Spec
+	out := make([]corev1.Container, 0,
+		len(spec.Containers)+len(spec.InitContainers)+len(spec.EphemeralContainers))
+	out = append(out, spec.Containers...)
+	out = append(out, spec.InitContainers...)
+	for _, ec := range spec.EphemeralContainers {
+		out = append(out, corev1.Container(ec.EphemeralContainerCommon))
+	}
+	return out
+}
+
 // detectRiskFactors returns a list of detected risk factor names.
 func (e *Evaluator) detectRiskFactors(pod *corev1.Pod, rf breakglassv1alpha1.RiskFactors) []string {
 	factors := []string{}
@@ -424,9 +449,8 @@ func (e *Evaluator) detectRiskFactors(pod *corev1.Pod, rf breakglassv1alpha1.Ris
 		factors = append(factors, "hostIPC")
 	}
 
-	// Check all containers (including init containers)
-	allContainers := append([]corev1.Container{}, pod.Spec.Containers...)
-	allContainers = append(allContainers, pod.Spec.InitContainers...)
+	// Check all containers (regular, init AND ephemeral)
+	allContainers := allPodContainers(pod)
 
 	for _, c := range allContainers {
 		if c.SecurityContext != nil {
@@ -475,9 +499,8 @@ func (e *Evaluator) calculateRiskScore(pod *corev1.Pod, rf breakglassv1alpha1.Ri
 		score += rf.HostIPC
 	}
 
-	// Check all containers
-	allContainers := append([]corev1.Container{}, pod.Spec.Containers...)
-	allContainers = append(allContainers, pod.Spec.InitContainers...)
+	// Check all containers (regular, init AND ephemeral)
+	allContainers := allPodContainers(pod)
 
 	privilegedCount := 0
 	rootCount := 0
@@ -525,8 +548,9 @@ func (e *Evaluator) calculateRiskScore(pod *corev1.Pod, rf breakglassv1alpha1.Ri
 
 // isHostPathWritable checks if a hostPath volume is mounted as writable by any container.
 func (e *Evaluator) isHostPathWritable(pod *corev1.Pod, volumeName string) bool {
-	allContainers := append([]corev1.Container{}, pod.Spec.Containers...)
-	allContainers = append(allContainers, pod.Spec.InitContainers...)
+	// Regular, init AND ephemeral containers: a writable hostPath mount in an
+	// injected ephemeral container is as dangerous as one in a regular container.
+	allContainers := allPodContainers(pod)
 
 	for _, c := range allContainers {
 		for _, vm := range c.VolumeMounts {

--- a/pkg/policy/deny_ephemeral_containers_test.go
+++ b/pkg/policy/deny_ephemeral_containers_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+// ephemeralRiskFactors mirrors the shape used by the existing scoring tests.
+func ephemeralRiskFactors() breakglassv1alpha1.RiskFactors {
+	return breakglassv1alpha1.RiskFactors{
+		HostNetwork:         10,
+		HostPID:             15,
+		HostIPC:             10,
+		PrivilegedContainer: 50,
+		HostPathWritable:    25,
+		HostPathReadOnly:    5,
+		RunAsRoot:           20,
+		Capabilities:        map[string]int{"NET_ADMIN": 30, "SYS_ADMIN": 40},
+	}
+}
+
+func newEphemeralTestEvaluator(t *testing.T, objs ...client.Object) *Evaluator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return NewEvaluator(c, zap.NewNop().Sugar())
+}
+
+// ephemeral builds a corev1.EphemeralContainer with the given common spec. Ephemeral
+// containers are exactly what a DebugSession injects, which is why DenyPolicy must
+// score them.
+func ephemeral(name string, sc *corev1.SecurityContext, mounts ...corev1.VolumeMount) corev1.EphemeralContainer {
+	return corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:            name,
+			Image:           "busybox:latest",
+			SecurityContext: sc,
+			VolumeMounts:    mounts,
+		},
+	}
+}
+
+// TestDetectRiskFactors_InspectsEphemeralContainers covers loop 1 (detectRiskFactors).
+// Before the fix allContainers was built from Containers ++ InitContainers only, so a
+// privileged / root / capability-carrying EPHEMERAL container produced no risk factors
+// at all — the debug primitive was exempt from the guardrail meant to police it.
+func TestDetectRiskFactors_InspectsEphemeralContainers(t *testing.T) {
+	eval := newEphemeralTestEvaluator(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			// The workload itself is entirely benign.
+			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				ephemeral("debugger", &corev1.SecurityContext{
+					Privileged: ptr.To(true),
+					RunAsUser:  ptr.To(int64(0)),
+					Capabilities: &corev1.Capabilities{
+						Add: []corev1.Capability{"SYS_ADMIN"},
+					},
+				}),
+			},
+		},
+	}
+
+	factors := eval.detectRiskFactors(pod, ephemeralRiskFactors())
+
+	assert.Contains(t, factors, "privilegedContainer:debugger",
+		"privileged ephemeral container was not detected")
+	assert.Contains(t, factors, "runAsRoot:debugger",
+		"root ephemeral container was not detected")
+	assert.Contains(t, factors, "capability:SYS_ADMIN:debugger",
+		"ephemeral container capability was not detected")
+}
+
+// TestCalculateRiskScore_ScoresEphemeralContainers covers loop 2 (calculateRiskScore).
+// An understated score is what flips deny into allow at the threshold comparison, so
+// scoring — not just factor naming — has to include ephemeral containers.
+func TestCalculateRiskScore_ScoresEphemeralContainers(t *testing.T) {
+	eval := newEphemeralTestEvaluator(t)
+	rf := ephemeralRiskFactors()
+
+	benign := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
+		},
+	}
+	require.Equal(t, 0, eval.calculateRiskScore(benign, rf),
+		"precondition: the workload on its own scores zero")
+
+	withEphemeral := benign.DeepCopy()
+	withEphemeral.Spec.EphemeralContainers = []corev1.EphemeralContainer{
+		ephemeral("debugger", &corev1.SecurityContext{
+			Privileged: ptr.To(true),     // +50
+			RunAsUser:  ptr.To(int64(0)), // +20
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN"}, // +30
+			},
+		}),
+	}
+
+	assert.Equal(t, 100, eval.calculateRiskScore(withEphemeral, rf),
+		"ephemeral container risk was not scored (privileged 50 + root 20 + NET_ADMIN 30)")
+}
+
+// TestIsHostPathWritable_InspectsEphemeralContainers covers loop 3 (isHostPathWritable).
+// The volume is declared on the pod but mounted read-write ONLY by the ephemeral
+// container: before the fix the mount was invisible, so the hostPath scored as
+// read-only (5) instead of writable (25).
+func TestIsHostPathWritable_InspectsEphemeralContainers(t *testing.T) {
+	eval := newEphemeralTestEvaluator(t)
+	rf := ephemeralRiskFactors()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "app",
+				// The workload mounts nothing.
+			}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				ephemeral("debugger", nil, corev1.VolumeMount{
+					Name:      "hostroot",
+					MountPath: "/host",
+					ReadOnly:  false,
+				}),
+			},
+			Volumes: []corev1.Volume{{
+				Name: "hostroot",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: "/"},
+				},
+			}},
+		},
+	}
+
+	assert.True(t, eval.isHostPathWritable(pod, "hostroot"),
+		"a read-write hostPath mount in an ephemeral container was treated as read-only")
+
+	factors := eval.detectRiskFactors(pod, rf)
+	assert.Contains(t, factors, "hostPathWritable:hostroot")
+	assert.NotContains(t, factors, "hostPathReadOnly:hostroot")
+	assert.Equal(t, 25, eval.calculateRiskScore(pod, rf),
+		"writable hostPath via ephemeral container must score HostPathWritable, not HostPathReadOnly")
+}
+
+// TestMatch_DeniesViaEphemeralContainerRisk is the end-to-end guardrail assertion:
+// a DenyPolicy whose threshold sits between the benign and the ephemeral-inclusive
+// score must now deny. This is the behaviour CHANGE documented under "Upgrade impact".
+func TestMatch_DeniesViaEphemeralContainerRisk(t *testing.T) {
+	pol := &breakglassv1alpha1.DenyPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-high-risk"},
+		Spec: breakglassv1alpha1.DenyPolicySpec{
+			PodSecurityRules: &breakglassv1alpha1.PodSecurityRules{
+				RiskFactors: breakglassv1alpha1.RiskFactors{PrivilegedContainer: 50},
+				Thresholds: []breakglassv1alpha1.RiskThreshold{
+					{MaxScore: 10, Action: "allow"},
+					{MaxScore: 100, Action: "deny"},
+				},
+			},
+		},
+	}
+	eval := newEphemeralTestEvaluator(t, pol)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				ephemeral("debugger", &corev1.SecurityContext{Privileged: ptr.To(true)}),
+			},
+		},
+	}
+
+	denied, _, err := eval.Match(context.Background(), Action{
+		Verb:        "create",
+		Resource:    "pods",
+		Subresource: "exec",
+		Namespace:   "default",
+		Pod:         pod,
+	})
+	require.NoError(t, err)
+	assert.True(t, denied,
+		"a privileged ephemeral container must be denied by the DenyPolicy guardrail")
+}
+
+// TestEphemeralContainers_NoBehaviourChangeWithoutEphemeral proves backwards
+// compatibility: for every pod that carries NO ephemeral containers, the new flattening
+// helper produces exactly the old Containers ++ InitContainers slice, so scores and
+// factors are byte-identical to the previous implementation.
+func TestEphemeralContainers_NoBehaviourChangeWithoutEphemeral(t *testing.T) {
+	eval := newEphemeralTestEvaluator(t)
+	rf := ephemeralRiskFactors()
+
+	pods := map[string]*corev1.Pod{
+		"empty spec": {ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"}},
+		"regular container only": {
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name:            "app",
+				SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)},
+			}}},
+		},
+		"init and regular containers": {
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name:            "init",
+					SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To(int64(0))},
+				}},
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{
+						Add: []corev1.Capability{"NET_ADMIN"},
+					}},
+				}},
+			},
+		},
+	}
+
+	// Expected values computed from the pre-fix semantics (Containers ++ InitContainers).
+	want := map[string]int{
+		"empty spec":                  0,
+		"regular container only":      50,
+		"init and regular containers": 50, // root 20 + NET_ADMIN 30
+	}
+
+	for name, pod := range pods {
+		t.Run(name, func(t *testing.T) {
+			flattened := allPodContainers(pod)
+			assert.Len(t, flattened,
+				len(pod.Spec.Containers)+len(pod.Spec.InitContainers),
+				"flattening must not invent containers when EphemeralContainers is empty")
+			assert.Equal(t, want[name], eval.calculateRiskScore(pod, rf))
+		})
+	}
+}
+
+// TestAllPodContainers_NilPod guards the helper against a nil pod, which several
+// DenyPolicy paths tolerate.
+func TestAllPodContainers_NilPod(t *testing.T) {
+	assert.Nil(t, allPodContainers(nil))
+}


### PR DESCRIPTION
## Summary

Four verified defects, each with a test that fails before the fix and passes after (revert
experiments and real output below).

Findings originated from an **AI security scan (Microsoft Defender CLI, "MDASH")** and were then
**independently verified** by reading the cited code on `origin/main` and tracing reachability from
real entrypoints. Bug 4 was **not** produced by the scanner — it was found during triage of the
scanner's output.

Honest calibration note: **Bug 1 was filed by the scanner as merely `Medium`, while being the most
serious real defect in the entire 263-finding set.** Two of the scan's five `Critical` CVSS scores
sat on operator footguns and spec-conformant Kubernetes behaviour. Bug 3 was filed `Medium`, Bug 2
was over-scored as `Critical` on a correct instinct. The tool is a good code *locator* and a poor
risk *ranker*.

---

## Bug 1 — impersonation written to the *shared cached* `*rest.Config`

`pkg/breakglass/debug/debug_session_reconciler.go:826-841` (`createImpersonatedClient`)

### The shared-cache chain

1. `c.ccProvider.GetRESTConfig(ctx, clusterName)` returns `cached.config` — the **shared cached
   pointer** held in `p.rest[key]`. Both cache-hit paths return it directly
   (`pkg/cluster/cache.go:328` and `:352`).
2. The caller then wrote `restCfg.Impersonate = rest.ImpersonationConfig{...}` **directly onto that
   shared object**, with no `rest.CopyConfig`.
3. The mutation therefore persists on the cache entry for the whole TTL
   (`RESTConfigCacheTTL`, default 5m).

### Why it is wrong

The impersonation identity of one `DebugSession` leaks onto the cached config for that spoke, so
*subsequent unrelated consumers* silently act as the impersonated ServiceAccount until the entry
expires:

- `pkg/webhook/authorize_helpers.go:495` and `:559` — the **authorization webhook's** RBAC and
  session SAR checks
- `pkg/breakglass/debug/debug_session_reconciler_lifecycle.go:89` and `:381` — allowed-pod tracking
  and cleanup
- `pkg/breakglass/debug/debug_session_reconciler_workload.go:96` — the base (non-impersonated!)
  deployment client
- `pkg/cluster/cache.go:506` — `GetClientset`, which builds and **caches** a `Clientset` from the
  same config
- `pkg/breakglass/debug/debug_session_api_email_ops.go:712` — the API adapter's `GetClient`

That is wrong-identity access to a production spoke cluster: a correctness bug and a security bug.
It is **also a data race** — concurrent reconciles perform unsynchronised writes to one shared
struct.

### This is an inconsistency, not a design choice

Every other impersonation site in the repo copies first:

| Site | Copies? |
|---|---|
| `pkg/breakglass/group_checker.go:60` | ✅ `cfg := rest.CopyConfig(rc)` — with the comment *"Copy to avoid mutating shared config"* |
| `pkg/breakglass/session_controller_approval_utils.go:601` | ✅ `remote := rest.CopyConfig(rc)` |
| `pkg/breakglass/group_checker.go:161` | n/a — operates on a per-call fresh config from `getConfigForClusterName` (`config.GetConfigWithContext`), never the shared cache |
| `debug_session_reconciler.go:836` | ❌ **the lone exception** |

So 2 of 3 sibling sites that touch the shared cache already do the right thing, and the third never
touches it. The fix restores consistency rather than introducing a new convention.

### Fix

`restCfg = rest.CopyConfig(sharedCfg)` before setting `Impersonate`.

### Full audit of `GetRESTConfig` / `GetClient` / `GetClientset` callers

Grepped every caller in the repo and read each one. **No mutation is `Impersonate`-specific — QPS,
Burst, Timeout and `WrapTransport` writes would poison the cache identically, so all were checked.**

| Caller | Mutates the returned config? | Verdict |
|---|---|---|
| `debug/debug_session_reconciler.go:827` | **YES — `Impersonate`** | 🔴 **the bug; fixed** |
| `debug/debug_session_reconciler_lifecycle.go:89` | No — builds a client and reads | ✅ |
| `debug/debug_session_reconciler_lifecycle.go:381` | No — builds a client for cleanup | ✅ |
| `debug/debug_session_reconciler_workload.go:96` | No — `baseRestCfg` passed straight to `ctrlclient.New` | ✅ |
| `debug/debug_session_api_email_ops.go:712` | No — passed straight to `ctrlclient.New` | ✅ |
| `webhook/authorize_helpers.go:495` | No — `rc` handed to `canDoFn`, which copies at `group_checker.go:60` | ✅ |
| `webhook/authorize_helpers.go:559` | No — `rc` handed to `authorizeViaSessions`, which only does `kubernetes.NewForConfig(rc)` (`webhook/controller.go:822`) | ✅ |
| `breakglass/session_controller_approval_utils.go:600` | Copies first | ✅ |
| `cluster/cache.go:506` (`GetClientset` → `GetRESTConfig`) | No — `kubernetes.NewForConfig(rc)` only | ✅ |
| `webhook/controller.go:1004`, `:1026` (`GetClientset`) | No — uses the returned clientset | ✅ |
| `debug/debug_session_kubectl.go:275/371/525/561/678/740` (`ccProvider.GetClient`) | No — interface returns a built `ctrlclient.Client`, config not exposed | ✅ |
| `clusterconfig/checker.go:369`, `:632` | Different method — `OIDCTokenProvider.GetRESTConfig`, which **builds a fresh config per call** (`cluster/oidc.go:149`), not the cache | ✅ n/a |

Other `*rest.Config` field writes in the repo, for completeness — all on freshly-built configs
inside the provider itself, before the object is published to the cache, so all safe:
`cluster/oidc.go:180` (`WrapTransport`), `:184/:187` (`QPS`/`Burst`); `cluster/cache.go:451`
(`WrapTransport`), `:594/:597` (`QPS`/`Burst`).

**Net: exactly one mutating caller existed, and it is fixed.**

### Should `GetRESTConfig` return a copy defensively?

Considered and **deliberately declined**, with the reasoning recorded in the doc comment instead:

- Pointer identity is **load-bearing**. `GetClientset` (`cache.go:506`) relies on the returned
  config corresponding to the cached entry to avoid duplicate clientsets, and the existing test
  `TestGetRESTConfig_RewritesLoopbackHostAndCaches` (`cache_test.go:156`) asserts
  `assert.Same(t, cfg, cfg2)` — as does `cache_additional_test.go:185`. Copying would silently
  change a contract two callers and two tests depend on.
- It is **not free** on a hot path. `GetRESTConfig` is called per authorization-webhook request
  (twice, `authorize_helpers.go:495` and `:559`). `rest.CopyConfig` deep-copies `TLSClientConfig`
  byte slices and impersonation string slices on every SAR — for the ~11 of 12 callers that never
  mutate anything.
- The cheap, precise alternative is what is implemented: an explicit **ownership contract** in the
  doc comment ("the returned value is the SHARED cached pointer; treat it as read-only; copy before
  mutating any field") plus the copy at the one site that needs it. That makes the invariant
  reviewable at every call site rather than paying for it at every call.

If maintainers prefer the defensive copy, the follow-up is small (update the two `assert.Same`
tests and re-key `GetClientset`) — happy to do it, but it trades a documented invariant for a
per-request allocation.

---

## Bug 2 — approval gate fails **open** when an explicit `bindingRef` cannot be resolved

`pkg/breakglass/debug/debug_session_reconciler.go:210-228` (`handlePending`) and `:265-270`
(`handlePendingApproval`)

### Why it is wrong

`getBinding` returning an error was only `log.Warnw`'d; flow then fell through to
`findBindingForSession`, which returns `nil, nil` when nothing matches. `requiresApproval`
(`:876-909`) sees a **nil binding** plus a template with no approvers and returns `false` — and the
session **activates with no approval at all**. A transient apiserver/cache error on the object that
*carries the approver configuration* silently disables the four-eyes gate of an emergency-access
tool.

This is in the **debug-session activation path**, not in `session_controller_approval_utils.go`, so
it is in scope here and does not collide with the sibling agent's file.

### Fix — and why "indeterminate" rather than "deny"

Failure modes are asymmetric, so neither obvious option is acceptable:

- **Auto-discover** (status quo) fails **open**, as above.
- **Fail the session** would fail closed but *destructively*: `DebugSessionStateFailed` is terminal
  and never requeues (`:189-191`), so a two-second apiserver blip would permanently kill an
  operator's emergency session mid-incident and force a manual re-request. **A wrong deny locks
  people out when they need access most.**

So the fix does **neither**. `deferOnUnresolvedBinding` leaves the session state **untouched** —
`Pending` or `PendingApproval`, so no access is granted and nothing is terminal — and returns the
error so controller-runtime requeues with exponential backoff. The condition is made loud instead
of silent:

- **Error**-level structured log with session, namespace, cluster, current state, binding
  coordinates and classified reason
- new audit event **`debug_session.binding_unresolved`** (severity `warning`, added to
  `IsSensitiveEvent` so it is never sampled or dropped) via `pkg/audit`
- new metric **`breakglass_debug_session_binding_unresolved_total{cluster,reason}}`**, `reason` ∈
  {`binding not found`, `binding lookup failed`}

`handlePendingApproval` gets the same treatment. Approval is already granted there, but the binding
can only **narrow** `AllowedPodOperations` (`MergeAllowedPodOperations`, `:454`), so activating
without it would grant a strictly *wider* set of pod operations than the approver saw. The existing
approval record is preserved, so no re-approval is needed once the ref resolves.

### No new lockout paths — analysis

- Scoped strictly to *"`spec.BindingRef != nil` **and** the lookup failed"*. Sessions with **no**
  `bindingRef` are untouched: auto-discovery still runs and an approver-less template still
  auto-approves. Regression test: `TestHandlePending_NoBindingRefStillAutoDiscovers`.
- A `bindingRef` that **resolves** behaves exactly as before. Regression test:
  `TestHandlePending_ResolvableBindingRefUnchanged` (still → `PendingApproval`, same
  `RequeueAfter`).
- The session is **never** driven to a terminal state, so nothing becomes unrecoverable. Every
  state that previously activated either still activates or is retried. Explicitly asserted:
  `assert.NotEqual(t, DebugSessionStateFailed, ds.Status.State)`.
- Nothing is persisted on the failure path, so the stored object is untouched and the next
  reconcile re-evaluates from scratch (asserted against the API server in the test).
- A permanently-bad ref (typo, deleted binding) requeues indefinitely but stays **visible** in three
  places instead of silently over-granting; and the existing approval-timeout path (`:283-317`)
  still bounds how long a `PendingApproval` session can linger.

---

## Bug 3 — DenyPolicy ignored `EphemeralContainers` (all **three** loops)

`pkg/policy/deny.go` — `detectRiskFactors:428`, `calculateRiskScore:479`, `isHostPathWritable:528`

Each of the three built `allContainers` from `pod.Spec.Containers ++ pod.Spec.InitContainers` only.
`spec.ephemeralContainers` was **never** inspected — and injecting an ephemeral container is the
primary debug primitive this operator exposes, so **the guardrail was blind to exactly the workload
it exists to police.** A privileged / root / capability-granting / writable-`hostPath` ephemeral
container contributed **zero**, and an understated score flips deny → allow at the threshold
comparison (`:314`, `:332`).

All three now flatten through one `allPodContainers` helper.
`corev1.EphemeralContainer` wraps an `EphemeralContainerCommon` whose layout is identical to
`corev1.Container`, so the risk-relevant fields (`SecurityContext`, `VolumeMounts`, `Name`) convert
directly. Each loop is covered by its own test, not just one.

**Out of scope as instructed:** the scanner's suggested patch for the related `denyPolicyRefs`
finding is **not** applied — triage found it would make sessions carrying `denyPolicyRefs` stop
matching *global* deny policies, converting an unenforced-addition bug into active *removal* of
enforcement.

### Upgrade impact

**This tightens enforcement. It is a behaviour change.** Full detail is in `CHANGELOG.md` under
*"Upgrade impact: DenyPolicy ephemeral containers"* and in `docs/deny-policy.md`.

**Config shape whose meaning changes** — any `DenyPolicy` with `spec.podSecurityRules`:

```yaml
apiVersion: breakglass.t-caas.telekom.com/v1alpha1
kind: DenyPolicy
spec:
  podSecurityRules:
    riskFactors:            # <- these weights now also apply to ephemeral containers
      privilegedContainer: 50
      runAsRoot: 20
      hostPathWritable: 25
      capabilities:
        SYS_ADMIN: 40
    thresholds:             # <- an unchanged threshold may now be crossed
      - maxScore: 40
        action: allow
      - maxScore: 100
        action: deny
```

No field added, removed, renamed, or changed in syntax. What changes is the computed `score`: a pod
whose only risky container is an *ephemeral* one previously scored 0 for it and could land in an
`allow` band; it now scores the configured weights and may cross `warn`/`deny`.

- **Affected:** clusters running a `DenyPolicy` **with** `podSecurityRules` **and** whose debug
  templates inject privileged/root/capability/writable-`hostPath` ephemeral containers. No
  `podSecurityRules`, or only unprivileged ephemeral containers → nothing changes.
- **Direction:** allow → warn/deny **only**. Nothing previously denied becomes allowed.
- **Before upgrading:** review `breakglass_pod_security_risk_score` against your `thresholds`. If
  you relied (unknowingly) on the under-scoring, raise the `maxScore` bands or add the affected
  factors to `podSecurityOverrides.exemptFactors` for escalations that legitimately need them.
- **Detection after upgrade:** step change in `breakglass_pod_security_denied_total` /
  `breakglass_pod_security_warnings_total` for a given `policy` label.

---

## Bug 4 — `GetAcrossAllNamespaces` returned a non-deterministic spoke

`pkg/cluster/cache.go:146` (cache scan) and the `List` fallback

Returned the **first Go map-iteration match** on `metadata.name`. Map iteration order is
randomised, so with two namespaces holding a `ClusterConfig` of the same name **the same cluster
name could resolve to a different spoke cluster across calls** — reached from the authorization
webhook (`pkg/webhook/controller.go:408`), i.e. hub→spoke selection for an authz decision. This is
squarely the cross-cluster-confusion class; the scan filed **19 SSRF findings and missed it**.

Its own unexported twin `getAcrossAllNamespacesLocked` (`:205-243`) **already errored** on
ambiguity — the safe implementation was the private one. The exported variant is now aligned with
it: deterministic, fails closed, identical error strings (asserted by a test that compares the two
variants directly).

Currently **masked** by `ClusterConfig.ValidateCreate` → `ensureClusterWideUniqueName` plus
`failurePolicy: Fail`, so this is **defence in depth** for the cases where duplicates exist anyway
(objects predating the validation, webhook bypass, direct etcd writes). Single-match and not-found
behaviour are unchanged and pinned by tests (canonical-key caching, pointer identity on the second
call, `ErrClusterConfigNotFound` sentinel).

---

## Before/after test evidence (revert experiments)

Each fix was reverted in place, the tests re-run, then the fix restored. Real output.

### Bug 1 — reverted `rest.CopyConfig` → **4/4 fail**

```
--- FAIL: TestCreateImpersonatedClient_DoesNotPoisonSharedCachedRESTConfig
        Error:      Should be empty, but was system:serviceaccount:kube-system:debug-sa
        Messages:   impersonation leaked onto the SHARED cached rest.Config; every other
                    consumer of this spoke's config would now act as the impersonated
                    ServiceAccount
        Error:      Should be empty, but was system:serviceaccount:kube-system:debug-sa
        Messages:   a subsequent unrelated consumer inherited impersonation from an earlier
                    DebugSession
--- FAIL: TestCreateImpersonatedClient_SessionsDoNotSeeEachOthersIdentity
        Error:      Should be empty, but was system:serviceaccount:team-a:sa-a
        Messages:   session A poisoned the cache
        Error:      Should be empty, but was system:serviceaccount:team-b:sa-b
        Messages:   session B poisoned the cache
--- FAIL: TestCreateImpersonatedClient_ConcurrentSessionsAreRaceFree
        Error:      Should be empty, but was system:serviceaccount:team:sa
        Messages:   concurrent sessions mutated the shared cached rest.Config
FAIL	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	1.354s
```

With the fix:

```
=== RUN   TestCreateImpersonatedClient_DoesNotPoisonSharedCachedRESTConfig
--- PASS: TestCreateImpersonatedClient_DoesNotPoisonSharedCachedRESTConfig (0.06s)
=== RUN   TestCreateImpersonatedClient_SessionsDoNotSeeEachOthersIdentity
--- PASS: TestCreateImpersonatedClient_SessionsDoNotSeeEachOthersIdentity (0.00s)
=== RUN   TestCreateImpersonatedClient_NoImpersonationConfigIsUnchanged
    --- PASS: .../nil_config (0.00s)
    --- PASS: .../config_without_serviceAccount (0.00s)
--- PASS: TestCreateImpersonatedClient_NoImpersonationConfigIsUnchanged (0.00s)
=== RUN   TestCreateImpersonatedClient_ConcurrentSessionsAreRaceFree
--- PASS: TestCreateImpersonatedClient_ConcurrentSessionsAreRaceFree (0.00s)
ok  	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	1.686s

# and under the race detector:
ok  	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	3.617s
```

Note the tests use a **real `cluster.ClientProvider`** over a fake hub client holding a valid
kubeconfig Secret — not a stub — because only the real provider reproduces the shared-pointer
caching that is the defect. `assert.Same(t, shared, again)` additionally proves the provider is
still handing back the cached pointer, i.e. the test would not pass vacuously if caching broke.

### Bug 2 — reverted to `log.Warnw` + fall-through → **3/3 fail**

```
--- FAIL: TestHandlePending_UnresolvableBindingRefDoesNotActivateWithoutApproval (0.04s)
        Error:      An error is expected but got nil.
        Messages:   an unresolvable bindingRef must not be silently ignored
--- FAIL: TestHandlePending_NotFoundBindingRefIsAlsoIndeterminate (0.00s)
        Error:      An error is expected but got nil.
--- FAIL: TestHandlePendingApproval_UnresolvableBindingRefDoesNotActivate (0.00s)
        Error:      An error is expected but got nil.
FAIL	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	1.069s
```

With the fix:

```
--- PASS: TestHandlePending_UnresolvableBindingRefDoesNotActivateWithoutApproval (0.04s)
--- PASS: TestHandlePending_NotFoundBindingRefIsAlsoIndeterminate (0.00s)
--- PASS: TestHandlePendingApproval_UnresolvableBindingRefDoesNotActivate (0.00s)
--- PASS: TestHandlePending_NoBindingRefStillAutoDiscovers (0.00s)
--- PASS: TestHandlePending_ResolvableBindingRefUnchanged (0.00s)
--- PASS: TestDeferOnUnresolvedBinding_ClassifiesReason (0.00s)
ok  	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	1.222s
```

The failing test reproduces the exact dangerous combination: explicit `bindingRef` + template with
**no** approvers + a binding that **does** require approval + a **transient** (not `NotFound`)
error injected via `interceptor.Funcs`.

### Bug 3 — reverted the ephemeral branch of `allPodContainers` → **4/4 fail, all three loops**

```
--- FAIL: TestDetectRiskFactors_InspectsEphemeralContainers
        Messages:   ephemeral container capability was not detected            # loop 1
--- FAIL: TestCalculateRiskScore_ScoresEphemeralContainers
        Error:      Not equal: expected: 100 / actual: 0                       # loop 2
        Messages:   ephemeral container risk was not scored (privileged 50 + root 20
                    + NET_ADMIN 30)
--- FAIL: TestIsHostPathWritable_InspectsEphemeralContainers
        Error:      Should be true                                             # loop 3
        Messages:   a read-write hostPath mount in an ephemeral container was treated as
                    read-only
        Error:      []string{"hostPathReadOnly:hostroot"} does not contain
                    "hostPathWritable:hostroot"
        Error:      Not equal: expected: 25 / actual: 5
--- FAIL: TestMatch_DeniesViaEphemeralContainerRisk
        Error:      Should be true                                             # end-to-end
        Messages:   a privileged ephemeral container must be denied by the DenyPolicy guardrail
FAIL	github.com/telekom/k8s-breakglass/pkg/policy	0.938s
```

Each loop fails with a *distinct* assertion, confirming all three were independently broken — this
is why they were fixed together rather than one-and-assume.

With the fix:

```
--- PASS: TestDetectRiskFactors_InspectsEphemeralContainers (0.06s)
--- PASS: TestCalculateRiskScore_ScoresEphemeralContainers (0.00s)
--- PASS: TestIsHostPathWritable_InspectsEphemeralContainers (0.00s)
--- PASS: TestMatch_DeniesViaEphemeralContainerRisk (0.00s)
--- PASS: TestEphemeralContainers_NoBehaviourChangeWithoutEphemeral (0.00s)
    --- PASS: .../empty_spec (0.00s)
    --- PASS: .../regular_container_only (0.00s)
    --- PASS: .../init_and_regular_containers (0.00s)
--- PASS: TestAllPodContainers_NilPod (0.00s)
ok  	github.com/telekom/k8s-breakglass/pkg/policy	0.945s
```

`TestEphemeralContainers_NoBehaviourChangeWithoutEphemeral` pins the compat guarantee with scores
computed from the **pre-fix** semantics.

### Bug 4 — reverted to first-match-wins → **3/3 fail**

```
--- FAIL: TestGetAcrossAllNamespaces_ErrorsOnAmbiguousListResult (0.00s)
        Error:      An error is expected but got nil.
        Messages:   ambiguous cluster name must not resolve to an arbitrary spoke
--- FAIL: TestGetAcrossAllNamespaces_ErrorsOnAmbiguousCacheContents (0.00s)
        Error:      An error is expected but got nil.
--- FAIL: TestGetAcrossAllNamespaces_MatchesUnexportedTwinSemantics/ambiguous:_both_error
        Error:      An error is expected but got nil.
FAIL	github.com/telekom/k8s-breakglass/pkg/cluster	0.952s
```

With the fix (note the pre-existing tests still pass, i.e. the single-match contract holds):

```
--- PASS: TestGetAcrossAllNamespaces_CachesResult (0.06s)          # pre-existing
--- PASS: TestGetAcrossAllNamespaces_NotFound (0.00s)              # pre-existing
--- PASS: TestGetAcrossAllNamespaces_DoesNotMatchSimilarNames      # pre-existing
--- PASS: TestGetAcrossAllNamespaces_ErrorsOnAmbiguousListResult (0.00s)
--- PASS: TestGetAcrossAllNamespaces_ErrorsOnAmbiguousCacheContents (0.00s)
--- PASS: TestGetAcrossAllNamespaces_SingleMatchUnchanged (0.00s)
--- PASS: TestGetAcrossAllNamespaces_NotFoundUnchanged (0.00s)
--- PASS: TestGetAcrossAllNamespaces_MatchesUnexportedTwinSemantics (0.01s)
    --- PASS: .../ambiguous:_both_error (0.00s)
    --- PASS: .../single_match:_both_resolve_to_the_same_object (0.00s)
ok  	github.com/telekom/k8s-breakglass/pkg/cluster	0.919s
```

---

## Verification — real output

```
$ make fmt vet lint-strict
go fmt ./...
go vet ./...
.../bin/golangci-lint run --timeout 10m
0 issues.
# exit 0; `git status` clean afterwards, i.e. fmt changed nothing

$ make test
# exit 0

$ go test -race ./pkg/policy/... ./pkg/cluster/... ./pkg/audit/... ./pkg/metrics/... ./pkg/breakglass/debug/...
ok  	github.com/telekom/k8s-breakglass/pkg/policy	4.449s
ok  	github.com/telekom/k8s-breakglass/pkg/cluster	15.965s
ok  	github.com/telekom/k8s-breakglass/pkg/audit	13.900s
ok  	github.com/telekom/k8s-breakglass/pkg/metrics	1.645s
ok  	github.com/telekom/k8s-breakglass/pkg/breakglass/debug	7.380s

$ make generate && make manifests
# no diff — `git status` shows only my own edits

$ make validate-crds validate-samples validate-fixtures
--- PASS: TestFixturesAreValid (0.10s)   # 16 fixtures, all subtests PASS
Validated fixture kinds: map[*v1alpha1.BreakglassEscalation:13 *v1alpha1.ClusterConfig:4
  *v1alpha1.DebugPodTemplate:3 *v1alpha1.DebugSessionTemplate:3 *v1alpha1.DenyPolicy:7
  *v1alpha1.IdentityProvider:2]
ok  	github.com/telekom/k8s-breakglass/e2e/helpers	0.790s
Fixture validation passed

$ reuse lint
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

### Coverage on new/changed code (`>70%` required)

```
pkg/policy/deny.go:423   allPodContainers          100.0%
pkg/policy/deny.go:439   detectRiskFactors         100.0%
pkg/policy/deny.go:489   calculateRiskScore        100.0%
pkg/policy/deny.go:550   isHostPathWritable        100.0%
pkg/cluster/cache.go:155 GetAcrossAllNamespaces     96.6%
.../debug_session_reconciler.go:746 deferOnUnresolvedBinding  92.3%
.../debug_session_reconciler.go:199 handlePending             92.6%
.../debug_session_reconciler.go:893 createImpersonatedClient  80.0%
.../debug_session_reconciler.go:260 handlePendingApproval     77.1%
```

---

## Backwards compatibility

Per the compat contract:

- **No new CRD fields**, no `*_types.go` change, no required field. `make generate && make
  manifests` produce **no diff** (verified above).
- **No feature gate, no version arithmetic, no startup version check.** Nothing added here depends
  on a Kubernetes version or gate: `spec.ephemeralContainers` has been GA since 1.25, well below
  every version in the support range, and it is only *read* — never written or required. Consistent
  with the hub-and-spoke rule, nothing infers spoke capability from the hub.
- **Nothing reports success for a no-op.** Bug 2 specifically replaces a silent success with a
  visible degraded state (Error log + audit event + metric), which is the compat contract's
  "surface degraded state" requirement applied to an approval gate.
- **Bugs 1 and 4 are behaviour-identical in the non-buggy case**, proven by test:
  `TestCreateImpersonatedClient_NoImpersonationConfigIsUnchanged` (nil / SA-less impersonation
  config leaves everything untouched, and `Host`/`BearerToken` on the shared config survive) and
  `TestGetAcrossAllNamespaces_SingleMatchUnchanged` + `_NotFoundUnchanged`.
- **Bug 2** introduces no new lockout path — analysis and regression tests above.
- **Bug 3** is the one intentional tightening — see **Upgrade impact**.

---

## Skipped / not done

- **`denyPolicyRefs` scanner patch** — deliberately not applied (would remove global deny-policy
  enforcement). Explained under Bug 3.
- **Defensive copy inside `GetRESTConfig`** — considered, declined with reasoning; documented in
  the code as an ownership contract instead. Rationale and the follow-up cost are under Bug 1.
- **"Frontend Security Audit" and "Trivy Filesystem Scan"** fail repo-wide on `main` and are
  handled by a separate PR — untouched here, as instructed.
- **Unverified:** nothing. All four cited locations were read on `origin/main` before implementation
  (there is no Go diff between the scanned commit `e8f93108a` and `origin/main` `1d1ff85dc`), and
  every fix has a revert experiment above. The only judgement call left open for maintainers is the
  `GetRESTConfig` defensive-copy trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
