### PR TITLE
fix: distinguish empty and missing approver groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **AD/Keycloak approver group reporting**: Existing empty groups are reported as `GroupMembersEmpty`, while missing groups return an explicit sync failure, remove stale cached approvers, and emit a `GroupNotFound` warning instead of being treated as successful empty groups.
+- **AD/Keycloak approver group reporting**: Existing empty groups are reported as `GroupMembersEmpty`, while missing groups return an explicit sync failure, remove stale cached approvers, and emit a `GroupNotFound` warning instead of being treated as successful empty groups. (#1224)
 
 ## [0.1.0-rc.4] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AD/Keycloak approver group reporting**: Existing empty groups are reported as `GroupMembersEmpty`, while missing groups return an explicit sync failure, remove stale cached approvers, and emit a `GroupNotFound` warning instead of being treated as successful empty groups.
+
 ## [0.1.0-rc.4] - 2026-08-05
 
 ### Fixed

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -623,6 +623,16 @@ Check related `BreakglassEscalation` and `IdentityProvider` events for the speci
 failing group or provider. Escalations with no approver groups report
 `NoApproverGroupsConfigured` because no group member lookup is required.
 
+An existing identity-provider group with no resolvable members is reported
+separately with `status: "True"` and reason `GroupMembersEmpty`. This is a
+successful lookup, but no approver can approve from that group, so pending
+sessions can reach `ApprovalTimeout`. A group that is not present in the
+identity provider is a sync failure: when it is the only sync failure, the
+condition is `False` with reason `GroupNotFound`; mixed failures retain
+`GroupSyncPartialFailure` or `GroupSyncFailed` and name the missing group in
+the condition message. In all cases, stale cached members are removed and a
+warning event identifies the missing group.
+
 #### Condition Reasons
 
 | Reason | Status | Description |
@@ -633,7 +643,9 @@ failing group or provider. Escalations with no approver groups report
 | `DenyPolicyReferenceInvalid` | False | Referenced deny policy doesn't exist |
 | `MailProviderValidationFailed` | False | Referenced MailProvider is missing or disabled |
 | `GroupMembersResolved` | True | Approver group members were resolved |
+| `GroupMembersEmpty` | True | The configured group exists but has no resolvable members; sessions relying on it may time out |
 | `NoApproverGroupsConfigured` | True | No approver groups require member resolution |
+| `GroupNotFound` | False | A configured approver group does not exist in an identity provider |
 | `GroupSyncPartialFailure` | False | Some approver groups or IDPs failed during group sync |
 | `GroupSyncFailed` | False | All approver group resolution failed |
 | `ValidationInProgress` | Unknown | Configuration being validated |

--- a/docs/keycloak-configuration.md
+++ b/docs/keycloak-configuration.md
@@ -906,9 +906,17 @@ Authorization: Bearer {token}
 
 **Required Keycloak role**: `query-groups` on `realm-management`
 
-**Behavior**: Returns groups whose name contains the search string. The resolver then does a case-insensitive exact match (`strings.EqualFold`) on `group.Name` to find the specific group.
+**Behavior**: Requests an exact Keycloak search for the configured name and
+still applies a case-insensitive exact match (`strings.EqualFold`) on
+`group.Name` before accepting the result.
 
-**Side effect**: If no matching group is found, caches an empty member list to avoid repeated queries.
+**Missing versus empty**: If no exact matching group is found, the resolver returns
+a classified `group not found` error and does not cache the result. If the exact
+group exists but has no direct or subgroup members with a usable email/username,
+the resolver returns an empty list without an error and caches that empty result
+for the configured `cacheTTL`. This distinction is reflected in the
+`BreakglassEscalation` `ApprovalGroupMembersResolved` condition and warning
+events, so an absent AD/Keycloak group cannot be mistaken for a valid empty group.
 
 ### API Call 3: GetGroupMembers (Direct Members)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -718,6 +718,39 @@ kubectl get secret <secret-name> -o yaml
 # Verify it has the right clientID and clientSecret
 ```
 
+### ApprovalGroupMembersResolved Condition: True (GroupMembersEmpty)
+
+**Cause:** The configured identity-provider group exists, but it currently has
+no members with a usable email or username. The lookup succeeded, but sessions
+depending only on that group cannot be approved and may transition to
+`ApprovalTimeout`.
+
+**Diagnosis:**
+
+```bash
+kubectl get breakglassescalation <name> -o jsonpath='{.status.conditions[?(@.type=="ApprovalGroupMembersResolved")]}'
+kubectl get events --field-selector involvedObject.name=<name>
+```
+
+**Solution:** Add the intended approver to the AD/Keycloak group, or configure
+an approver user/group that is populated in the selected identity provider.
+
+### ApprovalGroupMembersResolved Condition: False (GroupNotFound)
+
+**Cause:** A configured approver group does not exist in the selected identity
+provider. Breakglass removes stale cached members for that group and does not
+use the missing group as a successful empty lookup.
+
+**Diagnosis:**
+
+```bash
+kubectl get breakglassescalation <name> -o jsonpath='{.status.conditions[?(@.type=="ApprovalGroupMembersResolved")]}'
+kubectl get events --field-selector involvedObject.name=<name>
+```
+
+**Solution:** Verify the exact group name and the selected IdentityProvider,
+then create/rename the AD/Keycloak group or update the escalation configuration.
+
 ## General Debug Commands
 
 View all resources:

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -33,6 +35,8 @@ const (
 	groupSyncStatusFailed         = "Failed"
 
 	groupSyncReasonResolved       = "GroupMembersResolved"
+	groupSyncReasonEmpty          = "GroupMembersEmpty"
+	groupSyncReasonGroupNotFound  = "GroupNotFound"
 	groupSyncReasonNotRequired    = "NoApproverGroupsConfigured"
 	groupSyncReasonPartialFailure = "GroupSyncPartialFailure"
 	groupSyncReasonFailed         = "GroupSyncFailed"
@@ -165,11 +169,19 @@ func (k *KeycloakGroupMemberResolver) getToken(ctx context.Context) (string, err
 	})
 	if err != nil {
 		if k.log != nil {
-			k.log.Errorw("Failed to acquire token",
-				"clientID", k.cfg.ClientID,
-				"error", err,
-				"endpoint", tokenURL,
-				"grantType", "client_credentials")
+			if isContextTermination(err) {
+				k.log.Debugw("Keycloak token acquisition canceled",
+					"clientID", k.cfg.ClientID,
+					"error", err,
+					"endpoint", tokenURL,
+					"grantType", "client_credentials")
+			} else {
+				k.log.Errorw("Failed to acquire token",
+					"clientID", k.cfg.ClientID,
+					"error", err,
+					"endpoint", tokenURL,
+					"grantType", "client_credentials")
+			}
 		}
 		return "", err
 	}
@@ -198,9 +210,12 @@ func (k *KeycloakGroupMemberResolver) getToken(ctx context.Context) (string, err
 
 func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string) ([]string, error) {
 	if k == nil {
-		return nil, nil
+		return nil, fmt.Errorf("keycloak group member resolver is nil")
 	}
 	log := k.log
+	if strings.TrimSpace(group) == "" {
+		return nil, fmt.Errorf("keycloak group name is empty")
+	}
 	if k.cfg.BaseURL == "" || k.cfg.Realm == "" || k.cfg.ClientID == "" {
 		if log != nil {
 			log.Errorw("Keycloak resolver has incomplete configuration; cannot resolve groups",
@@ -226,7 +241,11 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	token, err := k.getToken(ctx)
 	if err != nil {
 		if log != nil {
-			log.Errorw("Failed to get Keycloak token", "group", system.RedactGroupName(group), "error", err)
+			if isContextTermination(err) {
+				log.Debugw("Keycloak token lookup canceled", "group", system.RedactGroupName(group), "error", err)
+			} else {
+				log.Errorw("Failed to get Keycloak token", "group", system.RedactGroupName(group), "error", err)
+			}
 		}
 		return nil, err
 	}
@@ -241,7 +260,10 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 			"tokenLen", len(token),
 			"endpoint", fmt.Sprintf("%s/admin/realms/%s/groups", k.cfg.BaseURL, k.cfg.Realm))
 	}
-	params := gocloak.GetGroupsParams{Search: gocloak.StringP(group)}
+	params := gocloak.GetGroupsParams{
+		Search: gocloak.StringP(group),
+		Exact:  gocloak.BoolP(true),
+	}
 	groups, err := k.gocloak.GetGroups(ctx, token, k.cfg.Realm, params)
 	if err != nil {
 		if log != nil {
@@ -259,6 +281,10 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 		log.Debugw("Keycloak groups search completed", "group", system.RedactGroupName(group), "returnedGroupCount", len(groups))
 		if len(groups) > 0 {
 			for i, g := range groups {
+				if g == nil {
+					log.Debugw("Keycloak group search returned a nil group entry", "index", i)
+					continue
+				}
 				log.Debugw("Group search result",
 					"index", i,
 					"groupID", g.ID,
@@ -276,7 +302,19 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	// Find matching group by name
 	var groupID *string
 	for _, g := range groups {
+		if g == nil {
+			continue
+		}
 		if g.Name != nil && strings.EqualFold(*g.Name, group) {
+			if g.ID == nil || strings.TrimSpace(*g.ID) == "" {
+				err := fmt.Errorf("keycloak group %q matched without an ID", group)
+				if log != nil {
+					log.Errorw("Keycloak group search returned a group without an ID",
+						"group", system.RedactGroupName(group),
+						"error", err)
+				}
+				return nil, err
+			}
 			groupID = g.ID
 			if log != nil {
 				log.Debugw("Found matching group by name", "group", system.RedactGroupName(group), "groupID", *groupID, "matchedNameHint", system.RedactGroupName(*g.Name))
@@ -285,11 +323,11 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 		}
 	}
 	if groupID == nil {
+		err := breakglass.NewGroupNotFoundError(group)
 		if log != nil {
-			log.Warnw("Group not found in search results", "group", system.RedactGroupName(group))
+			log.Warnw("Configured Keycloak group was not found", "group", system.RedactGroupName(group))
 		}
-		k.cache.set(group, []string{})
-		return []string{}, nil
+		return nil, err
 	}
 
 	// 2. Get direct group members
@@ -305,6 +343,7 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	params2 := gocloak.GetGroupsParams{}
 	members, err := k.gocloak.GetGroupMembers(ctx, token, k.cfg.Realm, *groupID, params2)
 	if err != nil {
+		err = classifyKeycloakGroupLookupError(group, err)
 		if log != nil {
 			log.Errorw("Keycloak members fetch failed",
 				"group", system.RedactGroupName(group),
@@ -323,6 +362,9 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	// Collect member identifiers
 	out := make([]string, 0, len(members))
 	for _, m := range members {
+		if m == nil {
+			continue
+		}
 		identifier := ""
 		if m.Email != nil && *m.Email != "" {
 			identifier = *m.Email
@@ -346,6 +388,15 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	}
 	groupDetail, err := k.gocloak.GetGroup(ctx, token, k.cfg.Realm, *groupID)
 	if err != nil {
+		if isKeycloakNotFoundError(err) {
+			err = breakglass.NewGroupNotFoundError(group)
+			if log != nil {
+				log.Warnw("Configured Keycloak group disappeared during lookup",
+					"group", system.RedactGroupName(group),
+					"error", err)
+			}
+			return nil, err
+		}
 		if log != nil {
 			log.Warnw("Keycloak group detail fetch failed",
 				"group", system.RedactGroupName(group),
@@ -401,6 +452,9 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 			}
 
 			for _, m := range sgMembers {
+				if m == nil {
+					continue
+				}
 				identifier := ""
 				if m.Email != nil && *m.Email != "" {
 					identifier = *m.Email
@@ -419,6 +473,10 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 		log.Debugw("Starting member list normalization", "group", system.RedactGroupName(group), "beforeNormalizationCount", len(out))
 	}
 	out = normalizeMembers(out)
+	if len(out) == 0 && log != nil {
+		log.Warnw("Configured Keycloak group exists but has no resolvable members",
+			"group", system.RedactGroupName(group))
+	}
 	if log != nil {
 		log.Infow("Keycloak group member resolution completed successfully", "group", system.RedactGroupName(group), "finalResolvedCount", len(out))
 	}
@@ -429,6 +487,22 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 		log.Debugw("Group member resolution returning successfully", "group", system.RedactGroupName(group), "memberCount", len(out))
 	}
 	return out, nil
+}
+
+func classifyKeycloakGroupLookupError(group string, err error) error {
+	if isKeycloakNotFoundError(err) {
+		return breakglass.NewGroupNotFoundError(group)
+	}
+	return err
+}
+
+func isKeycloakNotFoundError(err error) bool {
+	var apiErr *gocloak.APIError
+	return errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound
+}
+
+func isContextTermination(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // EscalationStatusUpdater periodically expands approver groups into member lists and stores in status.
@@ -479,15 +553,27 @@ func (u EscalationStatusUpdater) Start(ctx context.Context) {
 }
 
 func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLogger) {
+	if err := ctx.Err(); err != nil {
+		log.Debugw("Skipping escalation status update cycle because context is done", "error", err)
+		return
+	}
 	log.Debugw("Starting escalation status update cycle", "resolver", fmt.Sprintf("%T", u.Resolver))
 	escList := breakglassv1alpha1.BreakglassEscalationList{}
 	if err := u.K8sClient.List(ctx, &escList); err != nil {
+		if isContextTermination(err) {
+			log.Debugw("Escalation status update cycle canceled while listing escalations", "error", err)
+			return
+		}
 		log.Errorw("Failed listing BreakglassEscalations for status update", "error", err)
 		return
 	}
 	log.Debugw("Fetched escalations for status update", "count", len(escList.Items))
 
 	for _, esc := range escList.Items {
+		if err := ctx.Err(); err != nil {
+			log.Debugw("Stopping escalation status update cycle because context is done", "error", err)
+			return
+		}
 		// Collect approver groups
 		groups := esc.Spec.Approvers.Groups
 		if len(groups) == 0 {
@@ -532,6 +618,11 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			updated.Status.ApproverGroupMembers = map[string][]string{}
 		}
 
+		var emptyGroups []string
+		var missingGroups []string
+		syncErrorCount := 0
+		var syncStatus string
+
 		// Determine which IDPs to use for group resolution
 		// If allowedIdentityProvidersForApprovers is explicitly set, use those IDPs
 		// Otherwise, if IDPLoader is available and has multiple enabled IDPs, use all of them (auto multi-IDP mode)
@@ -545,6 +636,10 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			// Auto-detect: use all enabled IDPs
 			allIDPs, err := u.IDPLoader.LoadAllIdentityProviders(ctx)
 			if err != nil {
+				if isContextTermination(err) {
+					log.Debugw("Stopping escalation status update cycle because IDP loading was canceled", "error", err)
+					return
+				}
 				log.Warnw("Failed to load IDPs for auto-detection, falling back to legacy mode", "error", err, "escalation", esc.Name)
 			} else if len(allIDPs) > 0 {
 				idpsToUse = make([]string, 0, len(allIDPs))
@@ -559,13 +654,19 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			// Multi-IDP mode: Use multi-IDP group sync with IDP hierarchy storage
 			log.Debugw("Using multi-IDP group sync", "escalation", esc.Name, "idps", idpsToUse)
 
-			hierarchy, syncStatus, syncErrors := u.fetchGroupMembersFromMultipleIDPs(
+			syncReport := u.fetchGroupMembersFromMultipleIDPsReport(
 				ctx,
 				&esc,
 				idpsToUse,
 				groups,
 				log,
 			)
+			hierarchy := syncReport.hierarchy
+			syncStatus = syncReport.syncStatus
+			syncErrors := syncReport.syncErrors
+			syncErrorCount = len(syncErrors)
+			emptyGroups = syncReport.emptyGroups
+			missingGroups = syncReport.missingGroups
 
 			// Store full IDP hierarchy in status (NOT deduplicated)
 			if !equalIDPHierarchy(hierarchy, updated.Status.IDPGroupMemberships) {
@@ -581,7 +682,8 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			// The full per-IDP hierarchy is preserved in IDPGroupMemberships for debugging/auditing
 			for _, g := range groups {
 				dedupMembers := deduplicateMembersFromHierarchy(hierarchy, g)
-				if !equalStringSlices(dedupMembers, updated.Status.ApproverGroupMembers[g]) {
+				currentMembers, exists := updated.Status.ApproverGroupMembers[g]
+				if !exists || !equalStringSlices(dedupMembers, currentMembers) {
 					updated.Status.ApproverGroupMembers[g] = dedupMembers
 					changed = true
 				}
@@ -593,7 +695,12 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					idpCount = 1
 				}
 			}
-			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), idpCount, len(syncErrors)) {
+			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), idpCount, len(syncErrors),
+				groupSyncConditionDetails{
+					emptyGroups:         emptyGroups,
+					missingGroups:       syncReport.missingGroups,
+					missingFailureCount: syncReport.missingFailureCount,
+				}) {
 				changed = true
 			}
 		} else {
@@ -602,6 +709,7 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 
 			resolvedGroupCount := 0
 			failedGroupCount := 0
+			missingFailureCount := 0
 			for _, g := range groups {
 				log.Debugw("Resolving group for escalation", "escalation", esc.Name, "group", system.RedactGroupName(g), "resolverType", fmt.Sprintf("%T", u.Resolver))
 				var norm []string
@@ -611,18 +719,38 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 					if err != nil {
 						log.Errorw("Failed resolving group members from resolver", "group", system.RedactGroupName(g), "escalation", esc.Name, "error", err, "resolverType", fmt.Sprintf("%T", u.Resolver))
 						failedGroupCount++
+						if breakglass.IsGroupNotFound(err) {
+							currentMembers, exists := updated.Status.ApproverGroupMembers[g]
+							updated.Status.ApproverGroupMembers[g] = []string{}
+							prunedCachedMembers = true
+							if !exists || len(currentMembers) > 0 {
+								changed = true
+							}
+							missingGroups = append(missingGroups, g)
+							missingFailureCount++
+							log.Warnw("Configured approver group was not found; removed stale members from escalation status",
+								"group", system.RedactGroupName(g),
+								"escalation", esc.Name)
+						}
 						continue
 					}
 					log.Debugw("Group member resolver returned members", "group", system.RedactGroupName(g), "escalation", esc.Name, "rawMemberCount", len(members))
 					norm = normalizeMembers(members)
 					log.Infow("Resolved approver group members (normalized)", "group", system.RedactGroupName(g), "escalation", esc.Name, "rawCount", len(members), "normalizedCount", len(norm))
+					if len(norm) == 0 {
+						emptyGroups = append(emptyGroups, g)
+						log.Warnw("Configured approver group resolved but has no members",
+							"group", system.RedactGroupName(g),
+							"escalation", esc.Name)
+					}
 				} else {
 					log.Warnw("No group member resolver configured; skipping group resolution", "group", system.RedactGroupName(g), "escalation", esc.Name)
 					failedGroupCount++
 					continue
 				}
 				resolvedGroupCount++
-				if !equalStringSlices(norm, updated.Status.ApproverGroupMembers[g]) {
+				currentMembers, exists := updated.Status.ApproverGroupMembers[g]
+				if !exists || !equalStringSlices(norm, currentMembers) {
 					log.Debugw("Group members changed; marking for update", "group", system.RedactGroupName(g), "escalation", esc.Name, "oldCount", len(updated.Status.ApproverGroupMembers[g]), "newCount", len(norm))
 					updated.Status.ApproverGroupMembers[g] = norm
 					changed = true
@@ -632,7 +760,14 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 			if u.Resolver != nil {
 				idpCount = 1
 			}
-			if updateApprovalGroupMembersResolvedCondition(updated, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), len(groups), idpCount, failedGroupCount) {
+			syncStatus = legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount)
+			syncErrorCount = failedGroupCount
+			if updateApprovalGroupMembersResolvedCondition(updated, syncStatus, len(groups), idpCount, failedGroupCount,
+				groupSyncConditionDetails{
+					emptyGroups:         uniqueSortedGroupNames(emptyGroups),
+					missingGroups:       uniqueSortedGroupNames(missingGroups),
+					missingFailureCount: missingFailureCount,
+				}) {
 				changed = true
 			}
 		}
@@ -663,12 +798,12 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 				log.Debugw("Updated escalation successfully", "escalation", esc.Name, "groupCount", len(groups))
 				// Emit success event with details about what was synced
 				if u.EventRecorder != nil {
-					if len(idpsToUse) > 0 {
+					if syncStatus == groupSyncStatusSuccess && len(emptyGroups) == 0 && len(idpsToUse) > 0 {
 						// Multi-IDP mode
 						eventMsg := fmt.Sprintf("Group members synced successfully from %d IDPs. Updated %d group(s) with approvers.",
 							len(idpsToUse), len(groups))
 						u.EventRecorder.Eventf(updated, nil, "Normal", "GroupMembersSynced", "GroupMembersSynced", "%s", eventMsg)
-					} else {
+					} else if syncStatus == groupSyncStatusSuccess && len(emptyGroups) == 0 {
 						// Legacy single resolver mode
 						totalMembers := 0
 						for _, members := range updated.Status.ApproverGroupMembers {
@@ -677,6 +812,22 @@ func (u EscalationStatusUpdater) runOnce(ctx context.Context, log *zap.SugaredLo
 						u.EventRecorder.Eventf(updated, nil, "Normal", "GroupMembersSynced", "GroupMembersSynced",
 							"Group members resolved successfully. Total approvers from %d group(s): %d members.",
 							len(groups), totalMembers)
+					} else if syncStatus == groupSyncStatusSuccess {
+						u.EventRecorder.Eventf(updated, nil, "Warning", groupSyncReasonEmpty, groupSyncReasonEmpty,
+							"Group member sync completed, but configured approver group(s) have no members: %s. Sessions may remain pending until approval timeout.",
+							strings.Join(uniqueSortedGroupNames(emptyGroups), ", "))
+					} else if len(missingGroups) > 0 {
+						u.EventRecorder.Eventf(updated, nil, "Warning", groupSyncReasonGroupNotFound, groupSyncReasonGroupNotFound,
+							"Configured approver group(s) were not found: %s. Stale cached approvers were removed.",
+							strings.Join(uniqueSortedGroupNames(missingGroups), ", "))
+					} else if syncStatus == groupSyncStatusPartialFailure || syncStatus == groupSyncStatusFailed {
+						eventReason := groupSyncReasonPartialFailure
+						if syncStatus == groupSyncStatusFailed {
+							eventReason = groupSyncReasonFailed
+						}
+						u.EventRecorder.Eventf(updated, nil, "Warning", eventReason, eventReason,
+							"Approver group sync failed with %d error(s); inspect the ApprovalGroupMembersResolved condition and related events.",
+							syncErrorCount)
 					}
 				}
 			}
@@ -756,6 +907,21 @@ func pruneUnconfiguredApproverGroupStatus(escalation *breakglassv1alpha1.Breakgl
 	return changed
 }
 
+type groupSyncReport struct {
+	hierarchy           map[string]map[string][]string
+	syncStatus          string
+	syncErrors          []string
+	emptyGroups         []string
+	missingGroups       []string
+	missingFailureCount int
+}
+
+type groupSyncConditionDetails struct {
+	emptyGroups         []string
+	missingGroups       []string
+	missingFailureCount int
+}
+
 // fetchGroupMembersFromMultipleIDPs fetches group members from multiple IDPs and stores in IDP hierarchy structure.
 // Returns: map[idpName]map[groupName][]memberList, syncStatus, and error list (never blocks escalation creation)
 func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
@@ -765,9 +931,23 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 	groups []string,
 	log *zap.SugaredLogger,
 ) (map[string]map[string][]string, string, []string) {
+	report := u.fetchGroupMembersFromMultipleIDPsReport(ctx, escalation, idpNames, groups, log)
+	return report.hierarchy, report.syncStatus, report.syncErrors
+}
+
+func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPsReport(
+	ctx context.Context,
+	escalation *breakglassv1alpha1.BreakglassEscalation,
+	idpNames []string,
+	groups []string,
+	log *zap.SugaredLogger,
+) groupSyncReport {
 	// Structure: map[idpName]map[groupName][]memberList
 	hierarchy := make(map[string]map[string][]string)
 	var syncErrors []string
+	var emptyGroups []string
+	var missingGroups []string
+	missingFailureCount := 0
 	successCount := 0
 	failureCount := 0
 
@@ -796,7 +976,10 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 				log.Errorw("Failed to resolve group members", "escalation", escalation.Name, "group", system.RedactGroupName(g), "error", err)
 				syncErrors = append(syncErrors, errorMsg)
 				failedGroupCount++
-				if cachedIDP, ok := escalation.Status.IDPGroupMemberships[""]; ok {
+				if breakglass.IsGroupNotFound(err) {
+					missingGroups = append(missingGroups, g)
+					missingFailureCount++
+				} else if cachedIDP, ok := escalation.Status.IDPGroupMemberships[""]; ok {
 					if cachedMembers, ok := cachedIDP[g]; ok {
 						groupMembers[g] = cachedMembers
 					}
@@ -804,13 +987,23 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 				continue
 			}
 			groupMembers[g] = normalizeMembers(members)
+			if len(groupMembers[g]) == 0 {
+				emptyGroups = append(emptyGroups, g)
+			}
 			resolvedGroupCount++
 		}
 		// Store in hierarchy under empty IDP name for backward compat
 		if len(groupMembers) > 0 {
 			hierarchy[""] = groupMembers
 		}
-		return hierarchy, legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount), syncErrors
+		return groupSyncReport{
+			hierarchy:           hierarchy,
+			syncStatus:          legacyGroupSyncStatus(resolvedGroupCount, failedGroupCount),
+			syncErrors:          syncErrors,
+			emptyGroups:         uniqueSortedGroupNames(emptyGroups),
+			missingGroups:       uniqueSortedGroupNames(missingGroups),
+			missingFailureCount: missingFailureCount,
+		}
 	}
 
 	// Multi-IDP sync: fetch from each IDP for each group
@@ -865,17 +1058,31 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 				log.Warnw("Failed to resolve group members from IDP", "escalation", escalation.Name, "idp", idpName, "group", system.RedactGroupName(g), "error", err)
 				syncErrors = append(syncErrors, errorMsg)
 				idpSuccess = false
+				if breakglass.IsGroupNotFound(err) {
+					missingGroups = append(missingGroups, g)
+					missingFailureCount++
+				}
 
 				// Emit event on IdentityProvider resource
 				if u.EventRecorder != nil {
 					idp := &breakglassv1alpha1.IdentityProvider{}
 					idp.SetName(idpName)
-					u.EventRecorder.Eventf(idp, nil, "Warning", "GroupFetchFailed", "GroupFetchFailed",
-						"Failed to fetch group %s for escalation %s/%s: %v",
-						system.RedactGroupName(g), escalation.Namespace, escalation.Name, err)
+					eventReason := "GroupFetchFailed"
+					eventMessage := "Failed to fetch group %s for escalation %s/%s: %v"
+					if breakglass.IsGroupNotFound(err) {
+						eventReason = groupSyncReasonGroupNotFound
+						eventMessage = "Configured group %s was not found in IdentityProvider %s for escalation %s/%s"
+						u.EventRecorder.Eventf(idp, nil, "Warning", eventReason, eventReason,
+							eventMessage,
+							system.RedactGroupName(g), idpName, escalation.Namespace, escalation.Name)
+					} else {
+						u.EventRecorder.Eventf(idp, nil, "Warning", eventReason, eventReason,
+							eventMessage,
+							system.RedactGroupName(g), escalation.Namespace, escalation.Name, err)
+					}
 				}
 
-				if escalation.Status.IDPGroupMemberships != nil {
+				if !breakglass.IsGroupNotFound(err) && escalation.Status.IDPGroupMemberships != nil {
 					if cachedIDP, ok := escalation.Status.IDPGroupMemberships[idpName]; ok {
 						if cachedMembers, ok := cachedIDP[g]; ok {
 							idpGroupMembers[g] = cachedMembers
@@ -887,6 +1094,19 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 				continue
 			}
 			idpGroupMembers[g] = normalizeMembers(members)
+			if len(idpGroupMembers[g]) == 0 {
+				log.Warnw("Configured approver group exists but has no resolvable members",
+					"escalation", escalation.Name,
+					"idp", idpName,
+					"group", system.RedactGroupName(g))
+				if u.EventRecorder != nil {
+					idp := &breakglassv1alpha1.IdentityProvider{}
+					idp.SetName(idpName)
+					u.EventRecorder.Eventf(idp, nil, "Warning", groupSyncReasonEmpty, groupSyncReasonEmpty,
+						"Configured group %s exists but has no members for escalation %s/%s",
+						system.RedactGroupName(g), escalation.Namespace, escalation.Name)
+				}
+			}
 		}
 
 		if idpSuccess {
@@ -930,7 +1150,14 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPs(
 			successCount, failureCount)
 	}
 
-	return hierarchy, syncStatus, syncErrors
+	return groupSyncReport{
+		hierarchy:           hierarchy,
+		syncStatus:          syncStatus,
+		syncErrors:          syncErrors,
+		emptyGroups:         uniqueSortedGroupNames(emptyApproverGroups(hierarchy, groups)),
+		missingGroups:       uniqueSortedGroupNames(missingGroups),
+		missingFailureCount: missingFailureCount,
+	}
 }
 
 func updateNoApproverGroupsCondition(escalation *breakglassv1alpha1.BreakglassEscalation) bool {
@@ -948,7 +1175,15 @@ func updateApprovalGroupMembersResolvedCondition(
 	groupCount int,
 	idpCount int,
 	errorCount int,
+	details ...groupSyncConditionDetails,
 ) bool {
+	var conditionDetails groupSyncConditionDetails
+	if len(details) > 0 {
+		conditionDetails = details[0]
+	}
+	conditionDetails.emptyGroups = uniqueSortedGroupNames(conditionDetails.emptyGroups)
+	conditionDetails.missingGroups = uniqueSortedGroupNames(conditionDetails.missingGroups)
+
 	status := metav1.ConditionTrue
 	reason := groupSyncReasonResolved
 	message := fmt.Sprintf("Resolved approver group members for %d group(s).", groupCount)
@@ -958,14 +1193,25 @@ func updateApprovalGroupMembersResolvedCondition(
 
 	switch syncStatus {
 	case groupSyncStatusSuccess:
+		if len(conditionDetails.emptyGroups) > 0 {
+			reason = groupSyncReasonEmpty
+			message = fmt.Sprintf("%s Configured group(s) with no members: %s.",
+				strings.TrimSuffix(message, "."),
+				strings.Join(conditionDetails.emptyGroups, ", "))
+		}
 	case groupSyncStatusPartialFailure:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonPartialFailure
 		message = fmt.Sprintf("Approver group sync partially failed for %d group(s)%s; %d error(s) encountered.", groupCount, identityProviderConditionContext(idpCount), errorCount)
+		message = appendMissingGroupDetails(message, conditionDetails)
 	case groupSyncStatusFailed:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
 		message = fmt.Sprintf("Approver group sync failed for %d group(s)%s; %d error(s) encountered.", groupCount, identityProviderConditionContext(idpCount), errorCount)
+		if conditionDetails.missingFailureCount > 0 && conditionDetails.missingFailureCount == errorCount {
+			reason = groupSyncReasonGroupNotFound
+		}
+		message = appendMissingGroupDetails(message, conditionDetails)
 	default:
 		status = metav1.ConditionFalse
 		reason = groupSyncReasonFailed
@@ -973,6 +1219,43 @@ func updateApprovalGroupMembersResolvedCondition(
 	}
 
 	return setApprovalGroupMembersResolvedCondition(escalation, status, reason, message)
+}
+
+func appendMissingGroupDetails(message string, details groupSyncConditionDetails) string {
+	if len(details.missingGroups) == 0 {
+		return message
+	}
+	return fmt.Sprintf("%s Configured group(s) not found: %s.", message, strings.Join(details.missingGroups, ", "))
+}
+
+func emptyApproverGroups(hierarchy map[string]map[string][]string, groups []string) []string {
+	var emptyGroups []string
+	for _, group := range groups {
+		if len(deduplicateMembersFromHierarchy(hierarchy, group)) == 0 {
+			emptyGroups = append(emptyGroups, group)
+		}
+	}
+	return uniqueSortedGroupNames(emptyGroups)
+}
+
+func uniqueSortedGroupNames(groups []string) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	unique := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		if group != "" {
+			unique[group] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(unique))
+	for group := range unique {
+		result = append(result, group)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func identityProviderConditionContext(idpCount int) string {

--- a/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_idpgroupmemberships_test.go
@@ -398,6 +398,126 @@ func TestEscalationStatusUpdaterSetsApprovalGroupMembersResolvedPartialFailure(t
 	}
 }
 
+func TestEscalationStatusUpdaterReportsExistingEmptyApproverGroup(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "empty-approver-group",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"empty-group"},
+			},
+		},
+	}
+	assert.NoError(t, cli.Create(context.Background(), escalation))
+
+	recorder := fakeEventRecorder{Events: make(chan string, 2)}
+	updater := EscalationStatusUpdater{
+		Log:           logger.Sugar(),
+		K8sClient:     cli,
+		EventRecorder: recorder,
+		Resolver: &MockResolver{
+			members: map[string][]string{"empty-group": {}},
+			errors:  map[string]error{},
+		},
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	assert.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated))
+	assert.NotNil(t, updated.Status.ApproverGroupMembers)
+	assert.Empty(t, updated.Status.ApproverGroupMembers["empty-group"])
+
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "GroupMembersEmpty", condition.Reason)
+		assert.Contains(t, condition.Message, "empty-group")
+	}
+	assert.True(t, recordedEventContains(drainRecordedEvents(recorder.Events), "Warning GroupMembersEmpty", "empty-group"))
+}
+
+func TestEscalationStatusUpdaterReportsMissingApproverGroupAndClearsStaleMembers(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer func() {
+		_ = logger.Sync()
+	}()
+
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "missing-approver-group",
+			Namespace:  "default",
+			Generation: 4,
+		},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"my-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"missing-group"},
+			},
+		},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			ApproverGroupMembers: map[string][]string{
+				"missing-group": {"stale@example.com"},
+			},
+		},
+	}
+	assert.NoError(t, cli.Create(context.Background(), escalation))
+	assert.NoError(t, cli.Status().Update(context.Background(), escalation))
+
+	recorder := fakeEventRecorder{Events: make(chan string, 2)}
+	updater := EscalationStatusUpdater{
+		Log:           logger.Sugar(),
+		K8sClient:     cli,
+		EventRecorder: recorder,
+		Resolver: &MockResolver{
+			members: map[string][]string{},
+			errors: map[string]error{
+				"missing-group": breakglass.NewGroupNotFoundError("missing-group"),
+			},
+		},
+	}
+
+	updater.runOnce(context.Background(), logger.Sugar())
+
+	updated := &breakglassv1alpha1.BreakglassEscalation{}
+	assert.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated))
+	assert.NotNil(t, updated.Status.ApproverGroupMembers)
+	assert.Empty(t, updated.Status.ApproverGroupMembers["missing-group"])
+
+	condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, "GroupNotFound", condition.Reason)
+		assert.Contains(t, condition.Message, "missing-group")
+	}
+	assert.True(t, recordedEventContains(drainRecordedEvents(recorder.Events), "Warning GroupNotFound", "missing-group"))
+}
+
 func TestUpdateApprovalGroupMembersResolvedConditionIncludesIDPContextOnFailures(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/breakglass/escalation/escalation_status_updater_multi_idp_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_multi_idp_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package escalation
+
+import (
+	"context"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
+	cfgpkg "github.com/telekom/k8s-breakglass/pkg/config"
+)
+
+type keycloakFixtureMode string
+
+const (
+	keycloakFixtureSuccess   keycloakFixtureMode = "success"
+	keycloakFixtureEmpty     keycloakFixtureMode = "empty"
+	keycloakFixtureMissing   keycloakFixtureMode = "missing"
+	keycloakFixtureMalformed keycloakFixtureMode = "malformed"
+	keycloakFixtureDetail404 keycloakFixtureMode = "detail-404"
+	keycloakFixtureTransient keycloakFixtureMode = "transient"
+)
+
+func newKeycloakFixture(t *testing.T, mode keycloakFixtureMode) (string, string) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON := func(body string) {
+			if _, err := w.Write([]byte(body)); err != nil {
+				t.Errorf("write fixture response: %v", err)
+			}
+		}
+
+		switch r.URL.Path {
+		case "/realms/test-realm/protocol/openid-connect/token":
+			writeJSON(`{"access_token":"fixture-token","expires_in":300,"token_type":"Bearer"}`)
+		case "/admin/realms/test-realm/groups":
+			if mode == keycloakFixtureMissing {
+				writeJSON(`[]`)
+				return
+			}
+			if mode == keycloakFixtureMalformed {
+				writeJSON(`[{"name":"approvers"}]`)
+				return
+			}
+			writeJSON(`[{"id":"approver-group-id","name":"approvers"}]`)
+		case "/admin/realms/test-realm/groups/approver-group-id/members":
+			if mode == keycloakFixtureTransient {
+				http.Error(w, "temporary failure", http.StatusInternalServerError)
+				return
+			}
+			if mode == keycloakFixtureEmpty {
+				writeJSON(`[]`)
+				return
+			}
+			writeJSON(`[{"email":"approver@example.com"}]`)
+		case "/admin/realms/test-realm/groups/approver-group-id":
+			if mode == keycloakFixtureDetail404 {
+				http.Error(w, "group deleted", http.StatusNotFound)
+				return
+			}
+			writeJSON(`{"id":"approver-group-id","name":"approvers","subGroups":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	certificateAuthority := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+	return server.URL, string(certificateAuthority)
+}
+
+func newMultiIDPStatusTestClient(
+	t *testing.T,
+	serverURL, certificateAuthority string,
+	status breakglassv1alpha1.BreakglassEscalationStatus,
+) (client.Client, *breakglassv1alpha1.BreakglassEscalation) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	idp := &breakglassv1alpha1.IdentityProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "idp-a"},
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
+				Authority:        serverURL,
+				ClientID:         "breakglass-ui",
+				ExpectedAudience: "breakglass-ui",
+			},
+			GroupSyncProvider: breakglassv1alpha1.GroupSyncProviderKeycloak,
+			Keycloak: &breakglassv1alpha1.KeycloakGroupSync{
+				BaseURL:              serverURL,
+				Realm:                "test-realm",
+				ClientID:             "group-sync",
+				CertificateAuthority: certificateAuthority,
+				ClientSecretRef: breakglassv1alpha1.SecretKeyReference{
+					Name:      "group-sync-secret",
+					Namespace: "default",
+					Key:       "clientSecret",
+				},
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-sync-secret", Namespace: "default"},
+		Data:       map[string][]byte{"clientSecret": []byte("fixture-secret")},
+	}
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-idp-status", Namespace: "default"},
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			EscalatedGroup: "admin-group",
+			Allowed: breakglassv1alpha1.BreakglassEscalationAllowed{
+				Clusters: []string{"fixture-cluster"},
+			},
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				Groups: []string{"approvers"},
+			},
+		},
+		Status: status,
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}, &breakglassv1alpha1.IdentityProvider{}).
+		WithObjects(idp, secret, escalation).
+		Build(), escalation
+}
+
+func TestEscalationStatusUpdaterMultiIDPClassifiesGroupResults(t *testing.T) {
+	tests := []struct {
+		name          string
+		mode          keycloakFixtureMode
+		initialStatus breakglassv1alpha1.BreakglassEscalationStatus
+		wantMembers   []string
+		wantStatus    metav1.ConditionStatus
+		wantReason    string
+	}{
+		{
+			name:        "members resolved",
+			mode:        keycloakFixtureSuccess,
+			wantMembers: []string{"approver@example.com"},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "GroupMembersResolved",
+		},
+		{
+			name:        "existing group is empty",
+			mode:        keycloakFixtureEmpty,
+			wantMembers: []string{},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "GroupMembersEmpty",
+		},
+		{
+			name:        "group is missing",
+			mode:        keycloakFixtureMissing,
+			wantMembers: []string{},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "GroupNotFound",
+		},
+		{
+			name: "transient lookup failure retains stale members",
+			mode: keycloakFixtureTransient,
+			initialStatus: breakglassv1alpha1.BreakglassEscalationStatus{
+				ApproverGroupMembers: map[string][]string{
+					"approvers": {"stale@example.com"},
+				},
+				IDPGroupMemberships: map[string]map[string][]string{
+					"idp-a": {
+						"approvers": {"stale@example.com"},
+					},
+				},
+			},
+			wantMembers: []string{"stale@example.com"},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "GroupSyncFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverURL, certificateAuthority := newKeycloakFixture(t, tt.mode)
+			cli, escalation := newMultiIDPStatusTestClient(t, serverURL, certificateAuthority, tt.initialStatus)
+			log := zap.NewNop().Sugar()
+			recorder := fakeEventRecorder{Events: make(chan string, 10)}
+			updater := EscalationStatusUpdater{
+				Log:           log,
+				K8sClient:     cli,
+				IDPLoader:     cfgpkg.NewIdentityProviderLoader(cli),
+				EventRecorder: recorder,
+			}
+
+			updater.runOnce(context.Background(), log)
+
+			updated := &breakglassv1alpha1.BreakglassEscalation{}
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(escalation), updated))
+			members, hasGroup := updated.Status.ApproverGroupMembers["approvers"]
+			require.True(t, hasGroup)
+			if len(tt.wantMembers) == 0 {
+				assert.Empty(t, members)
+			} else {
+				assert.Equal(t, tt.wantMembers, members)
+			}
+
+			condition := updated.GetCondition(string(breakglassv1alpha1.BreakglassEscalationConditionApprovalGroupMembersResolved))
+			require.NotNil(t, condition)
+			assert.Equal(t, tt.wantStatus, condition.Status)
+			assert.Equal(t, tt.wantReason, condition.Reason)
+			_ = drainRecordedEvents(recorder.Events)
+		})
+	}
+}
+
+func TestFetchGroupMembersFromMultipleIDPsReport_FallbackRetainsCachedMembers(t *testing.T) {
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "cached-fallback", Namespace: "default"},
+		Status: breakglassv1alpha1.BreakglassEscalationStatus{
+			IDPGroupMemberships: map[string]map[string][]string{
+				"": {"approvers": {"cached@example.com"}},
+			},
+		},
+	}
+
+	t.Run("resolver unavailable", func(t *testing.T) {
+		report := (EscalationStatusUpdater{}).fetchGroupMembersFromMultipleIDPsReport(
+			context.Background(),
+			escalation,
+			nil,
+			[]string{"approvers"},
+			zap.NewNop().Sugar(),
+		)
+
+		assert.Equal(t, groupSyncStatusFailed, report.syncStatus)
+		assert.Equal(t, []string{"cached@example.com"}, report.hierarchy[""]["approvers"])
+	})
+
+	t.Run("resolver returns transient error", func(t *testing.T) {
+		report := (EscalationStatusUpdater{
+			Resolver: &MockResolver{
+				errors: map[string]error{"approvers": errors.New("temporary lookup failure")},
+			},
+		}).fetchGroupMembersFromMultipleIDPsReport(
+			context.Background(),
+			escalation,
+			nil,
+			[]string{"approvers"},
+			zap.NewNop().Sugar(),
+		)
+
+		assert.Equal(t, groupSyncStatusFailed, report.syncStatus)
+		assert.Equal(t, []string{"cached@example.com"}, report.hierarchy[""]["approvers"])
+	})
+}
+
+func TestFetchGroupMembersFromMultipleIDPsReport_MixedResolverAvailability(t *testing.T) {
+	serverURL, certificateAuthority := newKeycloakFixture(t, keycloakFixtureSuccess)
+	cli, escalation := newMultiIDPStatusTestClient(
+		t,
+		serverURL,
+		certificateAuthority,
+		breakglassv1alpha1.BreakglassEscalationStatus{},
+	)
+	oidcOnlyIDP := &breakglassv1alpha1.IdentityProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "idp-without-group-sync"},
+		Spec: breakglassv1alpha1.IdentityProviderSpec{
+			OIDC: breakglassv1alpha1.OIDCConfig{
+				Authority:        serverURL,
+				ClientID:         "breakglass-ui",
+				ExpectedAudience: "breakglass-ui",
+			},
+		},
+	}
+	require.NoError(t, cli.Create(context.Background(), oidcOnlyIDP))
+
+	log := zap.NewNop().Sugar()
+	recorder := fakeEventRecorder{Events: make(chan string, 2)}
+	report := (EscalationStatusUpdater{
+		IDPLoader:     cfgpkg.NewIdentityProviderLoader(cli),
+		EventRecorder: recorder,
+	}).fetchGroupMembersFromMultipleIDPsReport(
+		context.Background(),
+		escalation,
+		[]string{"idp-a", "idp-without-group-sync"},
+		[]string{"approvers"},
+		log,
+	)
+
+	assert.Equal(t, groupSyncStatusPartialFailure, report.syncStatus)
+	assert.Len(t, report.syncErrors, 1)
+	assert.Equal(t, []string{"approver@example.com"}, report.hierarchy["idp-a"]["approvers"])
+	assert.NotContains(t, report.hierarchy, "idp-without-group-sync")
+	assert.True(t, recordedEventContains(drainRecordedEvents(recorder.Events), "Warning GroupSyncResolverCreationFailed"))
+}
+
+func TestEscalationStatusUpdaterRunOnceSkipsCanceledContext(t *testing.T) {
+	cli := fake.NewClientBuilder().
+		WithScheme(breakglass.Scheme).
+		WithStatusSubresource(&breakglassv1alpha1.BreakglassEscalation{}).
+		Build()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	EscalationStatusUpdater{
+		K8sClient: cli,
+	}.runOnce(ctx, zap.NewNop().Sugar())
+}
+
+func TestIsContextTermination(t *testing.T) {
+	assert.True(t, isContextTermination(context.Canceled))
+	assert.True(t, isContextTermination(errors.Join(errors.New("request stopped"), context.DeadlineExceeded)))
+	assert.False(t, isContextTermination(errors.New("unavailable")))
+}
+
+func TestKeycloakGroupMemberResolverRejectsInvalidInputs(t *testing.T) {
+	var nilResolver *KeycloakGroupMemberResolver
+	_, err := nilResolver.Members(context.Background(), "approvers")
+	require.Error(t, err)
+
+	_, err = (&KeycloakGroupMemberResolver{}).Members(context.Background(), " ")
+	require.Error(t, err)
+}
+
+func TestKeycloakGroupMemberResolverRejectsMalformedGroupResponse(t *testing.T) {
+	serverURL, certificateAuthority := newKeycloakFixture(t, keycloakFixtureMalformed)
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:              serverURL,
+		Realm:                "test-realm",
+		ClientID:             "group-sync",
+		ClientSecret:         "fixture-secret",
+		CertificateAuthority: certificateAuthority,
+	})
+
+	_, err := resolver.Members(context.Background(), "approvers")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matched without an ID")
+}
+
+func TestKeycloakGroupMemberResolverClassifiesGroupDetailDeletion(t *testing.T) {
+	serverURL, certificateAuthority := newKeycloakFixture(t, keycloakFixtureDetail404)
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:              serverURL,
+		Realm:                "test-realm",
+		ClientID:             "group-sync",
+		ClientSecret:         "fixture-secret",
+		CertificateAuthority: certificateAuthority,
+	})
+
+	_, err := resolver.Members(context.Background(), "approvers")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, breakglass.ErrGroupNotFound)
+}
+
+func TestKeycloakGroupMemberResolverCachesClientCredentialToken(t *testing.T) {
+	serverURL, certificateAuthority := newKeycloakFixture(t, keycloakFixtureSuccess)
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:              serverURL,
+		Realm:                "test-realm",
+		ClientID:             "group-sync",
+		ClientSecret:         "fixture-secret",
+		CertificateAuthority: certificateAuthority,
+	})
+
+	first, err := resolver.getToken(context.Background())
+	require.NoError(t, err)
+	second, err := resolver.getToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestKeycloakGroupMemberResolverTokenCancellation(t *testing.T) {
+	serverURL, certificateAuthority := newKeycloakFixture(t, keycloakFixtureSuccess)
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:              serverURL,
+		Realm:                "test-realm",
+		ClientID:             "group-sync",
+		ClientSecret:         "fixture-secret",
+		CertificateAuthority: certificateAuthority,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolver.getToken(ctx)
+
+	require.Error(t, err)
+}

--- a/pkg/breakglass/escalation/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_test.go
@@ -21,10 +21,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	breakglass "github.com/telekom/k8s-breakglass/pkg/breakglass"
 	cfgpkg "github.com/telekom/k8s-breakglass/pkg/config"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -605,6 +608,101 @@ func TestNewKeycloakGroupMemberResolver_CustomCacheTTL(t *testing.T) {
 	assert.NotNil(t, resolver.cache)
 	// Cache TTL should be 30 minutes
 	assert.Equal(t, "30m", resolver.cfg.CacheTTL)
+}
+
+func TestKeycloakGroupMemberResolver_MissingGroupReturnsClassifiedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/admin/realms/test-realm/groups", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[]`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	group := "missing-group"
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:             server.URL,
+		Realm:               "test-realm",
+		ClientID:            "test-client",
+		ServiceAccountToken: "test-token",
+	})
+
+	members, err := resolver.Members(context.Background(), group)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, breakglass.ErrGroupNotFound)
+	assert.Nil(t, members)
+	_, cached := resolver.cache.get(group)
+	assert.False(t, cached, "missing groups must not be cached as empty groups")
+}
+
+func TestKeycloakGroupMemberResolver_GroupDeletedDuringLookupReturnsClassifiedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/admin/realms/test-realm/groups":
+			_, err := w.Write([]byte(`[{"id":"deleted-group-id","name":"deleted-group"}]`))
+			assert.NoError(t, err)
+		case "/admin/realms/test-realm/groups/deleted-group-id/members":
+			http.Error(w, "group deleted", http.StatusNotFound)
+		default:
+			t.Errorf("unexpected Keycloak path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	group := "deleted-group"
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:             server.URL,
+		Realm:               "test-realm",
+		ClientID:            "test-client",
+		ServiceAccountToken: "test-token",
+	})
+
+	members, err := resolver.Members(context.Background(), group)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, breakglass.ErrGroupNotFound)
+	assert.Nil(t, members)
+}
+
+func TestKeycloakGroupMemberResolver_ExistingEmptyGroupReturnsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var body string
+		switch r.URL.Path {
+		case "/admin/realms/test-realm/groups":
+			body = `[{"id":"empty-group-id","name":"empty-group"}]`
+		case "/admin/realms/test-realm/groups/empty-group-id/members":
+			body = `[]`
+		case "/admin/realms/test-realm/groups/empty-group-id":
+			body = `{"id":"empty-group-id","name":"empty-group","subGroups":[]}`
+		default:
+			t.Errorf("unexpected Keycloak path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		_, err := w.Write([]byte(body))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	group := "empty-group"
+	resolver := NewKeycloakGroupMemberResolver(zap.NewNop().Sugar(), cfgpkg.KeycloakRuntimeConfig{
+		BaseURL:             server.URL,
+		Realm:               "test-realm",
+		ClientID:            "test-client",
+		ServiceAccountToken: "test-token",
+	})
+
+	members, err := resolver.Members(context.Background(), group)
+
+	require.NoError(t, err)
+	assert.Empty(t, members)
+	cachedMembers, cached := resolver.cache.get(group)
+	require.True(t, cached)
+	assert.Empty(t, cachedMembers)
 }
 
 func TestSetupResolverReturnsQuietNoopWhenGroupSyncDisabled(t *testing.T) {

--- a/pkg/breakglass/group_resolver.go
+++ b/pkg/breakglass/group_resolver.go
@@ -1,10 +1,50 @@
 package breakglass
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+)
 
 // GroupMemberResolver abstracts IdP (Keycloak) group membership queries.
-// Implementations should return slice of user identifiers (emails/usernames) for provided group.
+// Implementations should return a slice of user identifiers (emails/usernames)
+// for the provided group. An empty slice and a nil error mean that the group
+// exists but has no resolvable members. Implementations must return
+// NewGroupNotFoundError when the configured group does not exist.
 // Defined in root so both root (EscalationManager) and sub-packages (escalation/) can use it.
 type GroupMemberResolver interface {
 	Members(ctx context.Context, group string) ([]string, error)
+}
+
+// ErrGroupNotFound identifies a configured group that does not exist in the
+// identity provider.
+var ErrGroupNotFound = errors.New("group not found")
+
+// GroupNotFoundError includes the configured group name while preserving
+// errors.Is(err, ErrGroupNotFound) classification for callers.
+type GroupNotFoundError struct {
+	Group string
+}
+
+// Error implements the error interface.
+func (e GroupNotFoundError) Error() string {
+	if e.Group == "" {
+		return ErrGroupNotFound.Error()
+	}
+	return fmt.Sprintf("%s: %q", ErrGroupNotFound, e.Group)
+}
+
+// Unwrap exposes the stable ErrGroupNotFound classification.
+func (e GroupNotFoundError) Unwrap() error {
+	return ErrGroupNotFound
+}
+
+// NewGroupNotFoundError creates a classified error for a missing group.
+func NewGroupNotFoundError(group string) error {
+	return GroupNotFoundError{Group: group}
+}
+
+// IsGroupNotFound reports whether err identifies a missing identity-provider group.
+func IsGroupNotFound(err error) bool {
+	return errors.Is(err, ErrGroupNotFound)
 }

--- a/pkg/breakglass/session_controller_approval_failopen_test.go
+++ b/pkg/breakglass/session_controller_approval_failopen_test.go
@@ -196,6 +196,26 @@ func TestApprovalGroupLookupFailureIsObservable(t *testing.T) {
 	}
 }
 
+func TestEmptyResolvedApproverGroupDoesNotFallBackToTokenGroup(t *testing.T) {
+	escalation := failOpenEscalation()
+	escalation.Status.ApproverGroupMembers = map[string][]string{
+		"cluster-approvers": {},
+	}
+
+	ctrl := newApprovalAuthorizationTestController(t, failOpenSession(), escalation)
+	ctrl.getUserGroupsFn = func(context.Context, ClusterUserGroup) ([]string, error) {
+		return []string{"cluster-approvers"}, nil
+	}
+
+	c := newApprovalAuthorizationTestContext("approver@example.com", "")
+	c.Set("groups", []string{"cluster-approvers"})
+
+	result := ctrl.checkApprovalAuthorization(c, *failOpenSession())
+
+	require.False(t, result.Allowed)
+	require.Equal(t, ApprovalDenialNotAnApprover, result.Reason)
+}
+
 // TestApprovalUnverifiedGroupsAuditSurvivesDisabledAuditService ensures the
 // observability path degrades safely: with audit disabled the metric still
 // increments and the decision is unchanged (no panic, no lockout).


### PR DESCRIPTION
## Summary

- distinguish existing empty AD/Keycloak approver groups from groups that are missing or deleted during lookup
- report `GroupMembersEmpty` and `GroupNotFound` conditions/events with actionable details
- remove stale cached approvers for confirmed missing groups and keep missing results out of the resolver cache
- avoid misleading Keycloak token/IDP fallback errors when the status updater context is canceled

## Validation

- `make lint`
- `make test`
- targeted Keycloak resolver and escalation status tests

Refs: user report about `dttcaas-glb-dci_appowner` resolving empty/missing and sessions ending in `ApprovalTimeout`.