### PR TITLE
fix: bump Helm chart version for release publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Helm chart release version**: Bumped `escalation-config` to chart version `0.3.3` so the next release can be published without colliding with the existing GHCR package version `0.3.2`.
+
 ## [0.1.0-rc.5] - 2026-08-11
 
 ### Fixed

--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:


### PR DESCRIPTION
## Summary

- bump `charts/escalation-config` from `0.3.2` to `0.3.3`
- fix the GHCR collision that blocked the `v0.1.0-rc.5` release workflow
- document the release fix in the changelog

The failed release workflow reported that chart version `0.3.2` already exists with appVersion `v0.1.0-rc.2`.