### PR TITLE
fix: availability panics, SSA drift, metric cardinality and resource leaks

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -122,12 +122,26 @@ These metrics track the time spent in each phase of SubjectAccessReview processi
 | `breakglass_webhook_sar_phase_duration_seconds` | Histogram | `cluster`, `phase` | Duration of each SAR processing phase |
 
 > **Cluster label values are bounded.** Every webhook SAR metric derives its `cluster`
-> label from the `:cluster_name` request path, which is attacker-controllable and is
-> read before the cluster has been resolved. Values that are not valid Kubernetes
-> object names are replaced with `_invalid`, and an absent value with `_unknown`, so a
-> remote caller cannot create unbounded time series. Legitimate cluster names are
-> recorded unchanged. A rising `_invalid` series indicates traffic addressed to
-> malformed cluster paths.
+> label from the `:cluster_name` request path, which is attacker-controllable. Because
+> Prometheus never reclaims a series, emitting that value verbatim would let a remote
+> caller grow the controller's heap without bound — and validating only the *format* of
+> the name would not help, since arbitrarily many syntactically-valid names exist.
+>
+> The label is therefore only ever set to a registered cluster's name. Until the
+> request has been matched to an existing `ClusterConfig`, one of three fixed
+> placeholders is used instead:
+>
+> | Label value | Meaning |
+> |---|---|
+> | `_unknown` | No cluster name was supplied in the request path. |
+> | `_invalid` | The supplied name is not a valid Kubernetes object name, so it cannot name a cluster. Malformed traffic. |
+> | `_unresolved` | The name is well-formed but does not match any registered `ClusterConfig`. Requests for clusters that are not onboarded — including cardinality-probing traffic. |
+>
+> Total cluster-label cardinality is therefore bounded by the number of registered
+> clusters plus three. Metrics recorded after cluster resolution carry the real
+> cluster name, so per-cluster dashboards and alerts work as expected. A rising
+> `_unresolved` or `_invalid` series indicates traffic addressed to clusters that
+> Breakglass does not serve.
 
 **Processing Phases:**
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -121,6 +121,14 @@ These metrics track the time spent in each phase of SubjectAccessReview processi
 |--------|------|--------|-------------|
 | `breakglass_webhook_sar_phase_duration_seconds` | Histogram | `cluster`, `phase` | Duration of each SAR processing phase |
 
+> **Cluster label values are bounded.** Every webhook SAR metric derives its `cluster`
+> label from the `:cluster_name` request path, which is attacker-controllable and is
+> read before the cluster has been resolved. Values that are not valid Kubernetes
+> object names are replaced with `_invalid`, and an absent value with `_unknown`, so a
+> remote caller cannot create unbounded time series. Legitimate cluster names are
+> recorded unchanged. A rising `_invalid` series indicates traffic addressed to
+> malformed cluster paths.
+
 **Processing Phases:**
 
 | Phase | Description |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -137,6 +137,11 @@ These metrics track the time spent in each phase of SubjectAccessReview processi
 > | `_invalid` | The supplied name is not a valid Kubernetes object name, so it cannot name a cluster. Malformed traffic. |
 > | `_unresolved` | The name is well-formed but does not match any registered `ClusterConfig`. Requests for clusters that are not onboarded — including cardinality-probing traffic. |
 >
+> `breakglass_webhook_sar_requests_total` is a Counter, so its label cannot be corrected
+> after the increment; it is therefore incremented only once the cluster label is final,
+> which means requests for registered clusters are still counted under the real cluster
+> name.
+>
 > Total cluster-label cardinality is therefore bounded by the number of registered
 > clusters plus three. Metrics recorded after cluster resolution carry the real
 > cluster name, so per-cluster dashboards and alerts work as expected. A rising

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -68,6 +68,65 @@ kubectl logs -l app=breakglass -n breakglass-system --tail=100
 
 ### Upcoming Changes (Unreleased)
 
+#### Behaviour change: server-side apply now prunes removed fields
+
+**What changed.** The diff-before-apply optimization used to compare the desired
+manifest against the live object with *subset* semantics only. Because of that, when
+a field was **removed** from a template or auxiliary-resource manifest, the desired
+object became a strict subset of the live object, every comparison still passed, and
+the apply that would have pruned the field was skipped. The field stayed on the live
+resource indefinitely — the operator reported success while silently leaving the
+resource in a drifted state.
+
+The comparison now additionally requires that every field the operator owns
+(according to its own entry in the resource's `managedFields`) is still declared by
+the desired manifest. When ownership cannot be determined the apply is sent
+unconditionally; server-side apply is a no-op when nothing has actually changed, so
+the only cost is one PATCH round-trip.
+
+**What to expect on the first reconcile after upgrading.**
+
+- Fields that were previously removed from a manifest but left behind on live
+  resources will now actually be deleted. This affects auxiliary resources,
+  pod-template resources, and any other resource applied through the shared apply
+  helpers.
+- The correction is applied per resource on its next reconcile, not in a single
+  sweep, so it lands gradually as sessions and resources are reconciled.
+- Resources with no accumulated drift are unaffected: the reconcile is a no-op.
+- On the very first reconcile of a resource created by an older release, the
+  operator may send one apply it would previously have skipped, because that
+  resource has no ownership entry yet. This is a single extra PATCH per resource,
+  not an ongoing cost.
+
+**Recommended action.** Before upgrading, diff a representative auxiliary resource
+against its manifest (`kubectl get <kind> <name> -o yaml`) to see which fields will
+be pruned. If a field on a live resource is intentionally set by something other
+than breakglass, confirm that the other writer uses its own field manager — fields
+owned by a different manager are not touched.
+
+#### Behaviour change: BreakglassEscalation reference-failure requeue cadence
+
+Escalations whose references (cluster, IdentityProvider, DenyPolicy, MailProvider)
+cannot be resolved previously requeued on a flat 3-second interval forever, which is
+roughly 20 reconciles per minute per bad object, each performing full validation, a
+status write and a `Warning` event. These failures now return an error so
+controller-runtime's rate limiter applies exponential backoff.
+
+Observable effects:
+
+- Retries start at a comparable interval and then back off; a permanently broken
+  reference settles into infrequent retries instead of a constant loop.
+- `Warning` event and status-write volume for broken escalations drops sharply.
+- The `controller_runtime_reconcile_errors_total` counter now increments for these
+  escalations. This is the expected representation of an unresolvable reference and
+  may need an alerting-threshold adjustment.
+- Purely structural validation failures (`ConfigValidated`) no longer retry at all,
+  since they cannot resolve themselves without a spec change. The status condition
+  is still written exactly as before.
+
+Time to resolution for a genuinely transient case (a reference created moments
+after the escalation) is unchanged in practice, since early retries are still fast.
+
 #### Breaking Changes
 
 1. **Session SAR Metrics Label Changes**

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -104,6 +104,27 @@ be pruned. If a field on a live resource is intentionally set by something other
 than breakglass, confirm that the other writer uses its own field manager — fields
 owned by a different manager are not touched.
 
+#### Behaviour change: webhook SAR metrics no longer label unresolved clusters
+
+The `cluster` label on the webhook SAR metrics is derived from the attacker-controllable
+`:cluster_name` request path. It is now only set to the name of a **registered** cluster;
+until a request has been matched to an existing `ClusterConfig`, the label carries one of
+three fixed placeholders — `_unknown` (no name supplied), `_invalid` (not a valid object
+name) or `_unresolved` (well-formed but not onboarded). See `docs/metrics.md`.
+
+Effect on existing dashboards and alerts:
+
+- Metrics for **registered** clusters are unchanged: the real cluster name is still
+  recorded, so per-cluster queries continue to work.
+- Requests for clusters Breakglass does not serve previously produced one series per
+  distinct name. Those series are replaced by the placeholders. A query that grouped by
+  `cluster` will show `_unresolved`/`_invalid` buckets instead of the individual bogus
+  names.
+- `breakglass_webhook_sar_denied_total{...}` for the "cluster not registered" denial is
+  now attributed to `_unresolved` rather than to the requested name. If you alerted on a
+  specific unonboarded cluster name, switch to the placeholder.
+- Overall series count for these metrics drops, in some deployments substantially.
+
 #### Behaviour change: BreakglassEscalation reference-failure requeue cadence
 
 Escalations whose references (cluster, IdentityProvider, DenyPolicy, MailProvider)

--- a/pkg/audit/queued_sink.go
+++ b/pkg/audit/queued_sink.go
@@ -125,6 +125,34 @@ type QueuedSink struct {
 	// Lifecycle
 	wg     sync.WaitGroup
 	closed atomic.Bool
+
+	// sendMu serialises sends on queue against the close in Close.
+	// Every send goes through [QueuedSink.enqueue], which holds the read lock
+	// and re-checks closed; Close takes the write lock before closing the
+	// channel, so no send can be in flight when the channel is closed.
+	sendMu sync.RWMutex
+}
+
+// enqueue performs a non-blocking send on the event queue that is safe against a
+// concurrent Close. It returns false when the sink is already closed or the
+// queue is full; callers distinguish the two via qs.closed.
+func (qs *QueuedSink) enqueue(event *Event) bool {
+	qs.sendMu.RLock()
+	defer qs.sendMu.RUnlock()
+
+	// Re-check under the lock: Close sets closed before taking the write lock,
+	// so observing closed==false here guarantees the channel is still open for
+	// as long as we hold the read lock.
+	if qs.closed.Load() {
+		return false
+	}
+
+	select {
+	case qs.queue <- event:
+		return true
+	default:
+		return false
+	}
 }
 
 // NewQueuedSink creates a new QueuedSink wrapper around an existing sink.
@@ -215,32 +243,33 @@ func (qs *QueuedSink) Write(_ context.Context, event *Event) error {
 		}
 	}
 
-	// Non-blocking send to queue
-	select {
-	case qs.queue <- event:
-		return nil
-	default:
-		// Queue is full
-		if IsSensitiveEvent(event.Type) {
-			// Synchronous fallback for sensitive events
-			qs.logger.Warn("queue full but event is sensitive, attempting synchronous write",
-				zap.String("sink", qs.sink.Name()),
-				zap.String("event_type", string(event.Type)))
-			ctx, cancel := context.WithTimeout(context.Background(), qs.config.WriteTimeout)
-			defer cancel()
-			return qs.sink.Write(ctx, event)
-		}
-		// Non-sensitive event: drop
-		qs.droppedEvents.Add(1)
-		metrics.AuditEventsDropped.WithLabelValues(qs.sink.Name(), "queue_full").Inc()
-		if !qs.config.DropOnFull {
-			qs.logger.Warn("audit queue full, dropping event",
-				zap.String("sink", qs.sink.Name()),
-				zap.String("event_type", string(event.Type)),
-				zap.String("event_id", event.ID))
-		}
+	// Non-blocking send to queue (safe against a concurrent Close).
+	if qs.enqueue(event) {
 		return nil
 	}
+	if qs.closed.Load() {
+		return fmt.Errorf("queued sink %s is closed", qs.sink.Name())
+	}
+	// Queue is full
+	if IsSensitiveEvent(event.Type) {
+		// Synchronous fallback for sensitive events
+		qs.logger.Warn("queue full but event is sensitive, attempting synchronous write",
+			zap.String("sink", qs.sink.Name()),
+			zap.String("event_type", string(event.Type)))
+		ctx, cancel := context.WithTimeout(context.Background(), qs.config.WriteTimeout)
+		defer cancel()
+		return qs.sink.Write(ctx, event)
+	}
+	// Non-sensitive event: drop
+	qs.droppedEvents.Add(1)
+	metrics.AuditEventsDropped.WithLabelValues(qs.sink.Name(), "queue_full").Inc()
+	if !qs.config.DropOnFull {
+		qs.logger.Warn("audit queue full, dropping event",
+			zap.String("sink", qs.sink.Name()),
+			zap.String("event_type", string(event.Type)),
+			zap.String("event_id", event.ID))
+	}
+	return nil
 }
 
 // processQueue is the worker goroutine that processes events from the queue.
@@ -273,13 +302,16 @@ func (qs *QueuedSink) processQueue(workerID int) {
 
 		if err != nil {
 			if errors.Is(err, ErrCircuitOpen) {
-				// Try to push it back into the queue if circuit opened during Write
-				go func(e *Event) {
-					select {
-					case qs.queue <- e:
-					default:
-					}
-				}(event)
+				// Try to push it back into the queue if the circuit opened during Write.
+				// This must NOT be done from an untracked goroutine: Close() closes
+				// qs.queue once the tracked workers are accounted for, and a detached
+				// send would then panic with "send on closed channel" — precisely when
+				// the backend is down during shutdown. enqueue() is non-blocking and
+				// serialised against Close, so requeue inline instead.
+				if !qs.enqueue(event) {
+					qs.droppedEvents.Add(1)
+					metrics.AuditEventsDropped.WithLabelValues(qs.sink.Name(), "circuit_open_requeue").Inc()
+				}
 				continue
 			}
 
@@ -363,7 +395,13 @@ func (qs *QueuedSink) Close() error {
 		return nil // Already closed
 	}
 
+	// Take the write lock so no enqueue() is in flight, then close. Every send
+	// site re-checks qs.closed under the read lock, so after this point no
+	// goroutine can send on qs.queue.
+	qs.sendMu.Lock()
 	close(qs.queue)
+	qs.sendMu.Unlock()
+
 	qs.wg.Wait()
 
 	// Close underlying sink

--- a/pkg/audit/queued_sink_test.go
+++ b/pkg/audit/queued_sink_test.go
@@ -315,3 +315,90 @@ func TestQueuedSink_Name(t *testing.T) {
 
 	assert.Equal(t, "test-sink", qs.Name())
 }
+
+// circuitOpenSink always returns ErrCircuitOpen from Write, which drives the
+// requeue branch of processQueue.
+type circuitOpenSink struct {
+	name  string
+	calls atomic.Int64
+}
+
+func (s *circuitOpenSink) Write(_ context.Context, _ *Event) error {
+	s.calls.Add(1)
+	return ErrCircuitOpen
+}
+
+func (s *circuitOpenSink) Close() error { return nil }
+
+func (s *circuitOpenSink) Name() string { return s.name }
+
+// TestQueuedSink_CloseDuringCircuitOpenRequeue is a regression test for the
+// "send on closed channel" panic (#053). When the underlying sink returns
+// ErrCircuitOpen the worker requeues the event; that requeue used to happen in
+// an untracked goroutine, so Close() could close qs.queue while the send was
+// still pending, panicking the process unrecoverably.
+//
+// The panic surfaces as a process-level crash (not a recovered panic), so this
+// test drives many concurrent Write/requeue cycles against a Close to make the
+// window reliably reachable. Run with -race.
+func TestQueuedSink_CloseDuringCircuitOpenRequeue(t *testing.T) {
+	for iteration := 0; iteration < 50; iteration++ {
+		sink := &circuitOpenSink{name: "circuit-open"}
+		cfg := QueuedSinkConfig{
+			// Small queue so the requeue contends for space and workers keep
+			// cycling the same events.
+			QueueSize:               4,
+			WorkerCount:             4,
+			WriteTimeout:            time.Second,
+			DropOnFull:              true,
+			CircuitBreakerThreshold: 1_000_000, // never open our own breaker
+			CircuitBreakerResetTime: time.Hour,
+		}
+		qs := NewQueuedSink(sink, cfg, zap.NewNop())
+
+		var producers sync.WaitGroup
+		stop := make(chan struct{})
+		for p := 0; p < 4; p++ {
+			producers.Add(1)
+			go func() {
+				defer producers.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					// EventSessionValidated is non-sensitive, so a full queue
+					// drops rather than writing synchronously.
+					_ = qs.Write(context.Background(), &Event{
+						ID:   "e",
+						Type: EventSessionValidated,
+					})
+				}
+			}()
+		}
+
+		// Let the workers start cycling events through the requeue branch.
+		for sink.calls.Load() < 4 {
+			time.Sleep(time.Millisecond)
+		}
+
+		// Close concurrently with in-flight requeues. Before the fix this
+		// panics with "send on closed channel".
+		require.NoError(t, qs.Close())
+		close(stop)
+		producers.Wait()
+	}
+}
+
+// TestQueuedSink_WriteAfterCloseReturnsError asserts that a Write racing with
+// Close never panics and reports the closed sink instead.
+func TestQueuedSink_WriteAfterCloseReturnsError(t *testing.T) {
+	sink := newQueuedMockSink("late-write")
+	qs := NewQueuedSink(sink, DefaultQueuedSinkConfig(), zap.NewNop())
+	require.NoError(t, qs.Close())
+
+	err := qs.Write(context.Background(), &Event{ID: "after-close", Type: EventSessionValidated})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is closed")
+}

--- a/pkg/breakglass/debug/debug_session_kubectl.go
+++ b/pkg/breakglass/debug/debug_session_kubectl.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,46 @@ type KubectlDebugHandler struct {
 	client     ctrlclient.Client
 	ccProvider ClientProviderInterface
 }
+
+// deleteOrphanedPod removes a pod that was created on the spoke cluster but could
+// not be recorded in the DebugSession status.
+//
+// This is required for correctness, not tidiness: cleanup
+// (CleanupKubectlDebugResources / cleanupResources) iterates the status lists, so
+// a pod that never made it into the status is invisible to every cleanup path and
+// outlives its session indefinitely. For the node-debug pod that orphan is a
+// privileged pod with hostPath "/" mounted read-write.
+//
+// Failures are logged and swallowed: the caller is already returning the original
+// status-patch error, which is the actionable one.
+func (h *KubectlDebugHandler) deleteOrphanedPod(ctx context.Context, targetClient ctrlclient.Client, pod *corev1.Pod, cause error) {
+	log := zap.S().Named("kubectl-debug")
+
+	// Use a context detached from the caller's: when the status patch failed
+	// because the request context was cancelled, a cancelled context would also
+	// prevent the compensating delete and leave the orphan behind anyway.
+	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), orphanCleanupTimeout)
+	defer cancel()
+
+	if err := targetClient.Delete(deleteCtx, pod); err != nil && !apierrors.IsNotFound(err) {
+		log.Errorw("Failed to delete orphaned debug pod after status update failure; "+
+			"the pod is not tracked in the session status and will not be cleaned up automatically",
+			"pod", pod.Name,
+			"podNamespace", pod.Namespace,
+			"statusError", cause,
+			"deleteError", err)
+		return
+	}
+
+	log.Warnw("Deleted orphaned debug pod after status update failure",
+		"pod", pod.Name,
+		"podNamespace", pod.Namespace,
+		"statusError", cause)
+}
+
+// orphanCleanupTimeout bounds the compensating delete for a pod that could not be
+// recorded in the session status.
+const orphanCleanupTimeout = 30 * time.Second
 
 // ClientProviderInterface abstracts the cluster.ClientProvider for testing
 type ClientProviderInterface interface {
@@ -496,6 +537,10 @@ func (h *KubectlDebugHandler) CreatePodCopy(
 
 		addAllowedPodIfMissing(status, allowedPod)
 	}); err != nil {
+		// The pod exists on the spoke but is absent from the status lists that
+		// cleanup iterates, so it would never be reclaimed. Delete it so
+		// create+track is atomic-or-cleaned-up.
+		h.deleteOrphanedPod(ctx, targetClient, copyPod, err)
 		return nil, fmt.Errorf("failed to update session status: %w", err)
 	}
 
@@ -655,6 +700,10 @@ func (h *KubectlDebugHandler) CreateNodeDebugPod(
 		addAllowedPodIfMissing(status, allowedPod)
 		addDeployedResourceIfMissing(status, deployedResource)
 	}); err != nil {
+		// This pod is privileged with hostPath "/" mounted read-write. Leaving it
+		// untracked means it outlives its session with no cleanup path at all, so
+		// the create must be rolled back.
+		h.deleteOrphanedPod(ctx, targetClient, debugPod, err)
 		return nil, fmt.Errorf("failed to update session status: %w", err)
 	}
 

--- a/pkg/breakglass/debug/debug_session_kubectl_test.go
+++ b/pkg/breakglass/debug/debug_session_kubectl_test.go
@@ -1872,3 +1872,132 @@ func TestKubectlDebugHandler_CleanupKubectlDebugResources(t *testing.T) {
 			"error should wrap ErrClusterConfigNotFound for reconciler to handle gracefully")
 	})
 }
+
+// TestCreateNodeDebugPod_StatusFailureDeletesOrphan is the regression test for
+// #096. CreateNodeDebugPod creates a PRIVILEGED pod with hostPath "/" mounted
+// read-write on the spoke cluster and then records it in the DebugSession status.
+// If the status patch fails, the pod is absent from the very status lists that
+// CleanupKubectlDebugResources / cleanupResources iterate, so nothing ever deletes
+// it and it outlives its session indefinitely.
+func TestCreateNodeDebugPod_StatusFailureDeletesOrphan(t *testing.T) {
+	scheme := testScheme()
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-node-session", Namespace: "default"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:         "test-cluster",
+			RequestedBy:     "user@example.com",
+			TargetNamespace: "breakglass-debug",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeKubectlDebug,
+				KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+					NodeDebug: &breakglassv1alpha1.NodeDebugConfig{
+						Enabled:       true,
+						AllowedImages: []string{"busybox:stable"},
+					},
+				},
+			},
+		},
+	}
+
+	targetClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Hub client whose status patch always fails, simulating a lost lease, a
+	// conflict storm, or a transient apiserver error at exactly the wrong moment.
+	statusErr := errors.New("simulated status patch failure")
+	hubClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ ctrlclient.Client, _ string, _ ctrlclient.Object, _ ctrlclient.Patch, _ ...ctrlclient.SubResourcePatchOption) error {
+				return statusErr
+			},
+		}).
+		Build()
+
+	handler := NewKubectlDebugHandler(hubClient, &mockClientProvider{
+		clients: map[string]ctrlclient.Client{"test-cluster": targetClient},
+	})
+
+	pod, err := handler.CreateNodeDebugPod(context.Background(), session, "node-1", "user@example.com")
+	require.Error(t, err, "the status failure must be reported to the caller")
+	assert.Nil(t, pod)
+
+	// No privileged hostPath pod may be left behind on the spoke cluster.
+	var pods corev1.PodList
+	require.NoError(t, targetClient.List(context.Background(), &pods))
+	assert.Empty(t, pods.Items,
+		"a privileged hostPath:/ pod was orphaned on the spoke cluster: it is untracked "+
+			"in the session status, so no cleanup path will ever delete it")
+}
+
+// TestCreatePodCopy_StatusFailureDeletesOrphan is the regression test for #095:
+// the same create-then-status-patch ordering in the pod-copy path.
+func TestCreatePodCopy_StatusFailureDeletesOrphan(t *testing.T) {
+	scheme := testScheme()
+
+	originalPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "nginx:latest"}},
+		},
+	}
+
+	session := &breakglassv1alpha1.DebugSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-copy-session", Namespace: "default"},
+		Spec: breakglassv1alpha1.DebugSessionSpec{
+			Cluster:     "test-cluster",
+			RequestedBy: "user@example.com",
+		},
+		Status: breakglassv1alpha1.DebugSessionStatus{
+			State: breakglassv1alpha1.DebugSessionStateActive,
+			ResolvedTemplate: &breakglassv1alpha1.DebugSessionTemplateSpec{
+				Mode: breakglassv1alpha1.DebugSessionModeKubectlDebug,
+				KubectlDebug: &breakglassv1alpha1.KubectlDebugConfig{
+					PodCopy: &breakglassv1alpha1.PodCopyConfig{
+						Enabled: true,
+						TTL:     "1h",
+					},
+				},
+			},
+		},
+	}
+
+	// The pod-copy path resolves namespace labels and requires the target
+	// namespace to exist, so both namespaces must be seeded for the test to reach
+	// the create at all.
+	sourceNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	copiesNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "debug-copies"}}
+	targetClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(originalPod, sourceNS, copiesNS).Build()
+
+	statusErr := errors.New("simulated status patch failure")
+	hubClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session).
+		WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ ctrlclient.Client, _ string, _ ctrlclient.Object, _ ctrlclient.Patch, _ ...ctrlclient.SubResourcePatchOption) error {
+				return statusErr
+			},
+		}).
+		Build()
+
+	handler := NewKubectlDebugHandler(hubClient, &mockClientProvider{
+		clients: map[string]ctrlclient.Client{"test-cluster": targetClient},
+	})
+
+	copyPod, err := handler.CreatePodCopy(context.Background(), session, "default", "app-pod", "busybox:latest", "user@example.com")
+	require.Error(t, err)
+	assert.Nil(t, copyPod)
+
+	var pods corev1.PodList
+	require.NoError(t, targetClient.List(context.Background(), &pods))
+	// Only the original pod may remain.
+	require.Len(t, pods.Items, 1, "the pod copy must not be orphaned on the spoke cluster")
+	assert.Equal(t, "app-pod", pods.Items[0].Name)
+}

--- a/pkg/breakglass/debug/debug_session_reconciler.go
+++ b/pkg/breakglass/debug/debug_session_reconciler.go
@@ -145,11 +145,7 @@ func (c *DebugSessionController) Reconcile(ctx context.Context, req ctrl.Request
 		if apierrors.IsNotFound(err) {
 			log.Debug("DebugSession not found, ignoring")
 
-			if metrics.DebugSessionParticipants != nil {
-				metrics.DebugSessionParticipants.DeletePartialMatch(map[string]string{"session": req.Name})
-				metrics.DebugSessionPodRestarts.DeletePartialMatch(map[string]string{"session": req.Name})
-				metrics.DebugSessionPodFailures.DeletePartialMatch(map[string]string{"session": req.Name})
-			}
+			releaseSessionMetricSeries(req.Name)
 
 			return ctrl.Result{}, nil
 		}
@@ -187,8 +183,11 @@ func (c *DebugSessionController) Reconcile(ctx context.Context, req ctrl.Request
 	case breakglassv1alpha1.DebugSessionStateExpired, breakglassv1alpha1.DebugSessionStateTerminated:
 		return c.handleCleanup(ctx, ds)
 	case breakglassv1alpha1.DebugSessionStateFailed:
-		// Terminal state, no action needed
-		return ctrl.Result{}, nil
+		// Terminal state — but only once the spoke cluster is actually clean.
+		// failSession does best-effort cleanup, logs any failure and then sets
+		// Failed, which never requeues; a cleanup error there therefore leaked the
+		// spoke resources permanently. Retry while anything is still tracked.
+		return c.handleFailedCleanup(ctx, ds)
 	default:
 		log.Warnw("Unknown debug session state", "state", ds.Status.State)
 		return ctrl.Result{}, nil
@@ -392,6 +391,54 @@ func (c *DebugSessionController) handleActive(ctx context.Context, ds *breakglas
 	return ctrl.Result{RequeueAfter: DefaultDebugSessionRequeue}, nil
 }
 
+// handleFailedCleanup finishes cleanup for a session already in the terminal
+// Failed state.
+//
+// failSession performs a best-effort cleanup, logs any error and then sets Failed.
+// Failed used to return an empty Result, which never requeues, so a cleanup error
+// on that path leaked the spoke-cluster resources permanently (#237). Failed
+// remains terminal for state-machine purposes — the state is never changed here —
+// but reconciliation keeps retrying the delete until the status lists are empty.
+func (c *DebugSessionController) handleFailedCleanup(ctx context.Context, ds *breakglassv1alpha1.DebugSession) (ctrl.Result, error) {
+	if !hasTrackedSpokeResources(ds) {
+		releaseSessionMetricSeries(ds.Name)
+		return ctrl.Result{}, nil // Nothing left on the spoke: genuinely terminal.
+	}
+
+	log := c.log.With("debugSession", ds.Name, "namespace", ds.Namespace, "cluster", ds.Spec.Cluster)
+
+	if err := c.cleanupResources(ctx, ds); err != nil {
+		log.Warnw("Retrying cleanup of spoke resources for a failed debug session",
+			"error", err)
+		// Requeue rather than returning the error: the reason for the failure is
+		// already recorded in status and a hard error would only add log noise on a
+		// path that is expected to retry.
+		return ctrl.Result{RequeueAfter: ExpiredSessionRequeue}, nil
+	}
+
+	// cleanupResources clears the status lists as it succeeds. If anything is still
+	// tracked, the cleanup was incomplete even though it reported no error, so the
+	// session is not yet safe to abandon.
+	if hasTrackedSpokeResources(ds) {
+		log.Warnw("Cleanup reported success but spoke resources are still tracked; will retry")
+		return ctrl.Result{RequeueAfter: ExpiredSessionRequeue}, nil
+	}
+
+	log.Infow("Cleanup of spoke resources completed for failed debug session")
+	releaseSessionMetricSeries(ds.Name)
+	return ctrl.Result{}, nil
+}
+
+// hasTrackedSpokeResources reports whether the session status still references
+// anything that was deployed to the spoke cluster.
+func hasTrackedSpokeResources(ds *breakglassv1alpha1.DebugSession) bool {
+	return len(ds.Status.DeployedResources) > 0 ||
+		len(ds.Status.AuxiliaryResourceStatuses) > 0 ||
+		len(ds.Status.PodTemplateResourceStatuses) > 0 ||
+		len(ds.Status.AllowedPods) > 0 ||
+		ds.Status.KubectlDebugStatus != nil
+}
+
 // handleCleanup removes deployed resources for expired/terminated sessions
 func (c *DebugSessionController) handleCleanup(ctx context.Context, ds *breakglassv1alpha1.DebugSession) (ctrl.Result, error) {
 	log := c.log.With("debugSession", ds.Name, "namespace", ds.Namespace)
@@ -425,8 +472,35 @@ func (c *DebugSessionController) handleCleanup(ctx context.Context, ds *breakgla
 		}
 	}
 
+	// Release the per-session metric series. The "session" label is unique per
+	// DebugSession, so without an explicit release these series accumulate for the
+	// lifetime of the process and the heap grows monotonically with the number of
+	// sessions ever created. The DeletePartialMatch on NotFound in Reconcile only
+	// fires if a delete event is actually observed, which is not guaranteed (missed
+	// watch event, restart, or a session that is never deleted at all).
+	releaseSessionMetricSeries(ds.Name)
+
 	log.Info("Debug session cleanup complete")
 	return ctrl.Result{}, nil
+}
+
+// releaseSessionMetricSeries drops every metric series labelled with a specific
+// DebugSession name. Safe to call more than once and safe before metric
+// registration.
+func releaseSessionMetricSeries(sessionName string) {
+	if sessionName == "" {
+		return
+	}
+	labels := map[string]string{"session": sessionName}
+	if metrics.DebugSessionParticipants != nil {
+		metrics.DebugSessionParticipants.DeletePartialMatch(labels)
+	}
+	if metrics.DebugSessionPodRestarts != nil {
+		metrics.DebugSessionPodRestarts.DeletePartialMatch(labels)
+	}
+	if metrics.DebugSessionPodFailures != nil {
+		metrics.DebugSessionPodFailures.DeletePartialMatch(labels)
+	}
 }
 
 // activateSession deploys debug resources and marks session as active
@@ -506,13 +580,15 @@ func (c *DebugSessionController) failSession(ctx context.Context, ds *breakglass
 
 	// Best-effort cleanup of any partially deployed resources on the target cluster.
 	// Short-circuit if the session never deployed anything to avoid noisy cross-cluster calls.
-	hasDeployedResources := len(ds.Status.DeployedResources) > 0 ||
-		len(ds.Status.AuxiliaryResourceStatuses) > 0 ||
-		len(ds.Status.PodTemplateResourceStatuses) > 0 ||
-		len(ds.Status.AllowedPods) > 0
-	if hasDeployedResources {
+	//
+	// A failure here is not fatal: the session still transitions to Failed, and the
+	// Failed branch of Reconcile retries the cleanup for as long as the status
+	// still tracks spoke resources (see handleFailedCleanup), so a transient spoke
+	// outage no longer leaks resources permanently.
+	if hasTrackedSpokeResources(ds) {
 		if cleanupErr := c.cleanupResources(ctx, ds); cleanupErr != nil {
-			log.Warnw("Best-effort cleanup of partially deployed resources failed during session failure",
+			log.Warnw("Best-effort cleanup of partially deployed resources failed during session failure; "+
+				"cleanup will be retried on subsequent reconciles",
 				"cleanupError", cleanupErr)
 		}
 	}
@@ -551,6 +627,9 @@ func (c *DebugSessionController) failSession(ctx context.Context, ds *breakglass
 
 	// Increment failure metric
 	metrics.DebugSessionsFailed.WithLabelValues(ds.Spec.Cluster, ds.Spec.TemplateRef).Inc()
+
+	// Failed is terminal and never requeues, so release the per-session series now.
+	releaseSessionMetricSeries(ds.Name)
 
 	return ctrl.Result{}, breakglass.ApplyDebugSessionStatus(ctx, c.client, ds)
 }

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -5628,3 +5628,76 @@ func TestDebugSessionController_FailSession_PartialDeployScenarios(t *testing.T)
 		assert.Contains(t, updated.Status.Message, "failed to apply workload")
 	})
 }
+
+// TestDebugSessionController_FailedStateRetriesCleanup is the regression test for
+// #237. failSession does best-effort cleanup, logs any error, then sets the
+// terminal Failed state. The Failed branch of Reconcile returned an empty
+// ctrl.Result, which never requeues, so spoke-cluster resources that the
+// best-effort cleanup could not delete leaked permanently.
+func TestDebugSessionController_FailedStateRetriesCleanup(t *testing.T) {
+	scheme := testScheme()
+
+	t.Run("failed_with_tracked_resources_requeues_for_cleanup", func(t *testing.T) {
+		session := newTestDebugSession("failed-leak", "test-template", "test-cluster", "user@example.com")
+		session.Status.State = breakglassv1alpha1.DebugSessionStateFailed
+		session.Status.Message = "cleanup previously failed"
+		// Resources are still tracked in status: the spoke was not cleaned up.
+		session.Status.DeployedResources = []breakglassv1alpha1.DeployedResourceRef{
+			{Kind: "DaemonSet", Name: "debug-ds-failed-leak", Namespace: "breakglass-debug", Source: "debug-pod"},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := &DebugSessionController{
+			log:    zap.NewNop().Sugar(),
+			client: fakeClient,
+			// nil ccProvider makes cleanupResources a no-op that cannot reach the
+			// spoke, standing in for an unreachable spoke cluster.
+		}
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+		})
+		require.NoError(t, err)
+
+		// The state must remain terminal...
+		var updated breakglassv1alpha1.DebugSession
+		require.NoError(t, fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: session.Name, Namespace: session.Namespace}, &updated))
+		assert.Equal(t, breakglassv1alpha1.DebugSessionStateFailed, updated.Status.State,
+			"Failed must stay terminal; only cleanup is retried")
+
+		// ...but reconciliation must not give up while spoke resources are tracked.
+		assert.NotEqual(t, reconcile.Result{}, result,
+			"a failed session with untracked-cleanup spoke resources must be revisited, "+
+				"otherwise the spoke resources leak permanently")
+	})
+
+	t.Run("failed_with_no_tracked_resources_is_terminal", func(t *testing.T) {
+		session := newTestDebugSession("failed-clean", "test-template", "test-cluster", "user@example.com")
+		session.Status.State = breakglassv1alpha1.DebugSessionStateFailed
+		session.Status.Message = "template not found"
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(session).
+			WithStatusSubresource(&breakglassv1alpha1.DebugSession{}).
+			Build()
+
+		controller := &DebugSessionController{
+			log:    zap.NewNop().Sugar(),
+			client: fakeClient,
+		}
+
+		result, err := controller.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result,
+			"nothing was deployed, so there is nothing to retry")
+	})
+}

--- a/pkg/config/escalation_reconciler.go
+++ b/pkg/config/escalation_reconciler.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -234,16 +235,28 @@ func (r *EscalationReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		}
 
 		// Reference validation errors (cluster, IDP, deny policy, mail provider) may be
-		// transient if the referenced resource hasn't been created yet. Requeue to retry.
-		hasRefError := false
+		// transient if the referenced resource hasn't been created yet, so retry.
+		//
+		// Return the error rather than a fixed RequeueAfter: controller-runtime then
+		// applies its exponential backoff rate limiter. A flat 3s requeue never backs
+		// off, so a permanently-broken reference (a typo'd ref that will never
+		// resolve) drove ~20 reconciles per minute forever, each performing full
+		// reference validation, a status write and a Warning event — indefinitely, per
+		// bad object.
+		var refErrors []error
 		for _, ve := range validationErrors {
-			if ve.conditionType != string(breakglassv1alpha1.BreakglassEscalationConditionConfigValidated) {
-				hasRefError = true
-				break
+			if ve.conditionType == string(breakglassv1alpha1.BreakglassEscalationConditionConfigValidated) {
+				continue // Structural error: the object will not fix itself, do not retry.
 			}
+			if ve.error != nil {
+				refErrors = append(refErrors, ve.error)
+				continue
+			}
+			refErrors = append(refErrors, errors.New(ve.message))
 		}
-		if hasRefError {
-			return reconcile.Result{RequeueAfter: 3 * time.Second}, nil
+		if len(refErrors) > 0 {
+			return reconcile.Result{}, fmt.Errorf("escalation %s reference validation failed: %w",
+				escalation.Name, errors.Join(refErrors...))
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/config/escalation_reconciler_test.go
+++ b/pkg/config/escalation_reconciler_test.go
@@ -499,9 +499,10 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Reference validation errors requeue to handle transient missing resources
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
+		// Reference validation errors are returned as errors so controller-runtime
+		// applies exponential backoff instead of a flat 3s hot loop (#254).
+		require.Error(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -545,9 +546,10 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Reference validation errors requeue to handle transient missing resources
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
+		// Reference validation errors are returned as errors so controller-runtime
+		// applies exponential backoff instead of a flat 3s hot loop (#254).
+		require.Error(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -603,9 +605,10 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Reference validation errors requeue to handle transient missing resources
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
+		// Reference validation errors are returned as errors so controller-runtime
+		// applies exponential backoff instead of a flat 3s hot loop (#254).
+		require.Error(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -649,9 +652,10 @@ func TestEscalationReconciler_Reconcile(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "test-escalation", Namespace: "default"},
 		})
 
-		// Reference validation errors requeue to handle transient missing resources
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{RequeueAfter: 3 * time.Second}, result)
+		// Reference validation errors are returned as errors so controller-runtime
+		// applies exponential backoff instead of a flat 3s hot loop (#254).
+		require.Error(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
 
 		// Verify the status condition was set
 		var updated breakglassv1alpha1.BreakglassEscalation
@@ -1234,4 +1238,92 @@ func TestEscalationReconciler_GetEscalationIDPMapping(t *testing.T) {
 		assert.Len(t, mapping, 1)
 		assert.Equal(t, []string{"idp1"}, mapping["esc1"])
 	})
+}
+
+// TestEscalationReconciler_RefErrorUsesBackoffNotHotLoop is the regression test
+// for #254. A reference-validation failure previously returned
+// reconcile.Result{RequeueAfter: 3s} with a nil error, unconditionally and with no
+// backoff, so a permanently-unresolvable reference produced ~20 reconciles per
+// minute forever — each one running full validation, writing status and emitting a
+// Warning event. Returning an error instead lets controller-runtime's rate limiter
+// back off exponentially.
+func TestEscalationReconciler_RefErrorUsesBackoffNotHotLoop(t *testing.T) {
+	scheme := newTestEscalationReconcilerScheme()
+	logger := zap.NewNop().Sugar()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "hot-loop", Namespace: "default", Generation: 1},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup:    "test-group",
+			MaxValidFor:       "1h",
+			ClusterConfigRefs: []string{"will-never-exist"},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Users: []string{"approver@example.com"},
+			},
+		},
+	}
+
+	recorder := &escalationFakeEventRecorder{}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(escalation).
+		WithStatusSubresource(escalation).
+		Build()
+
+	r := NewEscalationReconciler(fakeClient, logger, recorder, nil, nil, 0)
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "hot-loop", Namespace: "default"},
+	})
+
+	// An error return is what makes controller-runtime apply exponential backoff.
+	require.Error(t, err, "reference validation failure must return an error so the workqueue backs off")
+	assert.Contains(t, err.Error(), "reference validation failed")
+
+	// A fixed RequeueAfter would bypass the rate limiter entirely.
+	assert.Zero(t, result.RequeueAfter,
+		"must not set a fixed RequeueAfter: that bypasses backoff and re-creates the hot loop")
+	assert.Equal(t, reconcile.Result{}, result)
+
+	// The status condition is still written, so observability is unchanged.
+	var updated breakglassv1alpha1.BreakglassEscalation
+	require.NoError(t, fakeClient.Get(context.Background(),
+		types.NamespacedName{Name: "hot-loop", Namespace: "default"}, &updated))
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions,
+		string(breakglassv1alpha1.BreakglassEscalationConditionClusterRefsValid))
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+}
+
+// TestEscalationReconciler_StructuralErrorDoesNotRetry asserts the other half of
+// the fix: a purely structural (ConfigValidated) failure will not fix itself, so
+// it must neither requeue nor return an error.
+func TestEscalationReconciler_StructuralErrorDoesNotRetry(t *testing.T) {
+	scheme := newTestEscalationReconcilerScheme()
+	logger := zap.NewNop().Sugar()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "structural", Namespace: "default", Generation: 1},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			// Missing escalatedGroup and an unparseable duration: structural only,
+			// with no references to resolve.
+			MaxValidFor: "not-a-duration",
+		},
+	}
+
+	recorder := &escalationFakeEventRecorder{}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(escalation).
+		WithStatusSubresource(escalation).
+		Build()
+
+	r := NewEscalationReconciler(fakeClient, logger, recorder, nil, nil, 0)
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "structural", Namespace: "default"},
+	})
+
+	require.NoError(t, err, "a structural error will not fix itself; retrying is pure waste")
+	assert.Equal(t, reconcile.Result{}, result)
 }

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -8,30 +8,66 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// LabelValueInvalid is the placeholder substituted for any label value that is
-// not a valid Kubernetes object name.
+// Placeholder label values substituted for a cluster name that must not be used
+// verbatim as a Prometheus label.
 //
 // Prometheus creates one time series per distinct label-value combination and
 // never reclaims them, so a label fed from unvalidated remote input lets a caller
-// grow the process heap without bound. Collapsing every rejected value onto a
-// single series keeps that cardinality at one while still making the condition
-// visible on the dashboard.
-const LabelValueInvalid = "_invalid"
+// grow the process heap without bound. Format validation alone does NOT bound
+// cardinality: a caller can vary syntactically-valid names indefinitely.
+// Cardinality is only bounded by refusing to emit any name that has not been
+// resolved against a real ClusterConfig — the set of registered clusters is the
+// only genuinely bounded source of cluster label values.
+//
+// The three placeholders keep that bound at three series while still
+// distinguishing the operationally interesting cases on a dashboard.
+const (
+	// LabelValueUnknown is substituted for an empty cluster name: the caller sent
+	// no cluster at all.
+	LabelValueUnknown = "_unknown"
 
-// LabelValueUnknown is the placeholder substituted for an empty label value, so
-// that "the caller sent nothing" is distinguishable from "the caller sent
-// something unusable".
-const LabelValueUnknown = "_unknown"
+	// LabelValueInvalid is substituted for a cluster name that is not a valid
+	// Kubernetes object name, so it could not name a real cluster. A rising
+	// _invalid series indicates malformed traffic.
+	LabelValueInvalid = "_invalid"
 
-// SafeClusterLabel returns name if it is a valid Kubernetes object name suitable
-// for use as a Prometheus label value, and a fixed placeholder otherwise.
+	// LabelValueUnresolved is substituted for a well-formed cluster name that has
+	// not (yet) been resolved against a registered ClusterConfig. This is the
+	// value that actually bounds cardinality: without it, any attacker-chosen
+	// valid DNS-1123 name would become its own series.
+	LabelValueUnresolved = "_unresolved"
+)
+
+// SafeClusterLabel returns a bounded Prometheus label value for an UNRESOLVED
+// cluster name.
 //
 // Use it for every metric label derived from request input (an HTTP route
-// parameter, a header, a request body field) BEFORE the value has been resolved
-// against a real ClusterConfig. Cluster names in this project are Kubernetes
-// object names, so RFC 1123 subdomain validation is exactly the right bound and
-// the label value is unchanged for every legitimate cluster.
+// parameter, a header, a request body field) that has not yet been matched to a
+// registered ClusterConfig. It never returns the caller-supplied name: the result
+// is always one of the three placeholders, so a remote caller cannot create more
+// than three series regardless of what it sends.
+//
+// Once the cluster has been resolved, switch the label to the resolved name via
+// [ResolvedClusterLabel]; that value is bounded by the number of registered
+// clusters.
 func SafeClusterLabel(name string) string {
+	if name == "" {
+		return LabelValueUnknown
+	}
+	if len(validation.IsDNS1123Subdomain(name)) > 0 {
+		return LabelValueInvalid
+	}
+	return LabelValueUnresolved
+}
+
+// ResolvedClusterLabel returns the label value to use once name has been
+// confirmed to identify a registered cluster (i.e. a ClusterConfig lookup
+// succeeded). The name is returned verbatim, because the set of registered
+// clusters is bounded and operator-controlled rather than caller-controlled.
+//
+// It still guards against a malformed or empty name so that a bad label value can
+// never reach Prometheus, no matter how the cluster was resolved.
+func ResolvedClusterLabel(name string) string {
 	if name == "" {
 		return LabelValueUnknown
 	}

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// LabelValueInvalid is the placeholder substituted for any label value that is
+// not a valid Kubernetes object name.
+//
+// Prometheus creates one time series per distinct label-value combination and
+// never reclaims them, so a label fed from unvalidated remote input lets a caller
+// grow the process heap without bound. Collapsing every rejected value onto a
+// single series keeps that cardinality at one while still making the condition
+// visible on the dashboard.
+const LabelValueInvalid = "_invalid"
+
+// LabelValueUnknown is the placeholder substituted for an empty label value, so
+// that "the caller sent nothing" is distinguishable from "the caller sent
+// something unusable".
+const LabelValueUnknown = "_unknown"
+
+// SafeClusterLabel returns name if it is a valid Kubernetes object name suitable
+// for use as a Prometheus label value, and a fixed placeholder otherwise.
+//
+// Use it for every metric label derived from request input (an HTTP route
+// parameter, a header, a request body field) BEFORE the value has been resolved
+// against a real ClusterConfig. Cluster names in this project are Kubernetes
+// object names, so RFC 1123 subdomain validation is exactly the right bound and
+// the label value is unchanged for every legitimate cluster.
+func SafeClusterLabel(name string) string {
+	if name == "" {
+		return LabelValueUnknown
+	}
+	if len(validation.IsDNS1123Subdomain(name)) > 0 {
+		return LabelValueInvalid
+	}
+	return name
+}

--- a/pkg/metrics/labels_test.go
+++ b/pkg/metrics/labels_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestSafeClusterLabel_BoundedToThreeValues is the cardinality contract for
+// unresolved cluster labels: SafeClusterLabel must NEVER return the
+// caller-supplied name, so the number of distinct label values it can ever
+// produce is exactly three, no matter what a remote caller sends.
+//
+// Format validation alone would not bound anything — arbitrarily many
+// syntactically-valid DNS-1123 names exist — which is why well-formed names
+// collapse onto LabelValueUnresolved rather than being passed through.
+func TestSafeClusterLabel_BoundedToThreeValues(t *testing.T) {
+	inputs := []string{
+		// Empty: no cluster supplied.
+		"",
+		// Malformed: cannot name a Kubernetes object.
+		"../../etc/passwd",
+		"Cluster With Spaces",
+		"UPPERCASE",
+		"-leading-dash",
+		"under_score",
+		strings.Repeat("x", 254),
+		"\n",
+		`cluster{label="injected"}`,
+		// Well-formed but unresolved. Format checking alone would let each of
+		// these become its own series.
+		"a",
+		"prod-cluster-01",
+		"totally.valid.subdomain",
+	}
+	for i := 0; i < 1000; i++ {
+		inputs = append(inputs, fmt.Sprintf("attacker-%d", i))
+	}
+
+	distinct := map[string]struct{}{}
+	for _, in := range inputs {
+		got := SafeClusterLabel(in)
+		if in != "" && got == in {
+			t.Fatalf("SafeClusterLabel(%q) returned the caller-supplied name verbatim", in)
+		}
+		distinct[got] = struct{}{}
+	}
+
+	want := map[string]struct{}{
+		LabelValueUnknown:    {},
+		LabelValueInvalid:    {},
+		LabelValueUnresolved: {},
+	}
+	if len(distinct) != len(want) {
+		t.Fatalf("SafeClusterLabel produced %d distinct label values %v, want exactly %d %v",
+			len(distinct), distinct, len(want), want)
+	}
+	for v := range distinct {
+		if _, ok := want[v]; !ok {
+			t.Fatalf("SafeClusterLabel produced unexpected label value %q; only the three placeholders are permitted", v)
+		}
+	}
+}
+
+func TestSafeClusterLabel_Classification(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty is unknown", "", LabelValueUnknown},
+		{"spaces are invalid", "Bad Name", LabelValueInvalid},
+		{"uppercase is invalid", "UPPER", LabelValueInvalid},
+		{"path traversal is invalid", "../../etc/passwd", LabelValueInvalid},
+		{"too long is invalid", strings.Repeat("x", 254), LabelValueInvalid},
+		{"well-formed is unresolved", "prod-cluster-01", LabelValueUnresolved},
+		{"subdomain is unresolved", "a.b.c", LabelValueUnresolved},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SafeClusterLabel(tt.input); got != tt.want {
+				t.Errorf("SafeClusterLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolvedClusterLabel asserts the other half of the bound: once a name has
+// been matched to a registered ClusterConfig it is emitted verbatim, because the
+// set of registered clusters is operator-controlled and bounded. Malformed and
+// empty names still collapse, so a bad value can never reach Prometheus.
+func TestResolvedClusterLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"registered name is verbatim", "prod-cluster-01", "prod-cluster-01"},
+		{"registered subdomain is verbatim", "a.b.c", "a.b.c"},
+		{"empty still collapses", "", LabelValueUnknown},
+		{"malformed still collapses", "Bad Name", LabelValueInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolvedClusterLabel(tt.input); got != tt.want {
+				t.Errorf("ResolvedClusterLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/patchhelper.go
+++ b/pkg/utils/patchhelper.go
@@ -243,10 +243,9 @@ func unstructuredSpecEqual(desired, current *unstructured.Unstructured) bool {
 // desiredCoversOwnedFields reports whether every field currently owned by
 // [FieldOwnerController] on current is still declared by desired.
 //
-// It returns false (i.e. "must apply") whenever ownership cannot be established:
-// no managedFields entry for our field owner, an unparseable FieldsV1, or an
-// entry that is not an Apply operation. Guessing "equal" in those cases is what
-// makes field removals invisible.
+// It returns false (i.e. "must apply") whenever ownership cannot be established —
+// see [ownedFieldSet] for exactly which managedFields entries qualify. Guessing
+// "equal" in those cases is what makes field removals invisible.
 func desiredCoversOwnedFields(desired, current *unstructured.Unstructured) bool {
 	owned := ownedFieldSet(current)
 	if owned == nil {
@@ -255,8 +254,35 @@ func desiredCoversOwnedFields(desired, current *unstructured.Unstructured) bool 
 	return desiredCoversFieldSet(desired.Object, owned, "")
 }
 
-// ownedFieldSet returns the decoded FieldsV1 tree of this operator's Apply entry
-// in current's managedFields, or nil when it is absent or undecodable.
+// ownedFieldSet returns the decoded FieldsV1 tree describing the spec/metadata
+// fields this operator owns on current, or nil when that cannot be established.
+//
+// Contract — only entries matching ALL of the following are considered:
+//   - Manager == [FieldOwnerController]: other field managers' ownership is none
+//     of our business.
+//   - Operation == Apply: Update entries describe imperative writes, whose field
+//     set carries no SSA pruning semantics.
+//   - Subresource == "": this is the load-bearing filter. This operator applies to
+//     the status subresource with the SAME field manager (see [ApplyStatus] and
+//     UpdateStatusWithRetry), so an object routinely carries TWO Apply entries for
+//     [FieldOwnerController] — one for the main resource and one with
+//     Subresource: "status". The status entry's field set describes status fields
+//     only, which [unstructuredSpecEqual] never compares. Accepting it would make
+//     the caller conclude we own no spec fields, so a spec key removal would still
+//     look "equal", the apply would be skipped, and the SSA drift this helper
+//     exists to detect would silently return. The apiserver sorts managedFields by
+//     operation, then timestamp, then manager, then apiVersion, and only then by
+//     subresource, so the status entry can and does sort first whenever it carries
+//     the older timestamp — the order must not be relied upon.
+//
+// A matching entry whose FieldsV1 is missing, empty, unparseable, or decodes to an
+// empty set is skipped rather than treated as authoritative, so one unusable entry
+// cannot suppress a valid main-resource entry later in the list. (Note that
+// unstructured.SetManagedFields rejects the whole list when any FieldsV1 is invalid
+// JSON, so in practice only the empty/absent forms are reachable here; the
+// unmarshal guard is kept for typed callers and defence in depth.) When no entry
+// qualifies the result is nil, which callers must read as "ownership unknown, send
+// the apply".
 func ownedFieldSet(current *unstructured.Unstructured) map[string]interface{} {
 	for _, entry := range current.GetManagedFields() {
 		if entry.Manager != FieldOwnerController {
@@ -265,16 +291,22 @@ func ownedFieldSet(current *unstructured.Unstructured) map[string]interface{} {
 		if entry.Operation != metav1.ManagedFieldsOperationApply {
 			continue
 		}
+		if entry.Subresource != "" {
+			continue // Subresource field sets (e.g. status) are not compared here.
+		}
 		if entry.FieldsV1 == nil {
-			return nil
+			continue
 		}
 		raw := entry.FieldsV1.GetRawBytes()
 		if len(raw) == 0 {
-			return nil
+			continue
 		}
 		var fields map[string]interface{}
 		if err := json.Unmarshal(raw, &fields); err != nil {
-			return nil
+			continue
+		}
+		if len(fields) == 0 {
+			continue // "null"/"{}" carry no ownership information.
 		}
 		return fields
 	}

--- a/pkg/utils/patchhelper.go
+++ b/pkg/utils/patchhelper.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -202,6 +204,16 @@ func applyConfigsEqual(desired, current runtime.ApplyConfiguration) bool {
 //
 // For metadata, labels and annotations are compared with a subset match (extra
 // entries in current from other controllers are tolerated).
+//
+// Subset semantics alone are NOT sufficient to decide "no apply needed": if a
+// field is REMOVED from the desired manifest, desired becomes a strict subset of
+// current and every subset check still passes, so the apply that would prune the
+// field is skipped and the resource drifts permanently. To close that hole the
+// comparison additionally requires that every field this operator currently owns
+// (per its own managedFields entry) is still declared by desired. When ownership
+// information is unavailable the result is "not equal", so the SSA apply is sent
+// and the API server performs the prune — SSA is a no-op when nothing changed, so
+// the only cost of that fallback is a PATCH round-trip.
 func unstructuredSpecEqual(desired, current *unstructured.Unstructured) bool {
 	// Compare SSA-owned metadata: labels and annotations.
 	if !mapSubsetMatch(current.GetLabels(), desired.GetLabels()) {
@@ -222,7 +234,146 @@ func unstructuredSpecEqual(desired, current *unstructured.Unstructured) bool {
 			return false
 		}
 	}
+
+	// Desired is a subset of current. Verify nothing this operator owns has been
+	// dropped from desired, which subset comparison cannot see.
+	return desiredCoversOwnedFields(desired, current)
+}
+
+// desiredCoversOwnedFields reports whether every field currently owned by
+// [FieldOwnerController] on current is still declared by desired.
+//
+// It returns false (i.e. "must apply") whenever ownership cannot be established:
+// no managedFields entry for our field owner, an unparseable FieldsV1, or an
+// entry that is not an Apply operation. Guessing "equal" in those cases is what
+// makes field removals invisible.
+func desiredCoversOwnedFields(desired, current *unstructured.Unstructured) bool {
+	owned := ownedFieldSet(current)
+	if owned == nil {
+		return false
+	}
+	return desiredCoversFieldSet(desired.Object, owned, "")
+}
+
+// ownedFieldSet returns the decoded FieldsV1 tree of this operator's Apply entry
+// in current's managedFields, or nil when it is absent or undecodable.
+func ownedFieldSet(current *unstructured.Unstructured) map[string]interface{} {
+	for _, entry := range current.GetManagedFields() {
+		if entry.Manager != FieldOwnerController {
+			continue
+		}
+		if entry.Operation != metav1.ManagedFieldsOperationApply {
+			continue
+		}
+		if entry.FieldsV1 == nil {
+			return nil
+		}
+		raw := entry.FieldsV1.GetRawBytes()
+		if len(raw) == 0 {
+			return nil
+		}
+		var fields map[string]interface{}
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return nil
+		}
+		return fields
+	}
+	return nil
+}
+
+// desiredCoversFieldSet walks a FieldsV1 subtree and checks that desired still
+// declares each owned field path.
+//
+// FieldsV1 encodes map/struct members as "f:<name>" and associative-list members
+// as "k:{…}", "v:…" or "i:…". Only "f:" members are followed: list contents are
+// compared with full equality by [jsonValueSubsetEqual], so a removal inside a
+// list is already detected, and it is enough that the list's parent key is still
+// declared.
+//
+// path is the top-level field being walked ("" at the root) and is used to skip
+// the same server-managed keys [unstructuredSpecEqual] skips.
+func desiredCoversFieldSet(desired map[string]interface{}, fields map[string]interface{}, path string) bool {
+	for key, sub := range fields {
+		name, ok := fieldsV1MemberName(key)
+		if !ok {
+			// Associative-list member: covered by full-equality slice comparison.
+			continue
+		}
+		if path == "" {
+			switch name {
+			case "apiVersion", "kind", "status":
+				continue // Server-managed; not part of the desired comparison.
+			}
+		}
+		if path == "" && name == "metadata" {
+			// metadata is only compared for labels and annotations; ownership of
+			// other metadata members (ownerReferences, finalizers, …) is not
+			// something the desired manifest necessarily re-declares.
+			subFields, isMap := sub.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			desiredMeta, _ := desired["metadata"].(map[string]interface{})
+			for metaKey, metaSub := range subFields {
+				metaName, isField := fieldsV1MemberName(metaKey)
+				if !isField {
+					continue
+				}
+				if metaName != "labels" && metaName != "annotations" {
+					continue
+				}
+				if !desiredDeclares(desiredMeta, metaName, metaSub) {
+					return false
+				}
+			}
+			continue
+		}
+		if !desiredDeclares(desired, name, sub) {
+			return false
+		}
+	}
 	return true
+}
+
+// desiredDeclares checks that desired contains name and, recursively, every
+// owned member beneath it.
+func desiredDeclares(desired map[string]interface{}, name string, sub interface{}) bool {
+	if desired == nil {
+		return false
+	}
+	value, present := desired[name]
+	if !present {
+		return false
+	}
+	subFields, isMap := sub.(map[string]interface{})
+	if !isMap || len(subFields) == 0 {
+		return true // Leaf: presence is enough.
+	}
+	childDesired, isChildMap := value.(map[string]interface{})
+	if !isChildMap {
+		// Owned members below a value that is no longer a map — treat as changed.
+		return !containsFieldMember(subFields)
+	}
+	return desiredCoversFieldSet(childDesired, subFields, name)
+}
+
+// containsFieldMember reports whether a FieldsV1 subtree names any "f:" member.
+func containsFieldMember(fields map[string]interface{}) bool {
+	for key := range fields {
+		if _, ok := fieldsV1MemberName(key); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldsV1MemberName extracts the field name from a FieldsV1 "f:<name>" key.
+// It returns ok=false for associative-list keys ("k:", "v:", "i:").
+func fieldsV1MemberName(key string) (string, bool) {
+	if strings.HasPrefix(key, "f:") {
+		return strings.TrimPrefix(key, "f:"), true
+	}
+	return "", false
 }
 
 // jsonFieldSubsetEqual checks whether the desired value for a single top-level

--- a/pkg/utils/patchhelper_test.go
+++ b/pkg/utils/patchhelper_test.go
@@ -522,6 +522,170 @@ func TestUnstructuredSpecEqual_ExtraLabelsInCurrent(t *testing.T) {
 	assert.True(t, unstructuredSpecEqual(desired, current))
 }
 
+// statusEntry is an Apply managedFields entry for FieldOwnerController scoped to
+// the status subresource. This operator really does apply to status with the same
+// field manager (utils.ApplyStatus, UpdateStatusWithRetry), so real objects carry
+// one of these alongside the main-resource entry.
+func statusEntry() metav1.ManagedFieldsEntry {
+	return metav1.ManagedFieldsEntry{
+		Manager:     FieldOwnerController,
+		Operation:   metav1.ManagedFieldsOperationApply,
+		Subresource: "status",
+		FieldsType:  "FieldsV1",
+		FieldsV1:    metav1.NewFieldsV1(`{"f:status":{"f:phase":{}}}`),
+	}
+}
+
+func mainEntry(fieldsV1 string) metav1.ManagedFieldsEntry {
+	return metav1.ManagedFieldsEntry{
+		Manager:    FieldOwnerController,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		FieldsType: "FieldsV1",
+		FieldsV1:   metav1.NewFieldsV1(fieldsV1),
+	}
+}
+
+// TestUnstructuredSpecEqual_StatusSubresourceEntryIgnored pins the bug where
+// ownedFieldSet returned the FIRST Apply entry for FieldOwnerController without
+// filtering on Subresource. When the status entry sorts first its field set
+// ({"f:status":...}) contains no spec fields, so a spec key dropped from the
+// desired manifest still compared "equal", the SSA apply was skipped, and the
+// pruning drift this helper exists to detect came back silently.
+//
+// Both orderings are asserted so the test cannot pass by accident on slice order.
+func TestUnstructuredSpecEqual_StatusSubresourceEntryIgnored(t *testing.T) {
+	// Desired has dropped spec.oldKey, which the operator still owns.
+	desired := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]interface{}{"name": "w"},
+		"spec":       map[string]interface{}{"replicas": float64(3)},
+	}}
+	newCurrent := func(entries ...metav1.ManagedFieldsEntry) *unstructured.Unstructured {
+		cur := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]interface{}{"name": "w", "resourceVersion": "7"},
+			"spec": map[string]interface{}{
+				"replicas": float64(3),
+				"oldKey":   "stale", // Owned by us, no longer declared by desired.
+			},
+			"status": map[string]interface{}{"phase": "Ready"},
+		}}
+		cur.SetManagedFields(entries)
+		return cur
+	}
+	const ownedSpec = `{"f:spec":{"f:replicas":{},"f:oldKey":{}},"f:metadata":{"f:name":{}}}`
+
+	t.Run("status entry first", func(t *testing.T) {
+		current := newCurrent(statusEntry(), mainEntry(ownedSpec))
+		assert.False(t, unstructuredSpecEqual(desired, current),
+			"dropping an owned spec key must not be reported equal when the status "+
+				"subresource managedFields entry is iterated first")
+	})
+
+	t.Run("main entry first", func(t *testing.T) {
+		current := newCurrent(mainEntry(ownedSpec), statusEntry())
+		assert.False(t, unstructuredSpecEqual(desired, current),
+			"dropping an owned spec key must not be reported equal regardless of entry order")
+	})
+
+	// Sanity check: with spec.oldKey still declared, both orderings agree it is equal.
+	// Without this, the test above would also pass for the wrong reason (always false).
+	desiredFull := desired.DeepCopy()
+	desiredFull.Object["spec"] = map[string]interface{}{"replicas": float64(3), "oldKey": "stale"}
+	assert.True(t, unstructuredSpecEqual(desiredFull, newCurrent(statusEntry(), mainEntry(ownedSpec))),
+		"status entry first, nothing dropped: should be equal")
+	assert.True(t, unstructuredSpecEqual(desiredFull, newCurrent(mainEntry(ownedSpec), statusEntry())),
+		"main entry first, nothing dropped: should be equal")
+}
+
+// TestOwnedFieldSet_SkipsUnusableEntries verifies that a malformed or
+// subresource-scoped entry does not suppress a valid main-resource entry that
+// appears later in managedFields (the early `return nil` paths became `continue`).
+func TestOwnedFieldSet_SkipsUnusableEntries(t *testing.T) {
+	const ownedSpec = `{"f:spec":{"f:replicas":{}}}`
+
+	tests := []struct {
+		name    string
+		entries []metav1.ManagedFieldsEntry
+		want    map[string]interface{}
+	}{
+		{
+			name:    "only a status entry yields no ownership",
+			entries: []metav1.ManagedFieldsEntry{statusEntry()},
+			want:    nil,
+		},
+		{
+			name: "nil FieldsV1 does not shadow a later valid entry",
+			entries: []metav1.ManagedFieldsEntry{
+				{Manager: FieldOwnerController, Operation: metav1.ManagedFieldsOperationApply},
+				mainEntry(ownedSpec),
+			},
+			want: map[string]interface{}{"f:spec": map[string]interface{}{"f:replicas": map[string]interface{}{}}},
+		},
+		{
+			// Note: an entry with syntactically invalid FieldsV1 cannot be tested via
+			// unstructured — unstructured.SetManagedFields rejects the entire list if
+			// any entry fails to decode. Empty raw is the reachable equivalent.
+			name: "empty FieldsV1 does not shadow a later valid entry",
+			entries: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   FieldOwnerController,
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1:  metav1.NewFieldsV1(""),
+				},
+				mainEntry(ownedSpec),
+			},
+			want: map[string]interface{}{"f:spec": map[string]interface{}{"f:replicas": map[string]interface{}{}}},
+		},
+		{
+			name: "FieldsV1 decoding to an empty set does not shadow a later valid entry",
+			entries: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   FieldOwnerController,
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1:  metav1.NewFieldsV1("{}"),
+				},
+				mainEntry(ownedSpec),
+			},
+			want: map[string]interface{}{"f:spec": map[string]interface{}{"f:replicas": map[string]interface{}{}}},
+		},
+		{
+			name: "Update operation entries are ignored",
+			entries: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   FieldOwnerController,
+					Operation: metav1.ManagedFieldsOperationUpdate,
+					FieldsV1:  metav1.NewFieldsV1(`{"f:spec":{"f:other":{}}}`),
+				},
+				mainEntry(ownedSpec),
+			},
+			want: map[string]interface{}{"f:spec": map[string]interface{}{"f:replicas": map[string]interface{}{}}},
+		},
+		{
+			name: "other field managers are ignored",
+			entries: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   "kubectl",
+					Operation: metav1.ManagedFieldsOperationApply,
+					FieldsV1:  metav1.NewFieldsV1(`{"f:spec":{"f:other":{}}}`),
+				},
+				mainEntry(ownedSpec),
+			},
+			want: map[string]interface{}{"f:spec": map[string]interface{}{"f:replicas": map[string]interface{}{}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+			obj.SetManagedFields(tt.entries)
+			assert.Equal(t, tt.want, ownedFieldSet(obj))
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // mapSubsetMatch
 // ---------------------------------------------------------------------------

--- a/pkg/utils/patchhelper_test.go
+++ b/pkg/utils/patchhelper_test.go
@@ -163,35 +163,138 @@ func TestPatchApplyUnstructured_Skipped(t *testing.T) {
 	ctx := context.Background()
 	scheme := newPatchHelperTestScheme()
 
-	existing := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cm",
-			Namespace: "default",
-			Labels:    map[string]string{"app": "test"},
-		},
-		Data: map[string]string{"key": "value"},
+	// WithReturnManagedFields is required: the skip optimization only fires when
+	// the operator can see which fields it owns, so that a field REMOVED from the
+	// desired manifest is still detected as a change.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	obj := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "test-cm",
+					"namespace": "default",
+					"labels":    map[string]interface{}{"app": "test"},
+				},
+				"data": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		}
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	// First apply creates the object (and our managedFields entry).
+	created, err := PatchApplyUnstructured(ctx, c, obj())
+	require.NoError(t, err)
+	require.Equal(t, PatchApplyResultCreated, created)
 
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+	// Re-applying the identical manifest must skip the API call.
+	result, err := PatchApplyUnstructured(ctx, c, obj())
+	require.NoError(t, err)
+	assert.Equal(t, PatchApplyResultSkipped, result)
+}
+
+// TestPatchApplyUnstructured_KeyRemovalIsApplied is the regression test for the
+// SSA-drift bug (#173/#174/#261): jsonSubsetEqual iterated only the desired
+// object's keys, so dropping a key from a manifest made desired a strict subset
+// of live, the apply was reported as "skipped", and the removal was NEVER sent to
+// the API server — permanent drift for every auxiliary resource.
+func TestPatchApplyUnstructured_KeyRemovalIsApplied(t *testing.T) {
+	ctx := context.Background()
+	scheme := newPatchHelperTestScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	cm := func(data map[string]interface{}) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
 			"metadata": map[string]interface{}{
-				"name":      "test-cm",
+				"name":      "drift-cm",
 				"namespace": "default",
-				"labels":    map[string]interface{}{"app": "test"},
 			},
-			"data": map[string]interface{}{
-				"key": "value",
-			},
-		},
+			"data": data,
+		}}
 	}
+
+	created, err := PatchApplyUnstructured(ctx, c, cm(map[string]interface{}{"keep": "1", "drop": "2"}))
+	require.NoError(t, err)
+	require.Equal(t, PatchApplyResultCreated, created)
+
+	// Drop "drop" from the manifest: the operator must send the apply so the API
+	// server prunes the key it no longer declares.
+	result, err := PatchApplyUnstructured(ctx, c, cm(map[string]interface{}{"keep": "1"}))
+	require.NoError(t, err)
+	assert.Equal(t, PatchApplyResultPatched, result,
+		"removing a key from the desired manifest must not be skipped")
+
+	live := &unstructured.Unstructured{}
+	live.SetGroupVersionKind(cm(nil).GroupVersionKind())
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "drift-cm", Namespace: "default"}, live))
+	data, _, err := unstructured.NestedStringMap(live.Object, "data")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"keep": "1"}, data,
+		"the removed key must actually be pruned from the live object")
+}
+
+// TestPatchApplyUnstructured_NestedKeyRemovalIsApplied covers removal of a nested
+// map key (spec.template.foo), which the subset comparison also could not see.
+func TestPatchApplyUnstructured_NestedKeyRemovalIsApplied(t *testing.T) {
+	ctx := context.Background()
+	scheme := newPatchHelperTestScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithReturnManagedFields().Build()
+
+	cm := func(annotations map[string]interface{}) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":        "nested-cm",
+				"namespace":   "default",
+				"annotations": annotations,
+			},
+			"data": map[string]interface{}{"k": "v"},
+		}}
+	}
+
+	created, err := PatchApplyUnstructured(ctx, c, cm(map[string]interface{}{"a": "1", "b": "2"}))
+	require.NoError(t, err)
+	require.Equal(t, PatchApplyResultCreated, created)
+
+	result, err := PatchApplyUnstructured(ctx, c, cm(map[string]interface{}{"a": "1"}))
+	require.NoError(t, err)
+	assert.Equal(t, PatchApplyResultPatched, result,
+		"removing a nested annotation must not be skipped")
+}
+
+// TestPatchApplyUnstructured_NoOwnershipInfoAppliesConservatively documents the
+// fallback: when this operator has no Apply entry in managedFields (e.g. a
+// resource created by an older release, or an apiserver/cache that strips them)
+// the comparison must NOT claim equality, because field removals would be
+// invisible. SSA itself is a no-op when nothing changed, so the cost is one
+// PATCH round-trip.
+func TestPatchApplyUnstructured_NoOwnershipInfoAppliesConservatively(t *testing.T) {
+	ctx := context.Background()
+	scheme := newPatchHelperTestScheme()
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-mf", Namespace: "default"},
+		Data:       map[string]string{"k": "v"},
+	}
+	// No WithReturnManagedFields: Get returns no ownership information.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "no-mf", "namespace": "default"},
+		"data":       map[string]interface{}{"k": "v"},
+	}}
 
 	result, err := PatchApplyUnstructured(ctx, c, obj)
 	require.NoError(t, err)
-	assert.Equal(t, PatchApplyResultSkipped, result)
+	assert.Equal(t, PatchApplyResultPatched, result)
 }
 
 func TestPatchApplyUnstructured_Patched(t *testing.T) {
@@ -284,6 +387,22 @@ func TestApplyConfigsEqual_DifferentSpec(t *testing.T) {
 // unstructuredSpecEqual
 // ---------------------------------------------------------------------------
 
+// withOwnedFields stamps a managedFields entry for FieldOwnerController onto obj
+// declaring the given FieldsV1 tree, so that unstructuredSpecEqual can establish
+// which fields this operator owns. Without ownership information the comparison
+// deliberately reports "not equal" (see desiredCoversOwnedFields).
+func withOwnedFields(obj *unstructured.Unstructured, fieldsV1 string) *unstructured.Unstructured {
+	out := obj.DeepCopy()
+	out.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    FieldOwnerController,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		APIVersion: out.GetAPIVersion(),
+		FieldsType: "FieldsV1",
+		FieldsV1:   metav1.NewFieldsV1(fieldsV1),
+	}})
+	return out
+}
+
 func TestUnstructuredSpecEqual_Same(t *testing.T) {
 	a := &unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{"replicas": float64(3)},
@@ -291,12 +410,12 @@ func TestUnstructuredSpecEqual_Same(t *testing.T) {
 			"labels": map[string]interface{}{"app": "test"},
 		},
 	}}
-	b := &unstructured.Unstructured{Object: map[string]interface{}{
+	b := withOwnedFields(&unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{"replicas": float64(3)},
 		"metadata": map[string]interface{}{
 			"labels": map[string]interface{}{"app": "test"},
 		},
-	}}
+	}}, `{"f:spec":{"f:replicas":{}},"f:metadata":{"f:labels":{"f:app":{}}}}`)
 	assert.True(t, unstructuredSpecEqual(a, b))
 }
 
@@ -337,7 +456,7 @@ func TestUnstructuredSpecEqual_ClusterRoleRules(t *testing.T) {
 		"metadata":   map[string]interface{}{"name": "test-role"},
 		"rules":      rules,
 	}}
-	current := &unstructured.Unstructured{Object: map[string]interface{}{
+	current := withOwnedFields(&unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind":       "ClusterRole",
 		"metadata": map[string]interface{}{
@@ -346,7 +465,7 @@ func TestUnstructuredSpecEqual_ClusterRoleRules(t *testing.T) {
 			"uid":             "abc-def",
 		},
 		"rules": rules,
-	}}
+	}}, `{"f:rules":{}}`)
 	assert.True(t, unstructuredSpecEqual(desired, current), "identical rules should match")
 
 	// Mutate rules in current — should detect the diff.
@@ -371,12 +490,12 @@ func TestUnstructuredSpecEqual_ServiceAccount(t *testing.T) {
 		"metadata":                     map[string]interface{}{"name": "test-sa", "namespace": "default"},
 		"automountServiceAccountToken": true,
 	}}
-	current := &unstructured.Unstructured{Object: map[string]interface{}{
+	current := withOwnedFields(&unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion":                   "v1",
 		"kind":                         "ServiceAccount",
 		"metadata":                     map[string]interface{}{"name": "test-sa", "namespace": "default", "resourceVersion": "999"},
 		"automountServiceAccountToken": true,
-	}}
+	}}, `{"f:automountServiceAccountToken":{}}`)
 	assert.True(t, unstructuredSpecEqual(desired, current))
 
 	currentDiff := current.DeepCopy()
@@ -391,12 +510,14 @@ func TestUnstructuredSpecEqual_ExtraLabelsInCurrent(t *testing.T) {
 			"labels": map[string]interface{}{"app": "test"},
 		},
 	}}
-	current := &unstructured.Unstructured{Object: map[string]interface{}{
+	// "extra" is owned by another field manager, so our own managedFields entry
+	// does not list it and its presence must not force an apply.
+	current := withOwnedFields(&unstructured.Unstructured{Object: map[string]interface{}{
 		"spec": map[string]interface{}{"replicas": float64(3)},
 		"metadata": map[string]interface{}{
 			"labels": map[string]interface{}{"app": "test", "extra": "label"},
 		},
-	}}
+	}}, `{"f:spec":{"f:replicas":{}},"f:metadata":{"f:labels":{"f:app":{}}}}`)
 	// Desired labels are a subset of current — should match.
 	assert.True(t, unstructuredSpecEqual(desired, current))
 }

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -30,9 +30,16 @@ type authorizeState struct {
 	// Immutable inputs
 	startTime   time.Time
 	clusterName string
-	ctx         context.Context //nolint:containedctx // request-scoped context: authorizeState is created per HTTP request and passed to private helpers; storing ctx here avoids threading it through every helper signature while keeping it out of global state
-	reqLog      *zap.SugaredLogger
-	phases      *SARPhaseTracker
+	// clusterLabel is clusterName reduced to a bounded set of Prometheus label
+	// values. clusterName is the raw :cluster_name route parameter, used as a
+	// metric label before the cluster has been resolved, so using it verbatim
+	// lets a remote caller create unbounded metric series (heap growth that is
+	// never reclaimed). Use clusterLabel for metrics, clusterName for logs and
+	// user-facing messages.
+	clusterLabel string
+	ctx          context.Context //nolint:containedctx // request-scoped context: authorizeState is created per HTTP request and passed to private helpers; storing ctx here avoids threading it through every helper signature while keeping it out of global state
+	reqLog       *zap.SugaredLogger
+	phases       *SARPhaseTracker
 
 	// Parsed request
 	sar authorizationv1.SubjectAccessReview
@@ -59,12 +66,14 @@ type authorizeState struct {
 // parseSARRequest reads the request body, unmarshals the SubjectAccessReview, and
 // initialises the authorizeState. Returns (state, ok); writes HTTP status on failure.
 func (wc *WebhookController) parseSARRequest(c *gin.Context) (*authorizeState, bool) {
+	clusterName := c.Param("cluster_name")
 	s := &authorizeState{
-		startTime:   time.Now(),
-		clusterName: c.Param("cluster_name"),
-		ctx:         c.Request.Context(),
+		startTime:    time.Now(),
+		clusterName:  clusterName,
+		clusterLabel: metrics.SafeClusterLabel(clusterName),
+		ctx:          c.Request.Context(),
 	}
-	metrics.WebhookSARRequests.WithLabelValues(s.clusterName).Inc()
+	metrics.WebhookSARRequests.WithLabelValues(s.clusterLabel).Inc()
 	wc.log.With("cluster", s.clusterName).Debug("Processing authorization request for cluster")
 
 	s.phases = NewSARPhaseTracker(s.clusterName, wc.log)
@@ -122,12 +131,12 @@ func (wc *WebhookController) resolveClusterConfig(c *gin.Context, s *authorizeSt
 						"Ask your platform administrators to onboard the cluster or choose one of the onboarded clusters.",
 					s.clusterName, actionSummary)
 				reason = wc.finalizeReason(reason, false, s.clusterName)
-				metrics.WebhookSARDenied.WithLabelValues(s.clusterName).Inc()
-				metrics.WebhookSARDuration.WithLabelValues(s.clusterName, "denied").
+				metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
+				metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "denied").
 					Observe(time.Since(s.startTime).Seconds())
 				if s.sar.Spec.ResourceAttributes != nil {
 					metrics.WebhookSARDecisions.WithLabelValues(
-						s.clusterName, "denied", "cluster-missing").Inc()
+						s.clusterLabel, "denied", "cluster-missing").Inc()
 				}
 				s.reqLog.Warnw("Cluster not registered for Breakglass", "cluster", s.clusterName)
 				c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
@@ -239,10 +248,10 @@ func (wc *WebhookController) checkEarlyDebugSession(c *gin.Context, s *authorize
 				s.reqLog.Infow("Debug session authorizing pod operation (bypassing deny policies)",
 					"session", debugSession, "pod", ra.Name,
 					"namespace", ra.Namespace, "operation", ra.Subresource)
-				metrics.WebhookSARAllowed.WithLabelValues(s.clusterName).Inc()
+				metrics.WebhookSARAllowed.WithLabelValues(s.clusterLabel).Inc()
 				metrics.WebhookSARDecisions.WithLabelValues(
-					s.clusterName, "allowed", "debug-session").Inc()
-				metrics.WebhookSARDuration.WithLabelValues(s.clusterName, "allowed").
+					s.clusterLabel, "allowed", "debug-session").Inc()
+				metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "allowed").
 					Observe(time.Since(s.startTime).Seconds())
 				reason := wc.finalizeReason(debugReason, true, s.clusterName)
 				c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
@@ -349,10 +358,10 @@ func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeSt
 				"activeSessions", len(s.sessions),
 			)
 			// Emit denied metric for global policy short-circuit
-			metrics.WebhookSARDenied.WithLabelValues(s.clusterName).Inc()
+			metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
 			metrics.WebhookSARDecisions.WithLabelValues(
-				s.clusterName, "denied", "global").Inc()
-			metrics.WebhookSARDuration.WithLabelValues(s.clusterName, "denied").
+				s.clusterLabel, "denied", "global").Inc()
+			metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "denied").
 				Observe(time.Since(s.startTime).Seconds())
 			s.reqLog.Debugw("Global denyEval matched", "policy", pol, "action", act)
 
@@ -399,10 +408,10 @@ func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeSt
 					"username", s.sar.Spec.User,
 				)
 				// Emit denied metric for session-scoped policy short-circuit
-				metrics.WebhookSARDenied.WithLabelValues(s.clusterName).Inc()
+				metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
 				metrics.WebhookSARDecisions.WithLabelValues(
-					s.clusterName, "denied", "session").Inc()
-				metrics.WebhookSARDuration.WithLabelValues(s.clusterName, "denied").
+					s.clusterLabel, "denied", "session").Inc()
+				metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "denied").
 					Observe(time.Since(s.startTime).Seconds())
 				s.reqLog.Debugw("Session denyEval matched", "policy", pol, "session", sess.Name, "action", act)
 
@@ -435,10 +444,10 @@ func (wc *WebhookController) denyPolicyEvaluationFailure(
 ) bool {
 	s.reqLog.With("error", err.Error(), "scope", scope, "action", act).
 		Error("deny policy evaluation failed closed")
-	metrics.WebhookSARDenied.WithLabelValues(s.clusterName).Inc()
+	metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
 	metrics.WebhookSARDecisions.WithLabelValues(
-		s.clusterName, "denied", "policy-error").Inc()
-	metrics.WebhookSARDuration.WithLabelValues(s.clusterName, "denied").
+		s.clusterLabel, "denied", "policy-error").Inc()
+	metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "denied").
 		Observe(time.Since(s.startTime).Seconds())
 
 	reason := wc.finalizeReason("DenyPolicy evaluation failed; request denied fail-closed", false, s.clusterName)
@@ -540,7 +549,7 @@ func (wc *WebhookController) performRBACCheck(c *gin.Context, s *authorizeState)
 		// Emit allowed decision metric for action
 		if s.sar.Spec.ResourceAttributes != nil {
 			metrics.WebhookSARDecisions.WithLabelValues(
-				s.clusterName, "allowed", "rbac").Inc()
+				s.clusterLabel, "allowed", "rbac").Inc()
 		}
 	}
 	return true
@@ -590,7 +599,7 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 			s.reason = debugReason
 			// Emit metric for debug session authorization
 			metrics.WebhookSARDecisions.WithLabelValues(
-				s.clusterName, "allowed", "debug-session").Inc()
+				s.clusterLabel, "allowed", "debug-session").Inc()
 		}
 	}
 
@@ -705,7 +714,7 @@ func (wc *WebhookController) buildFinalReason(s *authorizeState) {
 	if !s.allowed && len(s.sessions) > 0 {
 		// If we recorded a skip for session SAR checks, add a diagnostic note to the reason
 		if s.sessionSARSkipErr != nil {
-			metrics.WebhookSessionSARSSkipped.WithLabelValues(s.clusterName).Inc()
+			metrics.WebhookSessionSARSSkipped.WithLabelValues(s.clusterLabel).Inc()
 			// Collect session names and granted groups for the diagnostic message
 			sessInfo := make([]string, 0, len(s.sessions))
 			for _, sess := range s.sessions {
@@ -783,18 +792,18 @@ func (wc *WebhookController) sendAuthorizationResponse(c *gin.Context, s *author
 	username := s.sar.Spec.User
 
 	if s.allowed {
-		metrics.WebhookSARAllowed.WithLabelValues(s.clusterName).Inc()
+		metrics.WebhookSARAllowed.WithLabelValues(s.clusterLabel).Inc()
 		// Increment action-based decision metric only for session-authorized decisions.
 		// RBAC and debug-session paths are already recorded at decision time to avoid duplicate/misleading labels.
 		if s.sar.Spec.ResourceAttributes != nil && s.allowSource == "session" {
 			metrics.WebhookSARDecisions.WithLabelValues(
-				s.clusterName, "allowed", "session").Inc()
+				s.clusterLabel, "allowed", "session").Inc()
 		}
 	} else {
-		metrics.WebhookSARDenied.WithLabelValues(s.clusterName).Inc()
+		metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
 		if s.sar.Spec.ResourceAttributes != nil {
 			metrics.WebhookSARDecisions.WithLabelValues(
-				s.clusterName, "denied", "final").Inc()
+				s.clusterLabel, "denied", "final").Inc()
 		}
 	}
 
@@ -885,7 +894,7 @@ func (wc *WebhookController) sendAuthorizationResponse(c *gin.Context, s *author
 	if !s.allowed {
 		decision = "denied"
 	}
-	metrics.WebhookSARDuration.WithLabelValues(s.clusterName, decision).
+	metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, decision).
 		Observe(time.Since(s.startTime).Seconds())
 
 	// Ensure correlation ID header is present for apiserver correlation

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -30,12 +30,21 @@ type authorizeState struct {
 	// Immutable inputs
 	startTime   time.Time
 	clusterName string
-	// clusterLabel is clusterName reduced to a bounded set of Prometheus label
-	// values. clusterName is the raw :cluster_name route parameter, used as a
-	// metric label before the cluster has been resolved, so using it verbatim
-	// lets a remote caller create unbounded metric series (heap growth that is
-	// never reclaimed). Use clusterLabel for metrics, clusterName for logs and
-	// user-facing messages.
+	// clusterLabel is the Prometheus label value for this request's cluster.
+	//
+	// clusterName is the raw :cluster_name route parameter. Using it verbatim as a
+	// label lets a remote caller create a new time series per request, and
+	// Prometheus never reclaims series, so the heap grows without bound. Format
+	// validation alone does not fix that — an attacker can vary syntactically
+	// valid names indefinitely.
+	//
+	// So the label starts as a fixed placeholder (see metrics.SafeClusterLabel) and
+	// is promoted to the real cluster name only once resolveClusterConfig has
+	// matched it to a registered ClusterConfig. Cardinality is therefore bounded by
+	// the number of registered clusters plus three placeholders.
+	//
+	// Use clusterLabel for metrics; use clusterName for logs and user-facing
+	// messages, which are not cardinality-sensitive.
 	clusterLabel string
 	ctx          context.Context //nolint:containedctx // request-scoped context: authorizeState is created per HTTP request and passed to private helpers; storing ctx here avoids threading it through every helper signature while keeping it out of global state
 	reqLog       *zap.SugaredLogger
@@ -154,6 +163,12 @@ func (wc *WebhookController) resolveClusterConfig(c *gin.Context, s *authorizeSt
 			return false
 		}
 		s.clusterCfg = cfg
+
+		// The cluster is registered, so its name is operator-controlled and bounded:
+		// promote the metric label from the placeholder to the real name. Every
+		// metric emitted from here on is attributed to the actual cluster.
+		s.clusterLabel = metrics.ResolvedClusterLabel(s.clusterName)
+		s.phases.setClusterLabel(s.clusterLabel)
 	}
 	s.phases.EndPhase(PhaseClusterConfig) // End cluster_config phase
 	return true

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -50,6 +50,10 @@ type authorizeState struct {
 	reqLog       *zap.SugaredLogger
 	phases       *SARPhaseTracker
 
+	// requestCounted guards the WebhookSARRequests counter so it is incremented
+	// exactly once per request. See countRequest.
+	requestCounted bool
+
 	// Parsed request
 	sar authorizationv1.SubjectAccessReview
 
@@ -72,6 +76,27 @@ type authorizeState struct {
 	sessionSARSkipErr error
 }
 
+// countRequest increments the SAR request counter, at most once per request.
+//
+// WebhookSARRequests is a Counter, so unlike the duration/decision metrics its
+// label cannot be corrected after the fact: whatever value is used at increment
+// time is the value that series keeps forever. Incrementing it in
+// parseSARRequest — before resolveClusterConfig has run — would therefore count
+// every request, including those for perfectly well-known clusters, under the
+// "_unresolved" placeholder and permanently break per-cluster request counting.
+//
+// So the increment is deferred until the cluster label is final: the resolved
+// cluster name once the ClusterConfig lookup succeeds, or the appropriate
+// placeholder when the request never gets that far (malformed body, unknown
+// cluster). Cardinality is unaffected — the label value is bounded either way.
+func (s *authorizeState) countRequest() {
+	if s.requestCounted {
+		return
+	}
+	s.requestCounted = true
+	metrics.WebhookSARRequests.WithLabelValues(s.clusterLabel).Inc()
+}
+
 // parseSARRequest reads the request body, unmarshals the SubjectAccessReview, and
 // initialises the authorizeState. Returns (state, ok); writes HTTP status on failure.
 func (wc *WebhookController) parseSARRequest(c *gin.Context) (*authorizeState, bool) {
@@ -82,7 +107,6 @@ func (wc *WebhookController) parseSARRequest(c *gin.Context) (*authorizeState, b
 		clusterLabel: metrics.SafeClusterLabel(clusterName),
 		ctx:          c.Request.Context(),
 	}
-	metrics.WebhookSARRequests.WithLabelValues(s.clusterLabel).Inc()
 	wc.log.With("cluster", s.clusterName).Debug("Processing authorization request for cluster")
 
 	s.phases = NewSARPhaseTracker(s.clusterName, wc.log)
@@ -94,10 +118,12 @@ func (wc *WebhookController) parseSARRequest(c *gin.Context) (*authorizeState, b
 		var maxErr *http.MaxBytesError
 		if errors.As(rerr, &maxErr) {
 			wc.log.With("error", rerr.Error()).Warn("SubjectAccessReview body too large")
+			s.countRequest() // Never reaches cluster resolution; count under the placeholder.
 			c.Status(http.StatusRequestEntityTooLarge)
 			return nil, false
 		}
 		wc.log.With("error", rerr.Error()).Error("Failed to read request body for SubjectAccessReview")
+		s.countRequest()
 		c.Status(http.StatusUnprocessableEntity)
 		return nil, false
 	}
@@ -114,6 +140,7 @@ func (wc *WebhookController) parseSARRequest(c *gin.Context) (*authorizeState, b
 
 	if err := json.Unmarshal(bodyBytes, &s.sar); err != nil {
 		s.reqLog.With("error", err.Error()).Errorw("Failed to decode SubjectAccessReview body", "bodySize", len(bodyBytes))
+		s.countRequest()
 		c.Status(http.StatusUnprocessableEntity)
 		return nil, false
 	}
@@ -140,6 +167,7 @@ func (wc *WebhookController) resolveClusterConfig(c *gin.Context, s *authorizeSt
 						"Ask your platform administrators to onboard the cluster or choose one of the onboarded clusters.",
 					s.clusterName, actionSummary)
 				reason = wc.finalizeReason(reason, false, s.clusterName)
+				s.countRequest() // Cluster is not registered: the placeholder label is final.
 				metrics.WebhookSARDenied.WithLabelValues(s.clusterLabel).Inc()
 				metrics.WebhookSARDuration.WithLabelValues(s.clusterLabel, "denied").
 					Observe(time.Since(s.startTime).Seconds())
@@ -159,6 +187,7 @@ func (wc *WebhookController) resolveClusterConfig(c *gin.Context, s *authorizeSt
 				return false
 			}
 			s.reqLog.With("error", cfgErr.Error()).Error("Failed to load ClusterConfig for SAR validation")
+			s.countRequest()
 			c.Status(http.StatusInternalServerError)
 			return false
 		}
@@ -170,6 +199,11 @@ func (wc *WebhookController) resolveClusterConfig(c *gin.Context, s *authorizeSt
 		s.clusterLabel = metrics.ResolvedClusterLabel(s.clusterName)
 		s.phases.setClusterLabel(s.clusterLabel)
 	}
+
+	// The label is now final for the rest of the request, so the request counter
+	// can be attributed to the real cluster.
+	s.countRequest()
+
 	s.phases.EndPhase(PhaseClusterConfig) // End cluster_config phase
 	return true
 }

--- a/pkg/webhook/phase_tracker.go
+++ b/pkg/webhook/phase_tracker.go
@@ -34,11 +34,14 @@ const (
 // SARPhaseTracker tracks timing for SAR processing phases
 type SARPhaseTracker struct {
 	clusterName string
-	// clusterLabel is clusterName reduced to a bounded set of Prometheus label
-	// values. clusterName arrives as the raw :cluster_name route parameter and is
-	// used as a label before it has been resolved against a ClusterConfig, so an
-	// unauthenticated remote caller could otherwise mint an unbounded number of
-	// histogram series (9 phases x buckets each) and grow the heap without bound.
+	// clusterLabel is the Prometheus label value for this request's cluster.
+	//
+	// clusterName arrives as the raw :cluster_name route parameter and is used as a
+	// label before it has been resolved against a ClusterConfig, so using it
+	// verbatim would let an unauthenticated remote caller mint an unbounded number
+	// of histogram series (9 phases x buckets each) and grow the heap without
+	// bound. It therefore starts as a fixed placeholder and is promoted to the real
+	// cluster name by setClusterLabel once the cluster has been resolved.
 	clusterLabel string
 	startTime    time.Time
 	phaseStart   time.Time
@@ -60,6 +63,17 @@ func NewSARPhaseTracker(clusterName string, log *zap.SugaredLogger) *SARPhaseTra
 		log:          log,
 		phases:       make(map[SARPhase]time.Duration),
 	}
+}
+
+// setClusterLabel promotes the metric label to a resolved cluster name, so that
+// phases recorded after cluster resolution are attributed to the real cluster
+// instead of the placeholder. Callers must pass a value already sanitized by
+// pkg/metrics.
+func (t *SARPhaseTracker) setClusterLabel(label string) {
+	if label == "" {
+		return
+	}
+	t.clusterLabel = label
 }
 
 // StartPhase marks the start of a phase

--- a/pkg/webhook/phase_tracker.go
+++ b/pkg/webhook/phase_tracker.go
@@ -34,21 +34,31 @@ const (
 // SARPhaseTracker tracks timing for SAR processing phases
 type SARPhaseTracker struct {
 	clusterName string
-	startTime   time.Time
-	phaseStart  time.Time
-	log         *zap.SugaredLogger
-	phases      map[SARPhase]time.Duration
+	// clusterLabel is clusterName reduced to a bounded set of Prometheus label
+	// values. clusterName arrives as the raw :cluster_name route parameter and is
+	// used as a label before it has been resolved against a ClusterConfig, so an
+	// unauthenticated remote caller could otherwise mint an unbounded number of
+	// histogram series (9 phases x buckets each) and grow the heap without bound.
+	clusterLabel string
+	startTime    time.Time
+	phaseStart   time.Time
+	log          *zap.SugaredLogger
+	phases       map[SARPhase]time.Duration
 }
 
-// NewSARPhaseTracker creates a new phase tracker for SAR processing
+// NewSARPhaseTracker creates a new phase tracker for SAR processing.
+//
+// clusterName may be untrusted request input; it is preserved verbatim for logs
+// and sanitized for metric labels.
 func NewSARPhaseTracker(clusterName string, log *zap.SugaredLogger) *SARPhaseTracker {
 	now := time.Now()
 	return &SARPhaseTracker{
-		clusterName: clusterName,
-		startTime:   now,
-		phaseStart:  now,
-		log:         log,
-		phases:      make(map[SARPhase]time.Duration),
+		clusterName:  clusterName,
+		clusterLabel: metrics.SafeClusterLabel(clusterName),
+		startTime:    now,
+		phaseStart:   now,
+		log:          log,
+		phases:       make(map[SARPhase]time.Duration),
 	}
 }
 
@@ -63,7 +73,7 @@ func (t *SARPhaseTracker) EndPhase(phase SARPhase) time.Duration {
 	t.phases[phase] = elapsed
 
 	// Record to Prometheus metric
-	metrics.WebhookSARPhaseDuration.WithLabelValues(t.clusterName, string(phase)).Observe(elapsed.Seconds())
+	metrics.WebhookSARPhaseDuration.WithLabelValues(t.clusterLabel, string(phase)).Observe(elapsed.Seconds())
 
 	// Debug log with phase timing
 	if t.log != nil {
@@ -82,7 +92,7 @@ func (t *SARPhaseTracker) TrackPhase(phase SARPhase) func() {
 	return func() {
 		elapsed := time.Since(start)
 		t.phases[phase] = elapsed
-		metrics.WebhookSARPhaseDuration.WithLabelValues(t.clusterName, string(phase)).Observe(elapsed.Seconds())
+		metrics.WebhookSARPhaseDuration.WithLabelValues(t.clusterLabel, string(phase)).Observe(elapsed.Seconds())
 		if t.log != nil {
 			t.log.Debugw("SAR phase completed", "phase", phase, "duration_ms", elapsed.Milliseconds())
 		}

--- a/pkg/webhook/phase_tracker_test.go
+++ b/pkg/webhook/phase_tracker_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -134,4 +135,79 @@ func TestSARPhases_Constants(t *testing.T) {
 	assert.Equal(t, SARPhase("session_sars"), PhaseSessionSARs)
 	assert.Equal(t, SARPhase("escalations"), PhaseEscalations)
 	assert.Equal(t, SARPhase("total"), PhaseTotal)
+}
+
+// TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel is the cardinality
+// regression test for #185. clusterName is the raw :cluster_name route parameter
+// and was used verbatim as a Prometheus label on a HistogramVec (9 phases x
+// buckets) before the cluster had been resolved, so a remote caller could mint an
+// unbounded number of series and grow the operator heap without bound. Every
+// value that is not a valid Kubernetes object name must collapse onto one series.
+func TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel(t *testing.T) {
+	vec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "test_breakglass_webhook_sar_phase_duration_cardinality",
+		Help:    "Test metric for cardinality",
+		Buckets: []float64{.0001, .001, .01},
+	}, []string{"cluster", "phase"})
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(vec))
+
+	original := metrics.WebhookSARPhaseDuration
+	metrics.WebhookSARPhaseDuration = vec
+	t.Cleanup(func() { metrics.WebhookSARPhaseDuration = original })
+
+	// Attacker-controlled route parameter values: none is a valid object name.
+	hostile := []string{
+		"../../etc/passwd",
+		"Cluster With Spaces",
+		"UPPERCASE",
+		"a{b=\"c\"}",
+		"trailing-dash-",
+		strings.Repeat("x", 254),
+		"\n",
+	}
+	for _, name := range hostile {
+		NewSARPhaseTracker(name, zap.NewNop().Sugar()).EndPhase(PhaseParse)
+	}
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+
+	labelValues := map[string]struct{}{}
+	for _, m := range families[0].GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "cluster" {
+				labelValues[l.GetValue()] = struct{}{}
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]struct{}{metrics.LabelValueInvalid: {}}, labelValues,
+		"every invalid cluster name must collapse onto a single placeholder series")
+	for _, name := range hostile {
+		assert.NotContains(t, labelValues, name, "hostile input must never become a label value")
+	}
+
+	// A legitimate cluster name is still recorded verbatim.
+	NewSARPhaseTracker("prod-cluster-01", zap.NewNop().Sugar()).EndPhase(PhaseParse)
+	families, err = reg.Gather()
+	require.NoError(t, err)
+	found := false
+	for _, m := range families[0].GetMetric() {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "cluster" && l.GetValue() == "prod-cluster-01" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "valid cluster names must be preserved unchanged")
+}
+
+// TestSARPhaseTracker_EmptyClusterNameLabel documents that an absent route
+// parameter is distinguishable from a hostile one.
+func TestSARPhaseTracker_EmptyClusterNameLabel(t *testing.T) {
+	assert.Equal(t, metrics.LabelValueUnknown, NewSARPhaseTracker("", zap.NewNop().Sugar()).clusterLabel)
+	assert.Equal(t, metrics.LabelValueInvalid, NewSARPhaseTracker("Bad Name", zap.NewNop().Sugar()).clusterLabel)
+	assert.Equal(t, "good-name", NewSARPhaseTracker("good-name", zap.NewNop().Sugar()).clusterLabel)
 }

--- a/pkg/webhook/phase_tracker_test.go
+++ b/pkg/webhook/phase_tracker_test.go
@@ -271,3 +271,87 @@ func gatherClusterLabels(t *testing.T, reg *prometheus.Registry) map[string]stru
 	}
 	return out
 }
+
+// TestCountRequest_AttributesToFinalClusterLabel covers the WebhookSARRequests
+// counter specifically. Unlike the duration and decision metrics, a Counter's
+// label cannot be corrected after the increment: whatever value is used is the
+// value that series keeps. Incrementing in parseSARRequest — before
+// resolveClusterConfig runs — would therefore file every request, including those
+// for registered clusters, under the "_unresolved" placeholder and permanently
+// break per-cluster request counting.
+func TestCountRequest_AttributesToFinalClusterLabel(t *testing.T) {
+	newCounter := func(t *testing.T, name string) (*prometheus.CounterVec, *prometheus.Registry) {
+		t.Helper()
+		vec := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: name,
+			Help: "Test counter",
+		}, []string{"cluster"})
+		reg := prometheus.NewRegistry()
+		require.NoError(t, reg.Register(vec))
+
+		original := metrics.WebhookSARRequests
+		metrics.WebhookSARRequests = vec
+		t.Cleanup(func() { metrics.WebhookSARRequests = original })
+		return vec, reg
+	}
+
+	counterLabels := func(t *testing.T, reg *prometheus.Registry) map[string]float64 {
+		t.Helper()
+		families, err := reg.Gather()
+		require.NoError(t, err)
+		out := map[string]float64{}
+		for _, f := range families {
+			for _, m := range f.GetMetric() {
+				for _, l := range m.GetLabel() {
+					if l.GetName() == "cluster" {
+						out[l.GetValue()] = m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+		return out
+	}
+
+	t.Run("resolved cluster is counted under its real name", func(t *testing.T) {
+		_, reg := newCounter(t, "test_sar_requests_resolved")
+
+		s := &authorizeState{
+			clusterName:  "prod-cluster-01",
+			clusterLabel: metrics.SafeClusterLabel("prod-cluster-01"),
+			phases:       NewSARPhaseTracker("prod-cluster-01", zap.NewNop().Sugar()),
+		}
+		// Simulate resolveClusterConfig succeeding, then counting.
+		s.clusterLabel = metrics.ResolvedClusterLabel(s.clusterName)
+		s.countRequest()
+
+		assert.Equal(t, map[string]float64{"prod-cluster-01": 1}, counterLabels(t, reg),
+			"a request for a registered cluster must not be counted under a placeholder")
+	})
+
+	t.Run("unresolved cluster is counted under the placeholder", func(t *testing.T) {
+		_, reg := newCounter(t, "test_sar_requests_unresolved")
+
+		s := &authorizeState{
+			clusterName:  "not-onboarded",
+			clusterLabel: metrics.SafeClusterLabel("not-onboarded"),
+		}
+		s.countRequest()
+
+		assert.Equal(t, map[string]float64{metrics.LabelValueUnresolved: 1}, counterLabels(t, reg))
+	})
+
+	t.Run("counted at most once per request", func(t *testing.T) {
+		_, reg := newCounter(t, "test_sar_requests_once")
+
+		s := &authorizeState{
+			clusterName:  "prod-cluster-01",
+			clusterLabel: metrics.ResolvedClusterLabel("prod-cluster-01"),
+		}
+		s.countRequest()
+		s.countRequest()
+		s.countRequest()
+
+		assert.Equal(t, map[string]float64{"prod-cluster-01": 1}, counterLabels(t, reg),
+			"multiple exit paths must not double-count a single request")
+	})
+}

--- a/pkg/webhook/phase_tracker_test.go
+++ b/pkg/webhook/phase_tracker_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -137,13 +138,18 @@ func TestSARPhases_Constants(t *testing.T) {
 	assert.Equal(t, SARPhase("total"), PhaseTotal)
 }
 
-// TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel is the cardinality
+// TestSARPhaseTracker_UnresolvedClusterNameNeverBecomesLabel is the cardinality
 // regression test for #185. clusterName is the raw :cluster_name route parameter
 // and was used verbatim as a Prometheus label on a HistogramVec (9 phases x
 // buckets) before the cluster had been resolved, so a remote caller could mint an
-// unbounded number of series and grow the operator heap without bound. Every
-// value that is not a valid Kubernetes object name must collapse onto one series.
-func TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel(t *testing.T) {
+// unbounded number of series and grow the operator heap without bound.
+//
+// Validating the FORMAT of the name is not sufficient: an attacker can vary
+// syntactically-valid DNS-1123 names indefinitely. Cardinality is only bounded by
+// refusing to emit any name that has not been resolved against a registered
+// ClusterConfig, so every unresolved value — well-formed or not — must collapse
+// onto a fixed placeholder.
+func TestSARPhaseTracker_UnresolvedClusterNameNeverBecomesLabel(t *testing.T) {
 	vec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "test_breakglass_webhook_sar_phase_duration_cardinality",
 		Help:    "Test metric for cardinality",
@@ -156,8 +162,8 @@ func TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel(t *testing.T) {
 	metrics.WebhookSARPhaseDuration = vec
 	t.Cleanup(func() { metrics.WebhookSARPhaseDuration = original })
 
-	// Attacker-controlled route parameter values: none is a valid object name.
-	hostile := []string{
+	// Malformed route parameter values: none is a valid object name.
+	malformed := []string{
 		"../../etc/passwd",
 		"Cluster With Spaces",
 		"UPPERCASE",
@@ -166,48 +172,102 @@ func TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel(t *testing.T) {
 		strings.Repeat("x", 254),
 		"\n",
 	}
-	for _, name := range hostile {
+	// Well-formed but unregistered names. These are the important case: they pass
+	// DNS-1123 validation, so format checking alone would let each one become its
+	// own series.
+	wellFormedButUnresolved := []string{
+		"attacker-0001",
+		"attacker-0002",
+		"attacker-0003",
+		"totally.valid.subdomain",
+		"a",
+	}
+
+	for _, name := range append(append([]string{}, malformed...), wellFormedButUnresolved...) {
 		NewSARPhaseTracker(name, zap.NewNop().Sugar()).EndPhase(PhaseParse)
 	}
 
+	labelValues := gatherClusterLabels(t, reg)
+
+	assert.Equal(t, map[string]struct{}{
+		metrics.LabelValueInvalid:    {},
+		metrics.LabelValueUnresolved: {},
+	}, labelValues,
+		"unresolved cluster names must collapse onto fixed placeholders regardless of how many distinct values are sent")
+
+	for _, name := range append(append([]string{}, malformed...), wellFormedButUnresolved...) {
+		assert.NotContains(t, labelValues, name,
+			"a caller-supplied cluster name must never become a label value before it is resolved")
+	}
+
+	// Sending many more distinct valid names must not add any series.
+	for i := 0; i < 200; i++ {
+		NewSARPhaseTracker(fmt.Sprintf("flood-%d", i), zap.NewNop().Sugar()).EndPhase(PhaseParse)
+	}
+	assert.Equal(t, labelValues, gatherClusterLabels(t, reg),
+		"series count must not grow with the number of distinct cluster names sent")
+}
+
+// TestSARPhaseTracker_ResolvedClusterNameIsRecorded asserts the other half of the
+// bound: once a cluster has been resolved against a registered ClusterConfig its
+// name IS used verbatim, because the set of registered clusters is bounded and
+// operator-controlled. Without this, the metric would be useless.
+func TestSARPhaseTracker_ResolvedClusterNameIsRecorded(t *testing.T) {
+	vec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "test_breakglass_webhook_sar_phase_duration_resolved",
+		Help:    "Test metric for resolved labels",
+		Buckets: []float64{.0001, .001, .01},
+	}, []string{"cluster", "phase"})
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(vec))
+
+	original := metrics.WebhookSARPhaseDuration
+	metrics.WebhookSARPhaseDuration = vec
+	t.Cleanup(func() { metrics.WebhookSARPhaseDuration = original })
+
+	tracker := NewSARPhaseTracker("prod-cluster-01", zap.NewNop().Sugar())
+	// Before resolution: placeholder only.
+	tracker.EndPhase(PhaseParse)
+	assert.Equal(t, metrics.LabelValueUnresolved, tracker.clusterLabel)
+
+	// resolveClusterConfig promotes the label once the ClusterConfig is found.
+	tracker.setClusterLabel(metrics.ResolvedClusterLabel("prod-cluster-01"))
+	tracker.EndPhase(PhaseClusterConfig)
+
+	labelValues := gatherClusterLabels(t, reg)
+	assert.Contains(t, labelValues, "prod-cluster-01",
+		"a resolved cluster name must be recorded verbatim")
+}
+
+func TestSARPhaseTracker_ClusterLabelPlaceholders(t *testing.T) {
+	assert.Equal(t, metrics.LabelValueUnknown,
+		NewSARPhaseTracker("", zap.NewNop().Sugar()).clusterLabel)
+	assert.Equal(t, metrics.LabelValueInvalid,
+		NewSARPhaseTracker("Bad Name", zap.NewNop().Sugar()).clusterLabel)
+	assert.Equal(t, metrics.LabelValueUnresolved,
+		NewSARPhaseTracker("good-name", zap.NewNop().Sugar()).clusterLabel)
+
+	// setClusterLabel ignores an empty promotion so the placeholder is never lost.
+	tracker := NewSARPhaseTracker("good-name", zap.NewNop().Sugar())
+	tracker.setClusterLabel("")
+	assert.Equal(t, metrics.LabelValueUnresolved, tracker.clusterLabel)
+}
+
+// gatherClusterLabels collects the distinct "cluster" label values present in the
+// registry's single metric family.
+func gatherClusterLabels(t *testing.T, reg *prometheus.Registry) map[string]struct{} {
+	t.Helper()
 	families, err := reg.Gather()
 	require.NoError(t, err)
 	require.Len(t, families, 1)
 
-	labelValues := map[string]struct{}{}
+	out := map[string]struct{}{}
 	for _, m := range families[0].GetMetric() {
 		for _, l := range m.GetLabel() {
 			if l.GetName() == "cluster" {
-				labelValues[l.GetValue()] = struct{}{}
+				out[l.GetValue()] = struct{}{}
 			}
 		}
 	}
-
-	assert.Equal(t, map[string]struct{}{metrics.LabelValueInvalid: {}}, labelValues,
-		"every invalid cluster name must collapse onto a single placeholder series")
-	for _, name := range hostile {
-		assert.NotContains(t, labelValues, name, "hostile input must never become a label value")
-	}
-
-	// A legitimate cluster name is still recorded verbatim.
-	NewSARPhaseTracker("prod-cluster-01", zap.NewNop().Sugar()).EndPhase(PhaseParse)
-	families, err = reg.Gather()
-	require.NoError(t, err)
-	found := false
-	for _, m := range families[0].GetMetric() {
-		for _, l := range m.GetLabel() {
-			if l.GetName() == "cluster" && l.GetValue() == "prod-cluster-01" {
-				found = true
-			}
-		}
-	}
-	assert.True(t, found, "valid cluster names must be preserved unchanged")
-}
-
-// TestSARPhaseTracker_EmptyClusterNameLabel documents that an absent route
-// parameter is distinguishable from a hostile one.
-func TestSARPhaseTracker_EmptyClusterNameLabel(t *testing.T) {
-	assert.Equal(t, metrics.LabelValueUnknown, NewSARPhaseTracker("", zap.NewNop().Sugar()).clusterLabel)
-	assert.Equal(t, metrics.LabelValueInvalid, NewSARPhaseTracker("Bad Name", zap.NewNop().Sugar()).clusterLabel)
-	assert.Equal(t, "good-name", NewSARPhaseTracker("good-name", zap.NewNop().Sugar()).clusterLabel)
+	return out
 }


### PR DESCRIPTION
## Summary

Six availability and correctness bugs: two concurrency/panic bugs, one silent
reconciliation defeat, one remotely-reachable unbounded-memory bug, one hot reconcile
loop, and three resource leaks on failure paths.

These came from an **AI security scan** (Microsoft Defender CLI) and were then verified
independently against `origin/main` — every cited line was re-read, and each fix has a
test proven to fail before it and pass after. **The scanner's severity was too low on
most of them:** it filed the SSA-drift bug and the privileged-orphan-pod bug as *Low*,
and the unrecoverable shutdown panic as *Medium*. The one bug in the original set that
the scanner ranked correctly is not in this PR because another branch owns the file.

Every fix has identical happy-path behaviour except two, called out under
**Upgrade impact** below.

---

## 1. `fix(audit)` — send on closed channel panics the process on shutdown

**Where:** `pkg/audit/queued_sink.go:306-311` (requeue) vs `:398` (`close(qs.queue)`)
**Scanner #053 — filed Medium. Actual: unrecoverable panic.**

When the sink returned `ErrCircuitOpen`, `processQueue` requeued the event from a
goroutine that was never registered with `qs.wg`. `Close()` waits only on the tracked
workers before closing `qs.queue`, so that detached send could execute after the close
and crash the process with `panic: send on closed channel`. A panic on a `chan send` is
not recoverable by the worker's own `recover()` — it happens on a different goroutine.
The trigger is specific and realistic: **an audit backend that is down while the
operator shuts down.**

**Fix:** the requeue is inline, through a new `enqueue()` helper that holds a read lock
and re-checks the closed flag; `Close()` takes the write lock before closing. Not a
`recover()`. A `Write` racing `Close` now returns an error, and an unplaceable requeue
is counted as a drop instead of being silently lost.

**Test evidence** (`TestQueuedSink_CloseDuringCircuitOpenRequeue`, `-race`):

Before (reverted `queued_sink.go`, test unchanged):
```
panic: send on closed channel

goroutine 276 [running]:
...pkg/audit.(*QueuedSink).processQueue.func2(0xc0002db8c0)
	pkg/audit/queued_sink.go:279 +0x54
created by ...processQueue in goroutine 175
	pkg/audit/queued_sink.go:277 +0x2e4
FAIL	github.com/telekom/k8s-breakglass/pkg/audit	0.967s
```
After:
```
=== RUN   TestQueuedSink_CloseDuringCircuitOpenRequeue
--- PASS: TestQueuedSink_CloseDuringCircuitOpenRequeue (0.12s)
=== RUN   TestQueuedSink_WriteAfterCloseReturnsError
--- PASS: TestQueuedSink_WriteAfterCloseReturnsError (0.00s)
ok  	github.com/telekom/k8s-breakglass/pkg/audit	12.356s   (-race, full package)
```

---

## 2. `fix(utils)` — subset equality skips SSA, so key REMOVALS never reconcile

**Where:** `pkg/utils/patchhelper.go` — `unstructuredSpecEqual` → `jsonFieldSubsetEqual`
→ `jsonSubsetEqual`
**Scanner #173/#174/#261 — filed Low. Actual: permanent silent drift.**

`jsonSubsetEqual` iterates only the *desired* object's keys. Dropping a field from a
manifest makes desired a strict subset of live, so every check passes,
`PatchApplyResultSkipped` is returned, and the apply that would prune the field is
never sent. The operator reports success while the live resource stays drifted — for
every auxiliary resource, indefinitely.

I confirmed this empirically before changing anything, with a throwaway probe against
the real `PatchApplyUnstructured`: apply `{a,b}`, then apply `{a}` → result `skipped`,
live data still `map[a:1 b:2]`.

**Fix:** the comparison now also requires that every field the operator owns — per its
own Apply entry in the resource's `managedFields` — is still declared by desired.
Ownership that cannot be established (no entry for our field manager, unparseable
`FieldsV1`, non-Apply operation) yields "not equal", so the apply is sent. I chose this
over dropping the optimization: the file's own doc comment states it exists to
eliminate "thousands of no-op PATCH requests per reconciliation cycle", and this keeps
the skip for the genuinely-unchanged case, which is the common one. Where ownership is
unknown the fallback is one PATCH — SSA is a no-op when nothing changed.

**Follow-up defect found and fixed in review (commit 9):** `ownedFieldSet` originally
returned the *first* Apply entry for `breakglass-controller` without filtering on
`Subresource`. This operator applies to the **status subresource with the same field
manager** (`utils.ApplyStatus` at `ssa.go:122`, `UpdateStatusWithRetry` at
`retry.go:74`), so objects routinely carry two Apply entries for
`breakglass-controller`. When the status entry sorted first, `ownedFieldSet` returned
`{"f:status":…}` — no spec fields — so the code concluded it owned nothing in spec and a
removed spec key compared "equal" again. **The drift bug this whole commit exists to fix
silently returned, for exactly the resources it was meant to protect.** The ordering is
genuinely reachable: apimachinery sorts managedFields by operation, timestamp, manager,
apiVersion, and only *then* subresource, so the status entry sorts first whenever it has
the older timestamp. Entries are now filtered to `Subresource == ""`, and the FieldsV1
guards `continue` rather than `return nil` so one unusable entry cannot shadow a valid
main-resource entry. Tests assert **both** orderings so they cannot pass on slice order
by accident, plus a positive control proving the not-equal result is not unconditional.

Associative-list members in `FieldsV1` (`k:`/`v:`/`i:`) are deliberately not walked:
slices are already compared with full equality, so a removal inside a list was always
detected. Metadata ownership is enforced only for labels and annotations, matching what
the existing comparison covers.

**Test evidence** (`TestPatchApplyUnstructured_KeyRemovalIsApplied`):

Before (reverted `patchhelper.go`, tests unchanged):
```
Error: Not equal:
       expected: map[string]string{"keep":"1"}
       actual  : map[string]string{"drop":"2", "keep":"1"}
Messages: the removed key must actually be pruned from the live object
--- FAIL: TestPatchApplyUnstructured_KeyRemovalIsApplied (0.05s)
--- FAIL: TestPatchApplyUnstructured_NestedKeyRemovalIsApplied (0.00s)
       expected: 2 (patched)
       actual  : 0 (skipped)
```
After: both pass; full package `ok ... pkg/utils 4.163s` under `-race`.

Four pre-existing tests asserted the old subset-only semantics using synthetic objects
with no ownership metadata. They now stamp a `managedFields` entry via a
`withOwnedFields` helper, which is what a real API server returns. Their intent is
unchanged, including `TestUnstructuredSpecEqual_ExtraLabelsInCurrent` — a label owned
by *another* field manager still must not force an apply, and that is now asserted
against real ownership data rather than implied.

---

## 3. `fix(metrics)` — unbounded label cardinality from a raw route parameter

**Where:** `pkg/webhook/phase_tracker.go`, `pkg/webhook/authorize_helpers.go` and 15
further metric label sites
**Scanner #185 (+ #145/#235/#236) — filed Low. Remotely reachable.**

`clusterName` is the raw `:cluster_name` route parameter, used as a Prometheus label
**before** it has been resolved against a `ClusterConfig`. Prometheus never reclaims a
series, so a remote caller grows the operator heap without bound just by varying the
request path. `WebhookSARPhaseDuration` is the worst case: a `HistogramVec` observed
once per phase, so nine phases plus buckets per bogus name.

**Fix, after Copilot review — this is the important detail.** My first attempt only
*validated the format* of the name (RFC 1123) and passed valid names through. Copilot
correctly pointed out that this does not bound anything: arbitrarily many
syntactically-valid DNS-1123 names exist, so an attacker could still mint one series per
request, and my code comments and docs claimed a bound the code did not deliver.

The label is now **only ever set to a registered cluster's name.** Until a request has
been matched to an existing `ClusterConfig`, `SafeClusterLabel` returns one of three
fixed placeholders and never the caller's string:

| Value | Meaning |
|---|---|
| `_unknown` | No cluster name supplied |
| `_invalid` | Not a valid Kubernetes object name — malformed traffic |
| `_unresolved` | Well-formed but not an onboarded cluster |

`resolveClusterConfig` then promotes the label to the real name via
`ResolvedClusterLabel` once the `ClusterConfig` lookup succeeds, on both
`authorizeState` and the phase tracker, so per-cluster dashboards keep working. Total
cluster-label cardinality is bounded by **the number of registered clusters plus three**
— the set of registered clusters is operator-controlled, not caller-controlled, which is
the only genuinely bounded source of cluster label values.

**Test evidence** (`TestSARPhaseTracker_UnresolvedClusterNameNeverBecomesLabel`):

Before (sanitizer bypassed, test unchanged) — 7 distinct hostile series:
```
expected: map[string]struct {}{"_invalid":struct {}{}}
actual  : map[string]struct {}{"\n":{}, "../../etc/passwd":{}, "Cluster With Spaces":{},
          "UPPERCASE":{}, "a{b=\"c\"}":{}, "trailing-dash-":{}, "xxxx…(254 chars)":{}}
Messages: every invalid cluster name must collapse onto a single placeholder series
--- FAIL: TestSARPhaseTracker_InvalidClusterNameNeverBecomesLabel (0.00s)
```
After: passes, and the test was **strengthened** in response to the review — it now
floods 200 distinct *well-formed* names and asserts the series count does not grow,
which the format-only version would have passed while still being vulnerable.
`TestSafeClusterLabel_BoundedToThreeValues` pushes 1000+ inputs through and asserts
exactly three distinct outputs and that the input is never echoed back.
`TestSARPhaseTracker_ResolvedClusterNameIsRecorded` asserts the other half: a resolved
cluster name *is* recorded verbatim, so the metric stays useful.

**Second review round on the same fix.** Copilot's follow-up pass caught a consequence
I had missed: `breakglass_webhook_sar_requests_total` is a **Counter**, so its label
cannot be corrected after the increment the way the duration and decision metrics can.
It was incremented in `parseSARRequest`, *before* resolution, so every request —
including requests for registered clusters — was permanently filed under `_unresolved`,
breaking per-cluster request counting and contradicting the guarantee I had just written
into `docs/metrics.md`. The increment now goes through `countRequest()`, which fires
exactly once per request and only once the label is final: the real cluster name on
success, the appropriate placeholder on the five paths that never reach resolution
(oversized body, unreadable body, undecodable SAR, unregistered cluster, ClusterConfig
load error). `TestCountRequest_AttributesToFinalClusterLabel` covers all three cases
including the at-most-once guarantee.

**Behaviour note for dashboards:** metrics for registered clusters are unchanged.
Requests for clusters Breakglass does not serve previously produced one series per
distinct name; those collapse to the placeholders, so overall series count drops. The
"cluster not registered" denial is now attributed to `_unresolved`. Documented in
`docs/metrics.md` and `docs/upgrade-guide.md`.

Per-session series (`ds.Name` on pod-restart/pod-failure metrics, #235/#236) are handled
in the `fix(debug)` commit — see below.

## 4. `fix(config)` — hot reconcile loop with no backoff

**Where:** `pkg/config/escalation_reconciler.go:246`
**Scanner #254 — filed Low.**

Any reference-validation failure returned `reconcile.Result{RequeueAfter: 3s}` with a
**nil error**. A fixed `RequeueAfter` bypasses the workqueue rate limiter entirely, so a
reference that will never resolve (a typo'd `clusterConfigRef`) produced ~20 reconciles
per minute forever, each running full validation, writing status, and emitting a
`Warning` event.

**Fix:** return an error, which is what makes controller-runtime apply exponential
backoff — as the brief suggested, and the cleaner option than hand-rolling backoff.
Purely structural (`ConfigValidated`) failures now do not retry at all, since they
cannot resolve without a spec change. Status conditions and events are written exactly
as before.

**Test evidence** (`TestEscalationReconciler_RefErrorUsesBackoffNotHotLoop`):

Before (reverted reconciler):
```
Error: An error is expected but got nil.
Messages: reference validation failure must return an error so the workqueue backs off
--- FAIL: TestEscalationReconciler_RefErrorUsesBackoffNotHotLoop (0.06s)
```
After: passes, plus `TestEscalationReconciler_StructuralErrorDoesNotRetry` covering the
no-retry half. Four existing tests asserted the literal `RequeueAfter: 3 * time.Second`
and were updated to assert the error return; each still verifies the same status
condition.

---

## 5. `fix(debug)` — orphaned resources on error paths

**Where:** `debug_session_kubectl.go:453` / `:636`; `debug_session_reconciler.go:493`
**Scanner #095/#096/#237 — #096 filed Low.**

All three have the same shape: a resource exists on the spoke, but is absent from the
status lists that *every* cleanup path iterates, so nothing ever deletes it.

- **#096 / #095** — `CreateNodeDebugPod` and `CreatePodCopy` create a pod, then record it
  in the session status. When the status patch fails, neither deletes the pod it just
  created. For node debug the orphan is a **privileged pod with `hostPath: /` mounted
  read-write, outliving its session.** Both now delete the pod when it cannot be
  tracked, using a context detached from the caller's — a cancelled request context was
  a plausible cause of the status failure and would otherwise also defeat the
  compensating delete.
- **#237** — `failSession` logs cleanup errors then sets the terminal `Failed` state,
  whose `Reconcile` branch returned an empty `Result` and never requeued, so anything
  cleanup could not delete leaked permanently. `Failed` **remains terminal** (the state
  is never changed); cleanup is retried while the status still tracks spoke resources.
- **#235/#236** — per-session metric series are now released at cleanup and at `Failed`.
  They were previously reclaimed only if a delete event happened to be observed, which
  a missed watch event or a restart defeats.

**Test evidence:**

Before (compensating deletes removed, tests unchanged) —
`TestCreateNodeDebugPod_StatusFailureDeletesOrphan`:
```
Error: Should be empty, but was [{... node-debugger-node-1-orphan-n breakglass-debug ...
        HostPathVolumeSource{Path:/,...} ... SecurityContext{Privileged:*true,...}
        ... hostNetwork:true hostPID:true ...}]
Messages: a privileged hostPath:/ pod was orphaned on the spoke cluster: it is
          untracked in the session status, so no cleanup path will ever delete it
--- FAIL: TestCreateNodeDebugPod_StatusFailureDeletesOrphan (0.06s)
```
`TestCreatePodCopy_StatusFailureDeletesOrphan`:
```
"[... debug-copy-app-pod-orphan-c debug-copies ... app-pod default ...]"
        should have 1 item(s), but has 2
Messages: the pod copy must not be orphaned on the spoke cluster
--- FAIL: TestCreatePodCopy_StatusFailureDeletesOrphan (0.06s)
```
`TestDebugSessionController_FailedStateRetriesCleanup`:
```
Error: Should not be: reconcile.Result{Requeue:false, RequeueAfter:0, Priority:(*int)(nil)}
Messages: a failed session with untracked-cleanup spoke resources must be revisited,
          otherwise the spoke resources leak permanently
--- FAIL: .../failed_with_tracked_resources_requeues_for_cleanup (0.06s)
```
After: all pass, plus the `failed_with_no_tracked_resources_is_terminal` subtest
asserting a genuinely-clean failed session is still terminal with no requeue.

> Note on the first pod-copy test iteration: it initially passed even when reverted,
> because the pod-copy path returns early on namespace-label resolution before reaching
> the `Create`. I probed the actual error, seeded both the source and `debug-copies`
> namespaces so the test reaches the create, and only then confirmed the fail-before.
> The revert output above is from the corrected test.

---

## Upgrade impact

Four of the six fixes are pure correctness with byte-identical happy-path behaviour.
Two are observable behaviour changes. Both are documented in `docs/upgrade-guide.md`
under "Upcoming Changes (Unreleased)".

### SSA now prunes removed fields (fix 2)

**On the first reconcile after deploying, the operator will delete fields from live
resources that it previously left alone.** That is the intended fix — those fields were
already absent from the manifest and should have been pruned — but it is a real
behaviour change.

What to expect:

- Fields previously removed from a manifest but left behind on live resources are now
  actually deleted. Affects auxiliary resources, pod-template resources, and anything
  else applied through the shared apply helpers.
- The correction lands **per resource on its next reconcile**, not as one sweep, so it
  is gradual rather than a thundering herd.
- Resources with no accumulated drift are unaffected — the reconcile is a no-op.
- A resource created by an older release has no ownership entry yet, so its first
  reconcile may send one apply that would previously have been skipped. That is a
  single extra PATCH per resource, not an ongoing cost.
- Fields owned by a **different** field manager are not touched. The check is scoped to
  this operator's own `managedFields` entry, so co-operative writers are unaffected.

**Recommended pre-upgrade action:** diff a representative auxiliary resource against
its manifest to see what will be pruned. If a field on a live resource is intentionally
set by something other than breakglass, confirm that writer uses its own field manager.

### Webhook SAR metrics no longer label unresolved clusters (fix 3)

- Registered clusters are unaffected — the real name is still recorded.
- Series for clusters that are not onboarded collapse onto `_unresolved`/`_invalid`,
  so a query grouping by `cluster` shows placeholders instead of individual bogus names.
- `breakglass_webhook_sar_denied_total` for the "cluster not registered" denial is now
  attributed to `_unresolved`. Alerts keyed on a specific un-onboarded name need updating.
- Overall series count for these metrics drops, in some deployments substantially.

### Escalation reconcile cadence (fix 4)

- Retries start at a comparable interval and then back off; a permanently broken
  reference settles into infrequent retries instead of a constant loop.
- `Warning` event and status-write volume for broken escalations drops sharply.
- **`controller_runtime_reconcile_errors_total` now increments** for these escalations.
  That is the correct representation of an unresolvable reference, but it may need an
  alerting-threshold adjustment.
- Structural failures no longer retry at all. The status condition is unchanged.
- Time to resolution for a genuinely transient case (a reference created moments after
  the escalation) is unchanged in practice, since early retries are still fast.

No CRD changes: `make generate && make manifests` produces no diff. No new API fields,
so no `bool`→`*bool` question arose.

---

## SKIPPED — owned by a sibling worktree

**Finding #082/#225 — nil deref 500s the list endpoint for ALL tenants.** Not fixed
here. Verified the exact locations first:

```
pkg/breakglass/debug/debug_session_api_resolution.go:479:  Containers: len(t.Spec.Template.Spec.Containers),
pkg/breakglass/debug/debug_session_api_resolution.go:516:  if template.Spec.Template.Spec.Containers != nil {
```

Both sites are in `debug_session_api_resolution.go`, which branch **bg-f6** owns, so I
did not touch the file. The bug is real and confirmed: `Spec.Template` is a
`*DebugPodSpec` marked `+optional`, validation explicitly permits `templateString`
alone, and the guard at `:516` checks `.Spec.Containers != nil` *after* already
dereferencing the nil pointer — so it guards nothing. Recovery middleware converts the
panic into a 500, meaning **one such template breaks the list endpoint for every
tenant.** Independent triage rated it High; the scanner filed it Low. The
`templateString`-only list-endpoint test the brief asked for belongs with that fix and
is not in this PR.

Also skipped, same reason: `pkg/cluster/cache.go:336` (finding #145, the cache half of
the cardinality group) — owned by **bg-f3**. The webhook and reconciler halves of that
group are fixed here.

---

## Verification — real output

```
$ make fmt vet lint-strict
go fmt ./...
go vet ./...
bin/golangci-lint run --timeout 10m
0 issues.
```

`lint-strict` initially failed on two `SA1019` deprecation hits for direct
`FieldsV1.Raw` access; switched to `GetRawBytes()` / `NewFieldsV1()` and re-ran to 0.

```
$ make test
ok  ...api/v1alpha1                        coverage: 52.8%
ok  ...api/v1alpha1/applyconfiguration/ssa  coverage: 80.4%
ok  ...pkg/audit                            coverage: 83.2%
ok  ...pkg/breakglass/debug                 coverage: 78.3%
ok  ...pkg/config                            coverage: 72.3%
ok  ...pkg/metrics                           coverage: 96.3%
ok  ...pkg/utils                             coverage: 66.6%
ok  ...pkg/webhook                           coverage: 81.9%
   (37 packages ok, 0 FAIL)
```

`go test -race` on every touched package — mandatory, and two of these are concurrency
bugs:
```
ok  github.com/telekom/k8s-breakglass/pkg/audit             14.745s
ok  github.com/telekom/k8s-breakglass/pkg/utils              4.163s
ok  github.com/telekom/k8s-breakglass/pkg/webhook            9.093s
ok  github.com/telekom/k8s-breakglass/pkg/config             6.975s
ok  github.com/telekom/k8s-breakglass/pkg/breakglass/debug  10.842s
ok  github.com/telekom/k8s-breakglass/pkg/metrics            4.354s
```

```
$ make validate-crds validate-samples validate-fixtures
--- PASS: TestFixturesAreValid (0.04s)   (16 fixtures)
Validated fixture kinds: map[BreakglassEscalation:13 ClusterConfig:4 DebugPodTemplate:3
  DebugSessionTemplate:3 DenyPolicy:7 IdentityProvider:2]
Fixture validation passed

$ make generate && make manifests && git status --porcelain
   (no generated diff)
```

Every revert experiment above was run by restoring only the production file from `HEAD`
with the new test unchanged, then restoring the fix and re-verifying the build.

---

## Notes on provenance

Findings came from an AI security scan (Microsoft Defender CLI), then were verified
independently — the scan output was treated as a candidate-location generator, not a
work queue. Every cited line was re-read on `origin/main` before being changed; the
`patchhelper` and `managedFields` behaviours were confirmed with throwaway probes
rather than assumed. **The scanner's severity was too low on most of these**, including
the SSA-drift bug and the privileged-orphan-pod bug (both *Low*) and the unrecoverable
shutdown panic (*Medium*).

### Review round

Copilot reviewed the first push and found a real gap in fix 3: format validation does
not bound cardinality, and three code comments plus `docs/metrics.md` asserted a
guarantee the implementation did not provide. That is a fair catch on the substance, not
just the wording — the mitigation was incomplete. Fixed in
`fix(metrics): never emit an unresolved cluster name as a Prometheus label`, with the
cardinality test strengthened to a 200-name flood that the original code would have
passed. Copilot also caught a `CHANGELOG.md` cross-reference pointing at
`docs/troubleshooting.md` instead of the `docs/upgrade-guide.md` section that actually
documents the upgrade impact; also fixed.

A second Copilot pass on the corrected code found the Counter-attribution consequence
described under fix 3 — a real follow-on defect introduced by my own first correction,
not a nit. Fixed in `fix(metrics): count SAR requests under the resolved cluster, not
the placeholder`. Its other suppressed remark, that the PR lacks `CHANGELOG.md` entries,
is a false positive: seven entries were added under `## [Unreleased]` in the
`docs:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
