### PR TITLE
release: prepare v0.1.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.8] - 2026-08-22
+
 ### Added
 
 - **User-flow recordings**: Added reproducible, narrated and paced E2E API/webhook, `bgctl`/`kubectl`, standalone browser/console, and synchronized browser-plus-console recordings covering denial, approval, Kubernetes identity/API access, deny-policy precedence, DebugSession creation, and debug-pod `tcpdump` usage.
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Persist empty approver-group membership as `[]` instead of invalid `null`, and
-  avoid repeated warning logs for an unchanged expected-empty group state.
+  avoid repeated warning logs for an unchanged expected-empty group state. (#1244)
 
 ## [0.1.0-rc.7] - 2026-08-12
 

--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:


### PR DESCRIPTION
## Summary
- cut v0.1.0-rc.8 release notes from current main
- publish the empty-approver-group status/log storm fix from #1244
- bump the escalation-config chart to 0.3.5

## Validation
- `git diff --check`
- `helm lint charts/escalation-config --values charts/escalation-config/ci/test-values.yaml`
- #1244 full CI and E2E suite green