### PR TITLE
deps(npm): update Terser to 5.50.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "jsdom": "^30.0.1",
         "playwright": "^1.58.2",
         "prettier": "^3.9.6",
-        "terser": "^5.49.2",
+        "terser": "^5.50.0",
         "typescript": "npm:@typescript/typescript6@~6.0.2",
         "vite": "^8.2.1",
         "vitest": "^4.1.10",
@@ -8460,9 +8460,9 @@
       "license": "MIT"
     },
     "node_modules/terser": {
-      "version": "5.49.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
-      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
     "jsdom": "^30.0.1",
     "playwright": "^1.58.2",
     "prettier": "^3.9.6",
-    "terser": "^5.49.2",
+    "terser": "^5.50.0",
     "typescript": "npm:@typescript/typescript6@~6.0.2",
     "vite": "^8.2.1",
     "vitest": "^4.1.10",


### PR DESCRIPTION
## Summary
- update Terser from 5.49.2 to 5.50.0
- keep the frontend dependency set current at the end of the dependency audit

## Validation
- frontend lint and dual TypeScript checks
- 1,068 frontend unit tests
- production frontend build
- UI E2E test discovery

`make lint` and the full `make test` suite passed on the immediately preceding final dependency state; this PR changes only the frontend minifier package and lockfile.