### PR TITLE
release: prepare v0.1.0-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.7] - 2026-08-12
+
+### Changed
+
+- Updated the frontend minifier to Terser 5.50.0 after completing the dependency audit.
+
+### Fixed
+
+- Bumped `escalation-config` to chart version `0.3.4` so the release can publish a unique OCI chart artifact.
+
 ## [0.1.0-rc.6] - 2026-08-11
 
 ### Fixed

--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:


### PR DESCRIPTION
## Summary
- bump `escalation-config` from 0.3.3 to the unused 0.3.4 chart version
- prepare v0.1.0-rc.7 release notes after the final dependency update
- avoid the OCI chart-version collision that broke earlier release attempts

## Validation
- `make helm-validate`
- `make lint`
- `make test`
- verified chart 0.3.3 exists with appVersion v0.1.0-rc.6
- verified chart 0.3.4 is not yet published

No release tag will be created until this PR is fully green and merged.