### PR TITLE
fix(security): bump Go to 1.26.6 and nanoid to 3.3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux; cd /workspace/frontend; \
 	npm run build
 
 # Build the manager binary
-FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
+FROM golang:1.26.6@sha256:640a234f4bea3e399c056b7b8f9c667c4939befae8db2f14e9785e16eccd4205 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7217,9 +7217,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/telekom/k8s-breakglass
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
## Problem

`Security Scan` fails on main. Run 31861366957 shows two failing jobs, not one.

**Go Vulnerability Check** exits 3 with 7 called vulnerabilities. Every one is a Go standard library issue and every one is fixed in go1.26.6. `go.mod` pinned `go 1.26.5`.

| ID | Package | Fixed in |
| --- | --- | --- |
| GO-2026-6218 | net/url | go1.26.6 |
| GO-2026-6091 | html/template | go1.26.6 |
| GO-2026-6090 | crypto/tls | go1.26.6 |
| GO-2026-6089 | net/http | go1.26.6 |
| GO-2026-6088 | encoding/xml | go1.26.6 |
| GO-2026-5972 | encoding/asn1 | go1.26.6 |
| GO-2026-5026 | net/http (x/net/idna) | go1.26.6 |

**Trivy Filesystem Scan** exits 1 on CVE-2026-67213 in nanoid 3.3.17, severity HIGH, fixed in 3.3.18. nanoid is transitive through postcss.

## Changes

- `go.mod`: `go 1.26.6`.
- `Dockerfile`: builder image `golang:1.26.6`, digest updated, so released binaries carry the same fix.
- `frontend/package-lock.json`: nanoid 3.3.17 to 3.3.18. 3.3.18 satisfies the existing `^3.3.16` range, so `package.json` is unchanged and the diff is 3 lines.

No security gate is disabled or made non-blocking. The `hack/check-govulncheck.py` classifier pattern from BOOTy#534 is not needed here, because the toolchain bump removes all 7 findings rather than reclassifying them.

## Validation

Run locally with go1.26.6 and trivy v0.70.0, matching the CI flags.

```
govulncheck ./...                 exit 0   (was exit 3, "affected by 7 vulnerabilities")
trivy fs . --exit-code 1 --ignore-unfixed \
  --severity CRITICAL,HIGH --pkg-types os,library   exit 0   (was exit 1)
go build ./...                    exit 0
```

Trivy report summary after the change: `frontend/package-lock.json` 0, `go.mod` 0.

One module-level advisory remains in a required module that the code does not call. It was present before this change and does not affect the exit code.