### PR TITLE
feat(chart): add standalone debug session catalogue (TCAAS-1620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Standalone debug-session catalogue**: Added the OCI-ready
+  `debug-session-catalogue` Helm chart with neutral workload, network,
+  storage, packet-capture, network-repair, node-recovery, and cluster-validation
+  profiles. Requesters, approvers, targets, images, and the target namespace are
+  configurable; elevated profiles are disabled and require explicit opt-in.
+
 ## [0.1.0-rc.8] - 2026-08-22
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,11 @@ $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: helm-validate
-helm-validate: ## Validate Helm chart syntax and templates for escalation-config
+helm-validate: ## Validate Helm chart syntax and templates
 	helm lint charts/escalation-config --strict --values charts/escalation-config/ci/test-values.yaml
 	helm template escalation-config charts/escalation-config --values charts/escalation-config/ci/test-values.yaml > /dev/null
+	helm lint charts/debug-session-catalogue --strict --values charts/debug-session-catalogue/ci/test-values.yaml
+	helm template debug-session-catalogue charts/debug-session-catalogue --values charts/debug-session-catalogue/ci/test-values.yaml > /dev/null
 	@echo "Helm chart validation passed"
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/charts/debug-session-catalogue/Chart.yaml
+++ b/charts/debug-session-catalogue/Chart.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: debug-session-catalogue
+description: >-
+  Generic, standalone DebugSessionTemplate and DebugPodTemplate catalogue for
+  k8s-breakglass. Profiles are restricted by default and configurable for the
+  requesters, approvers, and clusters of an installation.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/telekom/k8s-breakglass
+icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
+keywords:
+  - breakglass
+  - debug
+  - kubernetes
+  - troubleshooting
+maintainers:
+  - name: Telekom OSS
+    url: https://github.com/telekom/k8s-breakglass

--- a/charts/debug-session-catalogue/README.md
+++ b/charts/debug-session-catalogue/README.md
@@ -1,0 +1,86 @@
+# Debug Session Catalogue Helm Chart
+
+This standalone chart publishes a neutral catalogue of reusable
+`DebugPodTemplate` and `DebugSessionTemplate` resources for
+[k8s-breakglass](https://github.com/telekom/k8s-breakglass). It contains no
+tenant, platform, identity-provider, or cluster names and does not create
+namespaces or RBAC. The target namespace must be pre-created and authorized by
+the cluster administrator.
+
+## Install
+
+Install the CRDs and controller first, then configure access and targets:
+
+```yaml
+requesters:
+  groups: [sre]
+  users: []
+approvers:
+  groups: [incident-commanders]
+  users: []
+targets:
+  clusters: [cluster-a]
+targetNamespace: breakglass-debug
+```
+
+```bash
+helm install debug-catalogue \
+  oci://ghcr.io/telekom/k8s-breakglass/charts/debug-session-catalogue \
+  --version 0.1.0 \
+  -f access-values.yaml
+```
+
+The default empty requester, approver, and target lists intentionally make the
+catalogue unusable until an administrator supplies local policy. This prevents
+a chart installation from accidentally granting access to every user or
+cluster. `failMode: closed`, mandatory request reasons, one-hour maximum
+duration, no renewal, no attach/port-forward, no service-account token, and
+non-root isolated pods are also defaults.
+
+## Profiles
+
+The chart includes these profiles:
+
+| Profile | Default | Purpose |
+| --- | --- | --- |
+| `workload` | enabled | Isolated workload diagnostics |
+| `network` | enabled | Isolated DNS/network diagnostics |
+| `storage` | enabled | Ephemeral storage inspection |
+| `cluster-validation` | enabled | Isolated read-only validation checks |
+| `dump-access` | disabled | Host-network packet capture |
+| `network-repair` | disabled | Host-network network repair |
+| `node-recovery` | disabled | Host-network/host-PID node recovery |
+
+The last three profiles are elevated. Enable them only with an explicit
+two-part opt-in, for example:
+
+```yaml
+profiles:
+  dump-access:
+    enabled: true
+    elevated: true
+```
+
+The chart fails closed when an elevated profile is enabled without
+`elevated: true`. Replace the default public utility images with organization-
+approved images, ideally by digest:
+
+```yaml
+images:
+  dumpAccess:
+    repository: registry.example.invalid/debug-tools
+    tag: "2026.01"
+    digest: sha256:...
+```
+
+Images are an interface, not a dependency of this chart: each image should
+provide the command in its profile's `command`/`args` values and should be
+reviewed for the capabilities requested by that profile. The defaults are
+deliberately neutral and do not claim to include specialized tools such as
+`tcpdump` or `kubectl`.
+
+## Interface report
+
+See [`docs/debug-session-catalogue-interface.md`](../../docs/debug-session-catalogue-interface.md)
+for the resource naming contract, profile/image contract, and integration
+notes for adjacent image and controller work.

--- a/charts/debug-session-catalogue/ci/test-values.yaml
+++ b/charts/debug-session-catalogue/ci/test-values.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+requesters:
+  groups: [platform-debuggers]
+  users: [oncall@example.invalid]
+approvers:
+  groups: [platform-approvers]
+  users: [approver@example.invalid]
+targets:
+  clusters: [example-cluster]
+targetNamespace: debug-sessions

--- a/charts/debug-session-catalogue/ci/validate.sh
+++ b/charts/debug-session-catalogue/ci/validate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+
+helm lint "${chart_dir}" --strict
+helm template debug-catalogue "${chart_dir}" \
+  --values "${chart_dir}/ci/test-values.yaml" >"${rendered}"
+
+[[ "$(grep -c '^kind: DebugPodTemplate$' "${rendered}")" -eq 4 ]]
+[[ "$(grep -c '^kind: DebugSessionTemplate$' "${rendered}")" -eq 4 ]]
+! grep -q 'hostNetwork: true' "${rendered}"
+! grep -q 'privileged: true' "${rendered}"
+
+if helm template debug-catalogue "${chart_dir}" \
+  --set 'profiles.dump-access.enabled=true' >/dev/null 2>&1; then
+  echo "dump-access must require elevated: true" >&2
+  exit 1
+fi
+
+helm template debug-catalogue "${chart_dir}" \
+  --set 'profiles.dump-access.enabled=true' \
+  --set 'profiles.dump-access.elevated=true' >/dev/null
+
+echo "debug-session-catalogue validation passed"

--- a/charts/debug-session-catalogue/templates/_helpers.tpl
+++ b/charts/debug-session-catalogue/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- define "debug-session-catalogue.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "debug-session-catalogue.fullname" -}}
+{{- if .Values.fullnameOverride -}}{{ .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{{- else -}}{{ include "debug-session-catalogue.name" . }}{{- end -}}
+{{- end -}}
+{{- define "debug-session-catalogue.labels" -}}
+app.kubernetes.io/name: {{ include "debug-session-catalogue.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+{{- end -}}
+{{- define "debug-session-catalogue.image" -}}
+{{- $image := index .root.Values.images .key -}}
+{{- if $image.digest }}{{ printf "%s@%s" $image.repository $image.digest }}{{- else }}{{ printf "%s:%s" $image.repository $image.tag }}{{- end -}}
+{{- end -}}

--- a/charts/debug-session-catalogue/templates/debugpodtemplates.yaml
+++ b/charts/debug-session-catalogue/templates/debugpodtemplates.yaml
@@ -1,0 +1,78 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- if .Values.enabled }}
+{{- range $name, $profile := .Values.profiles }}
+{{- if $profile.enabled }}
+{{- if and $profile.requiredElevation (not $profile.elevated) }}
+{{- fail (printf "profiles.%s requires explicit elevated: true when enabled" $name) }}
+{{- end }}
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DebugPodTemplate
+metadata:
+  name: {{ printf "%s-%s" (include "debug-session-catalogue.fullname" $) $name | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "debug-session-catalogue.labels" $ | nindent 4 }}
+    breakglass.t-caas.telekom.com/catalogue-profile: {{ $name | quote }}
+    breakglass.t-caas.telekom.com/elevated: {{ $profile.elevated | default false | quote }}
+spec:
+  displayName: {{ required (printf "profiles.%s.displayName is required" $name) $profile.displayName | quote }}
+  description: {{ required (printf "profiles.%s.description is required" $name) $profile.description | quote }}
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: {{ if $profile.elevated }}false{{ else }}true{{ end }}
+        {{- if not $profile.elevated }}
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        {{- end }}
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: debug
+          image: {{ include "debug-session-catalogue.image" (dict "root" $ "key" $profile.imageKey) | quote }}
+          imagePullPolicy: {{ $.Values.imagePullPolicy }}
+          command:
+{{ toYaml $profile.command | nindent 12 }}
+          args:
+{{ toYaml $profile.args | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: {{ if $profile.elevated }}true{{ else }}false{{ end }}
+            privileged: {{ if $profile.elevated }}{{ $profile.privileged | default false }}{{ else }}false{{ end }}
+            capabilities:
+              drop: [ALL]
+              {{- if and $profile.elevated $profile.capabilities }}
+              add:
+{{ toYaml $profile.capabilities | nindent 16 }}
+              {{- end }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          {{- with $profile.volumeMounts }}
+          volumeMounts:
+{{ toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with $profile.volumes }}
+      volumes:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      hostNetwork: {{ if $profile.elevated }}{{ $profile.hostNetwork | default false }}{{ else }}false{{ end }}
+      hostPID: {{ if $profile.elevated }}{{ $profile.hostPID | default false }}{{ else }}false{{ end }}
+      hostIPC: {{ if $profile.elevated }}{{ $profile.hostIPC | default false }}{{ else }}false{{ end }}
+      {{- with $profile.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/debug-session-catalogue/templates/debugsessiontemplates.yaml
+++ b/charts/debug-session-catalogue/templates/debugsessiontemplates.yaml
@@ -1,0 +1,69 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- if .Values.enabled }}
+{{- range $name, $profile := .Values.profiles }}
+{{- if $profile.enabled }}
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DebugSessionTemplate
+metadata:
+  name: {{ printf "%s-%s" (include "debug-session-catalogue.fullname" $) $name | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "debug-session-catalogue.labels" $ | nindent 4 }}
+    breakglass.t-caas.telekom.com/catalogue-profile: {{ $name | quote }}
+    breakglass.t-caas.telekom.com/elevated: {{ $profile.elevated | default false | quote }}
+spec:
+  displayName: {{ required (printf "profiles.%s.displayName is required" $name) $profile.displayName | quote }}
+  description: {{ required (printf "profiles.%s.description is required" $name) $profile.description | quote }}
+  mode: workload
+  podTemplateRef:
+    name: {{ printf "%s-%s" (include "debug-session-catalogue.fullname" $) $name | replace "_" "-" | trunc 63 | trimSuffix "-" }}
+  workloadType: {{ $profile.workloadType | default "Deployment" }}
+  replicas: {{ $profile.replicas | default 1 }}
+  allowed:
+    groups:
+{{ toYaml $.Values.requesters.groups | nindent 6 }}
+    users:
+{{ toYaml $.Values.requesters.users | nindent 6 }}
+    clusters:
+{{ toYaml $.Values.targets.clusters | nindent 6 }}
+    {{- with $.Values.targets.clusterSelector }}
+    {{- if . }}
+    clusterSelector:
+{{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+  approvers:
+    groups:
+{{ toYaml $.Values.approvers.groups | nindent 6 }}
+    users:
+{{ toYaml $.Values.approvers.users | nindent 6 }}
+  constraints:
+    defaultDuration: {{ $.Values.defaultDuration | quote }}
+    maxDuration: {{ $.Values.maxDuration | quote }}
+    maxConcurrentSessions: {{ $.Values.maxConcurrentSessions }}
+    allowRenewal: false
+    maxRenewals: 0
+  targetNamespace: {{ $.Values.targetNamespace | quote }}
+  namespaceConstraints:
+    defaultNamespace: {{ $.Values.targetNamespace | quote }}
+    allowUserNamespace: false
+    createIfNotExists: false
+  failMode: closed
+  requestReason:
+    mandatory: true
+    minLength: 10
+    maxLength: 1000
+    description: Explain the incident, scope, and intended diagnostic action.
+  audit:
+    enabled: true
+  allowedPodOperations:
+    exec: true
+    attach: false
+    logs: true
+    portForward: false
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/debug-session-catalogue/values.schema.json
+++ b/charts/debug-session-catalogue/values.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enabled": { "type": "boolean" },
+    "requesters": { "type": "object", "additionalProperties": false, "properties": { "groups": { "type": "array", "items": { "type": "string" } }, "users": { "type": "array", "items": { "type": "string" } } } },
+    "approvers": { "type": "object", "additionalProperties": false, "properties": { "groups": { "type": "array", "items": { "type": "string" } }, "users": { "type": "array", "items": { "type": "string" } } } },
+    "targets": { "type": "object", "additionalProperties": false, "properties": { "clusters": { "type": "array", "items": { "type": "string" } }, "clusterSelector": { "type": "object" } } },
+    "targetNamespace": { "type": "string", "minLength": 1 },
+    "defaultDuration": { "type": "string", "pattern": "^[0-9]+(ns|us|ms|s|m|h|d)+$" },
+    "maxDuration": { "type": "string", "pattern": "^[0-9]+(ns|us|ms|s|m|h|d)+$" },
+    "maxConcurrentSessions": { "type": "integer", "minimum": 1 },
+    "imagePullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+    "images": { "type": "object" },
+    "profiles": { "type": "object" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" }
+  },
+  "required": ["requesters", "approvers", "targets", "profiles"]
+}

--- a/charts/debug-session-catalogue/values.yaml
+++ b/charts/debug-session-catalogue/values.yaml
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+# This chart creates cluster-scoped DebugPodTemplate and DebugSessionTemplate
+# resources. It does not create namespaces, RBAC, ClusterConfig resources, or
+# images. Install it after the k8s-breakglass CRDs and pre-create targetNamespace.
+
+enabled: true
+
+# Empty lists intentionally grant no access and target no clusters. Configure
+# these values for the installation; do not put tenant or provider names here.
+requesters:
+  groups: []
+  users: []
+approvers:
+  groups: []
+  users: []
+targets:
+  clusters: []
+  clusterSelector: {}
+
+targetNamespace: breakglass-debug
+defaultDuration: 30m
+maxDuration: 1h
+maxConcurrentSessions: 1
+imagePullPolicy: IfNotPresent
+
+# Replace these public, versioned utility images with images approved by your
+# organization. Image digests are supported by setting image.digest.
+images:
+  workload: {repository: busybox, tag: "1.36.1", digest: ""}
+  network: {repository: busybox, tag: "1.36.1", digest: ""}
+  storage: {repository: busybox, tag: "1.36.1", digest: ""}
+  dumpAccess: {repository: busybox, tag: "1.36.1", digest: ""}
+  networkRepair: {repository: busybox, tag: "1.36.1", digest: ""}
+  nodeRecovery: {repository: busybox, tag: "1.36.1", digest: ""}
+  clusterValidation: {repository: busybox, tag: "1.36.1", digest: ""}
+
+# Elevated profiles are disabled by default. To use one, set both enabled and
+# elevated to true. The chart fails closed if a required-elevation profile is
+# enabled without the explicit opt-in.
+profiles:
+  workload:
+    enabled: true
+    elevated: false
+    displayName: Workload diagnostics
+    description: Inspect a workload from an isolated, non-privileged pod.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: workload
+    command: ["sh", "-c"]
+    args: ["echo 'Workload diagnostics ready'; while true; do sleep 3600; done"]
+    requiredElevation: false
+    hostNetwork: false
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: []
+    volumeMounts: []
+    volumes: []
+  network:
+    enabled: true
+    elevated: false
+    displayName: Network diagnostics
+    description: Inspect DNS and network connectivity from an isolated pod.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: network
+    command: ["sh", "-c"]
+    args: ["echo 'Network diagnostics ready'; while true; do sleep 3600; done"]
+    requiredElevation: false
+    hostNetwork: false
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: []
+    volumeMounts: []
+    volumes: []
+  storage:
+    enabled: true
+    elevated: false
+    displayName: Storage diagnostics
+    description: Inspect ephemeral storage from an isolated pod.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: storage
+    command: ["sh", "-c"]
+    args: ["echo 'Storage diagnostics ready'; df -h /workspace; while true; do sleep 3600; done"]
+    requiredElevation: false
+    hostNetwork: false
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: []
+    volumeMounts:
+      - name: workspace
+        mountPath: /workspace
+    volumes:
+      - name: workspace
+        emptyDir: {}
+  dump-access:
+    enabled: false
+    elevated: false
+    displayName: Packet capture (opt-in)
+    description: Capture packets on a target node; requires explicit elevated opt-in.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: dumpAccess
+    command: ["sh", "-c"]
+    args: ["echo 'Packet capture ready; provide an approved capture command'; while true; do sleep 3600; done"]
+    requiredElevation: true
+    hostNetwork: true
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: [NET_RAW, NET_ADMIN]
+    volumeMounts: []
+    volumes: []
+  network-repair:
+    enabled: false
+    elevated: false
+    displayName: Network repair (opt-in)
+    description: Perform network repair actions on a target node; requires explicit elevated opt-in.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: networkRepair
+    command: ["sh", "-c"]
+    args: ["echo 'Network repair ready; provide an approved repair command'; while true; do sleep 3600; done"]
+    requiredElevation: true
+    hostNetwork: true
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: [NET_ADMIN]
+    volumeMounts: []
+    volumes: []
+  node-recovery:
+    enabled: false
+    elevated: false
+    displayName: Node recovery (opt-in)
+    description: Inspect and recover a node; requires explicit elevated opt-in.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: nodeRecovery
+    command: ["sh", "-c"]
+    args: ["echo 'Node recovery ready; provide an approved recovery command'; while true; do sleep 3600; done"]
+    requiredElevation: true
+    hostNetwork: true
+    hostPID: true
+    hostIPC: false
+    privileged: true
+    capabilities: []
+    volumeMounts: []
+    volumes: []
+  cluster-validation:
+    enabled: true
+    elevated: false
+    displayName: Cluster validation
+    description: Run read-only cluster validation checks from an isolated pod.
+    workloadType: Deployment
+    replicas: 1
+    imageKey: clusterValidation
+    command: ["sh", "-c"]
+    args: ["echo 'Cluster validation ready'; while true; do sleep 3600; done"]
+    requiredElevation: false
+    hostNetwork: false
+    hostPID: false
+    hostIPC: false
+    privileged: false
+    capabilities: []
+    volumeMounts: []
+    volumes: []

--- a/docs/debug-session-catalogue-interface.md
+++ b/docs/debug-session-catalogue-interface.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Debug session catalogue interface report
+
+This report records the file and value interfaces introduced by TCAAS-1620 so
+the catalogue can be coordinated with image, controller, and release work.
+
+## Resources
+
+The `charts/debug-session-catalogue` chart renders one cluster-scoped
+`DebugPodTemplate` and one cluster-scoped `DebugSessionTemplate` per enabled
+profile. Both names are deterministic:
+
+```text
+<release fullname>-<profile key>
+```
+
+The session template's `podTemplateRef.name` is the matching pod template name.
+Profile keys are `workload`, `network`, `storage`, `dump-access`,
+`network-repair`, `node-recovery`, and `cluster-validation`.
+
+## Access and targets
+
+`requesters.groups/users`, `approvers.groups/users`, and
+`targets.clusters/clusterSelector` are copied into every session template.
+They default to empty lists. This is intentional: installation alone grants no
+request, approval, or cluster access. The chart does not infer identities from
+the release namespace or environment.
+
+`targetNamespace` is copied to `spec.targetNamespace` and
+`spec.namespaceConstraints.defaultNamespace`; user-selected namespaces and
+namespace creation are disabled. Administrators must create and authorize that
+namespace separately.
+
+## Security contract
+
+All profiles use a non-root pod, RuntimeDefault seccomp, dropped capabilities,
+no service-account token, disabled service links, bounded CPU/memory, closed
+failure mode, mandatory request reasons, one-hour maximum duration, no renewal,
+and only exec/log operations by default. Elevated profiles are absent from the
+rendered output unless `enabled: true`, and the chart requires a second explicit
+`elevated: true` setting. Only then can host namespaces, privileged mode, or
+additional capabilities be rendered.
+
+The chart does not create RBAC. Cluster administrators must review controller
+and target-cluster permissions before enabling any elevated profile.
+
+## Image contract
+
+Each profile selects `images.<profile imageKey>` and runs the profile's
+`command`/`args`. Images are configurable and should be pinned by digest in
+production. The chart's neutral `busybox:1.36.1` defaults are intentionally
+minimal; specialized image work may replace them without changing CR names or
+the catalogue interface. In particular, the default dump, repair, and recovery
+profiles are disabled and must not be treated as shipping packet-capture or
+node-recovery tooling.
+
+## OCI and release integration
+
+The chart is packaged as `debug-session-catalogue-<version>.tgz` and is
+intended for the OCI repository:
+
+```text
+oci://ghcr.io/telekom/k8s-breakglass/charts/debug-session-catalogue
+```
+
+Release automation should stamp `appVersion` with the release tag and publish
+the chart independently from controller images. A chart package contains only
+CR templates and values; no image is bundled.


### PR DESCRIPTION
## Outcome

Adds a generic, standalone OCI-ready DebugSession catalogue with seven intent-based profiles and fail-closed access defaults. It intentionally contains no TDG/T-CaaS-specific identities, namespaces, or platform assumptions.

## Profiles

| Profile | Default | Intent |
| --- | --- | --- |
| workload | enabled | isolated workload diagnostics |
| network | enabled | DNS and network diagnostics |
| storage | enabled | ephemeral storage diagnostics |
| cluster-validation | enabled | read-only cluster validation |
| dump-access | disabled | elevated packet capture |
| network-repair | disabled | controlled network repair |
| node-recovery | disabled | privileged node recovery |

Elevated profiles require both `enabled: true` and `elevated: true`. Requesters, approvers, cluster targets and images are installation inputs and default to no access.

## Validation

- `helm lint --strict`
- `charts/debug-session-catalogue/ci/validate.sh`
- `make helm-validate`
- `helm package`
- `git diff --check origin/main...HEAD`

Jira: TCAAS-1620 (parent TCAAS-1551)