### PR TITLE
fix(debug): enforce namespace allow-lists and selector terms; add additive denyUserNamespace

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/namespaceconstraints.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/namespaceconstraints.go
@@ -27,6 +27,16 @@ type NamespaceConstraintsApplyConfiguration struct {
 	// allowUserNamespace allows users to request a specific namespace.
 	// If false, only defaultNamespace is used.
 	AllowUserNamespace *bool `json:"allowUserNamespace,omitempty"`
+	// denyUserNamespace disables user-selected namespaces regardless of
+	// allowUserNamespace. It exists so that a DebugSessionClusterBinding can
+	// narrow a permissive template: allowUserNamespace cannot express that
+	// intent because its zero value is indistinguishable from "unset".
+	// Absent or false preserves existing behaviour exactly. When true, only
+	// defaultNamespace is used, even if the template sets
+	// allowUserNamespace: true.
+	// This field intentionally carries no default so that stored objects
+	// written before it existed keep behaving as before.
+	DenyUserNamespace *bool `json:"denyUserNamespace,omitempty"`
 	// createIfNotExists creates the target namespace if it doesn't exist.
 	// Requires appropriate RBAC permissions.
 	CreateIfNotExists *bool `json:"createIfNotExists,omitempty"`
@@ -70,6 +80,14 @@ func (b *NamespaceConstraintsApplyConfiguration) WithDefaultNamespace(value stri
 // If called multiple times, the AllowUserNamespace field is set to the value of the last call.
 func (b *NamespaceConstraintsApplyConfiguration) WithAllowUserNamespace(value bool) *NamespaceConstraintsApplyConfiguration {
 	b.AllowUserNamespace = &value
+	return b
+}
+
+// WithDenyUserNamespace sets the DenyUserNamespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DenyUserNamespace field is set to the value of the last call.
+func (b *NamespaceConstraintsApplyConfiguration) WithDenyUserNamespace(value bool) *NamespaceConstraintsApplyConfiguration {
+	b.DenyUserNamespace = &value
 	return b
 }
 

--- a/api/v1alpha1/applyconfiguration/internal/internal.go
+++ b/api/v1alpha1/applyconfiguration/internal/internal.go
@@ -2574,6 +2574,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: deniedNamespaces
       type:
         namedType: com.github.telekom.k8s-breakglass.api.v1alpha1.NamespaceFilter
+    - name: denyUserNamespace
+      type:
+        scalar: boolean
     - name: namespaceLabels
       type:
         map:

--- a/api/v1alpha1/debug_session_template_types.go
+++ b/api/v1alpha1/debug_session_template_types.go
@@ -933,6 +933,18 @@ type NamespaceConstraints struct {
 	// +kubebuilder:default=false
 	AllowUserNamespace bool `json:"allowUserNamespace,omitempty"`
 
+	// denyUserNamespace disables user-selected namespaces regardless of
+	// allowUserNamespace. It exists so that a DebugSessionClusterBinding can
+	// narrow a permissive template: allowUserNamespace cannot express that
+	// intent because its zero value is indistinguishable from "unset".
+	// Absent or false preserves existing behaviour exactly. When true, only
+	// defaultNamespace is used, even if the template sets
+	// allowUserNamespace: true.
+	// This field intentionally carries no default so that stored objects
+	// written before it existed keep behaving as before.
+	// +optional
+	DenyUserNamespace bool `json:"denyUserNamespace,omitempty"`
+
 	// createIfNotExists creates the target namespace if it doesn't exist.
 	// Requires appropriate RBAC permissions.
 	// +optional

--- a/api/v1alpha1/debug_session_template_types_test.go
+++ b/api/v1alpha1/debug_session_template_types_test.go
@@ -18,8 +18,11 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2145,4 +2148,46 @@ spec:
 			t.Errorf("expected error for mutually exclusive fields, got %v", errs)
 		}
 	})
+}
+
+// TestNamespaceConstraints_DenyUserNamespaceIsAdditive is the backwards-
+// compatibility regression required by the project compat contract: an object
+// stored before denyUserNamespace existed must round-trip byte-identically and
+// must not gain the field on serialization.
+func TestNamespaceConstraints_DenyUserNamespaceIsAdditive(t *testing.T) {
+	// Exactly what an already-stored v1alpha1 object looks like: allowUserNamespace
+	// and defaultNamespace were defaulted at admission, denyUserNamespace absent.
+	stored := []byte(`{"defaultNamespace":"breakglass-debug","allowUserNamespace":true}`)
+
+	var nc NamespaceConstraints
+	require.NoError(t, json.Unmarshal(stored, &nc))
+
+	// Absent means false, i.e. today's behaviour.
+	assert.False(t, nc.DenyUserNamespace)
+
+	// Re-serializing must not add the new field.
+	roundTripped, err := json.Marshal(&nc)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(stored), string(roundTripped))
+	assert.NotContains(t, string(roundTripped), "denyUserNamespace")
+
+	// DeepCopy preserves the zero value.
+	assert.False(t, nc.DeepCopy().DenyUserNamespace)
+
+	// Only an explicit true is serialized.
+	nc.DenyUserNamespace = true
+	explicit, err := json.Marshal(&nc)
+	require.NoError(t, err)
+	assert.Contains(t, string(explicit), `"denyUserNamespace":true`)
+
+	// An explicit false from the wire is also inert and is not re-serialized,
+	// so no stored object can change meaning on upgrade.
+	var explicitFalse NamespaceConstraints
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"defaultNamespace":"breakglass-debug","allowUserNamespace":true,"denyUserNamespace":false}`),
+		&explicitFalse))
+	assert.False(t, explicitFalse.DenyUserNamespace)
+	out, err := json.Marshal(&explicitFalse)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "denyUserNamespace")
 }

--- a/api/v1alpha1/fuzz_test.go
+++ b/api/v1alpha1/fuzz_test.go
@@ -492,3 +492,81 @@ func FuzzValidateImpersonationDenyRules(f *testing.F) {
 		}
 	})
 }
+
+// FuzzNamespaceConstraintsDenyUserNamespace fuzzes the namespace-constraint
+// validation and warning helpers around the additive denyUserNamespace field.
+// Invariants:
+//   - validation must never panic for any combination of switches;
+//   - denyUserNamespace never adds a hard validation error, because it is an
+//     optional narrowing switch;
+//   - a constraint set with denyUserNamespace unset must produce exactly the
+//     same errors and warnings as before the field existed.
+func FuzzNamespaceConstraintsDenyUserNamespace(f *testing.F) {
+	seeds := []struct {
+		allowUser        bool
+		denyUser         bool
+		defaultNamespace string
+		allowedPattern   string
+		deniedPattern    string
+	}{
+		{false, false, "breakglass-debug", "", ""},
+		{true, false, "breakglass-debug", "debug-*", ""},
+		{false, true, "breakglass-debug", "", ""},
+		{true, true, "breakglass-debug", "debug-*", "kube-*"},
+		{true, true, "", "", ""},
+		{false, true, "", "*", "*"},
+		{true, false, "prod", "prod", "prod"},
+		{true, true, "unicode-日本語", "*", ""},
+		{false, false, string(make([]byte, 300)), "", ""},
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed.allowUser, seed.denyUser, seed.defaultNamespace, seed.allowedPattern, seed.deniedPattern)
+	}
+
+	f.Fuzz(func(t *testing.T, allowUser, denyUser bool, defaultNamespace, allowedPattern, deniedPattern string) {
+		build := func(deny bool) *NamespaceConstraints {
+			nc := &NamespaceConstraints{
+				AllowUserNamespace: allowUser,
+				DenyUserNamespace:  deny,
+				DefaultNamespace:   defaultNamespace,
+			}
+			if allowedPattern != "" {
+				nc.AllowedNamespaces = &NamespaceFilter{Patterns: []string{allowedPattern}}
+			}
+			if deniedPattern != "" {
+				nc.DeniedNamespaces = &NamespaceFilter{Patterns: []string{deniedPattern}}
+			}
+			return nc
+		}
+
+		path := field.NewPath("spec", "namespaceConstraints")
+
+		// Must never panic.
+		withDeny := validateNamespaceConstraints(build(true), path)
+		withoutDeny := validateNamespaceConstraints(build(false), path)
+
+		// denyUserNamespace must not introduce hard validation errors.
+		if len(withDeny) != len(withoutDeny) {
+			t.Errorf("denyUserNamespace changed validation errors: %v vs %v", withDeny, withoutDeny)
+		}
+
+		// Warnings must never panic either.
+		warnOff := warnNamespaceConstraintIssues(build(false), "")
+		warnOn := warnNamespaceConstraintIssues(build(true), "")
+
+		// With the field unset, warnings must match the pre-field behaviour:
+		// the only denyUserNamespace warning fires when both switches are set.
+		for _, w := range warnOff {
+			if w == "" {
+				t.Errorf("empty warning produced")
+			}
+		}
+		if !allowUser && len(warnOn) != len(warnOff) {
+			t.Errorf("denyUserNamespace warning fired without allowUserNamespace: %v vs %v", warnOn, warnOff)
+		}
+		if allowUser && len(warnOn) != len(warnOff)+1 {
+			t.Errorf("expected exactly one extra warning when both switches are set: %v vs %v", warnOn, warnOff)
+		}
+	})
+}

--- a/api/v1alpha1/validation_helpers.go
+++ b/api/v1alpha1/validation_helpers.go
@@ -1357,6 +1357,14 @@ func warnNamespaceConstraintIssues(nc *NamespaceConstraints, targetNamespace str
 				"the patterns will be ignored since users cannot specify namespaces.")
 	}
 
+	// Warn when both switches are set: denyUserNamespace narrows and wins,
+	// which makes allowUserNamespace inert.
+	if nc.DenyUserNamespace && nc.AllowUserNamespace {
+		warnings = append(warnings,
+			"namespaceConstraints.denyUserNamespace is true and overrides allowUserNamespace; "+
+				"user-selected namespaces are rejected and only defaultNamespace is used.")
+	}
+
 	// Warn if allowUserNamespace is true but no defaultNamespace is set
 	// If a user doesn't specify a namespace, what happens?
 	if nc.AllowUserNamespace && nc.DefaultNamespace == "" {

--- a/charts/escalation-config/templates/debugsessionclusterbinding.yaml
+++ b/charts/escalation-config/templates/debugsessionclusterbinding.yaml
@@ -162,6 +162,9 @@ spec:
     {{- if hasKey $binding.namespaceConstraints "allowUserNamespace" }}
     allowUserNamespace: {{ $binding.namespaceConstraints.allowUserNamespace }}
     {{- end }}
+    {{- if hasKey $binding.namespaceConstraints "denyUserNamespace" }}
+    denyUserNamespace: {{ $binding.namespaceConstraints.denyUserNamespace }}
+    {{- end }}
     {{- if hasKey $binding.namespaceConstraints "createIfNotExists" }}
     createIfNotExists: {{ $binding.namespaceConstraints.createIfNotExists }}
     {{- end }}

--- a/charts/escalation-config/values.schema.json
+++ b/charts/escalation-config/values.schema.json
@@ -449,6 +449,9 @@
               },
               "defaultNamespace": {
                 "type": "string"
+              },
+              "denyUserNamespace": {
+                "type": "boolean"
               }
             },
             "type": "object"

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessionclusterbindings.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessionclusterbindings.yaml
@@ -671,6 +671,18 @@ spec:
                           type: object
                         type: array
                     type: object
+                  denyUserNamespace:
+                    description: |-
+                      denyUserNamespace disables user-selected namespaces regardless of
+                      allowUserNamespace. It exists so that a DebugSessionClusterBinding can
+                      narrow a permissive template: allowUserNamespace cannot express that
+                      intent because its zero value is indistinguishable from "unset".
+                      Absent or false preserves existing behaviour exactly. When true, only
+                      defaultNamespace is used, even if the template sets
+                      allowUserNamespace: true.
+                      This field intentionally carries no default so that stored objects
+                      written before it existed keep behaving as before.
+                    type: boolean
                   namespaceLabels:
                     additionalProperties:
                       type: string

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessions.yaml
@@ -3696,6 +3696,18 @@ spec:
                               type: object
                             type: array
                         type: object
+                      denyUserNamespace:
+                        description: |-
+                          denyUserNamespace disables user-selected namespaces regardless of
+                          allowUserNamespace. It exists so that a DebugSessionClusterBinding can
+                          narrow a permissive template: allowUserNamespace cannot express that
+                          intent because its zero value is indistinguishable from "unset".
+                          Absent or false preserves existing behaviour exactly. When true, only
+                          defaultNamespace is used, even if the template sets
+                          allowUserNamespace: true.
+                          This field intentionally carries no default so that stored objects
+                          written before it existed keep behaving as before.
+                        type: boolean
                       namespaceLabels:
                         additionalProperties:
                           type: string

--- a/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
+++ b/config/crd/bases/breakglass.t-caas.telekom.com_debugsessiontemplates.yaml
@@ -2244,6 +2244,18 @@ spec:
                           type: object
                         type: array
                     type: object
+                  denyUserNamespace:
+                    description: |-
+                      denyUserNamespace disables user-selected namespaces regardless of
+                      allowUserNamespace. It exists so that a DebugSessionClusterBinding can
+                      narrow a permissive template: allowUserNamespace cannot express that
+                      intent because its zero value is indistinguishable from "unset".
+                      Absent or false preserves existing behaviour exactly. When true, only
+                      defaultNamespace is used, even if the template sets
+                      allowUserNamespace: true.
+                      This field intentionally carries no default so that stored objects
+                      written before it existed keep behaving as before.
+                    type: boolean
                   namespaceLabels:
                     additionalProperties:
                       type: string

--- a/docs/debug-session-cluster-binding.md
+++ b/docs/debug-session-cluster-binding.md
@@ -167,6 +167,7 @@ Override namespace restrictions:
 | `deniedPatterns` | string[] | Denied namespace patterns |
 | `defaultNamespace` | string | Default namespace for sessions |
 | `allowUserNamespace` | bool | Allow users to specify namespace |
+| `denyUserNamespace` | bool | Narrowing switch: when `true`, reject user-specified namespaces even if the template allows them. Absent or `false` keeps existing behaviour |
 
 ### schedulingConstraints
 
@@ -936,9 +937,10 @@ Namespace constraints are enforced as a restrictive combination of the template 
 | Field | Merge Behavior |
 |-------|----------------|
 | `allowUserNamespace` | Binding cannot enable user-selected namespaces when the template disables them |
+| `denyUserNamespace` | Narrowing only: if either the template or the binding sets `true`, user-selected namespaces are rejected |
 | `defaultNamespace` | Binding value is used only when it remains allowed by both template and binding filters |
-| `allowedNamespaces.patterns` | Requested namespaces must match the template boundary and any binding filter |
-| `deniedNamespaces.patterns` | Template denies are preserved; binding denies are added |
+| `allowedNamespaces` | The effective allow-list is the **intersection** of the template and binding filters. If neither side configures one, only `defaultNamespace` is allowed |
+| `deniedNamespaces` | Union: template denies are preserved and binding denies are added. `selectorTerms` are evaluated against live namespace labels on the target cluster |
 
 ```yaml
 # Template: restrictive base
@@ -969,7 +971,34 @@ namespaceConstraints:
 - Bindings can selectively narrow access per-cluster or per-team
 - Bindings cannot make templates more permissive than defined
 
-`allowUserNamespace` is a v1alpha1 boolean field, so a binding cannot distinguish an omitted value from an explicit `false`. Bindings therefore cannot disable user-selected namespaces when the template already enables them. To narrow that path, restrict the effective namespace set with `allowedNamespaces` / `deniedNamespaces`, or use a template with `allowUserNamespace: false`.
+##### Narrowing a permissive template with `denyUserNamespace`
+
+`allowUserNamespace` is a v1alpha1 boolean with `default: false`, so a binding cannot distinguish an omitted value from an explicit `false` and therefore cannot use it to disable user-selected namespaces that the template enables. Use the additive `denyUserNamespace` field for that instead:
+
+```yaml
+# Template: permissive base
+spec:
+  namespaceConstraints:
+    allowUserNamespace: true
+    defaultNamespace: "breakglass-debug"
+    allowedNamespaces:
+      patterns: ["app-*", "breakglass-debug"]
+
+---
+# Binding: locks this cluster down to the default namespace only
+spec:
+  namespaceConstraints:
+    defaultNamespace: "breakglass-debug"
+    denyUserNamespace: true          # Supported way to narrow a permissive template
+```
+
+Semantics:
+
+- Absent or `false` — behaviour is unchanged (this is why the field carries no `default`, so existing stored objects keep working byte-identically).
+- `true` — user-selected namespaces are rejected with an error naming `namespaceConstraints.denyUserNamespace` and the effective default namespace. Only `defaultNamespace` may be used, even if the template sets `allowUserNamespace: true`.
+- A binding cannot clear a template's `denyUserNamespace: true`; the merge is an OR because the field only ever narrows.
+
+`allowedNamespaces` / `deniedNamespaces` remain available for narrowing which namespaces are reachable, and are evaluated in addition to this switch.
 
 **Example: Production vs. Development Access**
 

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -943,11 +943,12 @@ selectorTerms:
 
 When a user creates a debug session:
 
-1. **No namespace specified**: Uses `defaultNamespace` from constraints
-2. **Namespace specified + `allowUserNamespace: false`**: Request rejected
-3. **Namespace specified + `allowUserNamespace: true`**: 
-   - Validated against `allowedNamespaces` name patterns. Selector terms may be returned to clients when they can be represented safely, but a create request that only supplies a namespace name is not accepted by selector-only allow rules unless an allowed name pattern also matches.
-   - Validated against `deniedNamespaces` name patterns (deny takes precedence). Selector terms are not treated as global name matches in the name-only validation path.
+1. **No namespace specified**: Uses `defaultNamespace` from constraints (falling back to `breakglass-debug`), still validated against the allow/deny filters
+2. **Namespace specified + `allowUserNamespace: false`** or **`denyUserNamespace: true`**: Request rejected. `denyUserNamespace` always wins over `allowUserNamespace`
+3. **Namespace specified + `allowUserNamespace: true`**:
+   - Validated against the **effective allow-list**, which is the intersection of every configured `allowedNamespaces` filter. If no `allowedNamespaces` is configured at all, **only `defaultNamespace` is allowed** — an empty allow-list is not "allow any".
+   - Validated against the union of every configured `deniedNamespaces` filter (deny takes precedence).
+   - `selectorTerms` on either the allow or the deny side are evaluated against **live namespace labels** read from the target cluster. If those labels cannot be read (spoke API error, namespace missing, no client configured), the request is **rejected** with an error naming the namespace and the offending filter — a selector-based policy is never silently skipped.
    - If a `DebugSessionClusterBinding` is selected, the namespace must satisfy both the template constraints and the binding constraints
 4. **Namespace doesn't exist**: 
    - `createIfNotExists: true`: Creates namespace with `namespaceLabels`

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -51,16 +51,20 @@ const debugSessionNamePrefix = "debug"
 
 // DebugSessionAPIController provides REST API endpoints for debug sessions
 type DebugSessionAPIController struct {
-	log          *zap.SugaredLogger
-	client       ctrlclient.Client
-	apiReader    ctrlclient.Reader // Uncached reader for consistent reads
-	ccProvider   *cluster.ClientProvider
-	middleware   gin.HandlerFunc
-	mailService  breakglass.MailEnqueuer
-	auditService breakglass.AuditEmitter
-	disableEmail bool
-	brandingName string
-	baseURL      string
+	log        *zap.SugaredLogger
+	client     ctrlclient.Client
+	apiReader  ctrlclient.Reader // Uncached reader for consistent reads
+	ccProvider *cluster.ClientProvider
+	// clusterClients optionally overrides how target-cluster clients are
+	// obtained. When nil, ccProvider is used. Tests set this to evaluate
+	// namespace selectorTerms without a live spoke cluster.
+	clusterClients ClientProviderInterface
+	middleware     gin.HandlerFunc
+	mailService    breakglass.MailEnqueuer
+	auditService   breakglass.AuditEmitter
+	disableEmail   bool
+	brandingName   string
+	baseURL        string
 }
 
 // NewDebugSessionAPIController creates a new debug session API controller
@@ -90,6 +94,14 @@ func (c *DebugSessionAPIController) WithAuditService(auditService breakglass.Aud
 // WithDisableEmail disables email notifications
 func (c *DebugSessionAPIController) WithDisableEmail(disable bool) *DebugSessionAPIController {
 	c.disableEmail = disable
+	return c
+}
+
+// WithClusterClients overrides how target-cluster clients are resolved when
+// evaluating namespace selectorTerms. When unset, the configured
+// cluster.ClientProvider is used.
+func (c *DebugSessionAPIController) WithClusterClients(provider ClientProviderInterface) *DebugSessionAPIController {
+	c.clusterClients = provider
 	return c
 }
 
@@ -1085,7 +1097,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	var warnings []string
 
 	// Validate and resolve target namespace (pass binding for constraint override)
-	targetNamespace, err := c.resolveTargetNamespace(template, req.TargetNamespace, resolvedBinding)
+	targetNamespace, err := c.resolveTargetNamespace(apiCtx, req.Cluster, template, req.TargetNamespace, resolvedBinding)
 	if err != nil {
 		// Provide more context about namespace constraints when validation fails
 		var effectiveAllowUserNs bool

--- a/pkg/breakglass/debug/debug_session_api_constraints.go
+++ b/pkg/breakglass/debug/debug_session_api_constraints.go
@@ -1,14 +1,22 @@
 package debug
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// defaultDebugNamespace is the fallback namespace used when neither the
+// template nor the binding defines a default namespace.
+const defaultDebugNamespace = "breakglass-debug"
 
 const maxRequiredNodeSelectorTerms = 128
 
@@ -26,7 +34,13 @@ func (e *schedulingOptionAccessError) Error() string {
 	return fmt.Sprintf("user is not allowed to select scheduling option '%s'", e.optionName)
 }
 
-func (c *DebugSessionAPIController) resolveTargetNamespace(template *breakglassv1alpha1.DebugSessionTemplate, requestedNamespace string, binding *breakglassv1alpha1.DebugSessionClusterBinding) (string, error) {
+func (c *DebugSessionAPIController) resolveTargetNamespace(
+	ctx context.Context,
+	cluster string,
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	requestedNamespace string,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+) (string, error) {
 	// Start with template's namespace constraints
 	nc := template.Spec.NamespaceConstraints
 
@@ -64,58 +78,49 @@ func (c *DebugSessionAPIController) resolveTargetNamespace(template *breakglassv
 		}
 		c.log.Debugw("No namespace constraints, using default",
 			"template", template.Name,
-			"resolvedNamespace", "breakglass-debug",
+			"resolvedNamespace", defaultDebugNamespace,
 		)
-		return "breakglass-debug", nil // Default namespace
+		return defaultDebugNamespace, nil // Default namespace
 	}
 
 	c.log.Debugw("Namespace constraints found",
 		"template", template.Name,
 		"allowUserNamespace", nc.AllowUserNamespace,
+		"denyUserNamespace", nc.DenyUserNamespace,
 		"defaultNamespace", nc.DefaultNamespace,
 		"hasAllowedNamespaces", nc.AllowedNamespaces != nil && !nc.AllowedNamespaces.IsEmpty(),
 		"hasDeniedNamespaces", nc.DeniedNamespaces != nil && !nc.DeniedNamespaces.IsEmpty(),
 	)
 
+	effectiveDefault := nc.DefaultNamespace
+	if effectiveDefault == "" {
+		effectiveDefault = defaultDebugNamespace
+	}
+
 	// If user didn't request a specific namespace, use the default
 	if requestedNamespace == "" {
-		if nc.DefaultNamespace != "" {
-			if err := validateEffectiveNamespaceConstraintFilters(nc.DefaultNamespace, template, binding); err != nil {
-				c.log.Debugw("Default namespace rejected by namespace constraints",
-					"template", template.Name,
-					"defaultNamespace", nc.DefaultNamespace,
-					"bindingUsed", binding != nil,
-					"error", err,
-				)
-				return "", err
-			}
-			c.log.Debugw("No namespace requested, using effective default namespace",
+		if err := c.validateEffectiveNamespaceConstraintFilters(ctx, cluster, effectiveDefault, effectiveDefault, template, binding); err != nil {
+			c.log.Debugw("Default namespace rejected by namespace constraints",
 				"template", template.Name,
-				"resolvedNamespace", nc.DefaultNamespace,
-				"bindingUsed", binding != nil,
-			)
-			return nc.DefaultNamespace, nil
-		}
-		if err := validateEffectiveNamespaceConstraintFilters("breakglass-debug", template, binding); err != nil {
-			c.log.Debugw("Fallback namespace rejected by namespace constraints",
-				"template", template.Name,
-				"fallbackNamespace", "breakglass-debug",
+				"defaultNamespace", effectiveDefault,
+				"templateDefaultSet", nc.DefaultNamespace != "",
 				"bindingUsed", binding != nil,
 				"error", err,
 			)
 			return "", err
 		}
-		c.log.Debugw("No namespace requested and no template default, using fallback",
+		c.log.Debugw("No namespace requested, using effective default namespace",
 			"template", template.Name,
-			"resolvedNamespace", "breakglass-debug",
+			"resolvedNamespace", effectiveDefault,
+			"bindingUsed", binding != nil,
 		)
-		return "breakglass-debug", nil
+		return effectiveDefault, nil
 	}
 
 	// If the requested namespace matches the default, allow it even when user namespace selection is disabled.
 	// This handles the case where the frontend sends the default namespace value in the request.
 	if nc.DefaultNamespace != "" && requestedNamespace == nc.DefaultNamespace {
-		if err := validateEffectiveNamespaceConstraintFilters(nc.DefaultNamespace, template, binding); err != nil {
+		if err := c.validateEffectiveNamespaceConstraintFilters(ctx, cluster, nc.DefaultNamespace, effectiveDefault, template, binding); err != nil {
 			c.log.Debugw("Requested default namespace rejected by namespace constraints",
 				"template", template.Name,
 				"defaultNamespace", nc.DefaultNamespace,
@@ -132,17 +137,30 @@ func (c *DebugSessionAPIController) resolveTargetNamespace(template *breakglassv
 		return nc.DefaultNamespace, nil
 	}
 
-	// Check if user is allowed to specify a namespace
+	// Check if user is allowed to specify a namespace. denyUserNamespace is an
+	// explicit narrowing switch and always wins over allowUserNamespace.
+	if nc.DenyUserNamespace {
+		c.log.Debugw("User-specified namespace explicitly denied",
+			"template", template.Name,
+			"requestedNamespace", requestedNamespace,
+			"denyUserNamespace", true,
+		)
+		return "", fmt.Errorf(
+			"template does not allow user-specified namespaces: namespaceConstraints.denyUserNamespace=true, only defaultNamespace '%s' may be used",
+			effectiveDefault)
+	}
 	if !nc.AllowUserNamespace {
 		c.log.Debugw("User-specified namespace not allowed by template",
 			"template", template.Name,
 			"requestedNamespace", requestedNamespace,
 			"allowUserNamespace", nc.AllowUserNamespace,
 		)
-		return "", fmt.Errorf("template does not allow user-specified namespaces")
+		return "", fmt.Errorf(
+			"template does not allow user-specified namespaces: namespaceConstraints.allowUserNamespace=false, only defaultNamespace '%s' may be used",
+			effectiveDefault)
 	}
 
-	if err := validateEffectiveNamespaceConstraintFilters(requestedNamespace, template, binding); err != nil {
+	if err := c.validateEffectiveNamespaceConstraintFilters(ctx, cluster, requestedNamespace, effectiveDefault, template, binding); err != nil {
 		c.log.Debugw("Namespace rejected by effective namespace constraints",
 			"template", template.Name,
 			"requestedNamespace", requestedNamespace,
@@ -179,13 +197,18 @@ func (c *DebugSessionAPIController) mergeNamespaceConstraints(
 	// AllowUserNamespace: binding cannot enable user-selected namespaces when
 	// the template disabled them. A false binding value is ambiguous because it
 	// is also the zero value, so it is not treated as an override here.
+	// Bindings that need to narrow a permissive template set the additive
+	// denyUserNamespace field instead.
 	merged.AllowUserNamespace = templateNC.AllowUserNamespace
+
+	// DenyUserNamespace: narrowing only, so either side setting it wins.
+	merged.DenyUserNamespace = templateNC.DenyUserNamespace || bindingNC.DenyUserNamespace
 
 	// DefaultNamespace: binding can change the default only to a namespace that
 	// remains allowed by both template and binding filters.
 	if bindingNC.DefaultNamespace != "" &&
-		namespaceAllowedByConstraintFilters(bindingNC.DefaultNamespace, templateNC) &&
-		namespaceAllowedByConstraintFilters(bindingNC.DefaultNamespace, bindingNC) {
+		namespaceAllowedByNameFilters(bindingNC.DefaultNamespace, templateNC) &&
+		namespaceAllowedByNameFilters(bindingNC.DefaultNamespace, bindingNC) {
 		merged.DefaultNamespace = bindingNC.DefaultNamespace
 	}
 
@@ -268,41 +291,254 @@ func namespaceTrailingStarPrefix(pattern string) (string, bool) {
 	return prefix, true
 }
 
-func namespaceAllowedByConstraintFilters(namespace string, constraints *breakglassv1alpha1.NamespaceConstraints) bool {
-	return validateNamespaceConstraintFilters(namespace, constraints) == nil
+// namespaceAllowedByNameFilters reports whether a namespace passes a single
+// constraint set using namespace names only. It is a pre-check used while
+// merging constraints (for example to decide whether a binding may move the
+// default namespace); the resolved namespace is always validated again by
+// validateEffectiveNamespaceConstraintFilters, which additionally evaluates
+// selectorTerms against live namespace labels and enforces the
+// "empty allowedNamespaces means defaultNamespace only" contract.
+func namespaceAllowedByNameFilters(namespace string, constraints *breakglassv1alpha1.NamespaceConstraints) bool {
+	if constraints == nil {
+		return true
+	}
+	if !constraints.AllowedNamespaces.IsEmpty() &&
+		!matchNamespaceFilter(namespace, constraints.AllowedNamespaces) {
+		return false
+	}
+	if !constraints.DeniedNamespaces.IsEmpty() &&
+		matchNamespaceFilter(namespace, constraints.DeniedNamespaces) {
+		return false
+	}
+	return true
 }
 
-func validateEffectiveNamespaceConstraintFilters(
+// namespaceConstraintSource pairs a constraint set with a human-readable field
+// path so that rejections can name the offending field and value.
+type namespaceConstraintSource struct {
+	fieldPath   string
+	constraints *breakglassv1alpha1.NamespaceConstraints
+}
+
+// validateEffectiveNamespaceConstraintFilters enforces the effective namespace
+// boundary of a template and (optionally) a binding.
+//
+// The allow side is evaluated ONCE against the effective allow-list, which is
+// the intersection of every configured allowedNamespaces filter. When no side
+// configures an allow-list at all, only defaultNamespace is allowed, as
+// documented on NamespaceConstraints.allowedNamespaces. Evaluating each side
+// independently would be wrong: DefaultNamespace carries a kubebuilder default,
+// so a deny-only binding has an empty allow-list plus a defaulted namespace and
+// would reject every namespace on the binding leg.
+//
+// The deny side is a union: a namespace matching any deniedNamespaces filter is
+// rejected. selectorTerms on either side are evaluated against live namespace
+// labels fetched from the target cluster; a namespace whose labels cannot be
+// resolved is rejected with an error naming the namespace and the selector,
+// because silently skipping a selector-based deny is a fail-open on a security
+// control.
+func (c *DebugSessionAPIController) validateEffectiveNamespaceConstraintFilters(
+	ctx context.Context,
+	cluster string,
 	namespace string,
+	defaultNamespace string,
 	template *breakglassv1alpha1.DebugSessionTemplate,
 	binding *breakglassv1alpha1.DebugSessionClusterBinding,
 ) error {
-	if template != nil {
-		if err := validateNamespaceConstraintFilters(namespace, template.Spec.NamespaceConstraints); err != nil {
-			return err
+	sources := make([]namespaceConstraintSource, 0, 2)
+	if template != nil && template.Spec.NamespaceConstraints != nil {
+		sources = append(sources, namespaceConstraintSource{
+			fieldPath:   fmt.Sprintf("template '%s' spec.namespaceConstraints", template.Name),
+			constraints: template.Spec.NamespaceConstraints,
+		})
+	}
+	if binding != nil && binding.Spec.NamespaceConstraints != nil {
+		sources = append(sources, namespaceConstraintSource{
+			fieldPath:   fmt.Sprintf("binding '%s/%s' spec.namespaceConstraints", binding.Namespace, binding.Name),
+			constraints: binding.Spec.NamespaceConstraints,
+		})
+	}
+	if len(sources) == 0 {
+		return nil
+	}
+
+	labels := c.newNamespaceLabelLookup(cluster, namespace)
+
+	if err := c.validateNamespaceAgainstEffectiveAllowList(ctx, namespace, defaultNamespace, sources, labels); err != nil {
+		return err
+	}
+	return c.validateNamespaceAgainstDenyUnion(ctx, namespace, sources, labels)
+}
+
+// validateNamespaceAgainstEffectiveAllowList applies the intersection of all
+// configured allowedNamespaces filters.
+func (c *DebugSessionAPIController) validateNamespaceAgainstEffectiveAllowList(
+	ctx context.Context,
+	namespace string,
+	defaultNamespace string,
+	sources []namespaceConstraintSource,
+	labels *namespaceLabelLookup,
+) error {
+	allowSources := make([]namespaceConstraintSource, 0, len(sources))
+	for _, source := range sources {
+		if !source.constraints.AllowedNamespaces.IsEmpty() {
+			allowSources = append(allowSources, source)
 		}
 	}
-	if binding != nil {
-		if err := validateNamespaceConstraintFilters(namespace, binding.Spec.NamespaceConstraints); err != nil {
-			return err
+
+	if len(allowSources) == 0 {
+		if namespace == defaultNamespace {
+			return nil
+		}
+		return fmt.Errorf(
+			"namespace '%s' is not in the allowed namespaces: no namespaceConstraints.allowedNamespaces is configured, so only defaultNamespace '%s' is allowed",
+			namespace, defaultNamespace)
+	}
+
+	for _, source := range allowSources {
+		matched, err := matchNamespaceFilterWithLabels(ctx, namespace, source.constraints.AllowedNamespaces, labels)
+		if err != nil {
+			return fmt.Errorf("namespace '%s' is not in the allowed namespaces: %s.allowedNamespaces (%s) requires namespace labels: %w",
+				namespace, source.fieldPath, describeNamespaceFilter(source.constraints.AllowedNamespaces), err)
+		}
+		if !matched {
+			return fmt.Errorf("namespace '%s' is not in the allowed namespaces: %s.allowedNamespaces (%s) does not match",
+				namespace, source.fieldPath, describeNamespaceFilter(source.constraints.AllowedNamespaces))
 		}
 	}
 	return nil
 }
 
-func validateNamespaceConstraintFilters(namespace string, constraints *breakglassv1alpha1.NamespaceConstraints) error {
-	if constraints == nil {
-		return nil
-	}
-	if constraints.AllowedNamespaces != nil && !constraints.AllowedNamespaces.IsEmpty() &&
-		!matchNamespaceFilter(namespace, constraints.AllowedNamespaces) {
-		return fmt.Errorf("namespace '%s' is not in the allowed namespaces", namespace)
-	}
-	if constraints.DeniedNamespaces != nil && !constraints.DeniedNamespaces.IsEmpty() &&
-		matchNamespaceFilter(namespace, constraints.DeniedNamespaces) {
-		return fmt.Errorf("namespace '%s' is explicitly denied", namespace)
+// validateNamespaceAgainstDenyUnion rejects the namespace if any configured
+// deniedNamespaces filter matches it.
+func (c *DebugSessionAPIController) validateNamespaceAgainstDenyUnion(
+	ctx context.Context,
+	namespace string,
+	sources []namespaceConstraintSource,
+	labels *namespaceLabelLookup,
+) error {
+	for _, source := range sources {
+		if source.constraints.DeniedNamespaces.IsEmpty() {
+			continue
+		}
+		matched, err := matchNamespaceFilterWithLabels(ctx, namespace, source.constraints.DeniedNamespaces, labels)
+		if err != nil {
+			return fmt.Errorf("namespace '%s' cannot be validated: %s.deniedNamespaces (%s) requires namespace labels: %w",
+				namespace, source.fieldPath, describeNamespaceFilter(source.constraints.DeniedNamespaces), err)
+		}
+		if matched {
+			return fmt.Errorf("namespace '%s' is explicitly denied by %s.deniedNamespaces (%s)",
+				namespace, source.fieldPath, describeNamespaceFilter(source.constraints.DeniedNamespaces))
+		}
 	}
 	return nil
+}
+
+// describeNamespaceFilter renders a filter for operator-facing error messages.
+func describeNamespaceFilter(filter *breakglassv1alpha1.NamespaceFilter) string {
+	if filter == nil {
+		return "empty"
+	}
+	parts := make([]string, 0, 2)
+	if len(filter.Patterns) > 0 {
+		parts = append(parts, fmt.Sprintf("patterns=%v", filter.Patterns))
+	}
+	if len(filter.SelectorTerms) > 0 {
+		parts = append(parts, fmt.Sprintf("selectorTerms=%d", len(filter.SelectorTerms)))
+	}
+	if len(parts) == 0 {
+		return "empty"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// matchNamespaceFilterWithLabels evaluates patterns first and only fetches live
+// namespace labels when the filter carries selectorTerms that could still match.
+func matchNamespaceFilterWithLabels(
+	ctx context.Context,
+	namespace string,
+	filter *breakglassv1alpha1.NamespaceFilter,
+	labels *namespaceLabelLookup,
+) (bool, error) {
+	if filter.IsEmpty() {
+		return false, nil
+	}
+	matcher := utils.NewNamespaceMatcher(filter)
+	if matcher.Matches(namespace) {
+		return true, nil
+	}
+	if !filter.HasSelectorTerms() {
+		return false, nil
+	}
+	if labels == nil {
+		return false, fmt.Errorf("namespace label lookup is not available")
+	}
+	nsLabels, err := labels.get(ctx)
+	if err != nil {
+		return false, err
+	}
+	return matcher.MatchesWithLabels(namespace, nsLabels), nil
+}
+
+// namespaceLabelLookup fetches namespace labels from the target cluster at most
+// once per validation pass, memoizing both the labels and any failure.
+type namespaceLabelLookup struct {
+	fetch  func(ctx context.Context) (map[string]string, error)
+	done   bool
+	labels map[string]string
+	err    error
+}
+
+func (l *namespaceLabelLookup) get(ctx context.Context) (map[string]string, error) {
+	if !l.done {
+		l.labels, l.err = l.fetch(ctx)
+		l.done = true
+	}
+	return l.labels, l.err
+}
+
+func (c *DebugSessionAPIController) newNamespaceLabelLookup(cluster, namespace string) *namespaceLabelLookup {
+	return &namespaceLabelLookup{
+		fetch: func(ctx context.Context) (map[string]string, error) {
+			return c.fetchTargetNamespaceLabels(ctx, cluster, namespace)
+		},
+	}
+}
+
+// fetchTargetNamespaceLabels reads the namespace from the target (spoke) cluster
+// so that selectorTerms can be evaluated. Errors are returned to the caller and
+// never treated as "no labels", which would silently disable selector denies.
+func (c *DebugSessionAPIController) fetchTargetNamespaceLabels(ctx context.Context, cluster, namespace string) (map[string]string, error) {
+	if cluster == "" {
+		return nil, fmt.Errorf("target cluster is unknown")
+	}
+	targetClient, err := c.targetClusterClient(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("get client for cluster '%s': %w", cluster, err)
+	}
+	if targetClient == nil {
+		return nil, fmt.Errorf("no kubernetes client is configured for cluster '%s'", cluster)
+	}
+	ns := &corev1.Namespace{}
+	if err := targetClient.Get(ctx, ctrlclient.ObjectKey{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("namespace '%s' does not exist on cluster '%s'", namespace, cluster)
+		}
+		return nil, fmt.Errorf("get namespace '%s' on cluster '%s': %w", namespace, cluster, err)
+	}
+	return ns.Labels, nil
+}
+
+// targetClusterClient resolves a client for the target cluster, reusing the same
+// ClientProviderInterface machinery as the kubectl-debug handlers.
+func (c *DebugSessionAPIController) targetClusterClient(ctx context.Context, cluster string) (ctrlclient.Client, error) {
+	if c.clusterClients != nil {
+		return c.clusterClients.GetClient(ctx, cluster)
+	}
+	if c.ccProvider == nil {
+		return nil, fmt.Errorf("cluster client provider is not configured")
+	}
+	return (&clusterClientAdapter{ccProvider: c.ccProvider}).GetClient(ctx, cluster)
 }
 
 func mergeNamespaceFilters(
@@ -332,9 +568,9 @@ func mergeNamespaceFilters(
 	return merged
 }
 
-// matchNamespaceFilter checks if a namespace name matches a NamespaceFilter.
-// Selector terms require namespace labels and are ignored by this name-only
-// validation path.
+// matchNamespaceFilter checks if a namespace name matches a NamespaceFilter
+// using patterns only. Selector terms require namespace labels; callers that
+// must honour them use matchNamespaceFilterWithLabels instead.
 func matchNamespaceFilter(namespace string, filter *breakglassv1alpha1.NamespaceFilter) bool {
 	if filter == nil || filter.IsEmpty() {
 		return false

--- a/pkg/breakglass/debug/debug_session_api_constraints.go
+++ b/pkg/breakglass/debug/debug_session_api_constraints.go
@@ -140,14 +140,16 @@ func (c *DebugSessionAPIController) resolveTargetNamespace(
 	// Check if user is allowed to specify a namespace. denyUserNamespace is an
 	// explicit narrowing switch and always wins over allowUserNamespace.
 	if nc.DenyUserNamespace {
+		source := denyUserNamespaceSource(template, binding)
 		c.log.Debugw("User-specified namespace explicitly denied",
 			"template", template.Name,
 			"requestedNamespace", requestedNamespace,
 			"denyUserNamespace", true,
+			"denySource", source,
 		)
 		return "", fmt.Errorf(
-			"template does not allow user-specified namespaces: namespaceConstraints.denyUserNamespace=true, only defaultNamespace '%s' may be used",
-			effectiveDefault)
+			"%s does not allow user-specified namespaces: namespaceConstraints.denyUserNamespace=true, only defaultNamespace '%s' may be used",
+			source, effectiveDefault)
 	}
 	if !nc.AllowUserNamespace {
 		c.log.Debugw("User-specified namespace not allowed by template",
@@ -155,9 +157,11 @@ func (c *DebugSessionAPIController) resolveTargetNamespace(
 			"requestedNamespace", requestedNamespace,
 			"allowUserNamespace", nc.AllowUserNamespace,
 		)
+		// allowUserNamespace is only ever taken from the template: a binding
+		// cannot enable or disable it (see mergeNamespaceConstraints).
 		return "", fmt.Errorf(
-			"template does not allow user-specified namespaces: namespaceConstraints.allowUserNamespace=false, only defaultNamespace '%s' may be used",
-			effectiveDefault)
+			"template '%s' does not allow user-specified namespaces: namespaceConstraints.allowUserNamespace=false, only defaultNamespace '%s' may be used",
+			template.Name, effectiveDefault)
 	}
 
 	if err := c.validateEffectiveNamespaceConstraintFilters(ctx, cluster, requestedNamespace, effectiveDefault, template, binding); err != nil {
@@ -170,6 +174,35 @@ func (c *DebugSessionAPIController) resolveTargetNamespace(
 	}
 
 	return requestedNamespace, nil
+}
+
+// denyUserNamespaceSource names the object(s) that set denyUserNamespace=true,
+// so a rejection attributes the denial to the responsible template, binding, or
+// both rather than blaming the template unconditionally.
+func denyUserNamespaceSource(
+	template *breakglassv1alpha1.DebugSessionTemplate,
+	binding *breakglassv1alpha1.DebugSessionClusterBinding,
+) string {
+	templateDenies := template != nil &&
+		template.Spec.NamespaceConstraints != nil &&
+		template.Spec.NamespaceConstraints.DenyUserNamespace
+	bindingDenies := binding != nil &&
+		binding.Spec.NamespaceConstraints != nil &&
+		binding.Spec.NamespaceConstraints.DenyUserNamespace
+
+	switch {
+	case templateDenies && bindingDenies:
+		return fmt.Sprintf("template '%s' and binding '%s/%s'",
+			template.Name, binding.Namespace, binding.Name)
+	case bindingDenies:
+		return fmt.Sprintf("binding '%s/%s'", binding.Namespace, binding.Name)
+	case templateDenies:
+		return fmt.Sprintf("template '%s'", template.Name)
+	default:
+		// Unreachable in practice: the caller only reaches this when the merged
+		// constraints deny, which requires one of the two sides to set it.
+		return "namespace constraints"
+	}
 }
 
 // mergeNamespaceConstraints merges template and binding namespace constraints.

--- a/pkg/breakglass/debug/debug_session_api_handlers_test.go
+++ b/pkg/breakglass/debug/debug_session_api_handlers_test.go
@@ -18,6 +18,7 @@ package debug
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2621,7 +2622,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
 		}
-		ns, err := ctrl.resolveTargetNamespace(template, "", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "breakglass-debug", ns)
 	})
@@ -2630,7 +2631,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{},
 		}
-		ns, err := ctrl.resolveTargetNamespace(template, "custom-ns", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "custom-ns", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "custom-ns", ns)
 	})
@@ -2643,7 +2644,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 				},
 			},
 		}
-		ns, err := ctrl.resolveTargetNamespace(template, "", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "my-debug-ns", ns)
 	})
@@ -2657,7 +2658,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 				},
 			},
 		}
-		_, err := ctrl.resolveTargetNamespace(template, "custom-ns", nil)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "custom-ns", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 	})
@@ -2673,7 +2674,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 				},
 			},
 		}
-		ns, err := ctrl.resolveTargetNamespace(template, "breakglass-debug", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "breakglass-debug", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "breakglass-debug", ns)
 	})
@@ -2691,12 +2692,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Allowed namespace
-		ns, err := ctrl.resolveTargetNamespace(template, "debug-my-session", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-my-session", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "debug-my-session", ns)
 
 		// Not allowed namespace
-		_, err = ctrl.resolveTargetNamespace(template, "prod-ns", nil)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "prod-ns", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 	})
@@ -2705,6 +2706,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					// An explicit "*" allow-list is required to opt into
+					// "any namespace except the denied ones"; an empty
+					// allowedNamespaces means defaultNamespace only.
+					AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+						Patterns: []string{"*"},
+					},
 					DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
 						Patterns: []string{"kube-*", "default"},
 					},
@@ -2714,12 +2721,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Allowed namespace
-		ns, err := ctrl.resolveTargetNamespace(template, "debug-ns", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-ns", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "debug-ns", ns)
 
 		// Denied namespace
-		_, err = ctrl.resolveTargetNamespace(template, "kube-system", nil)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "kube-system", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 	})
@@ -2738,7 +2745,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 			},
 		}
 
-		_, err := ctrl.resolveTargetNamespace(template, "debug-ns", nil)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-ns", nil)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
@@ -2748,6 +2755,9 @@ func TestResolveTargetNamespace(t *testing.T) {
 		template := &breakglassv1alpha1.DebugSessionTemplate{
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+						Patterns: []string{"*"},
+					},
 					DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
 						Patterns: []string{"kube-*"},
 						SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
@@ -2759,12 +2769,19 @@ func TestResolveTargetNamespace(t *testing.T) {
 			},
 		}
 
-		ns, err := ctrl.resolveTargetNamespace(template, "debug-ns", nil)
+		labelledCtrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+			WithClusterClients(newNamespaceLabelProvider(t, "spoke", map[string]map[string]string{
+				"debug-ns":    {"environment": "staging"},
+				"kube-system": {"environment": "production"},
+			}))
+
+		// A namespace whose labels do not match the selector is still allowed.
+		ns, err := labelledCtrl.resolveTargetNamespace(context.Background(), "spoke", template, "debug-ns", nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, "debug-ns", ns)
 
-		_, err = ctrl.resolveTargetNamespace(template, "kube-system", nil)
+		_, err = labelledCtrl.resolveTargetNamespace(context.Background(), "spoke", template, "kube-system", nil)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
@@ -2795,11 +2812,11 @@ func TestResolveTargetNamespace(t *testing.T) {
 			},
 		}
 
-		_, err := ctrl.resolveTargetNamespace(template, "custom-ns", nil)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "custom-ns", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 
-		_, err = ctrl.resolveTargetNamespace(template, "custom-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "custom-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 	})
@@ -2834,24 +2851,24 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Without binding - only debug-* is allowed
-		ns, err := ctrl.resolveTargetNamespace(template, "debug-app", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-app", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "debug-app", ns)
 
-		_, err = ctrl.resolveTargetNamespace(template, "tenant-app", nil)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "tenant-app", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 
 		// With binding - only namespaces matching both template and binding filters are allowed.
-		ns, err = ctrl.resolveTargetNamespace(template, "debug-team-app", binding)
+		ns, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-team-app", binding)
 		require.NoError(t, err)
 		assert.Equal(t, "debug-team-app", ns)
 
-		_, err = ctrl.resolveTargetNamespace(template, "debug-app", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-app", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 
-		_, err = ctrl.resolveTargetNamespace(template, "tenant-app", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "tenant-app", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 	})
@@ -2920,7 +2937,7 @@ func TestResolveTargetNamespace(t *testing.T) {
 
 		require.NotNil(t, response)
 		assert.Empty(t, response.AllowedPatterns)
-		_, err := ctrl.resolveTargetNamespace(template, "team-app", binding)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "team-app", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 	})
@@ -2953,12 +2970,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Without binding - uses template default
-		ns, err := ctrl.resolveTargetNamespace(template, "", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "template-default", ns)
 
 		// With binding - uses binding default
-		ns, err = ctrl.resolveTargetNamespace(template, "", binding)
+		ns, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "", binding)
 		require.NoError(t, err)
 		assert.Equal(t, "binding-default", ns)
 	})
@@ -2987,11 +3004,11 @@ func TestResolveTargetNamespace(t *testing.T) {
 			},
 		}
 
-		ns, err := ctrl.resolveTargetNamespace(template, "", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "template-default", ns)
 
-		_, err = ctrl.resolveTargetNamespace(template, "", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 	})
@@ -3018,11 +3035,11 @@ func TestResolveTargetNamespace(t *testing.T) {
 			},
 		}
 
-		ns, err := ctrl.resolveTargetNamespace(template, "", nil)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "breakglass-debug", ns)
 
-		_, err = ctrl.resolveTargetNamespace(template, "", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 	})
@@ -3033,6 +3050,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
 				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
 					AllowUserNamespace: true,
+					// Explicit "*" allow-list: an empty allowedNamespaces means
+					// defaultNamespace only, so the deny patterns below would
+					// otherwise never be the reason for a rejection.
+					AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+						Patterns: []string{"*"},
+					},
 					DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
 						Patterns: []string{"kube-*", "system-*"}, // Template denies kube-* and system-*
 					},
@@ -3057,27 +3080,27 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Without binding - kube-system denied
-		_, err := ctrl.resolveTargetNamespace(template, "kube-system", nil)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "kube-system", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 
 		// Without binding - system-test also denied
-		_, err = ctrl.resolveTargetNamespace(template, "system-test", nil)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "system-test", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 
 		// With binding - kube-system still denied
-		_, err = ctrl.resolveTargetNamespace(template, "kube-system", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "kube-system", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 
 		// With binding - system-test remains denied by the template.
-		_, err = ctrl.resolveTargetNamespace(template, "system-test", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "system-test", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 
 		// With binding - tenant namespaces are additionally denied by the binding.
-		_, err = ctrl.resolveTargetNamespace(template, "tenant-app", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "tenant-app", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "explicitly denied")
 	})
@@ -3105,12 +3128,12 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// With binding that has no constraints - uses template's default
-		ns, err := ctrl.resolveTargetNamespace(template, "", binding)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", binding)
 		require.NoError(t, err)
 		assert.Equal(t, "template-ns", ns)
 
 		// User namespace still blocked because binding didn't override
-		_, err = ctrl.resolveTargetNamespace(template, "custom-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "custom-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 	})
@@ -3166,24 +3189,24 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// Without binding - user namespace blocked by template
-		_, err := ctrl.resolveTargetNamespace(template, "debug-my-session", nil)
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-my-session", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 
-		_, err = ctrl.resolveTargetNamespace(template, "debug-my-session", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "debug-my-session", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 
-		_, err = ctrl.resolveTargetNamespace(template, "breakglass-test", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "breakglass-test", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 
-		_, err = ctrl.resolveTargetNamespace(template, "production-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "production-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not allow user-specified namespaces")
 
 		// With binding - empty namespace uses default
-		ns, err := ctrl.resolveTargetNamespace(template, "", binding)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "", binding)
 		require.NoError(t, err)
 		assert.Equal(t, "breakglass-debug", ns)
 	})
@@ -3219,22 +3242,22 @@ func TestResolveTargetNamespace(t *testing.T) {
 		}
 
 		// With binding - safe-team-* matches both the template and binding filters.
-		ns, err := ctrl.resolveTargetNamespace(template, "safe-team-ns", binding)
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "", template, "safe-team-ns", binding)
 		require.NoError(t, err)
 		assert.Equal(t, "safe-team-ns", ns)
 
 		// With binding - safe-* alone no longer satisfies the binding filter.
-		_, err = ctrl.resolveTargetNamespace(template, "safe-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "safe-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 
 		// With binding - binding-only patterns cannot widen the template boundary.
-		_, err = ctrl.resolveTargetNamespace(template, "extra-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "extra-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 
 		// With binding - random namespace still blocked
-		_, err = ctrl.resolveTargetNamespace(template, "random-ns", binding)
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "", template, "random-ns", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in the allowed namespaces")
 	})

--- a/pkg/breakglass/debug/debug_session_api_namespace_constraints_test.go
+++ b/pkg/breakglass/debug/debug_session_api_namespace_constraints_test.go
@@ -1,0 +1,624 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+)
+
+// newNamespaceLabelProvider returns a ClientProviderInterface whose client for
+// clusterName serves the given namespaces with the given labels.
+func newNamespaceLabelProvider(t *testing.T, clusterName string, namespaces map[string]map[string]string) ClientProviderInterface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for name, labels := range namespaces {
+		builder = builder.WithObjects(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		})
+	}
+	return &mockClientProvider{clients: map[string]ctrlclient.Client{clusterName: builder.Build()}}
+}
+
+// failingClientProvider simulates a spoke API failure while resolving the
+// target-cluster client.
+type failingClientProvider struct {
+	err error
+}
+
+func (f *failingClientProvider) GetClient(_ context.Context, _ string) (ctrlclient.Client, error) {
+	return nil, f.err
+}
+
+// =============================================================================
+// Finding 006 — an empty allowedNamespaces must mean "defaultNamespace only"
+// =============================================================================
+
+func TestResolveTargetNamespace_EmptyAllowListMeansDefaultOnly(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+	// Documented contract on NamespaceConstraints.allowedNamespaces:
+	// "If empty, only defaultNamespace is allowed."
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-allowlist"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				// No allowedNamespaces at all.
+			},
+		},
+	}
+
+	t.Run("arbitrary namespace is rejected", func(t *testing.T) {
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "kube-system", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace 'kube-system' is not in the allowed namespaces")
+		// The rejection names the field and the effective default so an
+		// operator can see why instantly.
+		assert.Contains(t, err.Error(), "namespaceConstraints.allowedNamespaces")
+		assert.Contains(t, err.Error(), "breakglass-debug")
+	})
+
+	t.Run("default namespace is still allowed", func(t *testing.T) {
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "breakglass-debug", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+	})
+
+	t.Run("implicit fallback default is still allowed", func(t *testing.T) {
+		noDefault := template.DeepCopy()
+		noDefault.Spec.NamespaceConstraints.DefaultNamespace = ""
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", noDefault, "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+	})
+}
+
+// TestResolveTargetNamespace_DenyOnlyBindingStillWorks pins the regression that
+// a naive "empty allow-list means default only" guard would introduce.
+// DefaultNamespace carries +kubebuilder:default="breakglass-debug", so a
+// deny-only binding always has an empty allow-list plus a defaulted namespace.
+// Evaluating the allow side per-side would reject every namespace on the binding
+// leg and break the shape the shipped Helm chart emits.
+func TestResolveTargetNamespace_DenyOnlyBindingStillWorks(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-allows-debug"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					Patterns: []string{"debug-*", "breakglass-debug"},
+				},
+			},
+		},
+	}
+
+	// Deny-only binding, exactly as the escalation-config chart renders it:
+	// defaultNamespace defaulted by the apiserver, deniedNamespaces set,
+	// allowedNamespaces absent.
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-only", Namespace: "tenant"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace: "breakglass-debug",
+				DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					Patterns: []string{"debug-prod-*"},
+				},
+			},
+		},
+	}
+
+	t.Run("template-allowed namespace remains allowed through a deny-only binding", func(t *testing.T) {
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "debug-team-a", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "debug-team-a", ns)
+	})
+
+	t.Run("binding deny is enforced", func(t *testing.T) {
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "debug-prod-a", binding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "explicitly denied")
+		assert.Contains(t, err.Error(), "binding 'tenant/deny-only'")
+	})
+
+	t.Run("template allow-list is still enforced through the binding", func(t *testing.T) {
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "tenant-app", binding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not in the allowed namespaces")
+		assert.Contains(t, err.Error(), "template 'template-allows-debug'")
+	})
+
+	t.Run("default namespace resolution still works", func(t *testing.T) {
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+	})
+}
+
+// =============================================================================
+// Finding 007 — selectorTerms must be evaluated against live namespace labels
+// =============================================================================
+
+func TestResolveTargetNamespace_SelectorDenyIsEnforcedWithLiveLabels(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "selector-deny"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					Patterns: []string{"app-*"},
+				},
+				DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					// Selector-only deny: no patterns at all, so the old
+					// name-only path could never fire.
+					SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+						{MatchLabels: map[string]string{"environment": "production"}},
+					},
+				},
+			},
+		},
+	}
+
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+		WithClusterClients(newNamespaceLabelProvider(t, "spoke", map[string]map[string]string{
+			"app-prod":    {"environment": "production"},
+			"app-staging": {"environment": "staging"},
+		}))
+
+	t.Run("selector-based deny rejects a production namespace", func(t *testing.T) {
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-prod", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace 'app-prod' is explicitly denied")
+		assert.Contains(t, err.Error(), "deniedNamespaces")
+		assert.Contains(t, err.Error(), "selectorTerms=1")
+	})
+
+	t.Run("non-matching labels are still allowed", func(t *testing.T) {
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-staging", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "app-staging", ns)
+	})
+}
+
+func TestResolveTargetNamespace_SelectorAllowIsEnforcedWithLiveLabels(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "selector-allow"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+						{MatchLabels: map[string]string{"debug-enabled": "true"}},
+					},
+				},
+			},
+		},
+	}
+
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+		WithClusterClients(newNamespaceLabelProvider(t, "spoke", map[string]map[string]string{
+			"opted-in":  {"debug-enabled": "true"},
+			"opted-out": {"debug-enabled": "false"},
+		}))
+
+	ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "opted-in", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "opted-in", ns)
+
+	_, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "opted-out", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in the allowed namespaces")
+}
+
+// TestResolveTargetNamespace_SelectorLabelFetchFailure documents the deliberate
+// fail-closed decision: when a selector-based filter cannot be evaluated, the
+// request is rejected with an error that names the namespace, the owning field
+// and the selector, rather than silently skipping the filter.
+func TestResolveTargetNamespace_SelectorLabelFetchFailure(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+
+	denyTemplate := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "selector-deny-unreachable"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					Patterns: []string{"app-*"},
+				},
+				DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+						{MatchLabels: map[string]string{"environment": "production"}},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("spoke API error rejects instead of allowing", func(t *testing.T) {
+		ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+			WithClusterClients(&failingClientProvider{err: errors.New("connection refused")})
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", denyTemplate, "app-prod", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace 'app-prod' cannot be validated")
+		assert.Contains(t, err.Error(), "deniedNamespaces")
+		assert.Contains(t, err.Error(), "selectorTerms=1")
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("missing namespace rejects with a clear message", func(t *testing.T) {
+		ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+			WithClusterClients(newNamespaceLabelProvider(t, "spoke", map[string]map[string]string{
+				"app-staging": {"environment": "staging"},
+			}))
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", denyTemplate, "app-prod", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace 'app-prod' does not exist on cluster 'spoke'")
+	})
+
+	t.Run("no cluster client configured rejects", func(t *testing.T) {
+		ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", denyTemplate, "app-prod", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cluster client provider is not configured")
+	})
+
+	t.Run("pattern-only constraints never need labels", func(t *testing.T) {
+		patternTemplate := &breakglassv1alpha1.DebugSessionTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "patterns-only"},
+			Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace:   "breakglass-debug",
+					AllowUserNamespace: true,
+					AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+						Patterns: []string{"app-*"},
+					},
+				},
+			},
+		}
+		ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+			WithClusterClients(&failingClientProvider{err: errors.New("connection refused")})
+
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", patternTemplate, "app-prod", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "app-prod", ns)
+	})
+}
+
+// =============================================================================
+// Finding 008 — additive denyUserNamespace
+// =============================================================================
+
+func TestResolveTargetNamespace_DenyUserNamespace(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+	// Permissive template: users may pick any app-* namespace.
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "permissive"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					Patterns: []string{"app-*", "breakglass-debug"},
+				},
+			},
+		},
+	}
+
+	t.Run("binding with denyUserNamespace narrows the permissive template", func(t *testing.T) {
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "locked-down", Namespace: "tenant"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace:  "breakglass-debug",
+					DenyUserNamespace: true,
+				},
+			},
+		}
+
+		// Without the binding the template permits the namespace.
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-one", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "app-one", ns)
+
+		// With the binding it is refused, naming the responsible field.
+		_, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-one", binding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
+		assert.Contains(t, err.Error(), "breakglass-debug")
+
+		// The default namespace still resolves.
+		ns, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+
+		// Requesting the default explicitly still works.
+		ns, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "breakglass-debug", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+	})
+
+	t.Run("template-level denyUserNamespace also narrows", func(t *testing.T) {
+		locked := template.DeepCopy()
+		locked.Spec.NamespaceConstraints.DenyUserNamespace = true
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", locked, "app-one", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
+	})
+
+	t.Run("bindings cannot clear a template denyUserNamespace", func(t *testing.T) {
+		locked := template.DeepCopy()
+		locked.Spec.NamespaceConstraints.DenyUserNamespace = true
+
+		permissiveBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "tries-to-widen", Namespace: "tenant"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace:   "breakglass-debug",
+					AllowUserNamespace: true,
+					DenyUserNamespace:  false,
+				},
+			},
+		}
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", locked, "app-one", permissiveBinding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
+	})
+
+	// Backwards-compatibility regression: existing objects that do not set the
+	// new field must behave exactly as before.
+	t.Run("field unset behaves exactly as today", func(t *testing.T) {
+		binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "legacy", Namespace: "tenant"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace: "breakglass-debug",
+					// denyUserNamespace intentionally absent.
+				},
+			},
+		}
+		require.False(t, binding.Spec.NamespaceConstraints.DenyUserNamespace)
+
+		ns, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-one", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "app-one", ns)
+
+		ns, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "", binding)
+		require.NoError(t, err)
+		assert.Equal(t, "breakglass-debug", ns)
+	})
+
+	t.Run("merge is a narrowing OR and leaves other fields untouched", func(t *testing.T) {
+		templateNC := template.Spec.NamespaceConstraints.DeepCopy()
+		bindingNC := &breakglassv1alpha1.NamespaceConstraints{DenyUserNamespace: true}
+
+		merged := ctrl.mergeNamespaceConstraints(templateNC, bindingNC)
+		require.NotNil(t, merged)
+		assert.True(t, merged.DenyUserNamespace)
+		assert.True(t, merged.AllowUserNamespace, "allowUserNamespace still comes from the template")
+
+		// Unset on both sides stays unset.
+		mergedUnset := ctrl.mergeNamespaceConstraints(templateNC, &breakglassv1alpha1.NamespaceConstraints{})
+		require.NotNil(t, mergedUnset)
+		assert.False(t, mergedUnset.DenyUserNamespace)
+	})
+}
+
+// TestResolveNamespaceConstraintsResponse_DenyUserNamespace verifies the API
+// hint surfaced to clients reflects the narrowing.
+func TestResolveNamespaceConstraintsResponse_DenyUserNamespace(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+	template := &breakglassv1alpha1.DebugSessionTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "permissive"},
+		Spec: breakglassv1alpha1.DebugSessionTemplateSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DefaultNamespace:   "breakglass-debug",
+				AllowUserNamespace: true,
+			},
+		},
+	}
+
+	response := ctrl.resolveNamespaceConstraints(template, nil)
+	require.NotNil(t, response)
+	assert.True(t, response.AllowUserNamespace)
+
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "locked-down", Namespace: "tenant"},
+		Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+			NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+				DenyUserNamespace: true,
+			},
+		},
+	}
+
+	narrowed := ctrl.resolveNamespaceConstraints(template, binding)
+	require.NotNil(t, narrowed)
+	assert.False(t, narrowed.AllowUserNamespace)
+}
+
+func TestNamespaceAllowedByNameFilters(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		constraints *breakglassv1alpha1.NamespaceConstraints
+		want        bool
+	}{
+		{name: "nil constraints allow", namespace: "any", constraints: nil, want: true},
+		{name: "no filters allow", namespace: "any", constraints: &breakglassv1alpha1.NamespaceConstraints{}, want: true},
+		{
+			name:      "allow pattern matches",
+			namespace: "debug-a",
+			constraints: &breakglassv1alpha1.NamespaceConstraints{
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"debug-*"}},
+			},
+			want: true,
+		},
+		{
+			name:      "allow pattern does not match",
+			namespace: "prod-a",
+			constraints: &breakglassv1alpha1.NamespaceConstraints{
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"debug-*"}},
+			},
+			want: false,
+		},
+		{
+			name:      "deny pattern matches",
+			namespace: "kube-system",
+			constraints: &breakglassv1alpha1.NamespaceConstraints{
+				DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"kube-*"}},
+			},
+			want: false,
+		},
+		{
+			name:      "deny pattern does not match",
+			namespace: "debug-a",
+			constraints: &breakglassv1alpha1.NamespaceConstraints{
+				DeniedNamespaces: &breakglassv1alpha1.NamespaceFilter{Patterns: []string{"kube-*"}},
+			},
+			want: true,
+		},
+		{
+			name:      "selector-only filters are not name matches",
+			namespace: "debug-a",
+			constraints: &breakglassv1alpha1.NamespaceConstraints{
+				AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+					SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+						{MatchLabels: map[string]string{"a": "b"}},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, namespaceAllowedByNameFilters(tt.namespace, tt.constraints))
+		})
+	}
+}
+
+func TestDescribeNamespaceFilter(t *testing.T) {
+	assert.Equal(t, "empty", describeNamespaceFilter(nil))
+	assert.Equal(t, "empty", describeNamespaceFilter(&breakglassv1alpha1.NamespaceFilter{}))
+	assert.Equal(t, "patterns=[a-*]", describeNamespaceFilter(
+		&breakglassv1alpha1.NamespaceFilter{Patterns: []string{"a-*"}}))
+	assert.Equal(t, "patterns=[a-*], selectorTerms=1", describeNamespaceFilter(
+		&breakglassv1alpha1.NamespaceFilter{
+			Patterns: []string{"a-*"},
+			SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+				{MatchLabels: map[string]string{"a": "b"}},
+			},
+		}))
+	assert.Equal(t, "selectorTerms=2", describeNamespaceFilter(
+		&breakglassv1alpha1.NamespaceFilter{
+			SelectorTerms: []breakglassv1alpha1.NamespaceSelectorTerm{
+				{MatchLabels: map[string]string{"a": "b"}},
+				{MatchLabels: map[string]string{"c": "d"}},
+			},
+		}))
+}
+
+// TestNamespaceLabelLookupMemoizes ensures the target namespace is read at most
+// once per validation pass, including when the read fails.
+func TestNamespaceLabelLookupMemoizes(t *testing.T) {
+	calls := 0
+	lookup := &namespaceLabelLookup{
+		fetch: func(_ context.Context) (map[string]string, error) {
+			calls++
+			return map[string]string{"a": "b"}, nil
+		},
+	}
+
+	got, err := lookup.get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "b"}, got)
+
+	got, err = lookup.get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "b"}, got)
+	assert.Equal(t, 1, calls, "labels must be fetched at most once")
+
+	failCalls := 0
+	failing := &namespaceLabelLookup{
+		fetch: func(_ context.Context) (map[string]string, error) {
+			failCalls++
+			return nil, errors.New("boom")
+		},
+	}
+	_, err = failing.get(context.Background())
+	require.Error(t, err)
+	_, err = failing.get(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, 1, failCalls, "failures must be memoized too")
+}
+
+func TestFetchTargetNamespaceLabels_UnknownCluster(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil)
+
+	_, err := ctrl.fetchTargetNamespaceLabels(context.Background(), "", "ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target cluster is unknown")
+}
+
+func TestTargetClusterClient_NilClientFromProvider(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	// mockClientProvider returns (nil, nil) for unknown clusters.
+	ctrl := NewDebugSessionAPIController(logger, nil, nil, nil).
+		WithClusterClients(&mockClientProvider{clients: map[string]ctrlclient.Client{}})
+
+	_, err := ctrl.fetchTargetNamespaceLabels(context.Background(), "unknown", "ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no kubernetes client is configured for cluster 'unknown'")
+}

--- a/pkg/breakglass/debug/debug_session_api_namespace_constraints_test.go
+++ b/pkg/breakglass/debug/debug_session_api_namespace_constraints_test.go
@@ -367,11 +367,14 @@ func TestResolveTargetNamespace_DenyUserNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "app-one", ns)
 
-		// With the binding it is refused, naming the responsible field.
+		// With the binding it is refused, naming the responsible object and field.
 		_, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "app-one", binding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
 		assert.Contains(t, err.Error(), "breakglass-debug")
+		// The binding set the switch, so the binding must be blamed, not the template.
+		assert.Contains(t, err.Error(), "binding 'tenant/locked-down'")
+		assert.NotContains(t, err.Error(), "template 'permissive'")
 
 		// The default namespace still resolves.
 		ns, err = ctrl.resolveTargetNamespace(context.Background(), "spoke", template, "", binding)
@@ -391,6 +394,7 @@ func TestResolveTargetNamespace_DenyUserNamespace(t *testing.T) {
 		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", locked, "app-one", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
+		assert.Contains(t, err.Error(), "template 'permissive'")
 	})
 
 	t.Run("bindings cannot clear a template denyUserNamespace", func(t *testing.T) {
@@ -411,6 +415,41 @@ func TestResolveTargetNamespace_DenyUserNamespace(t *testing.T) {
 		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", locked, "app-one", permissiveBinding)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "namespaceConstraints.denyUserNamespace=true")
+		assert.Contains(t, err.Error(), "template 'permissive'")
+	})
+
+	t.Run("both sides denying names both objects", func(t *testing.T) {
+		locked := template.DeepCopy()
+		locked.Spec.NamespaceConstraints.DenyUserNamespace = true
+
+		lockedBinding := &breakglassv1alpha1.DebugSessionClusterBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "also-locked", Namespace: "tenant"},
+			Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{
+				NamespaceConstraints: &breakglassv1alpha1.NamespaceConstraints{
+					DefaultNamespace:  "breakglass-debug",
+					DenyUserNamespace: true,
+				},
+			},
+		}
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", locked, "app-one", lockedBinding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "template 'permissive' and binding 'tenant/also-locked'")
+	})
+
+	t.Run("allowUserNamespace rejection names the template", func(t *testing.T) {
+		restrictive := template.DeepCopy()
+		restrictive.Spec.NamespaceConstraints.AllowUserNamespace = false
+
+		_, err := ctrl.resolveTargetNamespace(context.Background(), "spoke", restrictive, "app-one", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "template 'permissive'")
+		assert.Contains(t, err.Error(), "namespaceConstraints.allowUserNamespace=false")
+	})
+
+	t.Run("denyUserNamespaceSource fallback", func(t *testing.T) {
+		// Defensive branch: neither side sets the switch.
+		assert.Equal(t, "namespace constraints", denyUserNamespaceSource(nil, nil))
 	})
 
 	// Backwards-compatibility regression: existing objects that do not set the

--- a/pkg/breakglass/debug/debug_session_api_resolution.go
+++ b/pkg/breakglass/debug/debug_session_api_resolution.go
@@ -114,8 +114,10 @@ func (c *DebugSessionAPIController) resolveNamespaceConstraints(template *breakg
 	}
 
 	response := &NamespaceConstraintsResponse{
-		DefaultNamespace:   nc.DefaultNamespace,
-		AllowUserNamespace: nc.AllowUserNamespace,
+		DefaultNamespace: nc.DefaultNamespace,
+		// denyUserNamespace narrows, so it wins over allowUserNamespace in the
+		// hint surfaced to clients.
+		AllowUserNamespace: nc.AllowUserNamespace && !nc.DenyUserNamespace,
 	}
 
 	if nc.AllowedNamespaces != nil {

--- a/pkg/breakglass/debug/debug_session_api_templates.go
+++ b/pkg/breakglass/debug/debug_session_api_templates.go
@@ -348,8 +348,9 @@ func (c *DebugSessionAPIController) buildTemplateResponse(
 
 	if template.Spec.NamespaceConstraints != nil {
 		resp.NamespaceConstraints = &NamespaceConstraintsResponse{
-			DefaultNamespace:   template.Spec.NamespaceConstraints.DefaultNamespace,
-			AllowUserNamespace: template.Spec.NamespaceConstraints.AllowUserNamespace,
+			DefaultNamespace: template.Spec.NamespaceConstraints.DefaultNamespace,
+			AllowUserNamespace: template.Spec.NamespaceConstraints.AllowUserNamespace &&
+				!template.Spec.NamespaceConstraints.DenyUserNamespace,
 		}
 		if template.Spec.NamespaceConstraints.AllowedNamespaces != nil {
 			resp.NamespaceConstraints.AllowedPatterns = template.Spec.NamespaceConstraints.AllowedNamespaces.Patterns

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -3752,6 +3752,11 @@ func TestDebugSessionAPIController_HandleCreateDebugSession(t *testing.T) {
 		templateWithUserNamespace.Spec.NamespaceConstraints = &breakglassv1alpha1.NamespaceConstraints{
 			AllowUserNamespace: true,
 			DefaultNamespace:   "default-debug",
+			// An allow-list is required to permit user-selected namespaces:
+			// an empty allowedNamespaces means defaultNamespace only.
+			AllowedNamespaces: &breakglassv1alpha1.NamespaceFilter{
+				Patterns: []string{"debug-*"},
+			},
 		}
 		clusterConfig := &breakglassv1alpha1.ClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "production", Namespace: "breakglass-control"},


### PR DESCRIPTION
## Summary

Fixes three namespace-constraint **enforcement bugs inside the model introduced by PR #889**
("fix: prevent debug binding namespace widening", `e130127e9`). This PR does **not** reverse #889's
narrowing intent: bindings may still only narrow a template's namespace boundary, never widen it.
Every change here either closes a fail-open in that model or gives operators a supported way to
express narrowing that the current API shape cannot express.

| # | Bug | Location |
|---|---|---|
| 006 | Empty `allowedNamespaces` skipped the allow-list entirely, while the API contract documents *"If empty, only defaultNamespace is allowed"* | `pkg/breakglass/debug/debug_session_api_constraints.go:297` vs `api/v1alpha1/debug_session_template_types.go:915` |
| 007 | `matchNamespaceFilter` read only `Patterns`; `SelectorTerms` were populated by `mergeNamespaceFilters` and never evaluated, so a selector-based **deny** never fired | `pkg/breakglass/debug/debug_session_api_constraints.go:338` (populated at `:331`) |
| 008 | A binding could not disable user-selected namespaces on a permissive template, contradicting the documented "bindings only narrow" rule | `pkg/breakglass/debug/debug_session_api_constraints.go:182`, `docs/debug-session-cluster-binding.md:951` |

## 006 — effective allow-list, and why the naive fix is wrong

The obvious fix is a guard in `validateNamespaceConstraintFilters`: "allow-list empty ⇒ only
`defaultNamespace`". That breaks production configs.

`validateEffectiveNamespaceConstraintFilters` applied `validateNamespaceConstraintFilters` to the
template and the binding **independently**. `NamespaceConstraints.DefaultNamespace` carries
`+kubebuilder:default="breakglass-debug"`, so a binding that sets only `deniedNamespaces` always
arrives with an **empty allow-list plus a defaulted `breakglass-debug`**. A per-side guard therefore
rejects every namespace on the binding leg — breaking deny-only bindings, which is exactly the shape
the shipped Helm chart emits (`charts/escalation-config/templates/debugsessionclusterbinding.yaml`).

The fix restructures the validation instead:

- the **allow** side is evaluated **once** against the **effective allow-list** = intersection of every
  configured `allowedNamespaces` filter. If no side configures one at all, only `defaultNamespace` is
  allowed, as documented.
- the **deny** side remains a **union**: matching any configured `deniedNamespaces` rejects.

`TestResolveTargetNamespace_DenyOnlyBindingStillWorks` pins this. It is the most important regression
in the PR, and the "naive fix" experiment below shows it failing under that approach.

## 007 — live label plumbing

`selectorTerms` on either the allow or the deny side are now evaluated against **live namespace
labels** read from the target cluster, reusing the existing correct precedent
(`isNamespaceAllowedForEphemeral` at `pkg/breakglass/debug/debug_session_kubectl.go:727` →
`ccProvider` + `utils.NewNamespaceMatcher`/`MatchesWithLabels`) rather than inventing a second
mechanism.

- `resolveTargetNamespace` now takes `ctx` and the target cluster name; context is threaded through
  properly and **no client is stashed in a package-level var**.
- Labels are fetched **at most once per validation pass** (memoized, including failures) and **only**
  when a filter actually carries `selectorTerms` — pattern-only configurations never touch the spoke.
- Target-cluster clients resolve through the existing `ClientProviderInterface`; a new
  `WithClusterClients` option lets tests supply a fake without a live spoke.

**Failure handling: deny with a clear error, not requeue.** Justification: this is a synchronous
`POST /api/debugSessions` create path, not a reconcile loop, so there is no requeue to fall back to —
the alternatives are deny or allow. Allowing is a fail-open on a security control, which is the bug
being fixed. Because a wrong deny in an emergency-access tool is costly, the rejection is made maximally
diagnosable: it names the namespace, the owning object and field path, the offending filter
(`patterns=[...]`, `selectorTerms=N`), and wraps the underlying cause (`connection refused`,
`namespace 'x' does not exist on cluster 'y'`, `cluster client provider is not configured`). An operator
sees *why* immediately and can retry once the spoke is reachable.

## 008 — additive field, not `*bool`

`AllowUserNamespace` carries `+kubebuilder:default=false` and the generated CRDs persist
`default: false`. That makes the tri-state migration **not free**:

- **keep the marker** → apiserver structural defaulting fills the pointer on every create *and* update,
  so it is never nil for anything written through the API; an explicit `false` stays indistinguishable
  from unset and the bug is not fixed.
- **remove the marker** → every already-stored object has `false` persisted (defaulted at admission when
  written), which then reads as an *explicit override* and silently disables user namespaces on
  templates that permit them.

So this adds a new, unambiguously-named `denyUserNamespace` field with **no** `+kubebuilder:default`:

- absent or `false` = today's behaviour, byte-identically, with no migration of stored data;
- `true` = narrow: user-selected namespaces are rejected even if the template sets
  `allowUserNamespace: true`;
- the merge is a narrowing **OR**, so a binding can never clear a template's `true`.

## CHANGELOG correction

`CHANGELOG.md:570-574` still advertised the *pre*-#889 semantics ("Bindings can now override template
namespace constraints… Enables bindings to grant more namespace access than the base template allows"),
which #889 deliberately reversed. That contradiction is why an automated scan read these deliberate
shapes as bugs. The entry now records that it was superseded by #889 and points at the current docs.

## Upgrade impact

006 and 007 **tighten** enforcement, so configurations that work today may stop working. That is the
point, but it is a behaviour change:

| Config shape | Before | After | Action |
|---|---|---|---|
| `namespaceConstraints` with `allowUserNamespace: true` and **no** `allowedNamespaces` | any namespace accepted | only `defaultNamespace` accepted | add `allowedNamespaces.patterns` listing the intended namespaces, or `["*"]` to keep "any except denied" |
| Binding with only `deniedNamespaces` (no `allowedNamespaces`) | template allow-list enforced; binding denies enforced | **unchanged** | none — the effective-allow-list restructure preserves this shape deliberately |
| `deniedNamespaces` with `selectorTerms` | selector silently ignored on create; deny never fired | selector evaluated against live labels; matching namespaces rejected | verify the selector matches only what you intend to deny |
| `allowedNamespaces` with `selectorTerms` only | rejected everything (fail-closed) | namespaces whose labels match are accepted | none — relaxation in the intended direction |
| Any selector-based filter where the namespace or spoke API is unreachable | filter skipped, request allowed | request rejected with a diagnosable error | ensure the controller can read namespaces on the target cluster |

No new required fields. No stored object changes meaning on upgrade
(`TestNamespaceConstraints_DenyUserNamespaceIsAdditive` proves the round trip is byte-identical, and
that an explicit `false` on the wire is inert and is not re-serialized).

## Test evidence (before/after)

Each finding has a test that **fails before the fix and passes after**, verified by reverting the fix in
place.

**006 — revert the effective-allow-list check to the old "skip when empty":**
```
--- FAIL: TestResolveTargetNamespace_EmptyAllowListMeansDefaultOnly
    --- FAIL: .../arbitrary_namespace_is_rejected
            Error: An error is expected but got nil.
```

**006 trap — apply the *naive* per-side guard instead (this is why the restructure exists):**
```
--- FAIL: TestResolveTargetNamespace_DenyOnlyBindingStillWorks
    --- FAIL: .../template-allowed_namespace_remains_allowed_through_a_deny-only_binding
            Error: Received unexpected error:
    --- FAIL: .../binding_deny_is_enforced
            Error: "namespace 'debug-prod-a' is not in the allowed namespaces: binding 'tenant/deny-only'
                    spec.namespaceConstraints has no allowedNamespaces" does not contain "explicitly denied"
    --- FAIL: .../template_allow-list_is_still_enforced_through_the_binding
```

**007 — revert `matchNamespaceFilterWithLabels` to ignore `selectorTerms`:**
```
--- FAIL: TestResolveTargetNamespace_SelectorDenyIsEnforcedWithLiveLabels
    --- FAIL: .../selector-based_deny_rejects_a_production_namespace
            Error: An error is expected but got nil.
--- FAIL: TestResolveTargetNamespace_SelectorAllowIsEnforcedWithLiveLabels
--- FAIL: TestResolveTargetNamespace_SelectorLabelFetchFailure
    --- FAIL: .../spoke_API_error_rejects_instead_of_allowing
    --- FAIL: .../missing_namespace_rejects_with_a_clear_message
    --- FAIL: .../no_cluster_client_configured_rejects
```

**008 — revert the `denyUserNamespace` enforcement and merge:**
```
--- FAIL: TestResolveTargetNamespace_DenyUserNamespace
    --- FAIL: .../binding_with_denyUserNamespace_narrows_the_permissive_template
    --- FAIL: .../template-level_denyUserNamespace_also_narrows
    --- FAIL: .../bindings_cannot_clear_a_template_denyUserNamespace
    --- FAIL: .../merge_is_a_narrowing_OR_and_leaves_other_fields_untouched
--- FAIL: TestResolveNamespaceConstraintsResponse_DenyUserNamespace
```

**With all fixes in place:**
```
ok  github.com/telekom/k8s-breakglass/pkg/breakglass/debug   17.850s  coverage: 78.4% of statements
ok  github.com/telekom/k8s-breakglass/api/v1alpha1            8.099s  (-race)
ok  github.com/telekom/k8s-breakglass/pkg/breakglass/debug   13.752s  (-race)
```

Coverage of the new/changed functions: `validateNamespaceAgainstEffectiveAllowList` 100%,
`validateNamespaceAgainstDenyUnion` 100%, `describeNamespaceFilter` 100%,
`namespaceAllowedByNameFilters` 100%, `namespaceLabelLookup.get` 100%,
`fetchTargetNamespaceLabels` 92.3%, `resolveTargetNamespace` 92.5%,
`validateEffectiveNamespaceConstraintFilters` 90.9%, `matchNamespaceFilterWithLabels` 84.6%.

Fuzz case added per `api/AGENTS.md` rule 4:
```
fuzz: elapsed: 15s, execs: 141313 (10207/sec), new interesting: 3 (total: 12)
PASS
```

## Verification

- `make generate && make manifests` — clean, no further diff; committed CRD YAML updated (3 CRDs, +36 lines)
- `make fmt vet lint-strict` — `0 issues.`
- `make test` — all packages pass
- `go test -race ./pkg/breakglass/debug/ ./api/v1alpha1/` — pass
- `make validate-crds validate-samples validate-fixtures` — `CRD validation passed`, `Sample validation passed`, `Fixture validation passed`

Also updated: the `escalation-config` chart template and `values.schema.json` so `denyUserNamespace` is
reachable from Helm values, and the `NamespaceConstraintsResponse` API hint so the UI reflects the
narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
