### PR TITLE
feat(images): add bounded node-maintenance utility

### DIFF
--- a/.github/workflows/node-maintenance.yml
+++ b/.github/workflows/node-maintenance.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Node maintenance image
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "utils/node-maintenance/**"
+      - "docs/node-maintenance.md"
+      - ".github/workflows/node-maintenance.yml"
+  push:
+    branches: [main]
+    paths:
+      - "utils/node-maintenance/**"
+      - "docs/node-maintenance.md"
+      - ".github/workflows/node-maintenance.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: Static image checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Exercise image helper contracts
+        run: make -C utils/node-maintenance test
+      - name: ShellCheck image helpers
+        run: shellcheck utils/node-maintenance/bin/* utils/node-maintenance/lib/*.sh utils/node-maintenance/tests/*.sh
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: utils/node-maintenance/Dockerfile
+
+  behavior:
+    name: Real image behavior
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Exercise recovery, repair, boundary, evidence, and cleanup contracts
+        run: make -C utils/node-maintenance integration

--- a/.github/workflows/node-maintenance.yml
+++ b/.github/workflows/node-maintenance.yml
@@ -25,6 +25,7 @@ jobs:
   static:
     name: Static image checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Exercise image helper contracts
@@ -39,6 +40,7 @@ jobs:
   behavior:
     name: Real image behavior
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,6 +22,12 @@ path = ["config/**.yaml", "charts/**.yaml", "charts/**.txt", "e2e/**.yaml", "uti
 SPDX-FileCopyrightText = "2025 Deutsche Telekom AG"
 SPDX-License-Identifier = "Apache-2.0"
 
+[[annotations]]
+precedence = "aggregate"
+path = ["utils/node-maintenance/**.yaml", "utils/node-maintenance/**.lock"]
+SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
+SPDX-License-Identifier = "Apache-2.0"
+
 # Scripts
 [[annotations]]
 precedence = "aggregate"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,7 +24,7 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 precedence = "aggregate"
-path = ["utils/node-maintenance/**.yaml", "utils/node-maintenance/**.lock"]
+path = ["utils/node-maintenance/**.yaml", "utils/node-maintenance/**.json", "utils/node-maintenance/**.lock"]
 SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
 SPDX-License-Identifier = "Apache-2.0"
 

--- a/docs/node-maintenance.md
+++ b/docs/node-maintenance.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Node-maintenance image
+
+The standalone [`utils/node-maintenance`](../utils/node-maintenance/) image is
+for a narrowly scoped node-network incident workflow. It supports a read-only
+`node-recovery` preflight and three explicitly selected `network-repair`
+actions. It is not a
+replacement for a host-debug image and intentionally does not document an
+unrestricted shell or ship a general-purpose network toolbox.
+
+See the utility README and its [preflight](../utils/node-maintenance/runbooks/node-recovery-preflight.md)
+and [repair](../utils/node-maintenance/runbooks/network-repair.md) runbooks for
+the required host-networked pod, minimal `NET_ADMIN` capability, exact target,
+confirmation, and evidence workflow.
+
+Builds target `linux/amd64` and `linux/arm64`, pin the Alpine manifest and APK
+package versions, request BuildKit provenance/SBOM attestations, and sign only
+the resulting immutable registry digest. No image is pushed by the local
+Makefile.
+
+The Linux-only integration target (`make -C utils/node-maintenance integration`)
+builds and runs the image in disposable `--network none` namespaces with the
+intended `NET_ADMIN` capability boundary. It executes every allowlisted action,
+checks real before/after evidence and denial guards, and verifies container and
+volume cleanup. Missing Docker, namespace support, or security flags fails the
+job with diagnostics; the proof never silently skips.

--- a/docs/node-maintenance.md
+++ b/docs/node-maintenance.md
@@ -22,11 +22,12 @@ API `spec.nodeName`; hostname is not a trust input.
 
 Built-in runbooks remain under
 `/usr/share/breakglass/runbooks/upstream/node-maintenance/`. A downstream
-deployment may mount an optional, digest-pinned runbook bundle read-only at the
-shared `/usr/share/breakglass/runbooks/internal` root, without `subPath` and
-with an optional `INDEX.md`; the image does not hardcode, source, or execute
-bundle content. That wiring is an external immutable-template/admission
-responsibility.
+deployment may mount an optional, digest-pinned [OCI runbook bundle](runbook-bundle-contract.md)
+read-only at the shared `/usr/share/breakglass/runbooks/internal` root,
+without `subPath`. When selected, the bundle must follow that contract,
+including its required `bundle.yaml` and `INDEX.md`; the image does not
+hardcode, source, or execute bundle content. That wiring is an external
+immutable-template/admission responsibility.
 
 Builds target `linux/amd64` and `linux/arm64`, pin the Alpine manifest and APK
 package versions, request BuildKit provenance/SBOM attestations, and sign only

--- a/docs/node-maintenance.md
+++ b/docs/node-maintenance.md
@@ -20,11 +20,13 @@ contexts, controller-provided exact target, confirmation, and evidence
 workflow. Workload templates must inject `BREAKGLASS_NODE_NAME` from Downward
 API `spec.nodeName`; hostname is not a trust input.
 
-Built-in runbooks remain under `/usr/share/node-maintenance/`. A downstream
-deployment may read-only mount an optional, digest-pinned runbook bundle at
-`/runbooks/internal`, with an optional `INDEX.md`; the image does not hardcode,
-source, or execute bundle content. That wiring is an external immutable-
-template/admission responsibility.
+Built-in runbooks remain under
+`/usr/share/breakglass/runbooks/upstream/node-maintenance/`. A downstream
+deployment may mount an optional, digest-pinned runbook bundle read-only at the
+shared `/usr/share/breakglass/runbooks/internal` root, without `subPath` and
+with an optional `INDEX.md`; the image does not hardcode, source, or execute
+bundle content. That wiring is an external immutable-template/admission
+responsibility.
 
 Builds target `linux/amd64` and `linux/arm64`, pin the Alpine manifest and APK
 package versions, request BuildKit provenance/SBOM attestations, and sign only

--- a/docs/node-maintenance.md
+++ b/docs/node-maintenance.md
@@ -15,8 +15,10 @@ unrestricted shell or ship a general-purpose network toolbox.
 
 See the utility README and its [preflight](../utils/node-maintenance/runbooks/node-recovery-preflight.md)
 and [repair](../utils/node-maintenance/runbooks/network-repair.md) runbooks for
-the required host-networked pod, minimal `NET_ADMIN` capability, exact target,
-confirmation, and evidence workflow.
+the required separate no-capability preflight and `NET_ADMIN`-only repair
+contexts, controller-provided exact target, confirmation, and evidence
+workflow. Workload templates must inject `BREAKGLASS_NODE_NAME` from Downward
+API `spec.nodeName`; hostname is not a trust input.
 
 Builds target `linux/amd64` and `linux/arm64`, pin the Alpine manifest and APK
 package versions, request BuildKit provenance/SBOM attestations, and sign only
@@ -25,7 +27,7 @@ Makefile.
 
 The Linux-only integration target (`make -C utils/node-maintenance integration`)
 builds and runs the image in disposable `--network none` namespaces with the
-intended `NET_ADMIN` capability boundary. It executes every allowlisted action,
+separate preflight/repair capability boundaries. It executes every allowlisted action,
 checks real before/after evidence and denial guards, and verifies container and
 volume cleanup. Missing Docker, namespace support, or security flags fails the
 job with diagnostics; the proof never silently skips.

--- a/docs/node-maintenance.md
+++ b/docs/node-maintenance.md
@@ -20,6 +20,12 @@ contexts, controller-provided exact target, confirmation, and evidence
 workflow. Workload templates must inject `BREAKGLASS_NODE_NAME` from Downward
 API `spec.nodeName`; hostname is not a trust input.
 
+Built-in runbooks remain under `/usr/share/node-maintenance/`. A downstream
+deployment may read-only mount an optional, digest-pinned runbook bundle at
+`/runbooks/internal`, with an optional `INDEX.md`; the image does not hardcode,
+source, or execute bundle content. That wiring is an external immutable-
+template/admission responsibility.
+
 Builds target `linux/amd64` and `linux/arm64`, pin the Alpine manifest and APK
 package versions, request BuildKit provenance/SBOM attestations, and sign only
 the resulting immutable registry digest. No image is pushed by the local

--- a/utils/node-maintenance/Dockerfile
+++ b/utils/node-maintenance/Dockerfile
@@ -22,11 +22,17 @@ COPY lib/common.sh /usr/local/libexec/node-maintenance/common.sh
 COPY lib/network-repair.sh /usr/local/libexec/node-maintenance/network-repair
 COPY lib/node-recovery-preflight.sh /usr/local/libexec/node-maintenance/node-recovery
 COPY MOTD /etc/motd
+COPY README.md /usr/share/node-maintenance/README.md
+COPY runbooks/network-repair.md /usr/share/node-maintenance/runbooks/network-repair.md
+COPY runbooks/node-recovery-preflight.md /usr/share/node-maintenance/runbooks/node-recovery-preflight.md
 
 RUN chmod 0555 /usr/local/bin/node-maintenance \
         /usr/local/libexec/node-maintenance/network-repair \
         /usr/local/libexec/node-maintenance/node-recovery \
     && chmod 0444 /usr/local/libexec/node-maintenance/common.sh /etc/motd \
+        /usr/share/node-maintenance/README.md \
+        /usr/share/node-maintenance/runbooks/network-repair.md \
+        /usr/share/node-maintenance/runbooks/node-recovery-preflight.md \
     && mkdir -p /evidence \
     && chmod 0700 /evidence
 
@@ -44,7 +50,9 @@ LABEL org.opencontainers.image.title="Kubernetes node maintenance" \
       io.telekom.breakglass.node-maintenance.shell="not-supported" \
       io.telekom.breakglass.node-maintenance.capabilities="NET_ADMIN"
 
-# Network repair requires a privileged pod and host networking. The command
-# dispatcher rejects every operation outside its two fixed helper names.
+# The image is root only for the explicitly allowlisted host-network operation.
+# Controller-owned immutable templates must use a no-capabilities preflight
+# context and a separate NET_ADMIN-only repair context; privileged is not part
+# of this image contract. The dispatcher rejects every other helper name.
 USER 0
 ENTRYPOINT ["/usr/local/bin/node-maintenance"]

--- a/utils/node-maintenance/Dockerfile
+++ b/utils/node-maintenance/Dockerfile
@@ -22,20 +22,20 @@ COPY lib/common.sh /usr/local/libexec/node-maintenance/common.sh
 COPY lib/network-repair.sh /usr/local/libexec/node-maintenance/network-repair
 COPY lib/node-recovery-preflight.sh /usr/local/libexec/node-maintenance/node-recovery
 COPY MOTD /etc/motd
-COPY README.md /usr/share/node-maintenance/README.md
-COPY runbooks/network-repair.md /usr/share/node-maintenance/runbooks/network-repair.md
-COPY runbooks/node-recovery-preflight.md /usr/share/node-maintenance/runbooks/node-recovery-preflight.md
+COPY README.md /usr/share/breakglass/runbooks/upstream/node-maintenance/README.md
+COPY runbooks/network-repair.md /usr/share/breakglass/runbooks/upstream/node-maintenance/network-repair.md
+COPY runbooks/node-recovery-preflight.md /usr/share/breakglass/runbooks/upstream/node-maintenance/node-recovery-preflight.md
 
 RUN chmod 0555 /usr/local/bin/node-maintenance \
         /usr/local/libexec/node-maintenance/network-repair \
         /usr/local/libexec/node-maintenance/node-recovery \
     && chmod 0444 /usr/local/libexec/node-maintenance/common.sh /etc/motd \
-        /usr/share/node-maintenance/README.md \
-        /usr/share/node-maintenance/runbooks/network-repair.md \
-        /usr/share/node-maintenance/runbooks/node-recovery-preflight.md \
-    && mkdir -p /evidence /runbooks/internal \
+        /usr/share/breakglass/runbooks/upstream/node-maintenance/README.md \
+        /usr/share/breakglass/runbooks/upstream/node-maintenance/network-repair.md \
+        /usr/share/breakglass/runbooks/upstream/node-maintenance/node-recovery-preflight.md \
+    && mkdir -p /evidence /usr/share/breakglass/runbooks/internal \
     && chmod 0700 /evidence \
-    && chmod 0755 /runbooks /runbooks/internal
+    && chmod 0755 /usr/share/breakglass/runbooks/internal
 
 LABEL org.opencontainers.image.title="Kubernetes node maintenance" \
       org.opencontainers.image.description="Allowlisted, evidence-producing node network repair and recovery preflight helpers" \

--- a/utils/node-maintenance/Dockerfile
+++ b/utils/node-maintenance/Dockerfile
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The manifest digest is pinned so every architecture starts from the same
+# reviewed Alpine release. BuildKit resolves the selected architecture.
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+# Keep the runtime deliberately small. Do not add a general-purpose network
+# toolbox, a compiler, a package manager, or an interactive shell entrypoint.
+RUN apk add --no-cache \
+        ethtool=6.14.1-r0 \
+        iproute2-minimal=6.15.0-r0 \
+    && rm -f /sbin/apk /sbin/apk.static
+
+COPY bin/node-maintenance /usr/local/bin/node-maintenance
+COPY lib/common.sh /usr/local/libexec/node-maintenance/common.sh
+COPY lib/network-repair.sh /usr/local/libexec/node-maintenance/network-repair
+COPY lib/node-recovery-preflight.sh /usr/local/libexec/node-maintenance/node-recovery
+COPY MOTD /etc/motd
+
+RUN chmod 0555 /usr/local/bin/node-maintenance \
+        /usr/local/libexec/node-maintenance/network-repair \
+        /usr/local/libexec/node-maintenance/node-recovery \
+    && chmod 0444 /usr/local/libexec/node-maintenance/common.sh /etc/motd \
+    && mkdir -p /evidence \
+    && chmod 0700 /evidence
+
+LABEL org.opencontainers.image.title="Kubernetes node maintenance" \
+      org.opencontainers.image.description="Allowlisted, evidence-producing node network repair and recovery preflight helpers" \
+      org.opencontainers.image.source="https://github.com/telekom/k8s-breakglass" \
+      org.opencontainers.image.documentation="https://github.com/telekom/k8s-breakglass/blob/main/docs/node-maintenance.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Deutsche Telekom" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.base.name="alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1" \
+      io.telekom.breakglass.node-maintenance.commands="node-recovery,network-repair" \
+      io.telekom.breakglass.node-maintenance.shell="not-supported" \
+      io.telekom.breakglass.node-maintenance.capabilities="NET_ADMIN"
+
+# Network repair requires a privileged pod and host networking. The command
+# dispatcher rejects every operation outside its two fixed helper names.
+USER 0
+ENTRYPOINT ["/usr/local/bin/node-maintenance"]

--- a/utils/node-maintenance/Dockerfile
+++ b/utils/node-maintenance/Dockerfile
@@ -55,5 +55,6 @@ LABEL org.opencontainers.image.title="Kubernetes node maintenance" \
 # Controller-owned immutable templates must use a no-capabilities preflight
 # context and a separate NET_ADMIN-only repair context; privileged is not part
 # of this image contract. The dispatcher rejects every other helper name.
+# hadolint ignore=DL3002
 USER 0
 ENTRYPOINT ["/usr/local/bin/node-maintenance"]

--- a/utils/node-maintenance/Dockerfile
+++ b/utils/node-maintenance/Dockerfile
@@ -33,8 +33,9 @@ RUN chmod 0555 /usr/local/bin/node-maintenance \
         /usr/share/node-maintenance/README.md \
         /usr/share/node-maintenance/runbooks/network-repair.md \
         /usr/share/node-maintenance/runbooks/node-recovery-preflight.md \
-    && mkdir -p /evidence \
-    && chmod 0700 /evidence
+    && mkdir -p /evidence /runbooks/internal \
+    && chmod 0700 /evidence \
+    && chmod 0755 /runbooks /runbooks/internal
 
 LABEL org.opencontainers.image.title="Kubernetes node maintenance" \
       org.opencontainers.image.description="Allowlisted, evidence-producing node network repair and recovery preflight helpers" \

--- a/utils/node-maintenance/MOTD
+++ b/utils/node-maintenance/MOTD
@@ -7,7 +7,8 @@ Supported operations are fixed: node-recovery (read-only) and
 network-repair (three allowlisted actions). Every invocation must name a node,
 interface, evidence directory, and confirmation token. There is no supported
 unrestricted shell or general-purpose network toolbox in this image.
-Read /usr/share/node-maintenance/README.md and the runbooks in
-/usr/share/node-maintenance/runbooks/ before use.
+Read the generic runbooks in
+/usr/share/breakglass/runbooks/upstream/node-maintenance/ before use.
 An optional deployment-specific, read-only index may be mounted at
-/runbooks/internal/INDEX.md. It is not sourced or executed by this image.
+/usr/share/breakglass/runbooks/internal/INDEX.md. It is not sourced or executed
+by this image.

--- a/utils/node-maintenance/MOTD
+++ b/utils/node-maintenance/MOTD
@@ -1,0 +1,9 @@
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: Apache-2.0
+
+Kubernetes node-maintenance image
+
+Supported operations are fixed: node-recovery (read-only) and
+network-repair (three allowlisted actions). Every invocation must name a node,
+interface, evidence directory, and confirmation token. There is no supported
+unrestricted shell or general-purpose network toolbox in this image.

--- a/utils/node-maintenance/MOTD
+++ b/utils/node-maintenance/MOTD
@@ -9,6 +9,6 @@ interface, evidence directory, and confirmation token. There is no supported
 unrestricted shell or general-purpose network toolbox in this image.
 Read the generic runbooks in
 /usr/share/breakglass/runbooks/upstream/node-maintenance/ before use.
-An optional deployment-specific, read-only index may be mounted at
-/usr/share/breakglass/runbooks/internal/INDEX.md. It is not sourced or executed
-by this image.
+An optional deployment-specific, read-only OCI runbook bundle may be mounted
+at /usr/share/breakglass/runbooks/internal/. A selected bundle must contain
+bundle.yaml and INDEX.md and is not sourced or executed by this image.

--- a/utils/node-maintenance/MOTD
+++ b/utils/node-maintenance/MOTD
@@ -9,3 +9,5 @@ interface, evidence directory, and confirmation token. There is no supported
 unrestricted shell or general-purpose network toolbox in this image.
 Read /usr/share/node-maintenance/README.md and the runbooks in
 /usr/share/node-maintenance/runbooks/ before use.
+An optional deployment-specific, read-only index may be mounted at
+/runbooks/internal/INDEX.md. It is not sourced or executed by this image.

--- a/utils/node-maintenance/MOTD
+++ b/utils/node-maintenance/MOTD
@@ -7,3 +7,5 @@ Supported operations are fixed: node-recovery (read-only) and
 network-repair (three allowlisted actions). Every invocation must name a node,
 interface, evidence directory, and confirmation token. There is no supported
 unrestricted shell or general-purpose network toolbox in this image.
+Read /usr/share/node-maintenance/README.md and the runbooks in
+/usr/share/node-maintenance/runbooks/ before use.

--- a/utils/node-maintenance/Makefile
+++ b/utils/node-maintenance/Makefile
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SHELL := /bin/sh
+
+IMAGE ?= ghcr.io/telekom/k8s-breakglass/node-maintenance:dev
+PLATFORMS ?= linux/amd64,linux/arm64
+VERSION ?= dev
+VCS_REF ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+OCI_ARCHIVE ?= node-maintenance.oci.tar
+
+.PHONY: test integration build build-multiarch sbom sign
+
+test:
+	./tests/test-helpers.sh
+
+integration:
+	./tests/integration.sh
+
+build:
+	docker build --pull=false \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg VCS_REF=$(VCS_REF) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		-t $(IMAGE) .
+
+build-multiarch:
+	docker buildx build --pull=false --platform $(PLATFORMS) \
+		--provenance=true --sbom=true \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg VCS_REF=$(VCS_REF) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		--output=type=oci,dest=$(OCI_ARCHIVE) \
+		-t $(IMAGE) .
+
+# Signing and attestation are intentionally separate from the build. Release
+# automation must sign the immutable registry digest, never a mutable tag.
+sbom:
+	@test -n "$(DIGEST)" || (printf '%s\n' 'DIGEST is required' >&2; exit 2)
+	@case "$(DIGEST)" in sha256:*) ;; *) printf '%s\n' 'DIGEST must be an immutable sha256 digest' >&2; exit 2;; esac
+	@test -n "$(SBOM)" || (printf '%s\n' 'SBOM is required' >&2; exit 2)
+	cosign attest --yes --type spdxjson --predicate "$(SBOM)" "$(IMAGE)@$(DIGEST)"
+
+sign:
+	@test -n "$(DIGEST)" || (printf '%s\n' 'DIGEST is required' >&2; exit 2)
+	@case "$(DIGEST)" in sha256:*) ;; *) printf '%s\n' 'DIGEST must be an immutable sha256 digest' >&2; exit 2;; esac
+	cosign sign --yes "$(IMAGE)@$(DIGEST)"

--- a/utils/node-maintenance/Makefile
+++ b/utils/node-maintenance/Makefile
@@ -4,7 +4,7 @@
 
 SHELL := /bin/sh
 
-IMAGE ?= ghcr.io/telekom/k8s-breakglass/node-maintenance:dev
+IMAGE ?= ghcr.io/telekom/k8s-breakglass/utils/node-maintenance:dev
 PLATFORMS ?= linux/amd64,linux/arm64
 VERSION ?= dev
 VCS_REF ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)

--- a/utils/node-maintenance/README.md
+++ b/utils/node-maintenance/README.md
@@ -19,23 +19,23 @@ The image exposes exactly two supported commands:
 
 There is no supported unrestricted shell, package manager, compiler, packet
 capture tool, port scanner, or general-purpose network toolbox. The entrypoint
-dispatches only the two fixed command names. The image must run as root with a
-privileged, host-networked pod for repairs; preflight is read-only but still
-requires the same explicit target and confirmation gates.
+dispatches only the two fixed command names. It does not support kexec or
+reboot, crashdump collection, packet capture, arbitrary commands, sysctl
+changes, route replacement, or node discovery.
 
 ## Guardrails
 
 Every helper requires `--target-node NODE`, `--interface IFACE`,
 `--evidence-dir ABSOLUTE_PATH`, and the command-specific confirmation token.
-No default interface or node is inferred. The target must also exactly match
-the local host identity returned by `hostname`; a target name is never treated
-as merely descriptive. Targets accept only shell-safe identifiers, and repair
-actions are validated against a fixed allowlist before any mutation. Evidence
-must be a dedicated evidence mount or child directory (for example
-`/evidence/run-123`), may
-not be a system root, and may not resolve through a symlink. Evidence includes
-command exit statuses and metadata and is produced before and after a repair
-even when the action fails.
+No default interface or node is inferred. `BREAKGLASS_NODE_NAME` is required
+and must be injected by the controller-owned immutable workload template from
+the Downward API `spec.nodeName`; the requested target must exactly match it.
+`hostname` is never trusted for node identity. Targets accept only shell-safe
+identifiers, and repair actions are validated against a fixed allowlist before
+any mutation. Evidence is limited to `/evidence` or `/evidence/SAFE_CHILD`;
+the image rejects system paths and symlink or rename changes. Every probe and
+action has a fixed time and output limit, and evidence has a fixed total quota.
+Timeout and quota failures are recorded deterministically in the bundle.
 
 ## Invocation
 
@@ -62,10 +62,11 @@ normal, separately approved host-debug process.
 
 ## Pod security boundary
 
-Use host networking and the smallest required capability. The preflight is
-read-only; repairs require `NET_ADMIN`, not blanket privileged mode. Mount a
-dedicated empty directory at `/evidence` and do not mount `/`, `/etc`, `/proc`,
-`/sys`, or another host-system path. A representative security context is:
+Use separate immutable workload templates and the smallest required
+capability. Preflight drops `ALL` and adds none; repair drops `ALL` and adds
+only `NET_ADMIN`. Blanket `privileged: true` is not part of this contract.
+Mount a dedicated empty directory at `/evidence` and do not mount `/`, `/etc`,
+`/proc`, `/sys`, or another host-system path. A repair context is:
 
 ```yaml
 hostNetwork: true
@@ -81,9 +82,9 @@ securityContext:
 ```
 
 The command dispatcher is the only supported entrypoint. The Alpine runtime
-contains `/bin/sh` because the fixed helpers are POSIX scripts, but invoking a
-shell or any other binary by overriding the entrypoint is outside the support
-and incident-audit boundary.
+contains `/bin/sh` because the fixed helpers are POSIX scripts, but an
+entrypoint or shell override is an external immutable-template and admission
+control boundary, outside this image's support and incident-audit contract.
 
 ## Build, SBOM, and signing
 
@@ -100,8 +101,9 @@ signing subject. Package versions and the base manifest are in [`deps.lock`](dep
 
 `make integration` is a real-tool proof, not a help/argument smoke test. On a
 Linux Docker runner it builds the image and runs every command in disposable
-containers with `--network none`, a read-only root filesystem, all capabilities
-dropped except `NET_ADMIN`, and a disposable evidence volume. It exercises
+containers with `--network none`, a read-only root filesystem, and a
+disposable evidence volume. Preflight drops all capabilities with no add;
+repair adds only `NET_ADMIN` after dropping all capabilities. It exercises
 `node-recovery`, all three repair actions, failure evidence, confirmation and
 target guards, unsafe-path rejection, dispatcher rejection, and explicit
 container/volume cleanup. The harness explicitly verifies Docker's built-in

--- a/utils/node-maintenance/README.md
+++ b/utils/node-maintenance/README.md
@@ -1,0 +1,119 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Kubernetes node-maintenance image
+
+This is a generic, standalone image for a narrowly scoped node-network
+incident workflow. It is multi-architecture (`linux/amd64` and `linux/arm64`)
+and starts from the digest-pinned Alpine base in [`Dockerfile`](Dockerfile).
+
+The image exposes exactly two supported commands:
+
+* `node-recovery` collects read-only link, address, route, neighbor,
+  NIC, resolver, and kernel evidence.
+* `network-repair` performs exactly one of `link-cycle`, `flush-neighbors`, or
+  `restart-autonegotiation`.
+
+There is no supported unrestricted shell, package manager, compiler, packet
+capture tool, port scanner, or general-purpose network toolbox. The entrypoint
+dispatches only the two fixed command names. The image must run as root with a
+privileged, host-networked pod for repairs; preflight is read-only but still
+requires the same explicit target and confirmation gates.
+
+## Guardrails
+
+Every helper requires `--target-node NODE`, `--interface IFACE`,
+`--evidence-dir ABSOLUTE_PATH`, and the command-specific confirmation token.
+No default interface or node is inferred. The target must also exactly match
+the local host identity returned by `hostname`; a target name is never treated
+as merely descriptive. Targets accept only shell-safe identifiers, and repair
+actions are validated against a fixed allowlist before any mutation. Evidence
+must be a dedicated evidence mount or child directory (for example
+`/evidence/run-123`), may
+not be a system root, and may not resolve through a symlink. Evidence includes
+command exit statuses and metadata and is produced before and after a repair
+even when the action fails.
+
+## Invocation
+
+Use the runbooks in [`runbooks/`](runbooks/) and substitute every placeholder:
+
+```text
+node-recovery \
+  --target-node NODE_NAME \
+  --interface IFACE_NAME \
+  --evidence-dir /evidence \
+  --confirm NODE-RECOVERY-PREFLIGHT
+
+network-repair \
+  --target-node NODE_NAME \
+  --interface IFACE_NAME \
+  --action ACTION \
+  --evidence-dir /evidence \
+  --confirm NETWORK-REPAIR
+```
+
+Do not add `sh`, `bash`, or arbitrary commands to a pod specification. If the
+allowlisted helpers cannot diagnose an incident, stop and use the platform's
+normal, separately approved host-debug process.
+
+## Pod security boundary
+
+Use host networking and the smallest required capability. The preflight is
+read-only; repairs require `NET_ADMIN`, not blanket privileged mode. Mount a
+dedicated empty directory at `/evidence` and do not mount `/`, `/etc`, `/proc`,
+`/sys`, or another host-system path. A representative security context is:
+
+```yaml
+hostNetwork: true
+securityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+    add: [NET_ADMIN]
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+The command dispatcher is the only supported entrypoint. The Alpine runtime
+contains `/bin/sh` because the fixed helpers are POSIX scripts, but invoking a
+shell or any other binary by overriding the entrypoint is outside the support
+and incident-audit boundary.
+
+## Build, SBOM, and signing
+
+Run `make test` for helper tests. `make build` creates a local image;
+`make build-multiarch` uses BuildKit for both supported platforms and requests
+in-toto provenance plus an SPDX SBOM (`--provenance=true --sbom=true`), writing
+a local OCI archive (`node-maintenance.oci.tar` by default).
+Release automation must resolve and retain the immutable registry digest, then
+run `make sign DIGEST=...` and `make sbom DIGEST=... SBOM=...`. The Makefile
+refuses signing or attestation without a digest, so a mutable tag is never the
+signing subject. Package versions and the base manifest are in [`deps.lock`](deps.lock).
+
+## Integration proof
+
+`make integration` is a real-tool proof, not a help/argument smoke test. On a
+Linux Docker runner it builds the image and runs every command in disposable
+containers with `--network none`, a read-only root filesystem, all capabilities
+dropped except `NET_ADMIN`, and a disposable evidence volume. It exercises
+`node-recovery`, all three repair actions, failure evidence, confirmation and
+target guards, unsafe-path rejection, dispatcher rejection, and explicit
+container/volume cleanup. The harness explicitly verifies Docker's built-in
+RuntimeDefault seccomp profile and the requested capability boundary from
+container metadata. The loopback interface is used so no runner host
+network namespace is joined or modified; auto-negotiation is expected to fail
+and its evidence is required.
+
+The harness refuses to skip when Docker, Linux namespaces, or required Docker
+security flags are unavailable. Run it with `NODE_MAINTENANCE_TEST_IMAGE`
+to test an already-built image, or inspect the machine-readable
+[`integration-contract.json`](tests/integration-contract.json) used by
+aggregate CI/reference jobs. A macOS/Windows developer machine should run the
+unit helper tests locally and use the Linux integration workflow; the workflow
+failure is intentional rather than a feature skip.

--- a/utils/node-maintenance/README.md
+++ b/utils/node-maintenance/README.md
@@ -86,16 +86,16 @@ contains `/bin/sh` because the fixed helpers are POSIX scripts, but an
 entrypoint or shell override is an external immutable-template and admission
 control boundary, outside this image's support and incident-audit contract.
 
-## Optional downstream runbooks
+## Optional downstream runbook bundle
 
 Built-in documentation is image-owned at
 `/usr/share/breakglass/runbooks/upstream/node-maintenance/`. A deployment may
-additionally mount a read-only, digest-pinned downstream bundle at the shared
-`/usr/share/breakglass/runbooks/internal` root; its optional index is
-`/usr/share/breakglass/runbooks/internal/INDEX.md`. The bundle root is mounted
-directly, without `subPath`. The image neither hardcodes a bundle reference nor
-sources or executes any bundle content. Workload wiring and admission are
-external immutable-template responsibilities.
+additionally mount a read-only, digest-pinned downstream [OCI runbook bundle](../../docs/runbook-bundle-contract.md)
+at the shared `/usr/share/breakglass/runbooks/internal` root. The bundle root
+is mounted directly, without `subPath`, and a selected bundle must include its
+contract-required `bundle.yaml` and `INDEX.md`. The image neither hardcodes a
+bundle reference nor sources or executes any bundle content. Workload wiring
+and admission are external immutable-template responsibilities.
 
 ## Build, SBOM, and signing
 

--- a/utils/node-maintenance/README.md
+++ b/utils/node-maintenance/README.md
@@ -88,11 +88,13 @@ control boundary, outside this image's support and incident-audit contract.
 
 ## Optional downstream runbooks
 
-Built-in documentation is image-owned at `/usr/share/node-maintenance/`. A
-deployment may additionally mount a read-only, digest-pinned downstream bundle
-at `/runbooks/internal`; its optional index is
-`/runbooks/internal/INDEX.md`. The image neither hardcodes a bundle reference
-nor sources or executes any bundle content. Workload wiring and admission are
+Built-in documentation is image-owned at
+`/usr/share/breakglass/runbooks/upstream/node-maintenance/`. A deployment may
+additionally mount a read-only, digest-pinned downstream bundle at the shared
+`/usr/share/breakglass/runbooks/internal` root; its optional index is
+`/usr/share/breakglass/runbooks/internal/INDEX.md`. The bundle root is mounted
+directly, without `subPath`. The image neither hardcodes a bundle reference nor
+sources or executes any bundle content. Workload wiring and admission are
 external immutable-template responsibilities.
 
 ## Build, SBOM, and signing

--- a/utils/node-maintenance/README.md
+++ b/utils/node-maintenance/README.md
@@ -86,6 +86,15 @@ contains `/bin/sh` because the fixed helpers are POSIX scripts, but an
 entrypoint or shell override is an external immutable-template and admission
 control boundary, outside this image's support and incident-audit contract.
 
+## Optional downstream runbooks
+
+Built-in documentation is image-owned at `/usr/share/node-maintenance/`. A
+deployment may additionally mount a read-only, digest-pinned downstream bundle
+at `/runbooks/internal`; its optional index is
+`/runbooks/internal/INDEX.md`. The image neither hardcodes a bundle reference
+nor sources or executes any bundle content. Workload wiring and admission are
+external immutable-template responsibilities.
+
 ## Build, SBOM, and signing
 
 Run `make test` for helper tests. `make build` creates a local image;

--- a/utils/node-maintenance/bin/node-maintenance
+++ b/utils/node-maintenance/bin/node-maintenance
@@ -1,0 +1,45 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: node-maintenance <command> [options]
+
+Commands (the only supported entrypoints):
+  node-recovery             Collect read-only node evidence.
+  network-repair           Run one explicitly selected network repair.
+
+The image does not provide an unrestricted shell entrypoint. Use a runbook and
+pass an explicit target, evidence directory, and confirmation token.
+EOF
+}
+
+if [ "$#" -eq 0 ]; then
+	cat /etc/motd >&2
+	usage
+	exit 2
+fi
+
+command_name=$1
+shift
+case "$command_name" in
+	node-recovery)
+		exec /usr/local/libexec/node-maintenance/node-recovery "$@"
+		;;
+	network-repair)
+		exec /usr/local/libexec/node-maintenance/network-repair "$@"
+		;;
+	-h|--help)
+		usage
+		exit 0
+		;;
+	*)
+		printf 'Unsupported command: %s\n' "$command_name" >&2
+		usage
+		exit 2
+		;;
+esac

--- a/utils/node-maintenance/deps.lock
+++ b/utils/node-maintenance/deps.lock
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runtime dependency lock for Dockerfile. The base image is pinned by
+# manifest digest in Dockerfile. APK package versions are pinned below.
+base=alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+repository=https://dl-cdn.alpinelinux.org/alpine/v3.22/main
+ethtool=6.14.1-r0
+iproute2-minimal=6.15.0-r0

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -116,10 +116,11 @@ capture() {
 	assert_safe_bundle "$bundle"
 	command -v timeout >/dev/null 2>&1 || die "timeout utility is required for bounded evidence capture"
 	temporary_file=$(mktemp "$bundle/.capture.XXXXXX") || die "cannot create bounded capture temporary file"
-	set +e
-	timeout "$capture_timeout_seconds" "$@" >"$temporary_file" 2>&1
-	status=$?
-	set -e
+	if timeout "$capture_timeout_seconds" "$@" >"$temporary_file" 2>&1; then
+		status=0
+	else
+		status=$?
+	fi
 	bytes=$(wc -c <"$temporary_file" | tr -d ' ')
 	if [ "$bytes" -gt "$capture_max_bytes" ]; then
 		head -c "$capture_max_bytes" "$temporary_file" >"$output_file"

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -5,6 +5,13 @@
 
 set -eu
 
+# These limits are deliberately fixed in the image rather than configurable by
+# a request. They keep a failed driver, command, or mounted evidence volume
+# from turning a bounded maintenance request into unbounded work or storage.
+capture_timeout_seconds=10
+capture_max_bytes=32768
+evidence_max_bytes=393216
+
 die() {
 	printf 'node-maintenance: %s\n' "$*" >&2
 	exit 2
@@ -23,9 +30,9 @@ validate_value() {
 validate_target() {
 	target=$1
 	validate_value "target node" "$target"
-	actual_node=$(hostname 2>/dev/null || true)
-	[ -n "$actual_node" ] || die "cannot determine the local node identity"
-	[ "$target" = "$actual_node" ] || die "target node '$target' does not match local node '$actual_node'"
+	actual_node=${BREAKGLASS_NODE_NAME:-}
+	validate_value "BREAKGLASS_NODE_NAME" "$actual_node"
+	[ "$target" = "$actual_node" ] || die "target node '$target' does not match controller-provided node '$actual_node'"
 }
 
 validate_interface() {
@@ -40,41 +47,60 @@ validate_confirmation() {
 
 prepare_evidence_dir() {
 	directory=$1
-	[ -n "$directory" ] || die "evidence directory is required"
 	case "$directory" in
-		/*) ;;
-		*) die "evidence directory must be an absolute path" ;;
+		/evidence) ;;
+		/evidence/*)
+			child=${directory#/evidence/}
+			case "$child" in
+				''|*/*|.|..|*[!A-Za-z0-9_.-]*) die "evidence directory must be /evidence or one safe child" ;;
+			esac
+			;;
+		*) die "evidence directory must be /evidence or one safe child" ;;
 	esac
+	[ -d /evidence ] || die "/evidence must be a mounted directory"
+	[ ! -L /evidence ] || die "/evidence may not be a symlink"
+	root=$(readlink -f /evidence 2>/dev/null || true)
+	[ "$root" = /evidence ] || die "/evidence did not resolve safely"
+	if [ "$directory" != /evidence ]; then
+		mkdir "$directory" 2>/dev/null || [ -d "$directory" ] || die "cannot create evidence directory '$directory'"
+	fi
+	assert_safe_evidence_dir "$directory"
+	chmod 0700 "$directory" || die "cannot protect evidence directory '$directory'"
+	EVIDENCE_DIR=$directory
+}
+
+assert_safe_evidence_dir() {
+	directory=$1
 	case "$directory" in
-		*..*) die "evidence directory may not contain '..'" ;;
+		/evidence) ;;
+		/evidence/*)
+			child=${directory#/evidence/}
+			case "$child" in ''|*/*|.|..|*[!A-Za-z0-9_.-]*) die "unsafe evidence directory" ;; esac
+			;;
+		*) die "unsafe evidence directory" ;;
 	esac
-	case "$directory" in
-		/|/bin|/dev|/etc|/home|/proc|/root|/run|/sbin|/sys|/tmp|/usr|/var)
-			die "evidence directory must be a dedicated child directory, not '$directory'" ;;
-		/evidence|/evidence/*) ;;
-		/*/*) ;;
-		*) die "evidence directory must be a dedicated child directory" ;;
-	esac
-	mkdir -p "$directory" || die "cannot create evidence directory '$directory'"
+	[ -d /evidence ] && [ ! -L /evidence ] || die "/evidence changed while handling evidence"
 	[ ! -L "$directory" ] || die "evidence directory may not be a symlink"
 	resolved_directory=$(readlink -f "$directory" 2>/dev/null || true)
-	[ -n "$resolved_directory" ] || die "cannot resolve evidence directory safely"
-	protected_directory=$resolved_directory
-	case "$protected_directory" in
-		/private/*) protected_directory=${protected_directory#/private} ;;
-	esac
-	case "$protected_directory" in
-		/|/bin|/bin/*|/dev|/dev/*|/etc|/etc/*|/home|/home/*|/proc|/proc/*|/root|/root/*|/run|/run/*|/sbin|/sbin/*|/sys|/sys/*|/usr|/usr/*|/var|/var/run|/var/run/*|/var/lib|/var/lib/*|/var/log|/var/log/*|/var/db|/var/db/*|/var/root|/var/root/*)
-		die "evidence directory resolves to a protected system path" ;;
-	esac
-	chmod 0700 "$directory" || die "cannot protect evidence directory '$directory'"
+	[ "$resolved_directory" = "$directory" ] || die "evidence directory changed or resolves outside /evidence"
+}
+
+assert_safe_bundle() {
+	bundle=$1
+	assert_safe_evidence_dir "${EVIDENCE_DIR:?evidence directory is not initialized}"
+	case "$bundle" in "$EVIDENCE_DIR"/*) ;; *) die "unsafe evidence bundle" ;; esac
+	[ -d "$bundle" ] && [ ! -L "$bundle" ] || die "evidence bundle changed while handling evidence"
+	resolved_bundle=$(readlink -f "$bundle" 2>/dev/null || true)
+	[ "$resolved_bundle" = "$bundle" ] || die "evidence bundle did not resolve safely"
 }
 
 new_bundle() {
 	parent=$1
 	command_name=$2
+	assert_safe_evidence_dir "$parent"
 	timestamp=$(date -u +%Y%m%dT%H%M%SZ)
 	bundle=$(mktemp -d "$parent/${command_name}-${timestamp}-XXXXXX") || die "cannot create evidence bundle"
+	assert_safe_bundle "$bundle"
 	chmod 0700 "$bundle" || die "cannot protect evidence bundle"
 	printf '%s\n' "$bundle"
 }
@@ -82,11 +108,25 @@ new_bundle() {
 capture() {
 	output_file=$1
 	shift
+	case "$output_file" in "${bundle:?bundle is not initialized}"/*) ;; *) die "unsafe evidence output path" ;; esac
+	assert_safe_bundle "$bundle"
+	command -v timeout >/dev/null 2>&1 || die "timeout utility is required for bounded evidence capture"
+	temporary_file=$(mktemp "$bundle/.capture.XXXXXX") || die "cannot create bounded capture temporary file"
 	set +e
-	"$@" >"$output_file" 2>&1
+	timeout "$capture_timeout_seconds" "$@" >"$temporary_file" 2>&1
 	status=$?
 	set -e
+	bytes=$(wc -c <"$temporary_file" | tr -d ' ')
+	if [ "$bytes" -gt "$capture_max_bytes" ]; then
+		head -c "$capture_max_bytes" "$temporary_file" >"$output_file"
+		printf '\ncapture_result=output-quota-exceeded\nexit_status=75\n' >>"$output_file"
+		rm -f "$temporary_file"
+		return 75
+	fi
+	mv "$temporary_file" "$output_file"
 	printf '\nexit_status=%s\n' "$status" >>"$output_file"
+	used_kib=$(du -sk "$bundle" | awk '{print $1}')
+	[ "$used_kib" -le $((evidence_max_bytes / 1024)) ] || die "evidence quota exceeded"
 	return "$status"
 }
 
@@ -96,6 +136,7 @@ write_metadata() {
 	target_node=$3
 	interface=$4
 	action=$5
+	assert_safe_bundle "$(dirname "$metadata_file")"
 	{
 		printf 'command=%s\n' "$command_name"
 		printf 'target_node=%s\n' "$target_node"

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+die() {
+	printf 'node-maintenance: %s\n' "$*" >&2
+	exit 2
+}
+
+validate_value() {
+	label=$1
+	value=$2
+
+	[ -n "$value" ] || die "$label is required"
+	case "$value" in
+		*[!A-Za-z0-9_.:@-]*) die "$label contains unsupported characters" ;;
+	esac
+}
+
+validate_target() {
+	target=$1
+	validate_value "target node" "$target"
+	actual_node=$(hostname 2>/dev/null || true)
+	[ -n "$actual_node" ] || die "cannot determine the local node identity"
+	[ "$target" = "$actual_node" ] || die "target node '$target' does not match local node '$actual_node'"
+}
+
+validate_interface() {
+	validate_value "interface" "$1"
+}
+
+validate_confirmation() {
+	expected=$1
+	actual=$2
+	[ "$actual" = "$expected" ] || die "confirmation must be exactly '$expected'"
+}
+
+prepare_evidence_dir() {
+	directory=$1
+	[ -n "$directory" ] || die "evidence directory is required"
+	case "$directory" in
+		/*) ;;
+		*) die "evidence directory must be an absolute path" ;;
+	esac
+	case "$directory" in
+		*..*) die "evidence directory may not contain '..'" ;;
+	esac
+	case "$directory" in
+		/|/bin|/dev|/etc|/home|/proc|/root|/run|/sbin|/sys|/tmp|/usr|/var)
+			die "evidence directory must be a dedicated child directory, not '$directory'" ;;
+		/evidence|/evidence/*) ;;
+		/*/*) ;;
+		*) die "evidence directory must be a dedicated child directory" ;;
+	esac
+	mkdir -p "$directory" || die "cannot create evidence directory '$directory'"
+	[ ! -L "$directory" ] || die "evidence directory may not be a symlink"
+	resolved_directory=$(readlink -f "$directory" 2>/dev/null || true)
+	[ -n "$resolved_directory" ] || die "cannot resolve evidence directory safely"
+	protected_directory=$resolved_directory
+	case "$protected_directory" in
+		/private/*) protected_directory=${protected_directory#/private} ;;
+	esac
+	case "$protected_directory" in
+		/|/bin|/bin/*|/dev|/dev/*|/etc|/etc/*|/home|/home/*|/proc|/proc/*|/root|/root/*|/run|/run/*|/sbin|/sbin/*|/sys|/sys/*|/usr|/usr/*|/var|/var/run|/var/run/*|/var/lib|/var/lib/*|/var/log|/var/log/*|/var/db|/var/db/*|/var/root|/var/root/*)
+		die "evidence directory resolves to a protected system path" ;;
+	esac
+	chmod 0700 "$directory" || die "cannot protect evidence directory '$directory'"
+}
+
+new_bundle() {
+	parent=$1
+	command_name=$2
+	timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+	bundle=$(mktemp -d "$parent/${command_name}-${timestamp}-XXXXXX") || die "cannot create evidence bundle"
+	chmod 0700 "$bundle" || die "cannot protect evidence bundle"
+	printf '%s\n' "$bundle"
+}
+
+capture() {
+	output_file=$1
+	shift
+	set +e
+	"$@" >"$output_file" 2>&1
+	status=$?
+	set -e
+	printf '\nexit_status=%s\n' "$status" >>"$output_file"
+	return "$status"
+}
+
+write_metadata() {
+	metadata_file=$1
+	command_name=$2
+	target_node=$3
+	interface=$4
+	action=$5
+	{
+		printf 'command=%s\n' "$command_name"
+		printf 'target_node=%s\n' "$target_node"
+		printf 'interface=%s\n' "$interface"
+		printf 'action=%s\n' "$action"
+		printf 'started_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	} >"$metadata_file"
+}

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -62,6 +62,7 @@ prepare_evidence_dir() {
 	root=$(readlink -f /evidence 2>/dev/null || true)
 	[ "$root" = /evidence ] || die "/evidence did not resolve safely"
 	if [ "$directory" != /evidence ]; then
+		[ ! -L "$directory" ] || die "evidence directory may not be a symlink"
 		mkdir "$directory" 2>/dev/null || [ -d "$directory" ] || die "cannot create evidence directory '$directory'"
 	fi
 	assert_safe_evidence_dir "$directory"

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -79,7 +79,9 @@ assert_safe_evidence_dir() {
 			;;
 		*) die "unsafe evidence directory" ;;
 	esac
-	[ -d /evidence ] && [ ! -L /evidence ] || die "/evidence changed while handling evidence"
+	if [ ! -d /evidence ] || [ -L /evidence ]; then
+		die "/evidence changed while handling evidence"
+	fi
 	[ ! -L "$directory" ] || die "evidence directory may not be a symlink"
 	resolved_directory=$(readlink -f "$directory" 2>/dev/null || true)
 	[ "$resolved_directory" = "$directory" ] || die "evidence directory changed or resolves outside /evidence"
@@ -89,7 +91,9 @@ assert_safe_bundle() {
 	bundle=$1
 	assert_safe_evidence_dir "${EVIDENCE_DIR:?evidence directory is not initialized}"
 	case "$bundle" in "$EVIDENCE_DIR"/*) ;; *) die "unsafe evidence bundle" ;; esac
-	[ -d "$bundle" ] && [ ! -L "$bundle" ] || die "evidence bundle changed while handling evidence"
+	if [ ! -d "$bundle" ] || [ -L "$bundle" ]; then
+		die "evidence bundle changed while handling evidence"
+	fi
 	resolved_bundle=$(readlink -f "$bundle" 2>/dev/null || true)
 	[ "$resolved_bundle" = "$bundle" ] || die "evidence bundle did not resolve safely"
 }

--- a/utils/node-maintenance/lib/common.sh
+++ b/utils/node-maintenance/lib/common.sh
@@ -117,11 +117,31 @@ capture() {
 	assert_safe_bundle "$bundle"
 	command -v timeout >/dev/null 2>&1 || die "timeout utility is required for bounded evidence capture"
 	temporary_file=$(mktemp "$bundle/.capture.XXXXXX") || die "cannot create bounded capture temporary file"
-	if timeout "$capture_timeout_seconds" "$@" >"$temporary_file" 2>&1; then
-		status=0
-	else
-		status=$?
+	status_file=$(mktemp "$bundle/.capture-status.XXXXXX") || die "cannot create capture status file"
+	fifo=$(mktemp "$bundle/.capture-fifo.XXXXXX") || die "cannot reserve capture pipe"
+	rm -f "$fifo"
+	mkfifo -m 0600 "$fifo" || die "cannot create capture pipe"
+	(
+		set +e
+		timeout "$capture_timeout_seconds" "$@" >"$fifo" 2>&1
+		printf '%s\n' "$?" >"$status_file"
+	) &
+	producer_pid=$!
+	# Read at most one byte beyond the fixed quota. Closing the FIFO then
+	# back-pressures or terminates a noisy producer instead of allowing an
+	# unbounded temporary file to grow before the quota is checked.
+	if ! head -c "$((capture_max_bytes + 1))" "$fifo" >"$temporary_file"; then
+		rm -f "$fifo" "$status_file" "$temporary_file"
+		die "cannot read bounded command output"
 	fi
+	if wait "$producer_pid"; then :; else :; fi
+	rm -f "$fifo"
+	[ -s "$status_file" ] || {
+		rm -f "$status_file" "$temporary_file"
+		die "capture command did not report an exit status"
+	}
+	status=$(cat "$status_file")
+	rm -f "$status_file"
 	bytes=$(wc -c <"$temporary_file" | tr -d ' ')
 	if [ "$bytes" -gt "$capture_max_bytes" ]; then
 		head -c "$capture_max_bytes" "$temporary_file" >"$output_file"

--- a/utils/node-maintenance/lib/network-repair.sh
+++ b/utils/node-maintenance/lib/network-repair.sh
@@ -67,14 +67,21 @@ printf 'Confirmation accepted. Applying the allowlisted action...\n'
 set +e
 case "$action" in
 	link-cycle)
-		ip link set dev "$interface" down
-		first_status=$?
-		if [ "$first_status" -eq 0 ]; then ip link set dev "$interface" up; fi
-		action_status=$?
-		[ "$first_status" -eq 0 ] || action_status=$first_status
+		if capture "$bundle/action-link-down.txt" ip link set dev "$interface" down; then
+			capture "$bundle/action-link-up.txt" ip link set dev "$interface" up
+			action_status=$?
+		else
+			action_status=$?
+		fi
 		;;
-	flush-neighbors) ip neigh flush dev "$interface"; action_status=$? ;;
-	restart-autonegotiation) ethtool -r "$interface"; action_status=$? ;;
+	flush-neighbors)
+		capture "$bundle/action-flush-neighbors.txt" ip neigh flush dev "$interface"
+		action_status=$?
+		;;
+	restart-autonegotiation)
+		capture "$bundle/action-restart-autonegotiation.txt" ethtool -r "$interface"
+		action_status=$?
+		;;
 esac
 set -e
 
@@ -82,6 +89,7 @@ capture "$bundle/after-link.txt" ip -details link show dev "$interface" || true
 capture "$bundle/after-addresses.txt" ip -brief address show dev "$interface" || true
 capture "$bundle/after-routes.txt" ip route show dev "$interface" || true
 capture "$bundle/after-neighbors.txt" ip neigh show dev "$interface" || true
+assert_safe_bundle "$bundle"
 printf 'action_exit_status=%s\ncompleted_at_utc=%s\n' "$action_status" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$bundle/metadata"
 
 if [ "$action_status" -ne 0 ]; then

--- a/utils/node-maintenance/lib/network-repair.sh
+++ b/utils/node-maintenance/lib/network-repair.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$script_dir/common.sh"
+
+usage() {
+	cat >&2 <<'EOF'
+Usage:
+  network-repair --target-node NODE --interface IFACE --action ACTION \
+    --evidence-dir ABSOLUTE_PATH --confirm NETWORK-REPAIR
+
+Allowed actions:
+  link-cycle                 Take IFACE down, then bring it back up.
+  flush-neighbors            Flush neighbor entries belonging to IFACE.
+  restart-autonegotiation    Ask the NIC to restart auto-negotiation.
+EOF
+}
+
+target_node=
+interface=
+action=
+evidence_dir=
+confirmation=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--target-node) [ "$#" -ge 2 ] || die "--target-node needs a value"; target_node=$2; shift 2 ;;
+		--interface) [ "$#" -ge 2 ] || die "--interface needs a value"; interface=$2; shift 2 ;;
+		--action) [ "$#" -ge 2 ] || die "--action needs a value"; action=$2; shift 2 ;;
+		--evidence-dir) [ "$#" -ge 2 ] || die "--evidence-dir needs a value"; evidence_dir=$2; shift 2 ;;
+		--confirm) [ "$#" -ge 2 ] || die "--confirm needs a value"; confirmation=$2; shift 2 ;;
+		-h|--help) usage; exit 0 ;;
+		*) die "unsupported option '$1'" ;;
+	esac
+done
+
+validate_target "$target_node"
+validate_interface "$interface"
+validate_value "action" "$action"
+validate_confirmation NETWORK-REPAIR "$confirmation"
+prepare_evidence_dir "$evidence_dir"
+
+case "$action" in
+	link-cycle|flush-neighbors|restart-autonegotiation) ;;
+	*) die "action '$action' is not allowlisted" ;;
+esac
+
+bundle=$(new_bundle "$evidence_dir" network-repair)
+write_metadata "$bundle/metadata" network-repair "$target_node" "$interface" "$action"
+
+if ! capture "$bundle/before-link.txt" ip -details link show dev "$interface"; then
+	die "interface '$interface' was not found; no repair was attempted (evidence: $bundle)"
+fi
+capture "$bundle/before-addresses.txt" ip -brief address show dev "$interface" || true
+capture "$bundle/before-routes.txt" ip route show dev "$interface" || true
+capture "$bundle/before-neighbors.txt" ip neigh show dev "$interface" || true
+
+printf 'Target: %s\nInterface: %s\nAction: %s\nEvidence: %s\n' \
+	"$target_node" "$interface" "$action" "$bundle"
+printf 'Confirmation accepted. Applying the allowlisted action...\n'
+
+set +e
+case "$action" in
+	link-cycle)
+		ip link set dev "$interface" down
+		first_status=$?
+		if [ "$first_status" -eq 0 ]; then ip link set dev "$interface" up; fi
+		action_status=$?
+		[ "$first_status" -eq 0 ] || action_status=$first_status
+		;;
+	flush-neighbors) ip neigh flush dev "$interface"; action_status=$? ;;
+	restart-autonegotiation) ethtool -r "$interface"; action_status=$? ;;
+esac
+set -e
+
+capture "$bundle/after-link.txt" ip -details link show dev "$interface" || true
+capture "$bundle/after-addresses.txt" ip -brief address show dev "$interface" || true
+capture "$bundle/after-routes.txt" ip route show dev "$interface" || true
+capture "$bundle/after-neighbors.txt" ip neigh show dev "$interface" || true
+printf 'action_exit_status=%s\ncompleted_at_utc=%s\n' "$action_status" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$bundle/metadata"
+
+if [ "$action_status" -ne 0 ]; then
+	printf 'Repair failed; inspect before/after evidence at %s\n' "$bundle" >&2
+	exit "$action_status"
+fi
+printf 'Repair completed; inspect before/after evidence at %s\n' "$bundle"

--- a/utils/node-maintenance/lib/node-recovery-preflight.sh
+++ b/utils/node-maintenance/lib/node-recovery-preflight.sh
@@ -56,6 +56,7 @@ capture "$bundle/neighbors.txt" ip neigh show dev "$interface" || true
 capture "$bundle/ethtool.txt" ethtool "$interface" || true
 capture "$bundle/resolver.txt" cat /etc/resolv.conf || true
 capture "$bundle/kernel.txt" uname -a || true
+assert_safe_bundle "$bundle"
 printf 'completed_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$bundle/metadata"
 
 printf 'Preflight completed for target %s, interface %s. Evidence: %s\n' \

--- a/utils/node-maintenance/lib/node-recovery-preflight.sh
+++ b/utils/node-maintenance/lib/node-recovery-preflight.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1091
+. "$script_dir/common.sh"
+
+usage() {
+	cat >&2 <<'EOF'
+Usage:
+  node-recovery --target-node NODE --interface IFACE \
+    --evidence-dir ABSOLUTE_PATH --confirm NODE-RECOVERY-PREFLIGHT
+
+This command is read-only. It records link, address, route, neighbor, NIC,
+resolver, and kernel evidence for the explicitly named node and interface.
+EOF
+}
+
+target_node=
+interface=
+evidence_dir=
+confirmation=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--target-node) [ "$#" -ge 2 ] || die "--target-node needs a value"; target_node=$2; shift 2 ;;
+		--interface) [ "$#" -ge 2 ] || die "--interface needs a value"; interface=$2; shift 2 ;;
+		--evidence-dir) [ "$#" -ge 2 ] || die "--evidence-dir needs a value"; evidence_dir=$2; shift 2 ;;
+		--confirm) [ "$#" -ge 2 ] || die "--confirm needs a value"; confirmation=$2; shift 2 ;;
+		-h|--help) usage; exit 0 ;;
+		*) die "unsupported option '$1'" ;;
+	esac
+done
+
+validate_target "$target_node"
+validate_interface "$interface"
+validate_confirmation NODE-RECOVERY-PREFLIGHT "$confirmation"
+prepare_evidence_dir "$evidence_dir"
+
+bundle=$(new_bundle "$evidence_dir" node-recovery)
+write_metadata "$bundle/metadata" node-recovery "$target_node" "$interface" read-only
+
+if ! capture "$bundle/interface.txt" ip -details link show dev "$interface"; then
+	printf 'Interface %s was not found; evidence bundle is incomplete: %s\n' "$interface" "$bundle" >&2
+	exit 1
+fi
+
+# Each probe is fixed and read-only. A driver may not support every probe, so
+# its exit status is retained in the evidence and does not hide other probes.
+capture "$bundle/addresses.txt" ip -brief address show dev "$interface" || true
+capture "$bundle/routes.txt" ip route show dev "$interface" || true
+capture "$bundle/neighbors.txt" ip neigh show dev "$interface" || true
+capture "$bundle/ethtool.txt" ethtool "$interface" || true
+capture "$bundle/resolver.txt" cat /etc/resolv.conf || true
+capture "$bundle/kernel.txt" uname -a || true
+printf 'completed_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$bundle/metadata"
+
+printf 'Preflight completed for target %s, interface %s. Evidence: %s\n' \
+	"$target_node" "$interface" "$bundle"

--- a/utils/node-maintenance/runbooks/network-repair.md
+++ b/utils/node-maintenance/runbooks/network-repair.md
@@ -1,0 +1,37 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Allowlisted network repair
+
+Use this procedure only after preflight evidence has been reviewed and the
+incident ticket has explicit approval. Repairs can interrupt traffic.
+
+Allowed actions are `link-cycle` (take the named interface down/up),
+`flush-neighbors` (flush neighbor entries for the interface), and
+`restart-autonegotiation` (ask the NIC to restart auto-negotiation).
+
+Run exactly one action, replacing every uppercase placeholder:
+
+```text
+network-repair \
+  --target-node NODE_NAME \
+  --interface IFACE_NAME \
+  --action ACTION \
+  --evidence-dir /evidence \
+  --confirm NETWORK-REPAIR
+```
+
+The helper refuses a target node that does not exactly match the local host
+identity and refuses evidence paths that are system roots or symlink-resolved
+paths. Use a dedicated child directory under the `/evidence` mount. Run with
+`hostNetwork: true`, `allowPrivilegeEscalation: false`, all capabilities
+dropped except `NET_ADMIN`, and a read-only root filesystem; blanket
+`privileged: true` is not required.
+
+The helper captures link, address, route, and neighbor state before and after
+the action. Preserve the bundle even if the action exits non-zero. Verify node
+readiness and application health through the normal platform process; this
+image has no unrestricted shell or general-purpose diagnostic toolbox.

--- a/utils/node-maintenance/runbooks/network-repair.md
+++ b/utils/node-maintenance/runbooks/network-repair.md
@@ -24,9 +24,10 @@ network-repair \
   --confirm NETWORK-REPAIR
 ```
 
-The helper refuses a target node that does not exactly match the local host
-identity and refuses evidence paths that are system roots or symlink-resolved
-paths. Use a dedicated child directory under the `/evidence` mount. Run with
+The helper refuses a target node that does not exactly match the controller-
+provided `BREAKGLASS_NODE_NAME` (from Downward API `spec.nodeName`) and refuses
+evidence paths other than `/evidence` or one safe child, including symlink or
+rename changes. Run with
 `hostNetwork: true`, `allowPrivilegeEscalation: false`, all capabilities
 dropped except `NET_ADMIN`, and a read-only root filesystem; blanket
 `privileged: true` is not required.
@@ -35,3 +36,7 @@ The helper captures link, address, route, and neighbor state before and after
 the action. Preserve the bundle even if the action exits non-zero. Verify node
 readiness and application health through the normal platform process; this
 image has no unrestricted shell or general-purpose diagnostic toolbox.
+Every action and probe has a fixed time/output budget. This command cannot
+perform route replacement, sysctl changes, capture, crashdump collection,
+node discovery, arbitrary commands, kexec, or reboot. An entrypoint override
+is outside the external immutable-template and admission-control boundary.

--- a/utils/node-maintenance/runbooks/node-recovery-preflight.md
+++ b/utils/node-maintenance/runbooks/node-recovery-preflight.md
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Node recovery preflight
+
+Use this read-only procedure before changing a node network interface.
+
+1. Confirm the incident ticket, approval, exact node name, exact interface
+   name, and a writable evidence destination. The node name must match the
+   host identity reported by `hostname`; never proceed with a guess.
+2. Run a host-networked pod using the image. Mount an empty,
+   operator-controlled directory at `/evidence`; do not mount the host root.
+   Drop all capabilities and add only `NET_ADMIN` if the same pod will later
+   be used for a repair.
+3. Execute the fixed command, replacing every uppercase placeholder:
+
+   ```text
+   node-recovery \
+     --target-node NODE_NAME \
+     --interface IFACE_NAME \
+     --evidence-dir /evidence \
+     --confirm NODE-RECOVERY-PREFLIGHT
+   ```
+
+4. Preserve the printed evidence bundle and ticket it before proceeding. A
+   missing interface is a hard stop; an unsupported probe is recorded.
+5. Review `interface.txt`, `addresses.txt`, `routes.txt`, `neighbors.txt`,
+   `ethtool.txt`, `resolver.txt`, `kernel.txt`, and `metadata` with the
+   incident responder. The helper does not decide whether repair is safe.
+
+The image does not provide an interactive shell. If this preflight is
+insufficient, stop and follow the separately approved host-debug process.

--- a/utils/node-maintenance/runbooks/node-recovery-preflight.md
+++ b/utils/node-maintenance/runbooks/node-recovery-preflight.md
@@ -9,12 +9,13 @@ SPDX-License-Identifier: CC-BY-4.0
 Use this read-only procedure before changing a node network interface.
 
 1. Confirm the incident ticket, approval, exact node name, exact interface
-   name, and a writable evidence destination. The node name must match the
-   host identity reported by `hostname`; never proceed with a guess.
+   name, and a writable evidence destination. Ensure the controller's
+   immutable template injects `BREAKGLASS_NODE_NAME` from the Downward API
+   `spec.nodeName`; never proceed with a hostname-derived value or a guess.
 2. Run a host-networked pod using the image. Mount an empty,
    operator-controlled directory at `/evidence`; do not mount the host root.
-   Drop all capabilities and add only `NET_ADMIN` if the same pod will later
-   be used for a repair.
+   Drop all capabilities and add none. Use a separate repair workload context
+   if a mutation is approved later.
 3. Execute the fixed command, replacing every uppercase placeholder:
 
    ```text
@@ -29,7 +30,10 @@ Use this read-only procedure before changing a node network interface.
    missing interface is a hard stop; an unsupported probe is recorded.
 5. Review `interface.txt`, `addresses.txt`, `routes.txt`, `neighbors.txt`,
    `ethtool.txt`, `resolver.txt`, `kernel.txt`, and `metadata` with the
-   incident responder. The helper does not decide whether repair is safe.
+   incident responder. Timeout and quota status are explicit in the files.
+   The helper does not decide whether repair is safe.
 
 The image does not provide an interactive shell. If this preflight is
 insufficient, stop and follow the separately approved host-debug process.
+It does not provide node discovery, crashdump collection, capture, arbitrary
+commands, kexec/reboot, sysctl changes, or route replacement.

--- a/utils/node-maintenance/tests/integration-contract.json
+++ b/utils/node-maintenance/tests/integration-contract.json
@@ -12,7 +12,10 @@
     "seccompProfile": "runtime-default",
     "seccompOption": "builtin",
     "capabilitiesDrop": ["ALL"],
-    "capabilitiesAdd": ["NET_ADMIN"]
+    "contexts": {
+      "node-recovery": {"capabilitiesAdd": []},
+      "network-repair": {"capabilitiesAdd": ["NET_ADMIN"]}
+    }
   },
   "disposableResources": {
     "evidenceVolume": true,
@@ -22,6 +25,7 @@
   "commands": {
     "node-recovery": {
       "target": "node-a",
+      "nodeIdentityEnvironment": "BREAKGLASS_NODE_NAME",
       "interface": "lo",
       "confirmation": "NODE-RECOVERY-PREFLIGHT",
       "expectedExit": 0,
@@ -29,6 +33,7 @@
     },
     "network-repair": {
       "target": "node-a",
+      "nodeIdentityEnvironment": "BREAKGLASS_NODE_NAME",
       "interface": "lo",
       "confirmation": "NETWORK-REPAIR",
       "actions": {
@@ -43,6 +48,8 @@
     "missing-confirmation",
     "target-mismatch",
     "unsafe-evidence-path",
+    "evidence-symlink",
+    "evidence-rename",
     "unknown-dispatch-command"
   ]
 }

--- a/utils/node-maintenance/tests/integration-contract.json
+++ b/utils/node-maintenance/tests/integration-contract.json
@@ -1,0 +1,48 @@
+{
+  "contractVersion": "node-maintenance.integration/v1",
+  "imageContext": "utils/node-maintenance",
+  "network": {
+    "mode": "none",
+    "hostNetwork": false,
+    "hostNetworkMutation": false
+  },
+  "security": {
+    "readOnlyRootFilesystem": true,
+    "allowPrivilegeEscalation": false,
+    "seccompProfile": "runtime-default",
+    "seccompOption": "builtin",
+    "capabilitiesDrop": ["ALL"],
+    "capabilitiesAdd": ["NET_ADMIN"]
+  },
+  "disposableResources": {
+    "evidenceVolume": true,
+    "container": true,
+    "cleanupRequired": true
+  },
+  "commands": {
+    "node-recovery": {
+      "target": "node-a",
+      "interface": "lo",
+      "confirmation": "NODE-RECOVERY-PREFLIGHT",
+      "expectedExit": 0,
+      "requiredEvidence": ["interface.txt", "addresses.txt", "routes.txt", "neighbors.txt", "ethtool.txt", "resolver.txt", "kernel.txt", "metadata"]
+    },
+    "network-repair": {
+      "target": "node-a",
+      "interface": "lo",
+      "confirmation": "NETWORK-REPAIR",
+      "actions": {
+        "link-cycle": {"expectedExit": 0},
+        "flush-neighbors": {"expectedExit": 0},
+        "restart-autonegotiation": {"expectedExit": "nonzero"}
+      },
+      "requiredEvidence": ["before-link.txt", "before-addresses.txt", "before-routes.txt", "before-neighbors.txt", "after-link.txt", "after-addresses.txt", "after-routes.txt", "after-neighbors.txt", "metadata"]
+    }
+  },
+  "guards": [
+    "missing-confirmation",
+    "target-mismatch",
+    "unsafe-evidence-path",
+    "unknown-dispatch-command"
+  ]
+}

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -240,6 +240,40 @@ assert_capture_statuses() {
 	done
 }
 
+new_fixture capture-output-quota
+set +e
+# The quoted program is evaluated inside the test container; host-side
+# expansion would invalidate the namespace and evidence-path proof.
+# shellcheck disable=SC2016
+"$docker_bin" run \
+	--name "$container_name" --user 0 --network none --read-only --cap-drop ALL \
+	--security-opt no-new-privileges --security-opt seccomp=builtin \
+	--mount "source=$volume_name,destination=/evidence" \
+	--entrypoint /bin/sh "$image" -c '
+		. /usr/local/libexec/node-maintenance/common.sh
+		EVIDENCE_DIR=/evidence
+		bundle=/evidence/quota
+		mkdir -m 0700 "$bundle"
+		set +e
+		capture "$bundle/output" awk '\''BEGIN { for (i = 0; i < 40000; i++) printf "x" }'\''
+		status=$?
+		set -e
+		[ "$status" -eq 75 ]
+	' >"$fixture_dir/output" 2>&1
+quota_status=$?
+set -e
+cat "$fixture_dir/output"
+assert_container_security "$container_name" none
+[ "$quota_status" -eq 0 ] || fail "bounded capture behavior returned $quota_status"
+"$docker_bin" cp "$container_name:/evidence/quota/output" "$fixture_dir/quota-output" >/dev/null \
+	|| fail 'could not copy bounded capture evidence'
+[ "$(wc -c <"$fixture_dir/quota-output" | tr -d ' ')" -le 32832 ] \
+	|| fail 'oversized capture exceeded the bounded evidence allowance'
+grep -q '^capture_result=output-quota-exceeded$' "$fixture_dir/quota-output" \
+	|| fail 'oversized capture did not record the quota failure'
+destroy_fixture
+pass 'oversized command output is bounded while it is produced'
+
 run_command preflight 0 none node-recovery --target-node node-a --interface lo \
 	--evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
 preflight_bundle=$(bundle_from_output "$fixture_dir/output")

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -94,8 +94,51 @@ printf '%s\n' \
 	'schema: breakglass.runbook/v1' \
 	'intent: node-maintenance' \
 	'version: 0.1.0' \
+	'image:' \
+	'  name: ghcr.io/telekom/k8s-breakglass/utils/node-maintenance' \
+	'  digest: sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' \
+	'  architectures:' \
+	'    - amd64' \
+	'    - arm64' \
+	'compatibility:' \
+	'  kubernetes: ">=1.31.0"' \
+	'  utility: node-maintenance' \
+	'  utilityVersions:' \
+	'    - dev' \
+	'index:' \
+	'  - id: node-maintenance-overview' \
+	'    title: Node maintenance overview' \
+	'    path: runbooks/node-maintenance.md' \
+	'    summary: Bounded node recovery and repair procedures.' \
+	'    security: Fixed commands, explicit capabilities, and disposable evidence.' \
+	'source:' \
+	'  repository: https://github.com/telekom/k8s-breakglass' \
+	'  revision: 0123456789abcdef0123456789abcdef01234567' \
+	'  generatedAt: "2026-08-27T00:00:00Z"' \
 	>"$runbook_bundle/bundle.yaml"
-printf '%s\n' '# Deployment runbook fixture' >"$runbook_bundle/INDEX.md"
+mkdir -p "$runbook_bundle/runbooks"
+printf '%s\n' \
+	'# Deployment runbook fixture' \
+	'' \
+	'Intent: node-maintenance' \
+	'Bundle version: 0.1.0' \
+	'Utility image digest: sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' \
+	'Source revision: 0123456789abcdef0123456789abcdef01234567' \
+	'' \
+	'Prerequisites: Linux node, image-volume support, and an administrator-owned template.' \
+	'Limits: fixed node-recovery/network-repair commands and bounded probes.' \
+	'Evidence: use a dedicated /evidence volume and preserve the resulting bundle.' \
+	'Security boundary: read-only root, no privilege escalation, and explicit capabilities.' \
+	'Failure modes: stop on denied guards, failed pulls, or incomplete evidence.' \
+	'Cleanup: delete the disposable Pod, volume, and session-owned resources.' \
+	'' \
+	'- [Node maintenance overview](runbooks/node-maintenance.md)' \
+	>"$runbook_bundle/INDEX.md"
+printf '%s\n' \
+	'# Node maintenance overview' \
+	'' \
+	'Use the fixed node-recovery and network-repair commands with the required evidence and confirmation boundaries.' \
+	>"$runbook_bundle/runbooks/node-maintenance.md"
 docs_output=$(
 	"$docker_bin" run --rm --network none --read-only --cap-drop ALL \
 		--security-opt no-new-privileges --security-opt seccomp=builtin \
@@ -104,6 +147,8 @@ docs_output=$(
 			test -r /usr/share/breakglass/runbooks/upstream/node-maintenance/README.md
 			test -r /usr/share/breakglass/runbooks/upstream/node-maintenance/network-repair.md
 			test -r /usr/share/breakglass/runbooks/internal/bundle.yaml
+			test -r /usr/share/breakglass/runbooks/internal/INDEX.md
+			test -r /usr/share/breakglass/runbooks/internal/runbooks/node-maintenance.md
 			cat /usr/share/breakglass/runbooks/internal/bundle.yaml
 			if printf modified >>/usr/share/breakglass/runbooks/internal/bundle.yaml 2>/dev/null; then
 				exit 70
@@ -112,6 +157,10 @@ docs_output=$(
 ) || fail 'built-in and mounted runbooks were not readable with a read-only downstream bundle'
 printf '%s\n' "$docs_output" | grep -q '^schema: breakglass.runbook/v1$' \
 	|| fail 'mounted runbook bundle metadata was not discovered through the shared contract'
+printf '%s\n' "$docs_output" | grep -q '^  digest: sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff$' \
+	|| fail 'mounted runbook bundle did not expose its immutable utility digest'
+printf '%s\n' "$docs_output" | grep -q '^index:$' \
+	|| fail 'mounted runbook bundle did not expose its required index metadata'
 pass 'generic and optional downstream runbooks are readable while the bundle remains read-only'
 
 new_fixture() {

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -71,7 +71,7 @@ require_command sed
 "$docker_bin" info >/dev/null 2>&1 || fail "Docker daemon is unavailable; install/start Docker and rerun (no feature skip is allowed)"
 
 docker_help=$($docker_bin run --help 2>&1) || fail "Docker cannot advertise run capabilities"
-for required_flag in '--network' '--hostname' '--read-only' '--cap-drop' '--cap-add' '--security-opt' '--mount'; do
+for required_flag in '--network' '--read-only' '--cap-drop' '--cap-add' '--security-opt' '--mount'; do
 	printf '%s\n' "$docker_help" | grep -F -- "$required_flag" >/dev/null || fail "Docker lacks required '$required_flag' support"
 done
 
@@ -95,6 +95,19 @@ new_fixture() {
 	fixture_dir="$tmp_dir/$label"
 	mkdir -p "$fixture_dir"
 	"$docker_bin" volume create "$volume_name" >/dev/null || fail "could not create disposable volume '$volume_name'"
+	case "$label" in
+		guard-evidence-symlink)
+			"$docker_bin" run --rm --entrypoint /bin/sh \
+				--mount "source=$volume_name,destination=/evidence" "$image" \
+				-c 'ln -s /host/etc /evidence/escaped' || fail 'could not seed symlink attack fixture'
+			;;
+		guard-evidence-rename)
+			"$docker_bin" run --rm --entrypoint /bin/sh \
+				--mount "source=$volume_name,destination=/evidence" "$image" \
+				-c 'mkdir /evidence/race && mv /evidence/race /evidence/race-original && ln -s /host/etc /evidence/race' \
+				|| fail 'could not seed rename attack fixture'
+			;;
+	esac
 }
 
 destroy_fixture() {
@@ -111,26 +124,31 @@ destroy_fixture() {
 run_command() {
 	label=$1
 	expected_exit=$2
-	shift 2
+	capability=$3
+	shift 3
 	new_fixture "$label"
 	output_file="$fixture_dir/output"
 	set +e
-	"$docker_bin" run \
-		--name "$container_name" \
-		--user 0 \
-		--hostname node-a \
-		--network none \
-		--read-only \
-		--cap-drop ALL \
-		--cap-add NET_ADMIN \
-		--security-opt no-new-privileges \
-		--security-opt seccomp=builtin \
-		--mount "source=$volume_name,destination=/evidence" \
-		"$image" "$@" >"$output_file" 2>&1
+	if [ "$capability" = none ]; then
+		"$docker_bin" run \
+			--name "$container_name" --user 0 --env BREAKGLASS_NODE_NAME=node-a \
+			--network none --read-only --cap-drop ALL \
+			--security-opt no-new-privileges --security-opt seccomp=builtin \
+			--mount "source=$volume_name,destination=/evidence" \
+			"$image" "$@" >"$output_file" 2>&1
+	else
+		[ "$capability" = NET_ADMIN ] || fail "unsupported requested test capability '$capability'"
+		"$docker_bin" run \
+			--name "$container_name" --user 0 --env BREAKGLASS_NODE_NAME=node-a \
+			--network none --read-only --cap-drop ALL --cap-add NET_ADMIN \
+			--security-opt no-new-privileges --security-opt seccomp=builtin \
+			--mount "source=$volume_name,destination=/evidence" \
+			"$image" "$@" >"$output_file" 2>&1
+	fi
 	actual_exit=$?
 	set -e
 	cat "$output_file"
-	assert_container_security "$container_name"
+	assert_container_security "$container_name" "$capability"
 	if [ "$expected_exit" = nonzero ]; then
 		[ "$actual_exit" -ne 0 ] || fail "$label unexpectedly succeeded"
 	else
@@ -140,6 +158,7 @@ run_command() {
 
 assert_container_security() {
 	name=$1
+	expected_capability=$2
 	network_mode=$("$docker_bin" inspect --format '{{.HostConfig.NetworkMode}}' "$name") || fail "could not inspect container '$name'"
 	readonly_root=$("$docker_bin" inspect --format '{{.HostConfig.ReadonlyRootfs}}' "$name") || fail "could not inspect read-only root for '$name'"
 	user=$("$docker_bin" inspect --format '{{.Config.User}}' "$name") || fail "could not inspect user for '$name'"
@@ -150,7 +169,10 @@ assert_container_security() {
 	[ "$readonly_root" = true ] || fail "$name did not use a read-only root filesystem"
 	[ "$user" = 0 ] || fail "$name did not run as UID 0 for the capability-bound helper"
 	[ "$cap_drop" = ALL ] || fail "$name did not drop all capabilities (got '$cap_drop')"
-	[ "$cap_add" = NET_ADMIN ] || fail "$name did not add only NET_ADMIN (got '$cap_add')"
+	case "$expected_capability" in
+		none) [ -z "$cap_add" ] || fail "$name added capabilities for a read-only preflight (got '$cap_add')" ;;
+		NET_ADMIN) [ "$cap_add" = NET_ADMIN ] || fail "$name did not add only NET_ADMIN (got '$cap_add')" ;;
+	esac
 	case ",$security_opts," in
 		*,no-new-privileges,* ) ;;
 		*) fail "$name did not set no-new-privileges (got '$security_opts')" ;;
@@ -187,7 +209,7 @@ assert_capture_statuses() {
 	done
 }
 
-run_command preflight 0 node-recovery --target-node node-a --interface lo \
+run_command preflight 0 none node-recovery --target-node node-a --interface lo \
 	--evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
 preflight_bundle=$(bundle_from_output "$fixture_dir/output")
 preflight_host_bundle=$(copy_bundle "$fixture_dir/output" "$preflight_bundle")
@@ -206,7 +228,7 @@ pass 'node-recovery runs in isolated namespace and records evidence'
 run_repair() {
 	action=$1
 	expected_exit=$2
-	run_command "repair-$action" "$expected_exit" network-repair --target-node node-a --interface lo \
+	run_command "repair-$action" "$expected_exit" NET_ADMIN network-repair --target-node node-a --interface lo \
 		--action "$action" --evidence-dir /evidence --confirm NETWORK-REPAIR
 	repair_bundle=$(bundle_from_output "$fixture_dir/output")
 	repair_host_bundle=$(copy_bundle "$fixture_dir/output" "$repair_bundle")
@@ -232,25 +254,37 @@ run_repair flush-neighbors 0
 # path and proves that failure evidence is retained rather than hidden.
 run_repair restart-autonegotiation nonzero
 
-run_command guard-missing-confirmation 2 network-repair --target-node node-a --interface lo \
+run_command guard-missing-confirmation 2 none network-repair --target-node node-a --interface lo \
 	--action flush-neighbors --evidence-dir /evidence
 grep -q 'confirmation' "$fixture_dir/output" || fail 'missing confirmation produced no actionable denial'
 destroy_fixture
 pass 'missing confirmation is denied'
 
-run_command guard-target-mismatch 2 node-recovery --target-node node-b --interface lo \
+run_command guard-target-mismatch 2 none node-recovery --target-node node-b --interface lo \
 	--evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
-grep -q 'does not match local node' "$fixture_dir/output" || fail 'target mismatch produced no actionable denial'
+grep -q 'does not match controller-provided node' "$fixture_dir/output" || fail 'target mismatch produced no actionable denial'
 destroy_fixture
 pass 'target mismatch is denied'
 
-run_command guard-unsafe-path 2 node-recovery --target-node node-a --interface lo \
+run_command guard-unsafe-path 2 none node-recovery --target-node node-a --interface lo \
 	--evidence-dir / --confirm NODE-RECOVERY-PREFLIGHT
 grep -q 'evidence directory' "$fixture_dir/output" || fail 'unsafe evidence path produced no actionable denial'
 destroy_fixture
 pass 'unsafe evidence path is denied'
 
-run_command guard-unknown-command 2 unsupported-command
+run_command guard-evidence-symlink 2 none node-recovery --target-node node-a --interface lo \
+	--evidence-dir /evidence/escaped --confirm NODE-RECOVERY-PREFLIGHT
+grep -q 'symlink\|resolv' "$fixture_dir/output" || fail 'evidence symlink produced no actionable denial'
+destroy_fixture
+pass 'evidence symlink is denied'
+
+run_command guard-evidence-rename 2 none node-recovery --target-node node-a --interface lo \
+	--evidence-dir /evidence/race --confirm NODE-RECOVERY-PREFLIGHT
+grep -q 'symlink\|resolv' "$fixture_dir/output" || fail 'evidence rename attack produced no actionable denial'
+destroy_fixture
+pass 'evidence rename attack is denied'
+
+run_command guard-unknown-command 2 none unsupported-command
 grep -q 'Unsupported command' "$fixture_dir/output" || fail 'unknown command produced no actionable denial'
 destroy_fixture
 pass 'dispatcher rejects unknown commands'

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -1,0 +1,258 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Integration proof for the node-maintenance image. Every container uses a
+# disposable Docker network namespace (--network none) and named volume. The
+# runner's network namespaces are never joined or changed.
+set -eu
+
+test_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+root_dir=$(cd -- "$test_dir/.." && pwd)
+docker_bin=${DOCKER:-docker}
+image=${NODE_MAINTENANCE_TEST_IMAGE:-}
+keep_image=${NODE_MAINTENANCE_KEEP_IMAGE:-0}
+build_image=${NODE_MAINTENANCE_BUILD_IMAGE:-1}
+prefix="node-maintenance-it-$$"
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/node-maintenance-integration.XXXXXX")
+built_image=0
+image_owned=0
+container_name=
+volume_name=
+
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	exit 1
+}
+
+pass() {
+	printf 'PASS: %s\n' "$*"
+}
+
+cleanup() {
+	exit_code=$?
+	cleanup_failed=0
+	if [ -n "${container_name:-}" ]; then
+		"$docker_bin" rm -f "$container_name" >/dev/null 2>&1 || true
+		if "$docker_bin" container inspect "$container_name" >/dev/null 2>&1; then
+			printf 'FAIL: disposable container %s survived cleanup\n' "$container_name" >&2
+			cleanup_failed=1
+		fi
+	fi
+	if [ -n "${volume_name:-}" ]; then
+		"$docker_bin" volume rm "$volume_name" >/dev/null 2>&1 || true
+		if "$docker_bin" volume inspect "$volume_name" >/dev/null 2>&1; then
+			printf 'FAIL: disposable volume %s survived cleanup\n' "$volume_name" >&2
+			cleanup_failed=1
+		fi
+	fi
+	if [ "$built_image" -eq 1 ] && [ "$image_owned" -eq 1 ] && [ "$keep_image" != 1 ]; then
+		"$docker_bin" image rm "$image" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$tmp_dir"
+	if [ "$cleanup_failed" -ne 0 ] && [ "$exit_code" -eq 0 ]; then
+		exit_code=1
+	fi
+	exit "$exit_code"
+}
+trap cleanup EXIT
+
+require_command() {
+	command -v "$1" >/dev/null 2>&1 || fail "required command '$1' is not installed"
+}
+
+require_command "$docker_bin"
+require_command mktemp
+require_command grep
+require_command sed
+
+[ "$(uname -s)" = Linux ] || fail "integration requires Linux Docker namespaces; refusing to run on $(uname -s); run the Linux CI workflow or a Linux Docker runner"
+"$docker_bin" info >/dev/null 2>&1 || fail "Docker daemon is unavailable; install/start Docker and rerun (no feature skip is allowed)"
+
+docker_help=$($docker_bin run --help 2>&1) || fail "Docker cannot advertise run capabilities"
+for required_flag in '--network' '--hostname' '--read-only' '--cap-drop' '--cap-add' '--security-opt' '--mount'; do
+	printf '%s\n' "$docker_help" | grep -F -- "$required_flag" >/dev/null || fail "Docker lacks required '$required_flag' support"
+done
+
+if [ -z "$image" ]; then
+	image="node-maintenance-integration:$$"
+	build_image=1
+	image_owned=1
+fi
+if [ "$build_image" = 1 ]; then
+	printf 'Building integration image %s\n' "$image"
+	"$docker_bin" build --pull=false -t "$image" "$root_dir" || fail "image build failed; integration cannot be skipped"
+	built_image=1
+else
+	"$docker_bin" image inspect "$image" >/dev/null 2>&1 || fail "requested image '$image' is unavailable"
+fi
+
+new_fixture() {
+	label=$1
+	container_name="${prefix}-${label}"
+	volume_name="${prefix}-volume-${label}"
+	fixture_dir="$tmp_dir/$label"
+	mkdir -p "$fixture_dir"
+	"$docker_bin" volume create "$volume_name" >/dev/null || fail "could not create disposable volume '$volume_name'"
+}
+
+destroy_fixture() {
+	"$docker_bin" rm -f "$container_name" >/dev/null 2>&1 || true
+	if "$docker_bin" container inspect "$container_name" >/dev/null 2>&1; then
+		fail "disposable container '$container_name' survived cleanup"
+	fi
+	"$docker_bin" volume rm "$volume_name" >/dev/null 2>&1 || fail "cleanup failed for volume '$volume_name'"
+	"$docker_bin" volume inspect "$volume_name" >/dev/null 2>&1 && fail "disposable volume '$volume_name' survived cleanup"
+	container_name=
+	volume_name=
+}
+
+run_command() {
+	label=$1
+	expected_exit=$2
+	shift 2
+	new_fixture "$label"
+	output_file="$fixture_dir/output"
+	set +e
+	"$docker_bin" run \
+		--name "$container_name" \
+		--user 0 \
+		--hostname node-a \
+		--network none \
+		--read-only \
+		--cap-drop ALL \
+		--cap-add NET_ADMIN \
+		--security-opt no-new-privileges \
+		--security-opt seccomp=builtin \
+		--mount "source=$volume_name,destination=/evidence" \
+		"$image" "$@" >"$output_file" 2>&1
+	actual_exit=$?
+	set -e
+	cat "$output_file"
+	assert_container_security "$container_name"
+	if [ "$expected_exit" = nonzero ]; then
+		[ "$actual_exit" -ne 0 ] || fail "$label unexpectedly succeeded"
+	else
+		[ "$actual_exit" -eq "$expected_exit" ] || fail "$label returned $actual_exit, expected $expected_exit"
+	fi
+}
+
+assert_container_security() {
+	name=$1
+	network_mode=$("$docker_bin" inspect --format '{{.HostConfig.NetworkMode}}' "$name") || fail "could not inspect container '$name'"
+	readonly_root=$("$docker_bin" inspect --format '{{.HostConfig.ReadonlyRootfs}}' "$name") || fail "could not inspect read-only root for '$name'"
+	user=$("$docker_bin" inspect --format '{{.Config.User}}' "$name") || fail "could not inspect user for '$name'"
+	cap_drop=$("$docker_bin" inspect --format '{{join .HostConfig.CapDrop ","}}' "$name") || fail "could not inspect dropped capabilities for '$name'"
+	cap_add=$("$docker_bin" inspect --format '{{join .HostConfig.CapAdd ","}}' "$name") || fail "could not inspect added capabilities for '$name'"
+	security_opts=$("$docker_bin" inspect --format '{{join .HostConfig.SecurityOpt ","}}' "$name") || fail "could not inspect security options for '$name'"
+	[ "$network_mode" = none ] || fail "$name used network mode '$network_mode', expected none"
+	[ "$readonly_root" = true ] || fail "$name did not use a read-only root filesystem"
+	[ "$user" = 0 ] || fail "$name did not run as UID 0 for the capability-bound helper"
+	[ "$cap_drop" = ALL ] || fail "$name did not drop all capabilities (got '$cap_drop')"
+	[ "$cap_add" = NET_ADMIN ] || fail "$name did not add only NET_ADMIN (got '$cap_add')"
+	case ",$security_opts," in
+		*,no-new-privileges,* ) ;;
+		*) fail "$name did not set no-new-privileges (got '$security_opts')" ;;
+	esac
+	case ",$security_opts," in
+		*,seccomp=builtin,* ) ;;
+		*) fail "$name did not set the runtime-default seccomp profile (got '$security_opts')" ;;
+	esac
+}
+
+bundle_from_output() {
+	output_file=$1
+	bundle=$(sed -n 's/.*Evidence: //p' "$output_file" | tail -n 1)
+	case "$bundle" in
+		/evidence/*) ;;
+		*) fail "output did not contain a safe evidence bundle path: '$bundle'" ;;
+	esac
+	printf '%s\n' "$bundle"
+}
+
+copy_bundle() {
+	output_file=$1
+	bundle=$2
+	"$docker_bin" cp "$container_name:$bundle" "$fixture_dir/" >/dev/null || fail "could not copy evidence bundle '$bundle'"
+	host_bundle="$fixture_dir/$(basename "$bundle")"
+	printf '%s\n' "$host_bundle"
+}
+
+assert_capture_statuses() {
+	host_bundle=$1
+	shift
+	for evidence_file in "$@"; do
+		grep -q '^exit_status=' "$host_bundle/$evidence_file" || fail "evidence file lacks an exit status: $host_bundle/$evidence_file"
+	done
+}
+
+run_command preflight 0 node-recovery --target-node node-a --interface lo \
+	--evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
+preflight_bundle=$(bundle_from_output "$fixture_dir/output")
+preflight_host_bundle=$(copy_bundle "$fixture_dir/output" "$preflight_bundle")
+assert_capture_statuses "$preflight_host_bundle" interface.txt addresses.txt routes.txt neighbors.txt ethtool.txt resolver.txt kernel.txt
+grep -q '^exit_status=0$' "$preflight_host_bundle/interface.txt" || fail 'preflight interface probe did not succeed'
+grep -q 'command=node-recovery' "$preflight_host_bundle/metadata" || fail 'preflight metadata command mismatch'
+grep -q 'target_node=node-a' "$preflight_host_bundle/metadata" || fail 'preflight metadata target mismatch'
+grep -q 'interface=lo' "$preflight_host_bundle/metadata" || fail 'preflight metadata interface mismatch'
+grep -q 'action=read-only' "$preflight_host_bundle/metadata" || fail 'preflight metadata action mismatch'
+grep -Eq '(^|:) lo:' "$preflight_host_bundle/interface.txt" || fail 'preflight did not observe the loopback interface'
+grep -q '^Linux ' "$preflight_host_bundle/kernel.txt" || fail 'preflight did not observe Linux kernel evidence'
+grep -q '^exit_status=' "$preflight_host_bundle/resolver.txt" || fail 'preflight resolver evidence was not executed'
+destroy_fixture
+pass 'node-recovery runs in isolated namespace and records evidence'
+
+run_repair() {
+	action=$1
+	expected_exit=$2
+	run_command "repair-$action" "$expected_exit" network-repair --target-node node-a --interface lo \
+		--action "$action" --evidence-dir /evidence --confirm NETWORK-REPAIR
+	repair_bundle=$(bundle_from_output "$fixture_dir/output")
+	repair_host_bundle=$(copy_bundle "$fixture_dir/output" "$repair_bundle")
+	assert_capture_statuses "$repair_host_bundle" before-link.txt before-addresses.txt before-routes.txt before-neighbors.txt \
+		after-link.txt after-addresses.txt after-routes.txt after-neighbors.txt
+	grep -q '^exit_status=0$' "$repair_host_bundle/before-link.txt" || fail "$action before-link probe did not succeed"
+	grep -q '^exit_status=0$' "$repair_host_bundle/after-link.txt" || fail "$action after-link probe did not succeed"
+	grep -Eq '(^|:) lo:' "$repair_host_bundle/before-link.txt" || fail "$action did not observe the loopback interface before repair"
+	grep -Eq '(^|:) lo:' "$repair_host_bundle/after-link.txt" || fail "$action did not observe the loopback interface after repair"
+	grep -q "action=$action" "$repair_host_bundle/metadata" || fail "$action metadata action mismatch"
+	if [ "$expected_exit" = 0 ]; then
+		grep -q 'action_exit_status=0' "$repair_host_bundle/metadata" || fail "$action did not record success"
+	else
+		grep -Eq 'action_exit_status=[1-9][0-9]*' "$repair_host_bundle/metadata" || fail "$action did not record failure"
+	fi
+	destroy_fixture
+	pass "network-repair action '$action' records before/after evidence"
+}
+
+run_repair link-cycle 0
+run_repair flush-neighbors 0
+# loopback has no auto-negotiation; this is the expected real-tool failure
+# path and proves that failure evidence is retained rather than hidden.
+run_repair restart-autonegotiation nonzero
+
+run_command guard-missing-confirmation 2 network-repair --target-node node-a --interface lo \
+	--action flush-neighbors --evidence-dir /evidence
+grep -q 'confirmation' "$fixture_dir/output" || fail 'missing confirmation produced no actionable denial'
+destroy_fixture
+pass 'missing confirmation is denied'
+
+run_command guard-target-mismatch 2 node-recovery --target-node node-b --interface lo \
+	--evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
+grep -q 'does not match local node' "$fixture_dir/output" || fail 'target mismatch produced no actionable denial'
+destroy_fixture
+pass 'target mismatch is denied'
+
+run_command guard-unsafe-path 2 node-recovery --target-node node-a --interface lo \
+	--evidence-dir / --confirm NODE-RECOVERY-PREFLIGHT
+grep -q 'evidence directory' "$fixture_dir/output" || fail 'unsafe evidence path produced no actionable denial'
+destroy_fixture
+pass 'unsafe evidence path is denied'
+
+run_command guard-unknown-command 2 unsupported-command
+grep -q 'Unsupported command' "$fixture_dir/output" || fail 'unknown command produced no actionable denial'
+destroy_fixture
+pass 'dispatcher rejects unknown commands'
+
+printf 'PASS: node-maintenance integration contract completed with no host-network changes\n'

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -88,6 +88,28 @@ else
 	"$docker_bin" image inspect "$image" >/dev/null 2>&1 || fail "requested image '$image' is unavailable"
 fi
 
+runbook_bundle="$tmp_dir/runbook-bundle"
+mkdir -p "$runbook_bundle"
+printf '%s\n' 'schemaVersion: breakglass.telekom.com/v1alpha1' >"$runbook_bundle/bundle.yaml"
+printf '%s\n' '# Deployment runbook fixture' >"$runbook_bundle/INDEX.md"
+docs_output=$(
+	"$docker_bin" run --rm --network none --read-only --cap-drop ALL \
+		--security-opt no-new-privileges --security-opt seccomp=builtin \
+		--mount "type=bind,source=$runbook_bundle,destination=/usr/share/breakglass/runbooks/internal,readonly" \
+		--entrypoint /bin/sh "$image" -c '
+			test -r /usr/share/breakglass/runbooks/upstream/node-maintenance/README.md
+			test -r /usr/share/breakglass/runbooks/upstream/node-maintenance/network-repair.md
+			test -r /usr/share/breakglass/runbooks/internal/bundle.yaml
+			cat /usr/share/breakglass/runbooks/internal/bundle.yaml
+			if printf modified >>/usr/share/breakglass/runbooks/internal/bundle.yaml 2>/dev/null; then
+				exit 70
+			fi
+		' 2>/dev/null
+) || fail 'built-in and mounted runbooks were not readable with a read-only downstream bundle'
+printf '%s\n' "$docs_output" | grep -q '^schemaVersion: breakglass.telekom.com/v1alpha1$' \
+	|| fail 'mounted runbook bundle metadata was not discovered through the shared contract'
+pass 'generic and optional downstream runbooks are readable while the bundle remains read-only'
+
 new_fixture() {
 	label=$1
 	container_name="${prefix}-${label}"

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -90,7 +90,11 @@ fi
 
 runbook_bundle="$tmp_dir/runbook-bundle"
 mkdir -p "$runbook_bundle"
-printf '%s\n' 'schemaVersion: breakglass.telekom.com/v1alpha1' >"$runbook_bundle/bundle.yaml"
+printf '%s\n' \
+	'schema: breakglass.runbook/v1' \
+	'intent: node-maintenance' \
+	'version: 0.1.0' \
+	>"$runbook_bundle/bundle.yaml"
 printf '%s\n' '# Deployment runbook fixture' >"$runbook_bundle/INDEX.md"
 docs_output=$(
 	"$docker_bin" run --rm --network none --read-only --cap-drop ALL \
@@ -106,7 +110,7 @@ docs_output=$(
 			fi
 		' 2>/dev/null
 ) || fail 'built-in and mounted runbooks were not readable with a read-only downstream bundle'
-printf '%s\n' "$docs_output" | grep -q '^schemaVersion: breakglass.telekom.com/v1alpha1$' \
+printf '%s\n' "$docs_output" | grep -q '^schema: breakglass.runbook/v1$' \
 	|| fail 'mounted runbook bundle metadata was not discovered through the shared contract'
 pass 'generic and optional downstream runbooks are readable while the bundle remains read-only'
 

--- a/utils/node-maintenance/tests/integration.sh
+++ b/utils/node-maintenance/tests/integration.sh
@@ -193,7 +193,12 @@ assert_container_security() {
 	[ "$cap_drop" = ALL ] || fail "$name did not drop all capabilities (got '$cap_drop')"
 	case "$expected_capability" in
 		none) [ -z "$cap_add" ] || fail "$name added capabilities for a read-only preflight (got '$cap_add')" ;;
-		NET_ADMIN) [ "$cap_add" = NET_ADMIN ] || fail "$name did not add only NET_ADMIN (got '$cap_add')" ;;
+		NET_ADMIN)
+			case "$cap_add" in
+				NET_ADMIN|CAP_NET_ADMIN) ;;
+				*) fail "$name did not add only NET_ADMIN (got '$cap_add')" ;;
+			esac
+			;;
 	esac
 	case ",$security_opts," in
 		*,no-new-privileges,* ) ;;

--- a/utils/node-maintenance/tests/test-helpers.sh
+++ b/utils/node-maintenance/tests/test-helpers.sh
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Fast behavioral guards that do not need a container runtime. Positive
+# evidence-path and mutation behavior is exercised against the built image by
+# integration.sh, where /evidence is an actual disposable volume.
 set -eu
 
 test_dir=$(cd -- "$(dirname -- "$0")" && pwd)
@@ -24,84 +27,20 @@ assert_rejected() {
 
 network_repair="$root_dir/lib/network-repair.sh"
 preflight="$root_dir/lib/node-recovery-preflight.sh"
+
 assert_rejected 'network repair without target' "$network_repair" \
-	--interface eth0 --action flush-neighbors --evidence-dir "$tmp_dir/evidence" --confirm NETWORK-REPAIR
+	--interface eth0 --action flush-neighbors --evidence-dir /evidence --confirm NETWORK-REPAIR
 assert_rejected 'network repair without confirmation' "$network_repair" \
-	--target-node node-a --interface eth0 --action flush-neighbors --evidence-dir "$tmp_dir/evidence"
+	--target-node node-a --interface eth0 --action flush-neighbors --evidence-dir /evidence
 assert_rejected 'network repair with unallowlisted action' "$network_repair" \
-	--target-node node-a --interface eth0 --action route-replace --evidence-dir "$tmp_dir/evidence" --confirm NETWORK-REPAIR
+	--target-node node-a --interface eth0 --action route-replace --evidence-dir /evidence --confirm NETWORK-REPAIR
 assert_rejected 'preflight with unsafe interface' "$preflight" \
-	--target-node node-a --interface 'eth0;reboot' --evidence-dir "$tmp_dir/evidence" --confirm NODE-RECOVERY-PREFLIGHT
+	--target-node node-a --interface 'eth0;reboot' --evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
+assert_rejected 'hostname is not a node identity fallback' "$preflight" \
+	--target-node node-a --interface eth0 --evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
+BREAKGLASS_NODE_NAME=node-a assert_rejected 'controller node mismatch is rejected' "$preflight" \
+	--target-node node-b --interface eth0 --evidence-dir /evidence --confirm NODE-RECOVERY-PREFLIGHT
+BREAKGLASS_NODE_NAME=node-a assert_rejected 'host evidence path is rejected' "$preflight" \
+	--target-node node-a --interface eth0 --evidence-dir /host/etc/foo --confirm NODE-RECOVERY-PREFLIGHT
 
-fake_bin="$tmp_dir/bin"
-mkdir -p "$fake_bin"
-cat >"$fake_bin/ip" <<'EOF'
-#!/bin/sh
-case "$*" in
-  *"link show dev eth0"*) printf '%s\n' '2: eth0: <UP> mtu 1500' ;;
-  *"address show dev eth0"*) printf '%s\n' 'eth0 UP 192.0.2.10/24' ;;
-  *"route show dev eth0"*) printf '%s\n' 'default via 192.0.2.1 dev eth0' ;;
-  *"neigh show dev eth0"*) printf '%s\n' '192.0.2.1 lladdr 00:11:22:33:44:55 REACHABLE' ;;
-  *"link set dev eth0"*) exit 0 ;;
-  *"neigh flush dev eth0"*) printf '%s\n' '1 flushed' ;;
-  *) exit 1 ;;
-esac
-EOF
-cat >"$fake_bin/ethtool" <<'EOF'
-#!/bin/sh
-[ "${ETHTOOL_FAIL:-0}" = 1 ] && exit 7
-printf '%s\n' 'Settings for eth0: speed: 1000Mb/s'
-EOF
-cat >"$fake_bin/cat" <<'EOF'
-#!/bin/sh
-printf '%s\n' 'nameserver 192.0.2.53'
-EOF
-cat >"$fake_bin/uname" <<'EOF'
-#!/bin/sh
-printf '%s\n' 'Linux test-node 6.1.0'
-EOF
-cat >"$fake_bin/hostname" <<'EOF'
-#!/bin/sh
-printf '%s\n' 'node-a'
-EOF
-chmod 0555 "$fake_bin"/*
-
-evidence_dir="$tmp_dir/evidence"
-PATH="$fake_bin:$PATH" "$preflight" --target-node node-a --interface eth0 \
-	--evidence-dir "$evidence_dir" --confirm NODE-RECOVERY-PREFLIGHT >"$tmp_dir/preflight-output"
-bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/preflight-output")
-[ -n "$bundle" ] || fail 'preflight did not print an evidence bundle'
-grep -q '^exit_status=0$' "$bundle/interface.txt" || fail 'preflight interface probe did not execute successfully'
-grep -q '^command=node-recovery$' "$bundle/metadata" || fail 'preflight metadata command missing'
-grep -q 'target_node=node-a' "$bundle/metadata" || fail 'preflight target missing from metadata'
-pass 'preflight evidence and metadata'
-
-PATH="$fake_bin:$PATH" "$network_repair" --target-node node-a --interface eth0 \
-	--action flush-neighbors --evidence-dir "$evidence_dir" --confirm NETWORK-REPAIR >"$tmp_dir/repair-output"
-repair_bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/repair-output" | head -n 1)
-grep -q '^exit_status=0$' "$repair_bundle/before-link.txt" || fail 'repair before probe did not execute successfully'
-grep -q '^exit_status=0$' "$repair_bundle/after-link.txt" || fail 'repair after probe did not execute successfully'
-grep -q 'action=flush-neighbors' "$repair_bundle/metadata" || fail 'repair action missing from metadata'
-pass 'repair before/after evidence and metadata'
-
-if PATH="$fake_bin:$PATH" ETHTOOL_FAIL=1 "$network_repair" \
-	--target-node node-a --interface eth0 --action restart-autonegotiation \
-	--evidence-dir "$evidence_dir" --confirm NETWORK-REPAIR >"$tmp_dir/failed-repair-output" 2>&1; then
-	fail 'failed repair was accepted'
-fi
-failed_bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/failed-repair-output" | head -n 1)
-grep -q '^exit_status=0$' "$failed_bundle/before-link.txt" || fail 'failed repair before probe did not execute successfully'
-grep -q '^exit_status=0$' "$failed_bundle/after-link.txt" || fail 'failed repair after probe did not execute successfully'
-grep -q 'action_exit_status=7' "$failed_bundle/metadata" || fail 'failed action status missing from metadata'
-pass 'failed repair preserves before/after evidence'
-
-if PATH="$fake_bin:$PATH" "$preflight" --target-node node-b --interface eth0 \
-	--evidence-dir "$evidence_dir" --confirm NODE-RECOVERY-PREFLIGHT >"$tmp_dir/mismatch-output" 2>&1; then
-	fail 'preflight accepted a target different from the local node'
-fi
-pass 'target must match local node identity'
-
-PATH="$fake_bin:$PATH" assert_rejected 'evidence root is rejected' "$preflight" \
-	--target-node node-a --interface eth0 --evidence-dir / --confirm NODE-RECOVERY-PREFLIGHT
-PATH="$fake_bin:$PATH" assert_rejected 'host system path is rejected' "$preflight" \
-	--target-node node-a --interface eth0 --evidence-dir /etc --confirm NODE-RECOVERY-PREFLIGHT
+printf 'PASS: node-maintenance static behavior guards completed\n'

--- a/utils/node-maintenance/tests/test-helpers.sh
+++ b/utils/node-maintenance/tests/test-helpers.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+test_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+root_dir=$(cd -- "$test_dir/.." && pwd)
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/node-maintenance-test.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+assert_rejected() {
+	name=$1
+	shift
+	if "$@" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"; then
+		fail "$name was accepted"
+	fi
+	pass "$name"
+}
+
+network_repair="$root_dir/lib/network-repair.sh"
+preflight="$root_dir/lib/node-recovery-preflight.sh"
+assert_rejected 'network repair without target' "$network_repair" \
+	--interface eth0 --action flush-neighbors --evidence-dir "$tmp_dir/evidence" --confirm NETWORK-REPAIR
+assert_rejected 'network repair without confirmation' "$network_repair" \
+	--target-node node-a --interface eth0 --action flush-neighbors --evidence-dir "$tmp_dir/evidence"
+assert_rejected 'network repair with unallowlisted action' "$network_repair" \
+	--target-node node-a --interface eth0 --action route-replace --evidence-dir "$tmp_dir/evidence" --confirm NETWORK-REPAIR
+assert_rejected 'preflight with unsafe interface' "$preflight" \
+	--target-node node-a --interface 'eth0;reboot' --evidence-dir "$tmp_dir/evidence" --confirm NODE-RECOVERY-PREFLIGHT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/ip" <<'EOF'
+#!/bin/sh
+case "$*" in
+  *"link show dev eth0"*) printf '%s\n' '2: eth0: <UP> mtu 1500' ;;
+  *"address show dev eth0"*) printf '%s\n' 'eth0 UP 192.0.2.10/24' ;;
+  *"route show dev eth0"*) printf '%s\n' 'default via 192.0.2.1 dev eth0' ;;
+  *"neigh show dev eth0"*) printf '%s\n' '192.0.2.1 lladdr 00:11:22:33:44:55 REACHABLE' ;;
+  *"link set dev eth0"*) exit 0 ;;
+  *"neigh flush dev eth0"*) printf '%s\n' '1 flushed' ;;
+  *) exit 1 ;;
+esac
+EOF
+cat >"$fake_bin/ethtool" <<'EOF'
+#!/bin/sh
+[ "${ETHTOOL_FAIL:-0}" = 1 ] && exit 7
+printf '%s\n' 'Settings for eth0: speed: 1000Mb/s'
+EOF
+cat >"$fake_bin/cat" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'nameserver 192.0.2.53'
+EOF
+cat >"$fake_bin/uname" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'Linux test-node 6.1.0'
+EOF
+cat >"$fake_bin/hostname" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'node-a'
+EOF
+chmod 0555 "$fake_bin"/*
+
+evidence_dir="$tmp_dir/evidence"
+PATH="$fake_bin:$PATH" "$preflight" --target-node node-a --interface eth0 \
+	--evidence-dir "$evidence_dir" --confirm NODE-RECOVERY-PREFLIGHT >"$tmp_dir/preflight-output"
+bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/preflight-output")
+[ -n "$bundle" ] || fail 'preflight did not print an evidence bundle'
+grep -q '^exit_status=0$' "$bundle/interface.txt" || fail 'preflight interface probe did not execute successfully'
+grep -q '^command=node-recovery$' "$bundle/metadata" || fail 'preflight metadata command missing'
+grep -q 'target_node=node-a' "$bundle/metadata" || fail 'preflight target missing from metadata'
+pass 'preflight evidence and metadata'
+
+PATH="$fake_bin:$PATH" "$network_repair" --target-node node-a --interface eth0 \
+	--action flush-neighbors --evidence-dir "$evidence_dir" --confirm NETWORK-REPAIR >"$tmp_dir/repair-output"
+repair_bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/repair-output" | head -n 1)
+grep -q '^exit_status=0$' "$repair_bundle/before-link.txt" || fail 'repair before probe did not execute successfully'
+grep -q '^exit_status=0$' "$repair_bundle/after-link.txt" || fail 'repair after probe did not execute successfully'
+grep -q 'action=flush-neighbors' "$repair_bundle/metadata" || fail 'repair action missing from metadata'
+pass 'repair before/after evidence and metadata'
+
+if PATH="$fake_bin:$PATH" ETHTOOL_FAIL=1 "$network_repair" \
+	--target-node node-a --interface eth0 --action restart-autonegotiation \
+	--evidence-dir "$evidence_dir" --confirm NETWORK-REPAIR >"$tmp_dir/failed-repair-output" 2>&1; then
+	fail 'failed repair was accepted'
+fi
+failed_bundle=$(sed -n 's/.*Evidence: //p' "$tmp_dir/failed-repair-output" | head -n 1)
+grep -q '^exit_status=0$' "$failed_bundle/before-link.txt" || fail 'failed repair before probe did not execute successfully'
+grep -q '^exit_status=0$' "$failed_bundle/after-link.txt" || fail 'failed repair after probe did not execute successfully'
+grep -q 'action_exit_status=7' "$failed_bundle/metadata" || fail 'failed action status missing from metadata'
+pass 'failed repair preserves before/after evidence'
+
+if PATH="$fake_bin:$PATH" "$preflight" --target-node node-b --interface eth0 \
+	--evidence-dir "$evidence_dir" --confirm NODE-RECOVERY-PREFLIGHT >"$tmp_dir/mismatch-output" 2>&1; then
+	fail 'preflight accepted a target different from the local node'
+fi
+pass 'target must match local node identity'
+
+PATH="$fake_bin:$PATH" assert_rejected 'evidence root is rejected' "$preflight" \
+	--target-node node-a --interface eth0 --evidence-dir / --confirm NODE-RECOVERY-PREFLIGHT
+PATH="$fake_bin:$PATH" assert_rejected 'host system path is rejected' "$preflight" \
+	--target-node node-a --interface eth0 --evidence-dir /etc --confirm NODE-RECOVERY-PREFLIGHT


### PR DESCRIPTION
## Summary

Adds a standalone node-maintenance utility image for two explicit intents:

- read-only node recovery preflight;
- one allowlisted node network repair.

The image requires a controller-provided `spec.nodeName` value, an exact requested target, an explicit interface, a confirmation token, and a dedicated evidence volume. It does not expose an unrestricted supported shell workflow.

## Security and lifecycle contract

- Preflight drops all capabilities and adds none.
- Repair drops all capabilities and adds only `NET_ADMIN`.
- Privileged mode, host filesystem mounts, runtime sockets, arbitrary commands, route replacement, reboot, crashdump collection, and packet capture are outside this image.
- Evidence is confined to `/evidence` or one safe child; every command, output, and bundle is bounded.
- Controller-owned immutable templates must prevent entrypoint and argument replacement.
- Generic runbooks ship under `/usr/share/breakglass/runbooks/upstream/node-maintenance`.
- Deployments may mount a separate digest-pinned documentation bundle read-only at `/usr/share/breakglass/runbooks/internal`; the image never executes or sources it.

## Behavioral verification

- `make -C utils/node-maintenance test`
- ShellCheck for every helper and harness
- REUSE compliance and diff validation
- fresh container build from the committed tree
- real read-only container proof for built-in and mounted runbooks, including denied bundle writes
- Linux CI executes the real helper contract with disposable namespaces and volumes, separate capability contexts, every allowlisted action, negative target/path/confirmation cases, evidence assertions, and cleanup checks

## Limitations

The local developer host is Darwin, so Linux namespace and `NET_ADMIN` execution is intentionally left to the required GitHub Actions behavior job. The integration harness fails rather than skips when its Linux or Docker prerequisites are absent.

Tracking: TCAAS-1551 / TCAAS-1616.
