### PR TITLE
fix(escalation): persist empty approver groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **User-flow recordings**: Added reproducible, narrated and paced E2E API/webhook, `bgctl`/`kubectl`, standalone browser/console, and synchronized browser-plus-console recordings covering denial, approval, Kubernetes identity/API access, deny-policy precedence, DebugSession creation, and debug-pod `tcpdump` usage.
 
+### Fixed
+
+- Persist empty approver-group membership as `[]` instead of invalid `null`, and
+  avoid repeated warning logs for an unchanged expected-empty group state.
+
 ## [0.1.0-rc.7] - 2026-08-12
 
 ### Changed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -734,6 +734,9 @@ kubectl get events --field-selector involvedObject.name=<name>
 
 **Solution:** Add the intended approver to the AD/Keycloak group, or configure
 an approver user/group that is populated in the selected identity provider.
+Empty membership is persisted as an empty list. The controller emits a warning
+event when this state changes, while unchanged periodic checks are logged only
+at debug level.
 
 ### ApprovalGroupMembersResolved Condition: False (GroupNotFound)
 

--- a/pkg/breakglass/escalation/escalation_status_updater.go
+++ b/pkg/breakglass/escalation/escalation_status_updater.go
@@ -474,7 +474,7 @@ func (k *KeycloakGroupMemberResolver) Members(ctx context.Context, group string)
 	}
 	out = normalizeMembers(out)
 	if len(out) == 0 && log != nil {
-		log.Warnw("Configured Keycloak group exists but has no resolvable members",
+		log.Debugw("Configured Keycloak group exists but has no resolvable members",
 			"group", system.RedactGroupName(group))
 	}
 	if log != nil {
@@ -1095,7 +1095,7 @@ func (u EscalationStatusUpdater) fetchGroupMembersFromMultipleIDPsReport(
 			}
 			idpGroupMembers[g] = normalizeMembers(members)
 			if len(idpGroupMembers[g]) == 0 {
-				log.Warnw("Configured approver group exists but has no resolvable members",
+				log.Debugw("Configured approver group exists but has no resolvable members",
 					"escalation", escalation.Name,
 					"idp", idpName,
 					"group", system.RedactGroupName(g))
@@ -1393,7 +1393,7 @@ func equalIDPHierarchy(a, b map[string]map[string][]string) bool {
 // Returns the deduplicated list of members for that group from all IDPs, sorted for deterministic output
 func deduplicateMembersFromHierarchy(hierarchy map[string]map[string][]string, group string) []string {
 	seen := make(map[string]struct{})
-	var result []string
+	result := make([]string, 0)
 
 	// Iterate through each IDP in hierarchy
 	for _, groupMembers := range hierarchy {

--- a/pkg/breakglass/escalation/escalation_status_updater_dependencies_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_dependencies_test.go
@@ -291,7 +291,7 @@ func TestDeduplicateMembersFromHierarchy(t *testing.T) {
 			name:      "empty hierarchy",
 			hierarchy: map[string]map[string][]string{},
 			group:     "admin",
-			expected:  nil,
+			expected:  []string{},
 		},
 		{
 			name: "single IDP single group",
@@ -316,7 +316,7 @@ func TestDeduplicateMembersFromHierarchy(t *testing.T) {
 				"idp1": {"admin": {"user1@example.com"}},
 			},
 			group:    "developers",
-			expected: nil,
+			expected: []string{},
 		},
 		{
 			name: "normalizes to lowercase",

--- a/pkg/breakglass/escalation/escalation_status_updater_test.go
+++ b/pkg/breakglass/escalation/escalation_status_updater_test.go
@@ -272,6 +272,7 @@ func TestDeduplicateMembersFromHierarchy_EmptyHierarchy(t *testing.T) {
 	hierarchy := map[string]map[string][]string{}
 
 	result := deduplicateMembersFromHierarchy(hierarchy, "admin-group")
+	assert.NotNil(t, result)
 	assert.Len(t, result, 0)
 }
 
@@ -284,6 +285,7 @@ func TestDeduplicateMembersFromHierarchy_GroupNotFound(t *testing.T) {
 	}
 
 	result := deduplicateMembersFromHierarchy(hierarchy, "admin-group")
+	assert.NotNil(t, result)
 	assert.Len(t, result, 0)
 }
 


### PR DESCRIPTION
## Summary
- serialize empty approver groups as `[]` instead of invalid `null`
- avoid duplicate warning logs for expected empty groups while retaining status conditions/events
- document the behavior and add regression coverage

## Validation
- `go test ./pkg/breakglass/escalation`
- `make lint`
- `make test`

## Rollout impact
This fixes the recurring `Failed updating escalation status` bursts observed after deploying k8s-breakglass rc.15 to the DEV management plane.