### PR TITLE
fix: preserve notification group filters on resolver failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **AD/Keycloak approver group reporting**: Existing empty groups are reported as `GroupMembersEmpty`, while missing groups return an explicit sync failure, remove stale cached approvers, and emit a `GroupNotFound` warning instead of being treated as successful empty groups. (#1224)
+- Preserve notification exclusions and hidden approver filtering when a follow-up group resolver is unavailable by reusing request-resolved group memberships.
 
 ## [0.1.0-rc.4] - 2026-08-05
 

--- a/docs/breakglass-escalation.md
+++ b/docs/breakglass-escalation.md
@@ -224,6 +224,7 @@ notificationExclusions:
 
 - Excluded users will NOT receive emails when sessions are requested/approved/rejected
 - Excluded groups' members will NOT receive emails
+- Request notifications reuse the approver memberships already resolved for the session request, so excluded approver groups remain excluded if a follow-up identity-provider lookup is unavailable
 - All other approvers will receive emails as normal
 - Takes precedence over individual approver lists
 
@@ -266,6 +267,7 @@ approvers:
 
 - Hidden users/groups are NOT shown in the UI's approver list
 - Hidden users/groups do NOT receive email notifications
+- Request notifications reuse the memberships already resolved for the session request, including multi-identity-provider status, so a missing follow-up resolver cannot expose hidden approvers
 - Hidden users/groups CAN still approve sessions if they know about them
 - Hidden users/groups are still counted as valid approvers for approval requirements
 - Useful for "on-call" or "last resort" approver groups

--- a/pkg/breakglass/session_controller_actions.go
+++ b/pkg/breakglass/session_controller_actions.go
@@ -692,6 +692,7 @@ func (wc *BreakglassSessionController) sendOnRequestEmailsByGroup(
 func (wc *BreakglassSessionController) filterExcludedNotificationRecipients(
 	log *zap.SugaredLogger,
 	approvers []string,
+	approversByGroup map[string][]string,
 	escalation *breakglassv1alpha1.BreakglassEscalation,
 ) []string {
 	log.Debugw("filterExcludedNotificationRecipients called",
@@ -720,6 +721,12 @@ func (wc *BreakglassSessionController) filterExcludedNotificationRecipients(
 
 	// Get members of excluded groups
 	excludedGroupMembers := make(map[string]bool)
+	for _, group := range exclusions.Groups {
+		for _, member := range approversByGroup[group] {
+			excludedGroupMembers[member] = true
+		}
+	}
+	requestResolvedMemberCount := len(excludedGroupMembers)
 	if len(exclusions.Groups) > 0 && wc.escalationManager != nil && wc.escalationManager.GetResolver() != nil {
 		// Use a timeout context to prevent hanging on slow group resolution
 		ctx, cancel := context.WithTimeout(context.Background(), APIContextTimeout)
@@ -751,13 +758,15 @@ func (wc *BreakglassSessionController) filterExcludedNotificationRecipients(
 		log.Infow("Excluded group resolution summary",
 			"resolvedGroupCount", resolvedGroupsCount,
 			"totalGroupMemberCount", totalMembersCount,
+			"requestResolvedGroupMemberCount", requestResolvedMemberCount,
 			"uniqueExcludedGroupMemberCount", len(excludedGroupMembers))
 	} else {
 		resolverNil := wc.escalationManager != nil && wc.escalationManager.GetResolver() == nil
-		log.Debugw("Cannot resolve excluded group members",
+		log.Debugw("Cannot resolve additional excluded group members",
 			"groupCount", len(exclusions.Groups),
 			"escalationManagerNil", wc.escalationManager == nil,
-			"resolverNil", resolverNil)
+			"resolverNil", resolverNil,
+			"knownGroupMemberCount", len(excludedGroupMembers))
 	}
 
 	// Filter approvers
@@ -787,6 +796,7 @@ func (wc *BreakglassSessionController) filterExcludedNotificationRecipients(
 func (wc *BreakglassSessionController) filterHiddenFromUIRecipients(
 	log *zap.SugaredLogger,
 	approvers []string,
+	approversByGroup map[string][]string,
 	escalation *breakglassv1alpha1.BreakglassEscalation,
 ) []string {
 	hiddenFromUICount := 0
@@ -818,6 +828,12 @@ func (wc *BreakglassSessionController) filterHiddenFromUIRecipients(
 
 	// Get members of hidden groups
 	hiddenGroupMembers := make(map[string]bool)
+	for _, group := range escalation.Spec.Approvers.HiddenFromUI {
+		for _, member := range approversByGroup[group] {
+			hiddenGroupMembers[member] = true
+		}
+	}
+	requestResolvedMemberCount := len(hiddenGroupMembers)
 	if wc.escalationManager != nil && wc.escalationManager.GetResolver() != nil {
 		// Use a timeout context to prevent hanging on slow group resolution
 		ctx, cancel := context.WithTimeout(context.Background(), APIContextTimeout)
@@ -850,11 +866,13 @@ func (wc *BreakglassSessionController) filterHiddenFromUIRecipients(
 		log.Infow("Hidden group resolution summary",
 			"resolvedGroupCount", resolvedGroupsCount,
 			"totalGroupMemberCount", totalMembersCount,
+			"requestResolvedGroupMemberCount", requestResolvedMemberCount,
 			"uniqueHiddenGroupMemberCount", len(hiddenGroupMembers))
 	} else {
-		log.Warnw("Cannot resolve hidden group members - resolver not available",
+		log.Warnw("Cannot resolve additional hidden group members - resolver not available",
 			"escalationManagerNil", wc.escalationManager == nil,
-			"resolverNil", wc.escalationManager != nil && wc.escalationManager.GetResolver() == nil)
+			"resolverNil", wc.escalationManager != nil && wc.escalationManager.GetResolver() == nil,
+			"knownGroupMemberCount", len(hiddenGroupMembers))
 	}
 
 	// Filter approvers - only include those not in hidden lists

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -6499,8 +6499,10 @@ func TestFilterExcludedNotificationRecipientsUsesRequestResolvedMembers(t *testi
 	}
 
 	for _, tc := range []struct {
-		name string
-		ctrl *BreakglassSessionController
+		name      string
+		ctrl      *BreakglassSessionController
+		approvers []string
+		expected  []string
 	}{
 		{
 			name: "resolver unavailable",
@@ -6524,10 +6526,30 @@ func TestFilterExcludedNotificationRecipientsUsesRequestResolvedMembers(t *testi
 				},
 			},
 		},
+		{
+			name: "resolver augments request resolved members",
+			ctrl: &BreakglassSessionController{
+				escalationManager: &testEscalationLookup{
+					resolver: &MockGroupResolver{
+						members: map[string][]string{"silent-approvers": {"additional@example.com"}},
+					},
+				},
+			},
+			approvers: []string{"visible@example.com", "silent@example.com", "additional@example.com"},
+			expected:  []string{"visible@example.com"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.ctrl.filterExcludedNotificationRecipients(log, approvers, approversByGroup, escalation)
-			assert.Equal(t, []string{"visible@example.com"}, result)
+			testApprovers := approvers
+			if tc.approvers != nil {
+				testApprovers = tc.approvers
+			}
+			expected := []string{"visible@example.com"}
+			if tc.expected != nil {
+				expected = tc.expected
+			}
+			result := tc.ctrl.filterExcludedNotificationRecipients(log, testApprovers, approversByGroup, escalation)
+			assert.Equal(t, expected, result)
 		})
 	}
 }
@@ -6690,6 +6712,73 @@ func TestFilterHiddenFromUIRecipientsUsesRequestResolvedMembers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.ctrl.filterHiddenFromUIRecipients(log, approvers, approversByGroup, escalation)
 			assert.Equal(t, []string{"visible@example.com"}, result)
+		})
+	}
+}
+
+func TestSendSessionNotificationsUsesRequestResolvedGroupMembers(t *testing.T) {
+	log := zap.NewNop().Sugar()
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "request-resolved-members"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:         "requester@example.com",
+			Cluster:      "test-cluster",
+			GrantedGroup: "cluster-admin",
+		},
+	}
+	allApprovers := []string{"visible@example.com", "silent@example.com"}
+	approversByGroup := map[string][]string{
+		"visible-approvers": {"visible@example.com"},
+		"silent-approvers":  {"silent@example.com"},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		configure func(*breakglassv1alpha1.BreakglassEscalation)
+	}{
+		{
+			name: "notification exclusion",
+			configure: func(escalation *breakglassv1alpha1.BreakglassEscalation) {
+				escalation.Spec.NotificationExclusions = &breakglassv1alpha1.NotificationExclusions{
+					Groups: []string{"silent-approvers"},
+				}
+			},
+		},
+		{
+			name: "hidden approver",
+			configure: func(escalation *breakglassv1alpha1.BreakglassEscalation) {
+				escalation.Spec.Approvers.HiddenFromUI = []string{"silent-approvers"}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			escalation := &breakglassv1alpha1.BreakglassEscalation{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-escalation"},
+				Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+					Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+						Groups: []string{"visible-approvers", "silent-approvers"},
+					},
+				},
+			}
+			tc.configure(escalation)
+
+			mailSender := &FakeMailSender{}
+			ctrl := &BreakglassSessionController{
+				log:  log,
+				mail: mailSender,
+			}
+			ctrl.sendSessionNotifications(
+				session,
+				escalation,
+				allApprovers,
+				approversByGroup,
+				"requester@example.com",
+				"Requester",
+				log,
+			)
+
+			require.Equal(t, 1, mailSender.SendCallCount)
+			assert.Equal(t, []string{"visible@example.com"}, mailSender.LastRecivers)
 		})
 	}
 }

--- a/pkg/breakglass/session_controller_test.go
+++ b/pkg/breakglass/session_controller_test.go
@@ -6463,7 +6463,7 @@ func TestFilterExcludedNotificationRecipients(t *testing.T) {
 		}
 
 		ctrl := &BreakglassSessionController{}
-		result := ctrl.filterExcludedNotificationRecipients(log, tc.approvers, escalation)
+		result := ctrl.filterExcludedNotificationRecipients(log, tc.approvers, nil, escalation)
 
 		if len(result) != len(tc.expect) {
 			t.Fatalf("case %s: expected %d recipients, got %d: %v", tc.name, len(tc.expect), len(result), result)
@@ -6483,13 +6483,62 @@ func TestFilterExcludedNotificationRecipients(t *testing.T) {
 	}
 }
 
+func TestFilterExcludedNotificationRecipientsUsesRequestResolvedMembers(t *testing.T) {
+	log := zap.NewNop().Sugar()
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			NotificationExclusions: &breakglassv1alpha1.NotificationExclusions{
+				Groups: []string{"silent-approvers"},
+			},
+		},
+	}
+	approvers := []string{"visible@example.com", "silent@example.com"}
+	approversByGroup := map[string][]string{
+		"visible-approvers": {"visible@example.com"},
+		"silent-approvers":  {"silent@example.com"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		ctrl *BreakglassSessionController
+	}{
+		{
+			name: "resolver unavailable",
+			ctrl: &BreakglassSessionController{},
+		},
+		{
+			name: "resolver lookup fails",
+			ctrl: &BreakglassSessionController{
+				escalationManager: &testEscalationLookup{
+					resolver: &MockGroupResolver{members: map[string][]string{}},
+				},
+			},
+		},
+		{
+			name: "resolver returns empty result",
+			ctrl: &BreakglassSessionController{
+				escalationManager: &testEscalationLookup{
+					resolver: &MockGroupResolver{
+						members: map[string][]string{"silent-approvers": nil},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.ctrl.filterExcludedNotificationRecipients(log, approvers, approversByGroup, escalation)
+			assert.Equal(t, []string{"visible@example.com"}, result)
+		})
+	}
+}
+
 // TestDisableNotificationsFlag tests that disableNotifications prevents emails
 func TestDisableNotificationsFlag(t *testing.T) {
 	log := zap.NewNop().Sugar()
 
 	// Test with nil escalation
 	ctrl := &BreakglassSessionController{}
-	result := ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, nil)
+	result := ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, nil, nil)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 recipient with nil escalation, got %d", len(result))
 	}
@@ -6500,7 +6549,7 @@ func TestDisableNotificationsFlag(t *testing.T) {
 			NotificationExclusions: nil,
 		},
 	}
-	result = ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, escalation)
+	result = ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, nil, escalation)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 recipient with no exclusions, got %d", len(result))
 	}
@@ -6511,7 +6560,7 @@ func TestDisableNotificationsFlag(t *testing.T) {
 			NotificationExclusions: &breakglassv1alpha1.NotificationExclusions{},
 		},
 	}
-	result = ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, escalation)
+	result = ctrl.filterExcludedNotificationRecipients(log, []string{"user@example.com"}, nil, escalation)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 recipient with empty exclusions, got %d", len(result))
 	}
@@ -6569,7 +6618,7 @@ func TestFilterHiddenFromUIRecipients(t *testing.T) {
 					},
 				},
 			}
-			result := ctrl.filterHiddenFromUIRecipients(log, tt.approvers, escalation)
+			result := ctrl.filterHiddenFromUIRecipients(log, tt.approvers, nil, escalation)
 			if len(result) != tt.expected {
 				t.Fatalf("expected %d recipients, got %d; result: %v", tt.expected, len(result), result)
 			}
@@ -6577,7 +6626,7 @@ func TestFilterHiddenFromUIRecipients(t *testing.T) {
 	}
 
 	// Test with nil escalation
-	result := ctrl.filterHiddenFromUIRecipients(log, []string{"user@example.com"}, nil)
+	result := ctrl.filterHiddenFromUIRecipients(log, []string{"user@example.com"}, nil, nil)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 recipient with nil escalation, got %d", len(result))
 	}
@@ -6590,9 +6639,58 @@ func TestFilterHiddenFromUIRecipients(t *testing.T) {
 			},
 		},
 	}
-	result = ctrl.filterHiddenFromUIRecipients(log, []string{"user@example.com"}, escalation)
+	result = ctrl.filterHiddenFromUIRecipients(log, []string{"user@example.com"}, nil, escalation)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 recipient with empty hidden list, got %d", len(result))
+	}
+}
+
+func TestFilterHiddenFromUIRecipientsUsesRequestResolvedMembers(t *testing.T) {
+	log := zap.NewNop().Sugar()
+	escalation := &breakglassv1alpha1.BreakglassEscalation{
+		Spec: breakglassv1alpha1.BreakglassEscalationSpec{
+			Approvers: breakglassv1alpha1.BreakglassEscalationApprovers{
+				HiddenFromUI: []string{"fallback-approvers"},
+			},
+		},
+	}
+	approvers := []string{"visible@example.com", "fallback@example.com"}
+	approversByGroup := map[string][]string{
+		"visible-approvers":  {"visible@example.com"},
+		"fallback-approvers": {"fallback@example.com"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		ctrl *BreakglassSessionController
+	}{
+		{
+			name: "resolver unavailable",
+			ctrl: &BreakglassSessionController{},
+		},
+		{
+			name: "resolver lookup fails",
+			ctrl: &BreakglassSessionController{
+				escalationManager: &testEscalationLookup{
+					resolver: &MockGroupResolver{members: map[string][]string{}},
+				},
+			},
+		},
+		{
+			name: "resolver returns empty result",
+			ctrl: &BreakglassSessionController{
+				escalationManager: &testEscalationLookup{
+					resolver: &MockGroupResolver{
+						members: map[string][]string{"fallback-approvers": nil},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.ctrl.filterHiddenFromUIRecipients(log, approvers, approversByGroup, escalation)
+			assert.Equal(t, []string{"visible@example.com"}, result)
+		})
 	}
 }
 
@@ -6616,14 +6714,14 @@ func TestHiddenFromUIAndNotificationExclusionsCombined(t *testing.T) {
 	}
 
 	// First filter: notification exclusions
-	filtered := ctrl.filterExcludedNotificationRecipients(log, approvers, escalation)
+	filtered := ctrl.filterExcludedNotificationRecipients(log, approvers, nil, escalation)
 	// Should have: alice, bob, charlie (dave excluded)
 	if len(filtered) != 3 {
 		t.Fatalf("after notificationExclusions filter: expected 3, got %d; result: %v", len(filtered), filtered)
 	}
 
 	// Second filter: hidden from UI
-	filtered = ctrl.filterHiddenFromUIRecipients(log, filtered, escalation)
+	filtered = ctrl.filterHiddenFromUIRecipients(log, filtered, nil, escalation)
 	// Should have: alice, bob (charlie hidden, dave already excluded)
 	if len(filtered) != 2 {
 		t.Fatalf("after hiddenFromUI filter: expected 2, got %d; result: %v", len(filtered), filtered)
@@ -7361,7 +7459,7 @@ func TestUseCaseM2MAutomation(t *testing.T) {
 
 		// Test the notification filter logic
 		recipients := []string{"user1@example.com", "user2@example.com"}
-		result := ctrl.filterExcludedNotificationRecipients(log, recipients, escalation)
+		result := ctrl.filterExcludedNotificationRecipients(log, recipients, nil, escalation)
 
 		// With DisableNotifications, filterExcludedNotificationRecipients doesn't filter
 		// The actual email suppression happens at send time based on DisableNotifications flag

--- a/pkg/breakglass/session_request_helpers.go
+++ b/pkg/breakglass/session_request_helpers.go
@@ -856,12 +856,12 @@ func (wc *BreakglassSessionController) sendSessionNotifications(
 		"escalationName", matchedEsc.Name,
 		"preFilterApproverCount", len(allApprovers))
 
-	filteredApprovers := wc.filterExcludedNotificationRecipients(reqLog, allApprovers, matchedEsc)
+	filteredApprovers := wc.filterExcludedNotificationRecipients(reqLog, allApprovers, approversByGroup, matchedEsc)
 	reqLog.Debugw("After filterExcludedNotificationRecipients",
 		"postExcludeApproverCount", len(filteredApprovers),
 		"excludedCount", len(allApprovers)-len(filteredApprovers))
 
-	filteredApprovers = wc.filterHiddenFromUIRecipients(reqLog, filteredApprovers, matchedEsc)
+	filteredApprovers = wc.filterHiddenFromUIRecipients(reqLog, filteredApprovers, approversByGroup, matchedEsc)
 	reqLog.Debugw("After filterHiddenFromUIRecipients",
 		"postHiddenFilterApproverCount", len(filteredApprovers),
 		"hiddenFilteredOutCount", len(allApprovers)-len(filteredApprovers))


### PR DESCRIPTION
## Summary
- reuse request-resolved approver memberships when filtering `notificationExclusions.groups`
- reuse the same memberships for `approvers.hiddenFromUI`
- retain live resolver lookups only to augment that request-consistent membership set

## Concrete bug
Session request resolution already records each resolved approver in `approversByGroup`. Notification filtering then discarded that evidence and independently queried the current `GroupMemberResolver`. If that follow-up resolver was unavailable, returned an empty result, or failed (including a multi-IDP request followed by an unavailable legacy resolver), members already resolved for hidden/excluded groups were re-included and could receive email, contrary to the CRD/docs.

## Investigation
Reviewed all non-status-updater consumers:
- `session_request_helpers.go`: legacy and multi-IDP request/email resolution plus background refresh
- `session_controller_approval_utils.go`: direct/status/cluster-group approver authorization and its audited JWT fallback
- `session_controller_actions.go`: notification exclusions and hidden approvers
- `escalation_manager.go` / reconciler resolver replacement and cache behavior

Authorization already distinguishes resolved status membership from explicit fallback, and group lookup failures on approval are logged, metered, and audited. The concrete silent-success bug was limited to notification recipient filtering.

This branch is based on `origin/main` and is independent of #1224; that PR was used only for comparison.

## Validation
- `go test ./pkg/breakglass -run 'Test(FilterExcludedNotificationRecipients|FilterHiddenFromUIRecipients|HiddenFromUI_SessionRequest)' -count=1`
- `make lint` (0 issues)