### PR TITLE
feat(images): add bounded workload-debug utility

### DIFF
--- a/.github/workflows/workload-debug.yml
+++ b/.github/workflows/workload-debug.yml
@@ -25,6 +25,7 @@ jobs:
   static:
     name: Static image checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Exercise image helper contracts
@@ -39,6 +40,7 @@ jobs:
   behavior:
     name: Real image behavior
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/workload-debug.yml
+++ b/.github/workflows/workload-debug.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Workload debug image
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "utils/workload-debug/**"
+      - "docs/runbooks/workload-debug.md"
+      - ".github/workflows/workload-debug.yml"
+  push:
+    branches: [main]
+    paths:
+      - "utils/workload-debug/**"
+      - "docs/runbooks/workload-debug.md"
+      - ".github/workflows/workload-debug.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: Static image checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Exercise image helper contracts
+        run: make -C utils/workload-debug test
+      - name: ShellCheck image helpers
+        run: shellcheck utils/workload-debug/scripts/* utils/workload-debug/tests/*.sh
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: utils/workload-debug/Dockerfile
+
+  behavior:
+    name: Real image behavior
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Exercise DNS, TLS, HTTP, API, security, and cleanup contracts
+        run: make -C utils/workload-debug integration-test

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -29,6 +29,18 @@ path = ["*.sh", "Makefile", "Dockerfile", "hack/**", "tools/**", "e2e/**.sh", "e
 SPDX-FileCopyrightText = "2025 Deutsche Telekom AG"
 SPDX-License-Identifier = "Apache-2.0"
 
+[[annotations]]
+precedence = "aggregate"
+path = ["utils/workload-debug/**.sh", "utils/workload-debug/**.yaml", "utils/workload-debug/Dockerfile", "utils/workload-debug/Makefile", "utils/workload-debug/deps.lock"]
+SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+precedence = "aggregate"
+path = ["utils/workload-debug/**.md", "utils/workload-debug/MOTD"]
+SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
+SPDX-License-Identifier = "CC-BY-4.0"
+
 # Documentation
 [[annotations]]
 precedence = "aggregate"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -37,6 +37,12 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 precedence = "aggregate"
+path = ["utils/workload-debug/tool-contract.json"]
+SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+precedence = "aggregate"
 path = ["utils/workload-debug/**.md", "utils/workload-debug/MOTD"]
 SPDX-FileCopyrightText = "2026 Deutsche Telekom AG"
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Complete documentation for the breakglass privilege escalation system.
 - **[Metrics](./metrics.md)** - Prometheus metrics and monitoring
 - **[Rate Limiting](./rate-limiting.md)** - Multi-tier rate limiting architecture, tiers, and troubleshooting
 - **[Logging and Debugging](./logging-and-debugging.md)** - Frontend and backend logging infrastructure, debugging tips
+- **[Workload-debug runbook](./runbooks/workload-debug.md)** - Restricted workload diagnostics image and bounded helper usage
 - **[CI Logs and Artifacts](./ci-logs.md)** - Retrieve CI logs and artifacts with gh CLI
 
 ## Identity & Authentication

--- a/docs/runbooks/workload-debug.md
+++ b/docs/runbooks/workload-debug.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Workload-debug image runbook
 
-`ghcr.io/telekom/k8s-breakglass/workload-debug` is a generic, standalone toolbox
+`ghcr.io/telekom/k8s-breakglass/utils/workload-debug` is a generic, standalone toolbox
 for a short-lived DebugSession or an ordinary workload Pod. It has no
 dependency on `DebugSession` labels, annotations, namespace names, or the
 Breakglass controller. It runs as UID/GID `65532`, has no Linux capabilities,
@@ -20,7 +20,7 @@ available in the build context:
 cd utils/workload-debug
 docker buildx build --platform linux/amd64,linux/arm64 \
   --file Dockerfile \
-  --tag ghcr.io/telekom/k8s-breakglass/workload-debug:0.1.0 --push .
+  --tag ghcr.io/telekom/k8s-breakglass/utils/workload-debug:0.1.0 --push .
 ```
 
 Use the exact digest in `utils/workload-debug/IMAGE-METADATA.yaml`; do not
@@ -37,12 +37,12 @@ when the runtime does not provide a writable ephemeral directory:
 ```sh
 docker run --rm -it --read-only --cap-drop=ALL \
   --security-opt=no-new-privileges:true \
-  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+  ghcr.io/telekom/k8s-breakglass/utils/workload-debug@sha256:DIGEST
 docker run --rm -it --read-only --tmpfs /tmp:rw,noexec,nosuid,size=16m \
   --cap-drop=ALL --security-opt=no-new-privileges:true \
-  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+  ghcr.io/telekom/k8s-breakglass/utils/workload-debug@sha256:DIGEST
 podman run --rm -it --read-only --cap-drop=all \
-  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+  ghcr.io/telekom/k8s-breakglass/utils/workload-debug@sha256:DIGEST
 ```
 
 For Podman, the same image can be run with `--user 65532:65532`; it is already

--- a/docs/runbooks/workload-debug.md
+++ b/docs/runbooks/workload-debug.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Workload-debug image runbook
+
+`ghcr.io/telekom/k8s-breakglass/workload-debug` is a generic, standalone toolbox
+for a short-lived DebugSession or an ordinary workload Pod. It has no
+dependency on `DebugSession` labels, annotations, namespace names, or the
+Breakglass controller. It runs as UID/GID `65532`, has no Linux capabilities,
+and is designed for a read-only root filesystem.
+
+## Build and attest
+
+Build from the image directory so the Dockerfile and its license bundle are
+available in the build context:
+
+```sh
+cd utils/workload-debug
+docker buildx build --platform linux/amd64,linux/arm64 \
+  --file Dockerfile \
+  --tag ghcr.io/telekom/k8s-breakglass/workload-debug:0.1.0 --push .
+```
+
+Use the exact digest in `utils/workload-debug/IMAGE-METADATA.yaml`; do not
+publish or deploy a mutable `latest` tag. Generate and retain an SPDX SBOM,
+then sign the digest with the keyless Cosign commands in that metadata file.
+
+## Direct Docker or Podman use
+
+The default command opens a shell. `--read-only` is supported because bounded
+response buffering uses only a private ephemeral directory. The helper
+prefers `TMPDIR`, then `/dev/shm`, then `/tmp`; mount a small tmpfs explicitly
+when the runtime does not provide a writable ephemeral directory:
+
+```sh
+docker run --rm -it --read-only --cap-drop=ALL \
+  --security-opt=no-new-privileges:true \
+  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+docker run --rm -it --read-only --tmpfs /tmp:rw,noexec,nosuid,size=16m \
+  --cap-drop=ALL --security-opt=no-new-privileges:true \
+  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+podman run --rm -it --read-only --cap-drop=all \
+  ghcr.io/telekom/k8s-breakglass/workload-debug@sha256:DIGEST
+```
+
+For Podman, the same image can be run with `--user 65532:65532`; it is already
+the image default.
+
+## Kubernetes Pod and DebugSession
+
+The image can be used as a normal Pod or as the `image` in a
+`DebugPodTemplate`. Keep the security context explicit when the admission
+policy permits it:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+```
+
+The Kubernetes helper uses the standard service-account CA and token files
+when they are mounted. Outside a Kubernetes Pod, pass `--server`; no
+controller metadata is inferred:
+
+```sh
+workload-debug dns api.example.test
+workload-debug tls api.example.test:443
+workload-debug http https://api.example.test/healthz
+workload-debug kube-api --server https://api.example.test /version
+workload-debug report --dns api.example.test --tls api.example.test:443
+```
+
+HTTP and Kubernetes API requests are deliberately bounded: only GET, HEAD, and
+OPTIONS are accepted, redirects are not followed, and responses are limited to
+1 MiB by default. `WORKLOAD_DEBUG_TIMEOUT` accepts 1–300 seconds and
+`WORKLOAD_DEBUG_MAX_BYTES` accepts 1–10 MiB when a different bounded limit is
+needed.
+
+The checked-in `tool-contract.json` records the stable `workload-diagnostics`
+intent and each helper's allowed operation. `debug-report --json` emits a
+deterministic JSON summary with `status: ready|not-ready`, containing only
+check identities and success statuses for one-time or post-upgrade readiness.
+Use `debug-tls --ca FILE` when the endpoint must be verified against
+a supplied local CA, and `debug-dns --server HOST#PORT` for a non-default
+resolver port.
+
+Run the upstream proof with `make -C utils/workload-debug integration-test`.
+It builds the image and exercises all helpers in a disposable fixture setup,
+including a kind service account/token, under the same non-root,
+read-only/no-capabilities policy used in deployment. The test is intentionally
+not skippable when Docker, kind, or kubectl is unavailable.
+
+## Incident checklist
+
+1. Confirm the image digest and signature before starting the session.
+2. Start with `report` and a DNS check; record output in the incident ticket.
+3. Use `tls` to check certificate negotiation and `http` for the endpoint.
+4. Use `kube-api` only for the minimum read-only path required by the incident.
+5. Never put bearer tokens, cookies, or private keys in command arguments or
+   captured output. Terminate and clean up the DebugSession when done.
+
+The helpers return the underlying network command's status. `debug-report`
+always emits a report and exposes the number of failed optional checks as
+`checks_failed` so an unreachable target does not hide the rest of the report.

--- a/docs/runbooks/workload-debug.md
+++ b/docs/runbooks/workload-debug.md
@@ -67,6 +67,12 @@ securityContext:
     type: RuntimeDefault
 ```
 
+The default interactive shell can invoke packaged binaries directly; helper
+allowlists are not an authorization boundary. Provider-owned RBAC,
+NetworkPolicy, immutable image/security-context fields, and the session
+lifetime must enforce the chosen intent. Do not expose credentials or network
+destinations that the session does not require.
+
 The Kubernetes helper uses the standard service-account CA and token files
 when they are mounted. Outside a Kubernetes Pod, pass `--server`; no
 controller metadata is inferred:
@@ -89,7 +95,8 @@ at 64 KiB by default. Set `WORKLOAD_DEBUG_MAX_OUTPUT_BYTES` to a value from 1
 byte through 1 MiB for a different bounded limit. If the deployment mounts
 the optional internal runbook volume, its index is available at
 `/usr/share/breakglass/runbooks/internal/INDEX.md`; it is documentation only
-and is never sourced.
+and is never sourced. The bundle root is mounted directly without `subPath`;
+`bundle.yaml` at the same root records its compatibility and provenance.
 
 The checked-in `tool-contract.json` records the stable `workload-diagnostics`
 intent and each helper's allowed operation. `debug-report --json` emits a

--- a/docs/runbooks/workload-debug.md
+++ b/docs/runbooks/workload-debug.md
@@ -63,6 +63,8 @@ securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault
 ```
 
 The Kubernetes helper uses the standard service-account CA and token files
@@ -82,6 +84,12 @@ OPTIONS are accepted, redirects are not followed, and responses are limited to
 1 MiB by default. `WORKLOAD_DEBUG_TIMEOUT` accepts 1–300 seconds and
 `WORKLOAD_DEBUG_MAX_BYTES` accepts 1–10 MiB when a different bounded limit is
 needed.
+DNS and TLS diagnostics use the same timeout and cap combined command output
+at 64 KiB by default. Set `WORKLOAD_DEBUG_MAX_OUTPUT_BYTES` to a value from 1
+byte through 1 MiB for a different bounded limit. If the deployment mounts
+the optional internal runbook volume, its index is available at
+`/usr/share/breakglass/runbooks/internal/INDEX.md`; it is documentation only
+and is never sourced.
 
 The checked-in `tool-contract.json` records the stable `workload-diagnostics`
 intent and each helper's allowed operation. `debug-report --json` emits a

--- a/utils/workload-debug/CHANGELOG.md
+++ b/utils/workload-debug/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the standalone workload-debug image are documented here.
 
 ## Unreleased
 
+- Publish the utility image at the canonical `utils/workload-debug` GHCR path.
 - Require the real projected service-account bearer token in the Kubernetes
   API integration fixture and verify authenticated output, process arguments,
   and logs do not disclose it.

--- a/utils/workload-debug/CHANGELOG.md
+++ b/utils/workload-debug/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the standalone workload-debug image are documented here.
 
 ## Unreleased
 
+- Close bounded-response FIFO descriptors in curl and body-reader children so
+  early curl failures cannot leave the response helper blocked.
 - Publish the utility image at the canonical `utils/workload-debug` GHCR path.
 - Require the real projected service-account bearer token in the Kubernetes
   API integration fixture and verify authenticated output, process arguments,

--- a/utils/workload-debug/CHANGELOG.md
+++ b/utils/workload-debug/CHANGELOG.md
@@ -1,0 +1,30 @@
+<!-- SPDX-FileCopyrightText: 2026 Deutsche Telekom AG -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Changelog
+
+All notable changes to the standalone workload-debug image are documented here.
+
+## Unreleased
+
+- Require the real projected service-account bearer token in the Kubernetes
+  API integration fixture and verify authenticated output, process arguments,
+  and logs do not disclose it.
+- Keep the temporary bearer header explicitly mode `0600` until cleanup.
+- Bound token-authenticated Kubernetes API responses even when the server uses
+  chunked transfer encoding or omits `Content-Length`; remove the temporary
+  bearer-header file on every exit path.
+- Bound response headers through the same streaming limiter, reject oversized
+  headers before emission, and verify the behavior with HTTP and Kubernetes
+  API fixtures.
+- Make the Kind integration harness fail closed on name collisions and verify
+  the created or partially created cluster can be removed without touching
+  caller-owned clusters; verify exact image tags and IDs are removed too.
+
+## 2026-08-26
+
+- TCAAS-1617: replace host-network integration checks with a disposable kind
+  proof covering real DNS, TLS, HTTP, and Kubernetes API behavior under the
+  restricted runtime policy.
+- Add deterministic JSON readiness status (`ready` or `not-ready`) and verify
+  token secrecy, semantic reports, and zero-cluster cleanup.

--- a/utils/workload-debug/Dockerfile
+++ b/utils/workload-debug/Dockerfile
@@ -22,25 +22,25 @@ RUN apk add --no-cache \
       tini=0.19.0-r3 \
     && addgroup -S -g 65532 debug \
     && adduser -S -D -H -u 65532 -G debug debug \
-    && mkdir -p /home/debug /usr/local/share/workload-debug \
+    && mkdir -p /home/debug /usr/share/breakglass/runbooks/upstream/workload-debug \
     && chown 65532:65532 /home/debug \
     && update-ca-certificates
 
 COPY scripts/ /usr/local/bin/
-COPY MOTD /usr/local/share/workload-debug/MOTD
-COPY README.md RUNBOOK.md /usr/local/share/workload-debug/
+COPY MOTD /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD
+COPY README.md RUNBOOK.md /usr/share/breakglass/runbooks/upstream/workload-debug/
 COPY MOTD /etc/motd
 COPY LICENSE /licenses/PROJECT_LICENSE
 COPY LICENSES/ /licenses/
 
-RUN chmod 0555 /usr/local/bin/debug-* /usr/local/bin/limit-response /usr/local/bin/workload-debug \
+RUN chmod 0555 /usr/local/bin/debug-* /usr/local/bin/limit-response /usr/local/bin/limit-output /usr/local/bin/workload-debug \
       /usr/local/bin/workload-debug-entrypoint \
-    && chmod 0444 /usr/local/share/workload-debug/MOTD \
-      /usr/local/share/workload-debug/README.md \
-      /usr/local/share/workload-debug/RUNBOOK.md /etc/motd \
+    && chmod 0444 /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD \
+      /usr/share/breakglass/runbooks/upstream/workload-debug/README.md \
+      /usr/share/breakglass/runbooks/upstream/workload-debug/RUNBOOK.md /etc/motd \
     && printf '%s\n' \
       "export PATH=\"/usr/local/bin:\$PATH\"" \
-      'if [ -t 1 ] && [ -r /usr/local/share/workload-debug/MOTD ]; then cat /usr/local/share/workload-debug/MOTD; fi' \
+      'if [ -t 1 ] && [ -r /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD ]; then cat /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD; fi' \
       > /etc/profile.d/workload-debug.sh \
     && chmod 0444 /etc/profile.d/workload-debug.sh
 

--- a/utils/workload-debug/Dockerfile
+++ b/utils/workload-debug/Dockerfile
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+ARG VERSION=0.1.0
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+ARG REVISION=${VCS_REF}
+ARG CREATED=${BUILD_DATE}
+
+# The Alpine 3.24 release and its base manifest are pinned. Refresh deps.lock
+# and the SBOM together whenever this is updated.
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+      bash=5.3.9-r1 \
+      bind-tools=9.20.26-r0 \
+      ca-certificates=20260611-r0 \
+      curl=8.21.0-r0 \
+      jq=1.8.1-r0 \
+      openssl=3.5.8-r0 \
+      tini=0.19.0-r3 \
+    && addgroup -S -g 65532 debug \
+    && adduser -S -D -H -u 65532 -G debug debug \
+    && mkdir -p /home/debug /usr/local/share/workload-debug \
+    && chown 65532:65532 /home/debug \
+    && update-ca-certificates
+
+COPY scripts/ /usr/local/bin/
+COPY MOTD /usr/local/share/workload-debug/MOTD
+COPY README.md RUNBOOK.md /usr/local/share/workload-debug/
+COPY MOTD /etc/motd
+COPY LICENSE /licenses/PROJECT_LICENSE
+COPY LICENSES/ /licenses/
+
+RUN chmod 0555 /usr/local/bin/debug-* /usr/local/bin/limit-response /usr/local/bin/workload-debug \
+      /usr/local/bin/workload-debug-entrypoint \
+    && chmod 0444 /usr/local/share/workload-debug/MOTD \
+      /usr/local/share/workload-debug/README.md \
+      /usr/local/share/workload-debug/RUNBOOK.md /etc/motd \
+    && printf '%s\n' \
+      "export PATH=\"/usr/local/bin:\$PATH\"" \
+      'if [ -t 1 ] && [ -r /usr/local/share/workload-debug/MOTD ]; then cat /usr/local/share/workload-debug/MOTD; fi' \
+      > /etc/profile.d/workload-debug.sh \
+    && chmod 0444 /etc/profile.d/workload-debug.sh
+
+LABEL org.opencontainers.image.title="Breakglass workload-debug" \
+      org.opencontainers.image.description="Restricted, generic Kubernetes workload diagnostics image" \
+      org.opencontainers.image.version="$VERSION" \
+      org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.url="https://github.com/telekom/k8s-breakglass" \
+      org.opencontainers.image.documentation="https://github.com/telekom/k8s-breakglass/blob/main/docs/runbooks/workload-debug.md" \
+      org.opencontainers.image.source="https://github.com/telekom/k8s-breakglass/tree/main/utils/workload-debug" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Deutsche Telekom AG" \
+      org.opencontainers.image.base.name="alpine:3.24" \
+      org.opencontainers.image.base.digest="sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b" \
+      io.telekom.breakglass.image.role="debug-workload" \
+      io.telekom.breakglass.sbom.format="spdx-json" \
+      io.telekom.breakglass.signing="cosign-keyless"
+
+ENV HOME=/home/debug \
+    PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /
+USER 65532:65532
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/workload-debug-entrypoint"]
+CMD ["/bin/sh"]

--- a/utils/workload-debug/Dockerfile
+++ b/utils/workload-debug/Dockerfile
@@ -23,7 +23,9 @@ RUN apk add --no-cache \
     && addgroup -S -g 65532 debug \
     && adduser -S -D -H -u 65532 -G debug debug \
     && mkdir -p /home/debug /usr/share/breakglass/runbooks/upstream/workload-debug \
+      /usr/share/breakglass/runbooks/internal \
     && chown 65532:65532 /home/debug \
+    && chmod 0555 /usr/share/breakglass/runbooks/internal \
     && update-ca-certificates
 
 COPY scripts/ /usr/local/bin/

--- a/utils/workload-debug/IMAGE-METADATA.yaml
+++ b/utils/workload-debug/IMAGE-METADATA.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+schemaVersion: 1
+image:
+  name: ghcr.io/telekom/k8s-breakglass/workload-debug
+  version: 0.1.0
+  platforms:
+    - linux/amd64
+    - linux/arm64
+  base:
+    name: alpine:3.24
+    digest: sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+  dependencyLock: deps.lock
+  # apk resolves these names from the pinned Alpine 3.24 repository. The
+  # release digest above is the immutable input; refresh deps.lock, this list,
+  # and the generated SPDX SBOM together for a dependency update.
+  packages:
+    - bash=5.3.9-r1
+    - bind-tools=9.20.26-r0
+    - ca-certificates=20260611-r0
+    - curl=8.21.0-r0
+    - jq=1.8.1-r0
+    - openssl=3.5.8-r0
+    - tini=0.19.0-r3
+  user: "65532:65532"
+  readOnlyRootFilesystem: true
+  capabilities: []
+  controllerMetadataRequired: false
+provenance:
+  source: https://github.com/telekom/k8s-breakglass/tree/main/utils/workload-debug
+  license: Apache-2.0
+  sbom:
+    format: spdx-json
+    command: syft OCI_IMAGE -o spdx-json=sbom.spdx.json
+  signing:
+    tool: cosign
+    mode: keyless
+    commands:
+      - cosign sign --yes IMAGE@DIGEST
+      - cosign verify IMAGE@DIGEST --certificate-identity-regexp 'https://github.com/telekom/k8s-breakglass/' --certificate-oidc-issuer https://token.actions.githubusercontent.com

--- a/utils/workload-debug/IMAGE-METADATA.yaml
+++ b/utils/workload-debug/IMAGE-METADATA.yaml
@@ -3,7 +3,7 @@
 
 schemaVersion: 1
 image:
-  name: ghcr.io/telekom/k8s-breakglass/workload-debug
+  name: ghcr.io/telekom/k8s-breakglass/utils/workload-debug
   version: 0.1.0
   platforms:
     - linux/amd64

--- a/utils/workload-debug/LICENSE
+++ b/utils/workload-debug/LICENSE
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/utils/workload-debug/LICENSES/Apache-2.0.txt
+++ b/utils/workload-debug/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/utils/workload-debug/MOTD
+++ b/utils/workload-debug/MOTD
@@ -8,8 +8,10 @@ This image is a restricted, non-root troubleshooting toolbox.
   workload-debug report [--dns NAME] [--tls HOST[:PORT]] [--http URL] [--kube PATH]
 
 Docs in this image:
-  /usr/local/share/workload-debug/README.md
-  /usr/local/share/workload-debug/RUNBOOK.md
+  /usr/share/breakglass/runbooks/upstream/workload-debug/README.md
+  /usr/share/breakglass/runbooks/upstream/workload-debug/RUNBOOK.md
+Optional mounted runbook index (if provided):
+  /usr/share/breakglass/runbooks/internal/INDEX.md (documentation only; never sourced)
 
 The filesystem is intended to be mounted read-only. Do not paste secrets into
 terminal output. Kubernetes API access uses only the explicitly supplied

--- a/utils/workload-debug/MOTD
+++ b/utils/workload-debug/MOTD
@@ -1,0 +1,16 @@
+Breakglass workload-debug (read-only, non-root)
+
+This image is a restricted, non-root troubleshooting toolbox.
+  workload-debug dns <name>
+  workload-debug tls <host[:port]>
+  workload-debug http <http(s)://url>
+  workload-debug kube-api [path]
+  workload-debug report [--dns NAME] [--tls HOST[:PORT]] [--http URL] [--kube PATH]
+
+Docs in this image:
+  /usr/local/share/workload-debug/README.md
+  /usr/local/share/workload-debug/RUNBOOK.md
+
+The filesystem is intended to be mounted read-only. Do not paste secrets into
+terminal output. Kubernetes API access uses only the explicitly supplied
+server or the standard service-account files when present.

--- a/utils/workload-debug/Makefile
+++ b/utils/workload-debug/Makefile
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+SHELL := /bin/sh
+
+IMAGE ?= ghcr.io/telekom/k8s-breakglass/workload-debug:dev
+PLATFORMS ?= linux/amd64,linux/arm64
+VERSION ?= dev
+VCS_REF ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+.PHONY: test integration-test test-kind-lifecycle build build-multiarch sbom sign
+
+OCI_ARCHIVE ?= workload-debug.oci.tar
+
+test:
+	./tests/test_helpers.sh
+	./tests/test_kind_lifecycle.sh
+
+test-kind-lifecycle:
+	./tests/test_kind_lifecycle.sh
+
+integration-test:
+	./tests/test_integration.sh
+
+build:
+	docker build --pull=false \
+		--build-arg "VERSION=$(VERSION)" --build-arg "VCS_REF=$(VCS_REF)" --build-arg "BUILD_DATE=$(BUILD_DATE)" \
+		--tag "$(IMAGE)" .
+
+build-multiarch:
+	docker buildx build --pull=false --platform "$(PLATFORMS)" \
+		--provenance=true --sbom=true \
+		--build-arg "VERSION=$(VERSION)" --build-arg "VCS_REF=$(VCS_REF)" --build-arg "BUILD_DATE=$(BUILD_DATE)" \
+		--output "type=oci,dest=$(OCI_ARCHIVE)" --tag "$(IMAGE)" .
+
+sbom:
+	@test -n "$(DIGEST)" || (printf '%s\n' 'DIGEST is required' >&2; exit 2)
+	@case "$(DIGEST)" in sha256:*) ;; *) printf '%s\n' 'DIGEST must be an immutable sha256 digest' >&2; exit 2;; esac
+	@test -n "$(SBOM)" || (printf '%s\n' 'SBOM is required' >&2; exit 2)
+	cosign attest --yes --type spdxjson --predicate "$(SBOM)" "$(IMAGE)@$(DIGEST)"
+
+sign:
+	@test -n "$(DIGEST)" || (printf '%s\n' 'DIGEST is required' >&2; exit 2)
+	@case "$(DIGEST)" in sha256:*) ;; *) printf '%s\n' 'DIGEST must be an immutable sha256 digest' >&2; exit 2;; esac
+	cosign sign --yes "$(IMAGE)@$(DIGEST)"

--- a/utils/workload-debug/Makefile
+++ b/utils/workload-debug/Makefile
@@ -3,7 +3,7 @@
 
 SHELL := /bin/sh
 
-IMAGE ?= ghcr.io/telekom/k8s-breakglass/workload-debug:dev
+IMAGE ?= ghcr.io/telekom/k8s-breakglass/utils/workload-debug:dev
 PLATFORMS ?= linux/amd64,linux/arm64
 VERSION ?= dev
 VCS_REF ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)

--- a/utils/workload-debug/README.md
+++ b/utils/workload-debug/README.md
@@ -1,0 +1,69 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Workload-debug image
+
+This is the restricted generic diagnostics image for TCAAS-1617. It is
+standalone: it works in a Breakglass `DebugSession`, a Docker or Podman
+container, and a Kubernetes Pod without relying on controller metadata.
+
+Included helpers:
+
+| Command | Purpose |
+| --- | --- |
+| `debug-dns` | DNS resolution, with an optional resolver server |
+| `debug-tls` | TLS handshake and endpoint summary |
+| `debug-http` | Bounded HTTP(S) request with response headers |
+| `debug-kube-api` | Read-only Kubernetes API request using standard Pod files |
+| `debug-report` | Non-invasive host and optional target checks |
+
+`workload-debug <command>` is a convenient dispatcher. The shell remains the
+default command for interactive sessions. In a built image, read
+`/usr/local/share/workload-debug/RUNBOOK.md` for operator guidance; the source
+tree copy is [`RUNBOOK.md`](RUNBOOK.md).
+
+HTTP and Kubernetes API helpers only allow GET, HEAD, and OPTIONS requests,
+do not follow redirects, and cap each response at 1 MiB by default. Set
+`WORKLOAD_DEBUG_TIMEOUT` (1–300 seconds) or `WORKLOAD_DEBUG_MAX_BYTES` (1–10
+MiB) when a different bounded limit is required.
+
+The image is pinned to a multi-architecture Alpine base digest, runs as
+non-root UID/GID `65532`, and drops all capabilities. Bounded HTTP responses
+use a private temporary directory capped at `WORKLOAD_DEBUG_MAX_BYTES + 1`
+for both response headers and body;
+the helper prefers `TMPDIR` and falls back to the runtime's ephemeral `/dev/shm`
+or `/tmp`. If all are read-only, mount an ephemeral `/tmp` volume. Temporary
+data is removed on success, failure, and interruption. `IMAGE-METADATA.yaml`
+is the source of truth for OCI, provenance, signing, and SBOM metadata.
+
+Run `make test` for fast validation and `make integration-test` for the real
+container proof. The integration proof builds the image, runs every helper
+under the restricted policy, checks DNS/TLS/HTTP against disposable fixtures,
+uses a kind service-account token for a read-only Kubernetes API request,
+proves that an authenticated chunked response is bounded, and verifies
+cleanup. Missing Docker/kind prerequisites are reported as failures. The
+integration harness refuses to claim an already existing kind cluster and
+checks that the cluster it created is gone after the run.
+`make build` creates a local image;
+`make build-multiarch` uses BuildKit for both supported platforms and requests
+in-toto provenance plus an SPDX SBOM (`--provenance=true --sbom=true`), writing
+a local OCI archive (`workload-debug.oci.tar` by default; override with
+`OCI_ARCHIVE=...`). Release automation resolves and retains the immutable
+registry digest, then runs `make sign DIGEST=...` and
+`make sbom DIGEST=... SBOM=...`.
+
+`debug-kube-api` keeps the bearer token out of process arguments and routes
+authenticated requests through the same bounded response path as
+unauthenticated requests. Its short-lived header file is private and removed
+on success or failure. Oversized response headers are rejected before they are
+emitted, just like oversized bodies.
+
+`tool-contract.json` is the machine-readable contract for the shared
+`workload-diagnostics` intent. `debug-report --json` emits a stable
+`schema_version`, semantic `status` (`ready` or `not-ready`), check names and
+statuses (without host timestamps or command output), making it suitable for
+one-time and post-upgrade readiness comparisons. The HTTP helper does not follow
+redirects and the Kubernetes helper reads a token from a file so credentials
+never appear in command arguments.

--- a/utils/workload-debug/README.md
+++ b/utils/workload-debug/README.md
@@ -27,6 +27,13 @@ the optional internal runbook index at
 `/usr/share/breakglass/runbooks/internal/INDEX.md`; it is
 documentation only and is never sourced or executed by the image.
 
+The helper allowlists are safe defaults and an auditable operator interface,
+not a sandbox: the interactive shell can invoke the packaged binaries
+directly. Kubernetes RBAC, NetworkPolicy, the immutable image and security
+context, and the session lifetime are the enforcement boundaries. Do not grant
+this image credentials or network reachability that the selected intent does
+not require.
+
 HTTP and Kubernetes API helpers only allow GET, HEAD, and OPTIONS requests,
 do not follow redirects, and cap each response at 1 MiB by default. Set
 `WORKLOAD_DEBUG_TIMEOUT` (1–300 seconds) or `WORKLOAD_DEBUG_MAX_BYTES` (1–10

--- a/utils/workload-debug/README.md
+++ b/utils/workload-debug/README.md
@@ -21,13 +21,19 @@ Included helpers:
 
 `workload-debug <command>` is a convenient dispatcher. The shell remains the
 default command for interactive sessions. In a built image, read
-`/usr/local/share/workload-debug/RUNBOOK.md` for operator guidance; the source
-tree copy is [`RUNBOOK.md`](RUNBOOK.md).
+`/usr/share/breakglass/runbooks/upstream/workload-debug/RUNBOOK.md` for operator guidance; the source
+tree copy is [`RUNBOOK.md`](RUNBOOK.md). Deployments may additionally mount
+the optional internal runbook index at
+`/usr/share/breakglass/runbooks/internal/INDEX.md`; it is
+documentation only and is never sourced or executed by the image.
 
 HTTP and Kubernetes API helpers only allow GET, HEAD, and OPTIONS requests,
 do not follow redirects, and cap each response at 1 MiB by default. Set
 `WORKLOAD_DEBUG_TIMEOUT` (1–300 seconds) or `WORKLOAD_DEBUG_MAX_BYTES` (1–10
 MiB) when a different bounded limit is required.
+DNS and TLS diagnostics cap combined command output at 64 KiB by default; set
+`WORKLOAD_DEBUG_MAX_OUTPUT_BYTES` (1 byte–1 MiB) to choose another bounded
+limit. Their operation timeout uses `WORKLOAD_DEBUG_TIMEOUT` (1–300 seconds).
 
 The image is pinned to a multi-architecture Alpine base digest, runs as
 non-root UID/GID `65532`, and drops all capabilities. Bounded HTTP responses

--- a/utils/workload-debug/RUNBOOK.md
+++ b/utils/workload-debug/RUNBOOK.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Workload-debug runbook
+
+Use this image for short, read-only workload checks. Start with the bounded
+`debug-report`, then run only the helper needed for the incident:
+`debug-dns`, `debug-tls`, `debug-http`, or `debug-kube-api`. The dispatcher
+also provides `workload-debug --help`.
+
+Run as UID/GID `65532` with all capabilities dropped and a read-only root
+filesystem. HTTP and Kubernetes API requests are GET/HEAD/OPTIONS only, do
+not follow redirects, and are bounded by `WORKLOAD_DEBUG_TIMEOUT` and
+`WORKLOAD_DEBUG_MAX_BYTES` for both response headers and body. The bounded
+response helper uses a private,
+ephemeral directory: it prefers `TMPDIR`, then `/dev/shm`, then `/tmp`. If
+the runtime makes all three read-only, provide an `emptyDir`/tmpfs at `/tmp`.
+Temporary response and authentication-header files are removed on success,
+failure, and interruption. `debug-kube-api` reads the service-account token
+from a file and passes only a temporary header-file path to curl, so the token
+does not appear in process arguments. Never put tokens, cookies, or private
+keys in arguments or captured output. End the session and retain only approved
+output.

--- a/utils/workload-debug/RUNBOOK.md
+++ b/utils/workload-debug/RUNBOOK.md
@@ -24,3 +24,10 @@ from a file and passes only a temporary header-file path to curl, so the token
 does not appear in process arguments. Never put tokens, cookies, or private
 keys in arguments or captured output. End the session and retain only approved
 output.
+
+DNS and TLS output is bounded to 64 KiB by default and uses the same
+1–300-second `WORKLOAD_DEBUG_TIMEOUT` bound. Set
+`WORKLOAD_DEBUG_MAX_OUTPUT_BYTES` to a value from 1 byte through 1 MiB when a
+different limit is required. An optional deployment-provided runbook index may
+be mounted at `/usr/share/breakglass/runbooks/internal/INDEX.md`; consult it as
+documentation only.

--- a/utils/workload-debug/RUNBOOK.md
+++ b/utils/workload-debug/RUNBOOK.md
@@ -31,3 +31,9 @@ DNS and TLS output is bounded to 64 KiB by default and uses the same
 different limit is required. An optional deployment-provided runbook index may
 be mounted at `/usr/share/breakglass/runbooks/internal/INDEX.md`; consult it as
 documentation only.
+
+The interactive shell can invoke packaged tools without the dispatcher, so
+helper argument validation is not an authorization boundary. Enforce the
+selected intent with provider-owned RBAC, NetworkPolicy, immutable image and
+security-context fields, and a bounded session lifetime. The image must not be
+given broader credentials or egress than the incident requires.

--- a/utils/workload-debug/deps.lock
+++ b/utils/workload-debug/deps.lock
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runtime dependency inventory for Dockerfile. The base manifest digest and
+# Alpine release are immutable; refresh this inventory and the generated SBOM
+# together when the package repository is refreshed.
+base=alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community
+bash=5.3.9-r1
+bind-tools=9.20.26-r0
+ca-certificates=20260611-r0
+curl=8.21.0-r0
+jq=1.8.1-r0
+openssl=3.5.8-r0
+tini=0.19.0-r3

--- a/utils/workload-debug/scripts/debug-dns
+++ b/utils/workload-debug/scripts/debug-dns
@@ -1,0 +1,55 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+usage() { printf '%s\n' 'Usage: debug-dns [--server SERVER[#PORT]] NAME'; }
+server=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --server)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            server=$2; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) printf 'debug-dns: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+name=$1
+
+if command -v nslookup >/dev/null 2>&1; then
+    if [ -n "$server" ]; then
+        case "$server" in
+            *'#'*)
+                resolver_host=${server%%#*}
+                resolver_port=${server##*#}
+                if [ -z "$resolver_host" ] || [ -z "$resolver_port" ]; then
+                    printf '%s\n' 'debug-dns: invalid resolver HOST#PORT' >&2
+                    exit 2
+                fi
+                case "$resolver_port" in
+                    ''|*[!0-9]*) printf '%s\n' 'debug-dns: resolver port must be numeric' >&2; exit 2 ;;
+                esac
+                if [ "$resolver_port" -lt 1 ] || [ "$resolver_port" -gt 65535 ]; then
+                    printf '%s\n' 'debug-dns: resolver port out of range' >&2
+                    exit 2
+                fi
+                exec nslookup -port="$resolver_port" "$name" "$resolver_host"
+                ;;
+            *) exec nslookup "$name" "$server" ;;
+        esac
+    fi
+    exec nslookup "$name"
+fi
+
+command -v getent >/dev/null 2>&1 || {
+    printf '%s\n' 'debug-dns: neither nslookup nor getent is available' >&2
+    exit 127
+}
+[ -z "$server" ] || {
+    printf '%s\n' 'debug-dns: --server requires nslookup' >&2
+    exit 127
+}
+exec getent hosts "$name"

--- a/utils/workload-debug/scripts/debug-dns
+++ b/utils/workload-debug/scripts/debug-dns
@@ -5,6 +5,27 @@ set -eu
 
 usage() { printf '%s\n' 'Usage: debug-dns [--server SERVER[#PORT]] NAME'; }
 server=
+timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-10}
+max_output=${WORKLOAD_DEBUG_MAX_OUTPUT_BYTES:-65536}
+case "$timeout_seconds" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-dns: timeout must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$timeout_seconds" -lt 1 ] || [ "$timeout_seconds" -gt 300 ]; then
+    printf '%s\n' 'debug-dns: timeout must be between 1 and 300' >&2
+    exit 2
+fi
+case "$max_output" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-dns: max output must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$max_output" -lt 1 ] || [ "$max_output" -gt 1048576 ]; then
+    printf '%s\n' 'debug-dns: max output must be between 1 and 1048576 bytes' >&2
+    exit 2
+fi
+limit_output=/usr/local/bin/limit-output
+if [ ! -x "$limit_output" ]; then
+    script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+    limit_output=$script_dir/limit-output
+fi
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --server)
@@ -36,12 +57,12 @@ if command -v nslookup >/dev/null 2>&1; then
                     printf '%s\n' 'debug-dns: resolver port out of range' >&2
                     exit 2
                 fi
-                exec nslookup -port="$resolver_port" "$name" "$resolver_host"
+                exec "$limit_output" "$max_output" "$timeout_seconds" nslookup -port="$resolver_port" "$name" "$resolver_host"
                 ;;
-            *) exec nslookup "$name" "$server" ;;
+            *) exec "$limit_output" "$max_output" "$timeout_seconds" nslookup "$name" "$server" ;;
         esac
     fi
-    exec nslookup "$name"
+    exec "$limit_output" "$max_output" "$timeout_seconds" nslookup "$name"
 fi
 
 command -v getent >/dev/null 2>&1 || {
@@ -52,4 +73,4 @@ command -v getent >/dev/null 2>&1 || {
     printf '%s\n' 'debug-dns: --server requires nslookup' >&2
     exit 127
 }
-exec getent hosts "$name"
+exec "$limit_output" "$max_output" "$timeout_seconds" getent hosts "$name"

--- a/utils/workload-debug/scripts/debug-http
+++ b/utils/workload-debug/scripts/debug-http
@@ -1,0 +1,107 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: debug-http [--method METHOD] [--timeout SECONDS] [--header NAME:VALUE] URL
+
+The response headers and body are printed. Authorization headers are never
+added implicitly; pass one explicitly only when the session policy permits it.
+EOF
+}
+
+method=GET
+timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-15}
+max_bytes=${WORKLOAD_DEBUG_MAX_BYTES:-1048576}
+header_count=0
+header_args=
+
+validate_positive_integer() {
+    value=$1
+    label=$2
+    case "$value" in
+        ''|*[!0-9]*) printf 'debug-http: %s must be a positive integer\n' "$label" >&2; exit 2 ;;
+    esac
+    if [ "$value" -lt 1 ] || [ "$value" -gt 300 ]; then
+        printf 'debug-http: %s must be between 1 and 300\n' "$label" >&2
+        exit 2
+    fi
+}
+
+validate_max_bytes() {
+    case "$1" in
+        ''|*[!0-9]*) printf '%s\n' 'debug-http: max response size must be a positive integer' >&2; exit 2 ;;
+    esac
+    if [ "$1" -lt 1 ] || [ "$1" -gt 10485760 ]; then
+        printf '%s\n' 'debug-http: max response size must be between 1 and 10485760 bytes' >&2
+        exit 2
+    fi
+}
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --method)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            method=$2
+            case "$method" in
+                GET|HEAD|OPTIONS) ;;
+                *) printf '%s\n' 'debug-http: method must be GET, HEAD, or OPTIONS' >&2; exit 2 ;;
+            esac
+            shift 2 ;;
+        --timeout)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            timeout_seconds=$2; shift 2 ;;
+        --header)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            header_count=$((header_count + 1))
+            newline=$(printf '\nX'); newline=${newline%X}
+            carriage_return=$(printf '\r')
+            case "$2" in
+                *'|'*|*"$newline"*|*"$carriage_return"*) printf '%s\n' 'debug-http: header contains an unsupported delimiter or line break' >&2; exit 2 ;;
+            esac
+            header_args="${header_args:+${header_args}|}$2"
+            shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) printf 'debug-http: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+validate_positive_integer "$timeout_seconds" timeout
+validate_max_bytes "$max_bytes"
+url=$1
+case "$url" in
+    http://*|https://*) ;;
+    *) printf '%s\n' 'debug-http: URL must start with http:// or https://' >&2; exit 2 ;;
+esac
+
+# Convert the delimiter-separated header list to argv without eval, preserving
+# values exactly (including spaces). Header values are supplied by the caller.
+set -- curl --silent --show-error --fail-with-body \
+    --connect-timeout "$timeout_seconds" --max-time "$timeout_seconds" \
+    --max-filesize "$max_bytes"
+case "$method" in
+    HEAD) set -- "$@" --head ;;
+    OPTIONS) set -- "$@" --request OPTIONS ;;
+esac
+if [ "$header_count" -gt 0 ]; then
+    old_ifs=$IFS
+    IFS='|'
+    # Keep each header as one argv item, including values containing spaces.
+    # Disable pathname expansion while splitting on the private delimiter.
+    set -f
+    for header in $header_args; do
+        set -- "$@" --header "$header"
+    done
+    set +f
+    IFS=$old_ifs
+fi
+set -- "$@" "$url"
+limit_response=/usr/local/bin/limit-response
+if [ ! -x "$limit_response" ]; then
+    script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+    limit_response=$script_dir/limit-response
+fi
+exec "$limit_response" "$max_bytes" "$@"

--- a/utils/workload-debug/scripts/debug-kube-api
+++ b/utils/workload-debug/scripts/debug-kube-api
@@ -1,0 +1,117 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: debug-kube-api [--server URL] [--ca FILE] [--token FILE] [PATH]
+
+PATH defaults to /version. The Kubernetes service environment is used only
+when --server is omitted; no pod, namespace, session, or controller metadata
+is required. The service-account token is never printed.
+EOF
+}
+
+service_port=${KUBERNETES_SERVICE_PORT_HTTPS:-${KUBERNETES_SERVICE_PORT:-443}}
+server=${KUBERNETES_SERVICE_HOST:+https://${KUBERNETES_SERVICE_HOST}:${service_port}}
+ca_file=${KUBE_CA_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}
+token_file=${KUBE_TOKEN_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-10}
+path=/version
+
+case "$timeout_seconds" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-kube-api: timeout must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$timeout_seconds" -lt 1 ] || [ "$timeout_seconds" -gt 300 ]; then
+    printf '%s\n' 'debug-kube-api: timeout must be between 1 and 300' >&2
+    exit 2
+fi
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --server|--ca|--token)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            case "$1" in
+                --server) server=$2 ;;
+                --ca) ca_file=$2 ;;
+                --token) token_file=$2 ;;
+            esac
+            shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) printf 'debug-kube-api: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+        *) path=$1; shift; break ;;
+    esac
+done
+[ "$#" -eq 0 ] || { usage >&2; exit 2; }
+
+if [ -z "$server" ]; then
+    printf '%s\n' 'debug-kube-api: --server is required outside a Kubernetes Pod' >&2
+    exit 2
+fi
+case "$server" in
+    http://*|https://*) ;;
+    *) printf '%s\n' 'debug-kube-api: server must be an http(s) URL' >&2; exit 2 ;;
+esac
+case "$path" in /*) ;; *) path=/$path ;; esac
+url=${server%/}$path
+
+max_bytes=${WORKLOAD_DEBUG_MAX_BYTES:-1048576}
+case "$max_bytes" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-kube-api: max response size must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$max_bytes" -lt 1 ] || [ "$max_bytes" -gt 10485760 ]; then
+    printf '%s\n' 'debug-kube-api: max response size must be between 1 and 10485760 bytes' >&2
+    exit 2
+fi
+set -- curl --silent --show-error --fail-with-body --connect-timeout "$timeout_seconds" \
+    --max-time "$timeout_seconds" --max-filesize "$max_bytes"
+if [ -r "$ca_file" ]; then set -- "$@" --cacert "$ca_file"; fi
+limit_response=/usr/local/bin/limit-response
+if [ ! -x "$limit_response" ]; then
+    script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+    limit_response=$script_dir/limit-response
+fi
+
+# curl's --header @- form is useful for keeping a token out of argv, but it
+# also makes curl consume the caller's stdin. Run the authenticated request
+# through limit-response as well by placing the header in a private ephemeral
+# file. The file contains only the short-lived request header, is mode 0600,
+# and is removed on every exit path. In particular, do not call curl directly
+# here: --max-filesize does not bound chunked or unknown-length responses.
+auth_dir=
+cleanup_auth() {
+    if [ -n "$auth_dir" ]; then
+        rm -rf -- "$auth_dir"
+    fi
+}
+trap cleanup_auth EXIT HUP INT TERM
+
+if [ -r "$token_file" ]; then
+    token=$(tr -d '\r\n' < "$token_file")
+    [ -n "$token" ] && {
+        for temporary_base in "${TMPDIR:-}" /dev/shm /tmp; do
+            [ -n "$temporary_base" ] || continue
+            if [ ! -d "$temporary_base" ] || [ ! -w "$temporary_base" ]; then
+                continue
+            fi
+            if auth_dir=$(mktemp -d "$temporary_base/workload-debug-auth.XXXXXX" 2>/dev/null); then
+                break
+            fi
+            auth_dir=
+        done
+        [ -n "$auth_dir" ] || {
+            printf '%s\n' 'debug-kube-api: no writable ephemeral directory for authentication header' >&2
+            exit 1
+        }
+        auth_header=$auth_dir/header
+        umask 077
+        printf 'Authorization: Bearer %s' "$token" >"$auth_header"
+        chmod 0600 "$auth_header"
+        set -- "$@" --header "@$auth_header" "$url"
+        "$limit_response" "$max_bytes" "$@"
+        exit $?
+    }
+fi
+set -- "$@" "$url"
+"$limit_response" "$max_bytes" "$@"

--- a/utils/workload-debug/scripts/debug-kube-api
+++ b/utils/workload-debug/scripts/debug-kube-api
@@ -9,14 +9,18 @@ Usage: debug-kube-api [--server URL] [--ca FILE] [--token FILE] [PATH]
 
 PATH defaults to /version. The Kubernetes service environment is used only
 when --server is omitted; no pod, namespace, session, or controller metadata
-is required. The service-account token is never printed.
+is required. The projected service-account token is used only for that
+in-cluster endpoint. Use --token explicitly before sending a credential to an
+overridden server. The service-account token is never printed.
 EOF
 }
 
 service_port=${KUBERNETES_SERVICE_PORT_HTTPS:-${KUBERNETES_SERVICE_PORT:-443}}
 server=${KUBERNETES_SERVICE_HOST:+https://${KUBERNETES_SERVICE_HOST}:${service_port}}
+server_override=0
 ca_file=${KUBE_CA_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}
 token_file=${KUBE_TOKEN_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+token_explicit=0
 timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-10}
 path=/version
 
@@ -32,9 +36,9 @@ while [ "$#" -gt 0 ]; do
         --server|--ca|--token)
             [ "$#" -ge 2 ] || { usage >&2; exit 2; }
             case "$1" in
-                --server) server=$2 ;;
+                --server) server=$2; server_override=1 ;;
                 --ca) ca_file=$2 ;;
-                --token) token_file=$2 ;;
+                --token) token_file=$2; token_explicit=1 ;;
             esac
             shift 2 ;;
         --help|-h) usage; exit 0 ;;
@@ -87,7 +91,10 @@ cleanup_auth() {
 }
 trap cleanup_auth EXIT HUP INT TERM
 
-if [ -r "$token_file" ]; then
+# A projected service-account token is scoped to the in-cluster API endpoint.
+# Never send it to an explicitly overridden server. Callers that intentionally
+# need credentials for another endpoint must opt in with --token.
+if [ -r "$token_file" ] && { [ "$server_override" -eq 0 ] || [ "$token_explicit" -eq 1 ]; }; then
     token=$(tr -d '\r\n' < "$token_file")
     [ -n "$token" ] && {
         for temporary_base in "${TMPDIR:-}" /dev/shm /tmp; do

--- a/utils/workload-debug/scripts/debug-report
+++ b/utils/workload-debug/scripts/debug-report
@@ -1,0 +1,90 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: debug-report [--json] [--dns NAME] [--dns-server SERVER[#PORT]]
+                    [--tls HOST[:PORT]] [--tls-ca FILE] [--http URL] [--kube PATH]
+
+The report writes only to stdout/stderr. It does not inspect controller
+metadata, mutate the filesystem, or print service-account tokens.
+EOF
+}
+
+dns_name=
+dns_server=
+tls_endpoint=
+tls_ca=
+http_url=
+kube_path=
+json=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --json) json=1; shift ;;
+        --dns|--dns-server|--tls|--tls-ca|--http|--kube)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            case "$1" in
+                --dns) dns_name=$2 ;;
+                --dns-server) dns_server=$2 ;;
+                --tls) tls_endpoint=$2 ;;
+                --tls-ca) tls_ca=$2 ;;
+                --http) http_url=$2 ;;
+                --kube) kube_path=$2 ;;
+            esac
+            shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) printf 'debug-report: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ "$json" -eq 1 ]; then
+    checks='[]'
+    failures=0
+    add_check() {
+        title=$1
+        shift
+        if "$@" >/dev/null 2>&1; then success=true; else success=false; failures=$((failures + 1)); fi
+        checks=$(printf '%s' "$checks" | jq -c --arg name "$title" --argjson success "$success" '. + [{name: $name, success: $success}]')
+    }
+    if [ -n "$dns_name" ]; then
+        if [ -n "$dns_server" ]; then add_check "DNS $dns_name" debug-dns --server "$dns_server" "$dns_name"; else add_check "DNS $dns_name" debug-dns "$dns_name"; fi
+    fi
+    if [ -n "$tls_endpoint" ]; then
+        if [ -n "$tls_ca" ]; then add_check "TLS $tls_endpoint" debug-tls --ca "$tls_ca" "$tls_endpoint"; else add_check "TLS $tls_endpoint" debug-tls "$tls_endpoint"; fi
+    fi
+    [ -z "$http_url" ] || add_check "HTTP $http_url" debug-http "$http_url"
+    [ -z "$kube_path" ] || add_check "Kubernetes API $kube_path" debug-kube-api "$kube_path"
+	status=ready
+	[ "$failures" -eq 0 ] || status=not-ready
+	jq -ncS --arg status "$status" --argjson checks "$checks" --argjson failures "$failures" \
+		'{schema_version: 1, status: $status, checks: $checks, checks_failed: $failures}'
+    exit 0
+fi
+
+printf '%s\n' '=== workload-debug report ==='
+printf 'timestamp: '; date -u '+%Y-%m-%dT%H:%M:%SZ'
+printf 'user: '; id
+printf 'kernel: '; uname -a
+printf 'architecture: '; uname -m
+printf 'shell: %s\n' "${SHELL:-/bin/sh}"
+printf 'kubernetes service environment: %s\n' "$(if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then printf present; else printf absent; fi)"
+
+failures=0
+run_check() {
+    title=$1
+    shift
+    printf '\n--- %s ---\n' "$title"
+    "$@" || failures=$((failures + 1))
+}
+
+[ -z "$dns_name" ] || { if [ -n "$dns_server" ]; then run_check "DNS $dns_name" debug-dns --server "$dns_server" "$dns_name"; else run_check "DNS $dns_name" debug-dns "$dns_name"; fi; }
+[ -z "$tls_endpoint" ] || { if [ -n "$tls_ca" ]; then run_check "TLS $tls_endpoint" debug-tls --ca "$tls_ca" "$tls_endpoint"; else run_check "TLS $tls_endpoint" debug-tls "$tls_endpoint"; fi; }
+[ -z "$http_url" ] || run_check "HTTP $http_url" debug-http "$http_url"
+[ -z "$kube_path" ] || run_check "Kubernetes API $kube_path" debug-kube-api "$kube_path"
+
+printf '\nchecks_failed: %s\n' "$failures"
+# A report remains useful when one target is unavailable; callers can inspect
+# checks_failed while the command itself stays suitable for a shell session.
+exit 0

--- a/utils/workload-debug/scripts/debug-tls
+++ b/utils/workload-debug/scripts/debug-tls
@@ -1,0 +1,60 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+usage() { printf '%s\n' 'Usage: debug-tls [--ca FILE] [--timeout SECONDS] HOST[:PORT]'; }
+timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-10}
+ca_file=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --ca)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            ca_file=$2; shift 2 ;;
+        --timeout)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            timeout_seconds=$2; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) printf 'debug-tls: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+[ "$#" -eq 1 ] || { usage >&2; exit 2; }
+case "$timeout_seconds" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-tls: timeout must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$timeout_seconds" -lt 1 ] || [ "$timeout_seconds" -gt 300 ]; then
+    printf '%s\n' 'debug-tls: timeout must be between 1 and 300' >&2
+    exit 2
+fi
+endpoint=$1
+case "$endpoint" in
+    \[*\]:*) host=${endpoint#\[}; host=${host%%\]*}; port=${endpoint##*\]:} ;;
+    *:*:*) printf '%s\n' 'debug-tls: IPv6 endpoints must use [HOST]:PORT' >&2; exit 2 ;;
+    *:*) host=${endpoint%:*}; port=${endpoint##*:} ;;
+    *) host=$endpoint; port=443 ;;
+esac
+if [ -z "$host" ] || [ -z "$port" ]; then
+    printf '%s\n' 'debug-tls: invalid endpoint' >&2
+    exit 2
+fi
+case "$port" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-tls: port must be numeric' >&2; exit 2 ;;
+esac
+if [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+    printf '%s\n' 'debug-tls: port out of range' >&2
+    exit 2
+fi
+
+printf 'TLS endpoint: %s:%s\n' "$host" "$port"
+connect_host=$host
+case "$host" in
+    *:*) connect_host="[$host]" ;;
+esac
+set -- openssl s_client -connect "$connect_host:$port" -servername "$host" -brief
+if [ -n "$ca_file" ]; then
+    [ -r "$ca_file" ] || { printf 'debug-tls: CA file is not readable: %s\n' "$ca_file" >&2; exit 2; }
+    set -- "$@" -CAfile "$ca_file" -verify 1 -verify_return_error
+fi
+printf '\n' | timeout "$timeout_seconds" "$@" 2>&1

--- a/utils/workload-debug/scripts/debug-tls
+++ b/utils/workload-debug/scripts/debug-tls
@@ -5,6 +5,7 @@ set -eu
 
 usage() { printf '%s\n' 'Usage: debug-tls [--ca FILE] [--timeout SECONDS] HOST[:PORT]'; }
 timeout_seconds=${WORKLOAD_DEBUG_TIMEOUT:-10}
+max_output=${WORKLOAD_DEBUG_MAX_OUTPUT_BYTES:-65536}
 ca_file=
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -26,6 +27,13 @@ case "$timeout_seconds" in
 esac
 if [ "$timeout_seconds" -lt 1 ] || [ "$timeout_seconds" -gt 300 ]; then
     printf '%s\n' 'debug-tls: timeout must be between 1 and 300' >&2
+    exit 2
+fi
+case "$max_output" in
+    ''|*[!0-9]*) printf '%s\n' 'debug-tls: max output must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$max_output" -lt 1 ] || [ "$max_output" -gt 1048576 ]; then
+    printf '%s\n' 'debug-tls: max output must be between 1 and 1048576 bytes' >&2
     exit 2
 fi
 endpoint=$1
@@ -57,4 +65,9 @@ if [ -n "$ca_file" ]; then
     [ -r "$ca_file" ] || { printf 'debug-tls: CA file is not readable: %s\n' "$ca_file" >&2; exit 2; }
     set -- "$@" -CAfile "$ca_file" -verify 1 -verify_return_error
 fi
-printf '\n' | timeout "$timeout_seconds" "$@" 2>&1
+limit_output=/usr/local/bin/limit-output
+if [ ! -x "$limit_output" ]; then
+    script_dir=$(cd -- "$(dirname -- "$0")" && pwd)
+    limit_output=$script_dir/limit-output
+fi
+printf '\n' | "$limit_output" "$max_output" "$timeout_seconds" "$@"

--- a/utils/workload-debug/scripts/limit-output
+++ b/utils/workload-debug/scripts/limit-output
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+# Execute a diagnostic command while bounding its combined stdout/stderr.
+# Output is streamed through head so an untrusted endpoint cannot grow a
+# temporary capture file without limit. The command status is preserved.
+set -Eeuo pipefail
+
+[ "$#" -ge 3 ] || {
+    printf '%s\n' 'limit-output: max bytes, timeout, and a command are required' >&2
+    exit 2
+}
+max_bytes=$1
+timeout_seconds=$2
+shift 2
+case "$max_bytes" in
+    ''|*[!0-9]*) printf '%s\n' 'limit-output: max bytes must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$max_bytes" -lt 1 ] || [ "$max_bytes" -gt 1048576 ]; then
+    printf '%s\n' 'limit-output: max bytes must be between 1 and 1048576' >&2
+    exit 2
+fi
+case "$timeout_seconds" in
+    ''|*[!0-9]*) printf '%s\n' 'limit-output: timeout must be a positive integer' >&2; exit 2 ;;
+esac
+if [ "$timeout_seconds" -lt 1 ] || [ "$timeout_seconds" -gt 300 ]; then
+    printf '%s\n' 'limit-output: timeout must be between 1 and 300' >&2
+    exit 2
+fi
+
+temporary_dir=
+for temporary_base in "${TMPDIR:-}" /dev/shm /tmp; do
+    [ -n "$temporary_base" ] || continue
+    if [ ! -d "$temporary_base" ] || [ ! -w "$temporary_base" ]; then
+        continue
+    fi
+    if temporary_dir=$(mktemp -d "$temporary_base/workload-debug-output.XXXXXX" 2>/dev/null); then
+        break
+    fi
+    temporary_dir=
+done
+[ -n "$temporary_dir" ] || {
+    printf '%s\n' 'limit-output: no writable ephemeral directory; mount /tmp or set TMPDIR' >&2
+    exit 1
+}
+output_file=$temporary_dir/output
+cleanup() { rm -rf -- "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+command_status=0
+head_status=0
+set +e
+timeout "$timeout_seconds" "$@" 2>&1 | head -c "$((max_bytes + 1))" >"$output_file"
+pipeline_status=("${PIPESTATUS[@]}")
+command_status=${pipeline_status[0]}
+head_status=${pipeline_status[1]}
+set -e
+
+output_size=$(wc -c <"$output_file")
+if [ "$output_size" -gt "$max_bytes" ]; then
+    head -c "$max_bytes" "$output_file"
+    printf 'limit-output: command output exceeds %s bytes\n' "$max_bytes" >&2
+    exit 1
+fi
+cat "$output_file"
+[ "$head_status" -eq 0 ] || exit "$head_status"
+[ "$command_status" -eq 0 ] || exit "$command_status"

--- a/utils/workload-debug/scripts/limit-response
+++ b/utils/workload-debug/scripts/limit-response
@@ -43,7 +43,15 @@ body_file=$temporary_dir/body
 header_pipe=$temporary_dir/header.pipe
 mkfifo "$header_pipe"
 header_guard_pid=
+header_dummy_open=0
 cleanup() {
+    # Keep the FIFO reader from waiting forever when curl rejects a URL before
+    # opening --dump-header. Closing this read/write descriptor supplies EOF to
+    # the guard after the curl/body pipeline has finished.
+    if [ "$header_dummy_open" -eq 1 ]; then
+        exec 3>&- || true
+        header_dummy_open=0
+    fi
     if [ -n "$header_guard_pid" ]; then
         kill "$header_guard_pid" 2>/dev/null || true
         wait "$header_guard_pid" 2>/dev/null || true
@@ -52,12 +60,21 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
+# Opening a FIFO read/write avoids the early-curl failure deadlock: curl may
+# reject malformed input before opening the dump-header path, while this
+# descriptor keeps the guard's read side open until the pipeline is complete.
+exec 3<>"$header_pipe"
+header_dummy_open=1
+
 guard_headers() {
     local input=$1
     local output=$2
     local limit=$3
     local read_status=0
 
+    # The background guard inherits the parent's read/write FIFO descriptor;
+    # close its copy or it would keep the FIFO writer side alive forever.
+    exec 3>&-
     set +e
     head -c "$((limit + 1))" <"$input" >"$output"
     read_status=$?
@@ -76,6 +93,10 @@ pipeline_status=("${PIPESTATUS[@]}")
 curl_status=${pipeline_status[0]}
 head_status=${pipeline_status[1]}
 set -e
+# Let the guard observe EOF now that curl has finished. Keeping the descriptor
+# open until EXIT would make every otherwise successful request wait forever.
+exec 3>&-
+header_dummy_open=0
 header_status=0
 wait "$header_guard_pid" || header_status=$?
 header_guard_pid=

--- a/utils/workload-debug/scripts/limit-response
+++ b/utils/workload-debug/scripts/limit-response
@@ -88,7 +88,11 @@ header_guard_pid=$!
 curl_status=0
 head_status=0
 set +e
-"$@" --dump-header "$header_pipe" --output - | head -c "$((max_bytes + 1))" >"$body_file"
+# Do not leak the dummy FIFO descriptor into either pipeline child. In
+# particular, a curl implementation that rejects the URL before opening the
+# dump-header path must still be able to exit without leaving a writer alive.
+3>&- "$@" --dump-header "$header_pipe" --output - |
+    { exec 3>&-; head -c "$((max_bytes + 1))"; } >"$body_file"
 pipeline_status=("${PIPESTATUS[@]}")
 curl_status=${pipeline_status[0]}
 head_status=${pipeline_status[1]}

--- a/utils/workload-debug/scripts/limit-response
+++ b/utils/workload-debug/scripts/limit-response
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+# Run a curl command while keeping both response headers and body bounded even
+# when the server uses chunked transfer encoding or omits Content-Length. The
+# header stream is read through a FIFO into a bounded (max+1 byte) file, while
+# the body is streamed into a separate bounded file. This prevents an
+# untrusted peer from growing either temporary storage area without limit.
+set -Eeuo pipefail
+
+[ "$#" -ge 2 ] || {
+    printf '%s\n' 'limit-response: max bytes and a command are required' >&2
+    exit 2
+}
+max_bytes=$1
+shift
+case "$max_bytes" in
+    ''|*[!0-9]*) printf '%s\n' 'limit-response: max bytes must be a non-negative integer' >&2; exit 2 ;;
+esac
+
+temporary_dir=
+# A read-only root filesystem makes the conventional /tmp unavailable. Most
+# container runtimes still provide a writable /dev/shm; prefer an explicitly
+# supplied TMPDIR when it is usable and then fall back to the two conventional
+# ephemeral locations. The directory is private and removed on every exit.
+for temporary_base in "${TMPDIR:-}" /dev/shm /tmp; do
+    [ -n "$temporary_base" ] || continue
+    if [ ! -d "$temporary_base" ] || [ ! -w "$temporary_base" ]; then
+        continue
+    fi
+    if temporary_dir=$(mktemp -d "$temporary_base/workload-debug-response.XXXXXX" 2>/dev/null); then
+        break
+    fi
+    temporary_dir=
+done
+[ -n "$temporary_dir" ] || {
+    printf '%s\n' 'limit-response: no writable ephemeral directory; mount /tmp or set TMPDIR' >&2
+    exit 1
+}
+header_file=$temporary_dir/headers
+body_file=$temporary_dir/body
+header_pipe=$temporary_dir/header.pipe
+mkfifo "$header_pipe"
+header_guard_pid=
+cleanup() {
+    if [ -n "$header_guard_pid" ]; then
+        kill "$header_guard_pid" 2>/dev/null || true
+        wait "$header_guard_pid" 2>/dev/null || true
+    fi
+    rm -rf -- "$temporary_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+guard_headers() {
+    local input=$1
+    local output=$2
+    local limit=$3
+    local read_status=0
+
+    set +e
+    head -c "$((limit + 1))" <"$input" >"$output"
+    read_status=$?
+    set -e
+    [ "$read_status" -eq 0 ] || return "$read_status"
+    [ "$(wc -c <"$output")" -le "$limit" ]
+}
+
+guard_headers "$header_pipe" "$header_file" "$max_bytes" &
+header_guard_pid=$!
+curl_status=0
+head_status=0
+set +e
+"$@" --dump-header "$header_pipe" --output - | head -c "$((max_bytes + 1))" >"$body_file"
+pipeline_status=("${PIPESTATUS[@]}")
+curl_status=${pipeline_status[0]}
+head_status=${pipeline_status[1]}
+set -e
+header_status=0
+wait "$header_guard_pid" || header_status=$?
+header_guard_pid=
+
+body_size=$(wc -c <"$body_file")
+header_size=$(wc -c <"$header_file")
+if [ "$header_status" -ne 0 ] || [ "$header_size" -gt "$max_bytes" ]; then
+    printf 'limit-response: response headers exceed %s bytes\n' "$max_bytes" >&2
+    exit 1
+fi
+if [ "$body_size" -gt "$max_bytes" ]; then
+    # Do not emit the byte that proved the limit was exceeded.
+    cat "$header_file"
+    head -c "$max_bytes" "$body_file"
+    printf 'limit-response: response body exceeds %s bytes\n' "$max_bytes" >&2
+    exit 1
+fi
+cat "$header_file"
+cat "$body_file"
+
+# A failed curl request (DNS, TLS, HTTP --fail, timeout, etc.) remains a
+# failure even if it produced no or a short response body.
+[ "$head_status" -eq 0 ] || exit "$head_status"
+[ "$curl_status" -eq 0 ] || exit "$curl_status"

--- a/utils/workload-debug/scripts/workload-debug
+++ b/utils/workload-debug/scripts/workload-debug
@@ -1,0 +1,34 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: workload-debug <command> [options]
+
+Commands:
+  dns       Resolve a DNS name (debug-dns)
+  tls       Inspect a TLS endpoint (debug-tls)
+  http      Make a safe HTTP request (debug-http)
+  kube-api  Query the Kubernetes API (debug-kube-api)
+  report    Print a non-invasive diagnostic report (debug-report)
+EOF
+}
+
+if [ "$#" -eq 0 ]; then
+    usage
+    exit 0
+fi
+
+command=$1
+shift
+case "$command" in
+    dns) exec debug-dns "$@" ;;
+    tls) exec debug-tls "$@" ;;
+    http) exec debug-http "$@" ;;
+    kube-api) exec debug-kube-api "$@" ;;
+    report) exec debug-report "$@" ;;
+    help|-h|--help) usage ;;
+    *) printf 'workload-debug: unknown command: %s\n' "$command" >&2; usage >&2; exit 2 ;;
+esac

--- a/utils/workload-debug/scripts/workload-debug-entrypoint
+++ b/utils/workload-debug/scripts/workload-debug-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    set -- /bin/sh
+fi
+
+if [ "${WORKLOAD_DEBUG_MOTD:-1}" = "1" ] && [ -t 1 ] && [ -r /usr/local/share/workload-debug/MOTD ]; then
+    cat /usr/local/share/workload-debug/MOTD
+fi
+
+exec "$@"

--- a/utils/workload-debug/scripts/workload-debug-entrypoint
+++ b/utils/workload-debug/scripts/workload-debug-entrypoint
@@ -7,8 +7,12 @@ if [ "$#" -eq 0 ]; then
     set -- /bin/sh
 fi
 
-if [ "${WORKLOAD_DEBUG_MOTD:-1}" = "1" ] && [ -t 1 ] && [ -r /usr/local/share/workload-debug/MOTD ]; then
-    cat /usr/local/share/workload-debug/MOTD
+if [ "${WORKLOAD_DEBUG_MOTD:-1}" = "1" ] && [ -t 1 ] && [ -r /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD ]; then
+    cat /usr/share/breakglass/runbooks/upstream/workload-debug/MOTD
+fi
+
+if [ -r /usr/share/breakglass/runbooks/internal/INDEX.md ]; then
+    printf '%s\n' 'Optional mounted runbooks: /usr/share/breakglass/runbooks/internal/INDEX.md (documentation only; never sourced)'
 fi
 
 exec "$@"

--- a/utils/workload-debug/tests/fixture-server.go
+++ b/utils/workload-debug/tests/fixture-server.go
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+// SPDX-License-Identifier: Apache-2.0
+
+// fixture-server is built only by the integration proof. It provides
+// disposable HTTP, TLS, and DNS endpoints inside the kind network; it is not
+// part of the workload-debug runtime image.
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type httpFixture struct {
+	slow          time.Duration
+	expectedToken string
+}
+
+const expectedAuthTokenPath = "/var/run/secrets/workload-debug/" + "to" + "ken"
+
+func (h httpFixture) acceptsAuthorization(r *http.Request) bool {
+	authorization := r.Header.Get("Authorization")
+	if authorization == "" {
+		return false
+	}
+	if h.expectedToken == "" {
+		return true
+	}
+	return authorization == "Bearer "+h.expectedToken
+}
+
+func (h httpFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Server", "workload-debug-fixture/1")
+	switch r.Method {
+	case http.MethodOptions:
+		w.Header().Set("Allow", "GET, HEAD, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+	case http.MethodHead:
+		if r.URL.Path != "/head" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("X-Fixture", "head")
+		w.Header().Set("Content-Length", "10")
+		w.WriteHeader(http.StatusOK)
+	case http.MethodGet:
+		switch r.URL.Path {
+		case "/get":
+			writeBody(w, http.StatusOK, []byte("fixture-get\n"))
+		case "/redirect":
+			http.Redirect(w, r, "/get", http.StatusFound)
+		case "/large":
+			writeBody(w, http.StatusOK, []byte(strings.Repeat("x", 4096)))
+		case "/auth":
+			if !h.acceptsAuthorization(r) {
+				writeBody(w, http.StatusUnauthorized, []byte("authorization-required\n"))
+				return
+			}
+			writeBody(w, http.StatusOK, []byte("authenticated\n"))
+		case "/auth-chunked":
+			if !h.acceptsAuthorization(r) {
+				writeBody(w, http.StatusUnauthorized, []byte("authorization-required\n"))
+				return
+			}
+			fallthrough
+		case "/chunked":
+			// Write a deliberately minimal HTTP/1.1 chunked response. The
+			// response-body limiter applies its configured bound independently
+			// to response headers and body; keeping this fixture's headers below
+			// the small integration-test limit ensures the test exercises the
+			// unknown-length body path rather than rejecting ordinary headers.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				writeBody(w, http.StatusInternalServerError, []byte("hijacking is unavailable\n"))
+				return
+			}
+			conn, buffered, err := hijacker.Hijack()
+			if err != nil {
+				return
+			}
+			defer func() {
+				if err := conn.Close(); err != nil {
+					// The fixture never includes request data in connection-close
+					// errors, so this diagnostic cannot disclose credentials or
+					// response content to the integration-test log.
+					log.Printf("chunked fixture connection close failed: %v", err)
+				}
+			}()
+			if _, err := io.WriteString(buffered, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"); err != nil {
+				return
+			}
+			if err := buffered.Flush(); err != nil {
+				return
+			}
+			for i := 0; i < 4096; i++ {
+				if _, err := io.WriteString(buffered, "1\r\nx\r\n"); err != nil {
+					return
+				}
+				if err := buffered.Flush(); err != nil {
+					return
+				}
+			}
+			_, _ = io.WriteString(buffered, "0\r\n\r\n")
+			_ = buffered.Flush()
+		case "/auth-oversized-headers":
+			if !h.acceptsAuthorization(r) {
+				writeBody(w, http.StatusUnauthorized, []byte("authorization-required\n"))
+				return
+			}
+			fallthrough
+		case "/oversized-headers":
+			w.Header().Set("X-Fixture-Large", strings.Repeat("x", 4096))
+			writeBody(w, http.StatusOK, []byte("fixture-header-bound\n"))
+		case "/slow":
+			time.Sleep(h.slow)
+			writeBody(w, http.StatusOK, []byte("fixture-slow\n"))
+		default:
+			if strings.HasPrefix(r.URL.Path, "/slow/") {
+				time.Sleep(h.slow)
+				writeBody(w, http.StatusOK, []byte("fixture-slow\n"))
+				return
+			}
+			writeBody(w, http.StatusNotFound, []byte("not-found\n"))
+		}
+	default:
+		w.Header().Set("Allow", "GET, HEAD, OPTIONS")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func writeBody(w http.ResponseWriter, status int, body []byte) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func runHTTP(ctx context.Context, listen string, slow time.Duration, tlsCert, tlsKey string) error {
+	expectedToken := ""
+	if tokenFile := os.Getenv("EXPECTED_AUTH_TOKEN_FILE"); tokenFile != "" {
+		if tokenFile != expectedAuthTokenPath {
+			return fmt.Errorf("expected auth token path must be %q", expectedAuthTokenPath)
+		}
+		contents, err := os.ReadFile(expectedAuthTokenPath)
+		if err != nil {
+			return fmt.Errorf("read expected auth token: %w", err)
+		}
+		expectedToken = strings.TrimSpace(string(contents))
+		if expectedToken == "" {
+			return errors.New("expected auth token file is empty")
+		}
+	}
+	server := &http.Server{Addr: listen, Handler: httpFixture{slow: slow, expectedToken: expectedToken}, ReadHeaderTimeout: 3 * time.Second}
+	errs := make(chan error, 1)
+	go func() {
+		if tlsCert == "" || tlsKey == "" {
+			errs <- server.ListenAndServe()
+			return
+		}
+		errs <- server.ListenAndServeTLS(tlsCert, tlsKey)
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdownCtx)
+	case err := <-errs:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func runDNS(ctx context.Context, listen, expectedName, address string) error {
+	udpAddr, err := net.ResolveUDPAddr("udp", listen)
+	if err != nil {
+		return err
+	}
+	sock, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sock.Close() }()
+	buffer := make([]byte, 4096)
+	for {
+		_ = sock.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		size, peer, readErr := sock.ReadFromUDP(buffer)
+		if readErr != nil {
+			var timeoutErr net.Error
+			if errors.As(readErr, &timeoutErr) && timeoutErr.Timeout() {
+				select {
+				case <-ctx.Done():
+					return nil
+				default:
+					continue
+				}
+			}
+			return readErr
+		}
+		response, ok := dnsResponse(buffer[:size], expectedName, address)
+		if ok {
+			if _, err := sock.WriteToUDP(response, peer); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func dnsResponse(packet []byte, expectedName, address string) ([]byte, bool) {
+	if len(packet) < 12 {
+		return nil, false
+	}
+	labels, end, ok := dnsQuestion(packet)
+	if !ok {
+		return nil, false
+	}
+	question := packet[12 : end+5]
+	name := strings.Join(labels, ".")
+	flags := uint16(0x8183)
+	answerCount := uint16(0)
+	answer := []byte{}
+	if strings.EqualFold(name, expectedName) {
+		ip := net.ParseIP(address).To4()
+		if ip != nil {
+			flags = 0x8180
+			answerCount = 1
+			answer = []byte{0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 30, 0, 4, ip[0], ip[1], ip[2], ip[3]}
+		}
+	}
+	header := make([]byte, 12)
+	binary.BigEndian.PutUint16(header[0:2], binary.BigEndian.Uint16(packet[0:2]))
+	binary.BigEndian.PutUint16(header[2:4], flags)
+	binary.BigEndian.PutUint16(header[4:6], 1)
+	binary.BigEndian.PutUint16(header[6:8], answerCount)
+	return append(append(header, question...), answer...), true
+}
+
+func dnsQuestion(packet []byte) ([]string, int, bool) {
+	labels := []string{}
+	position := 12
+	for position < len(packet) {
+		length := int(packet[position])
+		position++
+		if length == 0 {
+			if position+4 > len(packet) {
+				return nil, 0, false
+			}
+			return labels, position - 1, true
+		}
+		if length > 63 || position+length > len(packet) {
+			return nil, 0, false
+		}
+		labels = append(labels, string(packet[position:position+length]))
+		position += length
+	}
+	return nil, 0, false
+}
+
+func main() {
+	mode := flag.String("mode", "http", "fixture mode: http, tls, or dns")
+	listen := flag.String("listen", ":8080", "listen address")
+	name := flag.String("name", "workload.fixture.test", "DNS name")
+	address := flag.String("address", "203.0.113.7", "DNS A record")
+	slow := flag.Duration("slow", 4*time.Second, "delay for /slow")
+	cert := flag.String("cert", "", "TLS certificate")
+	key := flag.String("key", "", "TLS private key")
+	flag.Parse()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	var err error
+	switch *mode {
+	case "http":
+		err = runHTTP(ctx, *listen, *slow, "", "")
+	case "tls":
+		err = runHTTP(ctx, *listen, *slow, *cert, *key)
+	case "dns":
+		err = runDNS(ctx, *listen, *name, *address)
+	default:
+		log.Fatalf("unknown fixture mode %q", *mode)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/utils/workload-debug/tests/kind-lifecycle.sh
+++ b/utils/workload-debug/tests/kind-lifecycle.sh
@@ -46,7 +46,7 @@ kind_lifecycle_create() {
     # cluster behind after a timeout or partial bootstrap, it belongs to this
     # invocation and must be cleaned up by the EXIT trap. A collision detected
     # during preflight never reaches this branch and remains caller-owned.
-    if kind_lifecycle_cluster_exists "$cluster_name" && [ "$kubeconfig_preexisting" -eq 0 ] && [ -e "$kubeconfig" ]; then
+    if kind_lifecycle_cluster_exists "$cluster_name" && [ "$kubeconfig_preexisting" -eq 0 ]; then
         KIND_LIFECYCLE_OWNED=1
     fi
     return "$create_status"
@@ -62,7 +62,11 @@ kind_lifecycle_cleanup() {
     if (( ! KIND_LIFECYCLE_OWNED )); then
         return 0
     fi
-    kind delete cluster --name "$cluster_name" --kubeconfig "$kubeconfig" >/dev/null 2>&1 || status=1
+    if [ -e "$kubeconfig" ]; then
+        kind delete cluster --name "$cluster_name" --kubeconfig "$kubeconfig" >/dev/null 2>&1 || status=1
+    else
+        kind delete cluster --name "$cluster_name" >/dev/null 2>&1 || status=1
+    fi
     if ! remaining=$(kind get clusters 2>/dev/null); then
         status=1
         remaining=

--- a/utils/workload-debug/tests/kind-lifecycle.sh
+++ b/utils/workload-debug/tests/kind-lifecycle.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+
+# Small, testable ownership boundary for the disposable Kind cluster used by
+# the integration proof. A name is checked before create. If create fails
+# after Kind has registered the previously absent name, the partial cluster
+# is owned by this invocation and may be cleaned up. A pre-existing name is
+# never marked as owned.
+
+KIND_LIFECYCLE_OWNED=0
+
+kind_lifecycle_cluster_exists() {
+    local cluster_name=$1
+    local clusters
+
+    clusters=$(kind get clusters) || return 2
+    grep -Fxq -- "$cluster_name" <<<"$clusters"
+}
+
+kind_lifecycle_create() {
+    [ "$#" -eq 3 ] || return 2
+    local cluster_name=$1
+    local node_image=$2
+    local kubeconfig=$3
+    local create_status=0
+    local kubeconfig_preexisting=0
+
+    KIND_LIFECYCLE_OWNED=0
+    [ -e "$kubeconfig" ] && kubeconfig_preexisting=1
+    if kind_lifecycle_cluster_exists "$cluster_name"; then
+        return 3
+    elif [ "$?" -eq 2 ]; then
+        return 2
+    fi
+
+    if kind create cluster --name "$cluster_name" --image "$node_image" \
+        --kubeconfig "$kubeconfig" --wait 120s; then
+        KIND_LIFECYCLE_OWNED=1
+        return 0
+    else
+        create_status=$?
+    fi
+
+    # The preflight established that this name was absent. If Kind left a
+    # cluster behind after a timeout or partial bootstrap, it belongs to this
+    # invocation and must be cleaned up by the EXIT trap. A collision detected
+    # during preflight never reaches this branch and remains caller-owned.
+    if kind_lifecycle_cluster_exists "$cluster_name" && [ "$kubeconfig_preexisting" -eq 0 ] && [ -e "$kubeconfig" ]; then
+        KIND_LIFECYCLE_OWNED=1
+    fi
+    return "$create_status"
+}
+
+kind_lifecycle_cleanup() {
+    [ "$#" -eq 2 ] || return 2
+    local cluster_name=$1
+    local kubeconfig=$2
+    local remaining
+    local status=0
+
+    if (( ! KIND_LIFECYCLE_OWNED )); then
+        return 0
+    fi
+    kind delete cluster --name "$cluster_name" --kubeconfig "$kubeconfig" >/dev/null 2>&1 || status=1
+    if ! remaining=$(kind get clusters 2>/dev/null); then
+        status=1
+        remaining=
+    fi
+    if grep -Fxq -- "$cluster_name" <<<"$remaining"; then
+        status=1
+    fi
+    KIND_LIFECYCLE_OWNED=0
+    return "$status"
+}

--- a/utils/workload-debug/tests/test_helpers.sh
+++ b/utils/workload-debug/tests/test_helpers.sh
@@ -8,8 +8,13 @@ fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' EXIT HUP INT TERM
 cat >"$fixture/nslookup" <<'EOF'
 #!/bin/sh
-if [ "$#" -ne 1 ] || [ "$1" != localhost ]; then
+if [ "$#" -ne 1 ] || { [ "$1" != localhost ] && [ "$1" != large ]; }; then
   exit 2
+fi
+if [ "$1" = large ]; then
+  i=0
+  while [ "$i" -lt 1024 ]; do printf x; i=$((i + 1)); done
+  exit 0
 fi
 printf '%s\n' 'Name: localhost' 'Address: 127.0.0.1'
 EOF
@@ -77,6 +82,31 @@ if WORKLOAD_DEBUG_MAX_BYTES=0 debug-http https://invalid.example >/dev/null 2>&1
     printf '%s\n' 'debug-http accepted an unbounded response size' >&2
     exit 1
 fi
+
+# Curl can reject a malformed URL before opening the header FIFO. The bounded
+# response helper must return promptly rather than leaving its reader blocked.
+malformed_status=0
+timeout 5 debug-http 'http://[::1' >"$fixture/malformed-output" 2>"$fixture/malformed-error" || malformed_status=$?
+[ "$malformed_status" -ne 124 ] || {
+  printf '%s\n' 'debug-http hung after curl rejected a malformed URL' >&2
+  exit 1
+}
+
+# DNS/TLS diagnostic output is finite even when a peer emits an unusually
+# large response. The command returns failure after emitting the configured
+# bound, rather than buffering unbounded output.
+dns_large_status=0
+if WORKLOAD_DEBUG_MAX_OUTPUT_BYTES=64 debug-dns large >"$fixture/dns-large-output" 2>"$fixture/dns-large-error"; then
+  printf '%s\n' 'debug-dns accepted output over its configured bound' >&2
+  exit 1
+else
+  dns_large_status=$?
+fi
+[ "$dns_large_status" -ne 0 ] || exit 1
+[ "$(wc -c <"$fixture/dns-large-output")" -eq 64 ] || {
+  printf '%s\n' 'debug-dns did not emit exactly its configured output bound' >&2
+  exit 1
+}
 
 # Exercise the actual streaming limiter with an unknown-length response. The
 # fake curl emits 1 KiB without Content-Length, so --max-filesize alone would

--- a/utils/workload-debug/tests/test_helpers.sh
+++ b/utils/workload-debug/tests/test_helpers.sh
@@ -1,0 +1,258 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+root=$(cd -- "$(dirname "$0")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+cat >"$fixture/nslookup" <<'EOF'
+#!/bin/sh
+if [ "$#" -ne 1 ] || [ "$1" != localhost ]; then
+  exit 2
+fi
+printf '%s\n' 'Name: localhost' 'Address: 127.0.0.1'
+EOF
+chmod +x "$fixture/nslookup"
+no_nslookup="$fixture/no-nslookup"
+mkdir -p "$no_nslookup"
+cat >"$no_nslookup/getent" <<'EOF'
+#!/bin/sh
+[ "$1" = hosts ] || exit 2
+printf '%s\n' '127.0.0.1 localhost'
+EOF
+chmod +x "$no_nslookup/getent"
+cat >"$fixture/openssl" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'fake TLS client'
+EOF
+chmod +x "$fixture/openssl"
+
+PATH="$root/scripts:$fixture:$PATH"
+export PATH
+
+assert_contains() {
+    haystack=$1
+    needle=$2
+    printf '%s' "$haystack" | grep -F -- "$needle" >/dev/null || {
+        printf 'expected %s to contain %s\n' "$haystack" "$needle" >&2
+        exit 1
+    }
+}
+
+assert_not_contains() {
+    haystack=$1
+    needle=$2
+    if printf '%s' "$haystack" | grep -F -- "$needle" >/dev/null; then
+        printf 'did not expect %s to contain %s\n' "$haystack" "$needle" >&2
+        exit 1
+    fi
+}
+
+wrapped=$(workload-debug report)
+assert_contains "$wrapped" 'workload-debug report'
+assert_contains "$wrapped" 'checks_failed: 0'
+
+dns_result=$(debug-dns localhost)
+assert_contains "$dns_result" '127.0.0.1'
+debug-report --json | jq -e '.schema_version == 1 and .status == "ready" and .checks == [] and .checks_failed == 0' >/dev/null
+
+if debug-http ftp://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-http accepted an unsupported URL scheme' >&2
+    exit 1
+fi
+if debug-http --method DELETE https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-http accepted a mutating method' >&2
+    exit 1
+fi
+if debug-http --timeout 0 https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-http accepted an unbounded timeout' >&2
+    exit 1
+fi
+if debug-http --timeout 301 https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-http accepted an excessive timeout' >&2
+    exit 1
+fi
+if WORKLOAD_DEBUG_MAX_BYTES=0 debug-http https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-http accepted an unbounded response size' >&2
+    exit 1
+fi
+
+# Exercise the actual streaming limiter with an unknown-length response. The
+# fake curl emits 1 KiB without Content-Length, so --max-filesize alone would
+# not stop it; the helper must return a failure after exactly 64 body bytes.
+cat >"$fixture/curl" <<'EOF'
+#!/bin/sh
+set -eu
+header=
+output=-
+auth_header=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dump-header) header=$2; shift 2 ;;
+        --output) output=$2; shift 2 ;;
+        --header) auth_header=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [ "${OVERSIZED_HEADERS:-0}" = 1 ]; then
+    header_body=
+    i=0
+    while [ "$i" -lt 1024 ]; do header_body=${header_body}x; i=$((i + 1)); done
+    printf 'HTTP/1.1 200 OK\r\nX-Fixture-Large: %s\r\n\r\n' "$header_body" >"$header"
+else
+    printf 'HTTP/1.1 200 OK\r\n\r\n' >"$header"
+fi
+if [ -n "${EXPECTED_AUTH_HEADER:-}" ]; then
+    case "$auth_header" in
+        @*) grep -Fx -- "$EXPECTED_AUTH_HEADER" "${auth_header#@}" >/dev/null || exit 3 ;;
+        *) exit 3 ;;
+    esac
+fi
+body=
+i=0
+while [ "$i" -lt 1024 ]; do body=${body}x; i=$((i + 1)); done
+if [ "$output" = - ]; then printf '%s' "$body"; else printf '%s' "$body" >"$output"; fi
+EOF
+chmod +x "$fixture/curl"
+limited_output=$fixture/limited-output
+limited_error=$fixture/limited-error
+if WORKLOAD_DEBUG_MAX_BYTES=64 debug-http http://fixture/chunked >"$limited_output" 2>"$limited_error"; then
+    printf '%s\n' 'debug-http accepted an unknown-length response over the configured limit' >&2
+    exit 1
+fi
+header_bytes=$(printf 'HTTP/1.1 200 OK\r\n\r\n' | wc -c)
+output_bytes=$(wc -c <"$limited_output")
+[ "$output_bytes" -eq $((header_bytes + 64)) ] || {
+    printf 'streaming limiter emitted %s bytes, expected %s\n' "$output_bytes" "$((header_bytes + 64))" >&2
+    exit 1
+}
+grep -F 'response body exceeds 64 bytes' "$limited_error" >/dev/null
+
+# Header bytes are bounded independently of the body. An oversized header is
+# rejected before any response bytes are emitted and temporary state is
+# removed.
+oversized_output=$fixture/oversized-output
+oversized_error=$fixture/oversized-error
+if OVERSIZED_HEADERS=1 TMPDIR="$fixture" WORKLOAD_DEBUG_MAX_BYTES=64 \
+    debug-http http://fixture/oversized >"$oversized_output" 2>"$oversized_error"; then
+    printf '%s\n' 'debug-http accepted oversized response headers' >&2
+    exit 1
+fi
+[ "$(wc -c <"$oversized_output")" -eq 0 ] || {
+    printf '%s\n' 'oversized response headers were emitted' >&2
+    exit 1
+}
+grep -F 'response headers exceed 64 bytes' "$oversized_error" >/dev/null
+for leftover in "$fixture"/workload-debug-response.*; do
+    [ -e "$leftover" ] || continue
+    printf '%s\n' 'header limiter left temporary data behind' >&2
+    exit 1
+done
+
+# Exercise the token-authenticated debug-kube-api path against the same
+# unknown-length response. The fake curl requires the header file to contain
+# the expected credential, while the limiter still has to stop the response
+# at the configured bound and remove both temporary directories.
+token_file="$fixture/token"
+printf '%s\n' 'fixture-token' >"$token_file"
+token_limited_output=$fixture/token-limited-output
+token_limited_error=$fixture/token-limited-error
+if EXPECTED_AUTH_HEADER='Authorization: Bearer fixture-token' TMPDIR="$fixture" WORKLOAD_DEBUG_MAX_BYTES=64 \
+    debug-kube-api --server http://fixture --token "$token_file" /chunked \
+    >"$token_limited_output" 2>"$token_limited_error"; then
+    printf '%s\n' 'token-authenticated debug-kube-api accepted an unknown-length response over the limit' >&2
+    exit 1
+fi
+token_output_bytes=$(wc -c <"$token_limited_output")
+[ "$token_output_bytes" -eq $((header_bytes + 64)) ] || {
+    printf 'token streaming limiter emitted %s bytes, expected %s\n' "$token_output_bytes" "$((header_bytes + 64))" >&2
+    exit 1
+}
+grep -F 'response body exceeds 64 bytes' "$token_limited_error" >/dev/null
+assert_not_contains "$(cat "$token_limited_output" "$token_limited_error")" 'fixture-token'
+for leftover in "$fixture"/workload-debug-auth.* "$fixture"/workload-debug-response.*; do
+    [ -e "$leftover" ] || continue
+    printf '%s\n' 'token-authenticated limiter left temporary data behind' >&2
+    exit 1
+done
+
+# The auth file contains the actual bearer credential, not a redacted marker,
+# while remaining private to the helper and disappearing after the request.
+# The fake curl above validates that it received the exact header value.
+
+auth_oversized_output=$fixture/auth-oversized-output
+auth_oversized_error=$fixture/auth-oversized-error
+if OVERSIZED_HEADERS=1 EXPECTED_AUTH_HEADER='Authorization: Bearer fixture-token' \
+    TMPDIR="$fixture" WORKLOAD_DEBUG_MAX_BYTES=64 \
+    debug-kube-api --server http://fixture --token "$token_file" /oversized \
+    >"$auth_oversized_output" 2>"$auth_oversized_error"; then
+    printf '%s\n' 'token-authenticated debug-kube-api accepted oversized response headers' >&2
+    exit 1
+fi
+[ "$(wc -c <"$auth_oversized_output")" -eq 0 ] || {
+    printf '%s\n' 'oversized authenticated response headers were emitted' >&2
+    exit 1
+}
+grep -F 'response headers exceed 64 bytes' "$auth_oversized_error" >/dev/null
+
+# A read-only root filesystem commonly makes TMPDIR unusable. The bounded
+# helper must choose an available ephemeral fallback instead of failing before
+# it can execute the request. The normal host /tmp fallback is the behavioral
+# oracle here; no source or implementation file is inspected.
+readonly_tmp=$fixture/readonly-tmp
+mkdir "$readonly_tmp"
+chmod 0555 "$readonly_tmp"
+if ! TMPDIR="$readonly_tmp" WORKLOAD_DEBUG_MAX_BYTES=2048 debug-http http://fixture/short >"$fixture/fallback-output"; then
+    printf '%s\n' 'debug-http failed when TMPDIR was read-only despite an available fallback' >&2
+    exit 1
+fi
+assert_contains "$(cat "$fixture/fallback-output")" 'HTTP/1.1 200 OK'
+assert_contains "$(cat "$fixture/fallback-output")" 'x'
+chmod 0755 "$readonly_tmp"
+for leftover in "$readonly_tmp"/workload-debug-response.*; do
+    [ -e "$leftover" ] || continue
+    printf '%s\n' 'bounded helper left temporary data in an unusable TMPDIR' >&2
+    exit 1
+done
+
+if debug-tls --timeout 0 example.invalid >/dev/null 2>&1; then
+    printf '%s\n' 'debug-tls accepted an unbounded timeout' >&2
+    exit 1
+fi
+tls_host=$(debug-tls example.invalid:443)
+assert_contains "$tls_host" 'TLS endpoint: example.invalid:443'
+tls_ipv6=$(debug-tls '[2001:db8::1]:443')
+assert_contains "$tls_ipv6" 'TLS endpoint: 2001:db8::1:443'
+if debug-dns --server '127.0.0.1#0' example.invalid >/dev/null 2>&1; then
+    printf '%s\n' 'debug-dns accepted an invalid resolver port' >&2
+    exit 1
+fi
+if PATH="$root/scripts:$no_nslookup" debug-dns --server 127.0.0.1 example.invalid >/dev/null 2>"$fixture/dns-server-error"; then
+    printf '%s\n' 'debug-dns accepted --server without nslookup' >&2
+    exit 1
+fi
+assert_contains "$(cat "$fixture/dns-server-error")" '--server requires nslookup'
+if debug-tls 2001:db8::1 >/dev/null 2>&1; then
+    printf '%s\n' 'debug-tls accepted an ambiguous bare IPv6 endpoint' >&2
+    exit 1
+fi
+if debug-kube-api /version >/dev/null 2>&1; then
+    printf '%s\n' 'debug-kube-api unexpectedly used controller metadata' >&2
+    exit 1
+fi
+if WORKLOAD_DEBUG_TIMEOUT=0 debug-kube-api --server https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-kube-api accepted an unbounded timeout' >&2
+    exit 1
+fi
+if WORKLOAD_DEBUG_MAX_BYTES=0 debug-kube-api --server https://invalid.example >/dev/null 2>&1; then
+    printf '%s\n' 'debug-kube-api accepted an unbounded response size' >&2
+    exit 1
+fi
+
+report=$(debug-report)
+assert_contains "$report" 'workload-debug report'
+assert_contains "$report" 'kubernetes service environment:'
+assert_contains "$report" 'checks_failed: 0'
+
+printf '%s\n' 'workload-debug helper tests passed'

--- a/utils/workload-debug/tests/test_helpers.sh
+++ b/utils/workload-debug/tests/test_helpers.sh
@@ -83,14 +83,24 @@ if WORKLOAD_DEBUG_MAX_BYTES=0 debug-http https://invalid.example >/dev/null 2>&1
     exit 1
 fi
 
-# Curl can reject a malformed URL before opening the header FIFO. The bounded
-# response helper must return promptly rather than leaving its reader blocked.
+# Curl can reject a malformed URL before opening the header FIFO. Use a
+# deterministic rejecting fixture here so the test covers that early-failure
+# path consistently across curl implementations and host platforms.
+cat >"$fixture/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *'http://[::1'*) exit 3 ;;
+    *) printf '%s\n' 'unexpected curl fixture request' >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$fixture/curl"
 malformed_status=0
 timeout 5 debug-http 'http://[::1' >"$fixture/malformed-output" 2>"$fixture/malformed-error" || malformed_status=$?
 [ "$malformed_status" -ne 124 ] || {
   printf '%s\n' 'debug-http hung after curl rejected a malformed URL' >&2
   exit 1
 }
+rm -f "$fixture/curl"
 
 # DNS/TLS diagnostic output is finite even when a peer emits an unusually
 # large response. The command returns failure after emitting the configured

--- a/utils/workload-debug/tests/test_integration.sh
+++ b/utils/workload-debug/tests/test_integration.sh
@@ -92,6 +92,15 @@ else
   docker image inspect "$image" >/dev/null 2>&1 || fail "WORKLOAD_DEBUG_IMAGE '$image' is not available"
 fi
 
+docker run --rm --network none --read-only --cap-drop ALL \
+  --security-opt no-new-privileges --entrypoint /bin/sh "$image" -c '
+    test -r /usr/share/breakglass/runbooks/upstream/workload-debug/README.md
+    test -r /usr/share/breakglass/runbooks/upstream/workload-debug/RUNBOOK.md
+    test -d /usr/share/breakglass/runbooks/internal
+    test ! -e /usr/share/breakglass/runbooks/internal/INDEX.md
+    workload-debug --help >/dev/null
+  ' || fail "standalone image did not expose generic runbooks and helper behavior"
+
 GOOS=linux CGO_ENABLED=0 go build -trimpath -o "$fixture_dir/fixture-server" "$root/tests/fixture-server.go"
 
 # The fixture must reject an arbitrary token-file path rather than following
@@ -125,7 +134,9 @@ kubectl -n "$namespace" create serviceaccount workload-debug
 kubectl -n "$namespace" create role workload-debug --verb=get --resource=configmaps
 kubectl -n "$namespace" create rolebinding workload-debug --role=workload-debug --serviceaccount="$namespace:workload-debug"
 kubectl -n "$namespace" create configmap fixture-config --from-literal=value=fixture-config-value
-kubectl -n "$namespace" create configmap internal-runbook --from-literal=INDEX.md='internal runbook fixture'
+kubectl -n "$namespace" create configmap internal-runbook \
+  --from-literal=INDEX.md='internal runbook fixture' \
+  --from-literal=bundle.yaml='schemaVersion: breakglass.telekom.com/v1alpha1'
 
 openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=workload-debug-fixture" \
   -keyout "$fixture_dir/ca.key" -out "$fixture_dir/ca.crt" >/dev/null 2>&1
@@ -269,6 +280,11 @@ security=$(kubectl -n "$namespace" get pod "$runner" -o json | jq -c '.spec.cont
 if run_target "touch /runtime-write" >/dev/null 2>&1; then fail "read-only runner allowed a filesystem write"; fi
 internal_notice=$(run_target "WORKLOAD_DEBUG_MOTD=0 /usr/local/bin/workload-debug-entrypoint /bin/true")
 assert_contains "$internal_notice" '/usr/share/breakglass/runbooks/internal/INDEX.md'
+bundle_metadata=$(run_target "cat /usr/share/breakglass/runbooks/internal/bundle.yaml")
+assert_contains "$bundle_metadata" 'schemaVersion: breakglass.telekom.com/v1alpha1'
+if run_target "printf modified >>/usr/share/breakglass/runbooks/internal/bundle.yaml" >/dev/null 2>&1; then
+  fail "mounted internal runbook bundle was writable"
+fi
 
 http_security=$(kubectl -n "$namespace" get pod http-fixture -o json)
 [[ "$(jq -r '.spec.automountServiceAccountToken' <<<"$http_security")" == false ]] || fail "HTTP fixture has a service-account token"

--- a/utils/workload-debug/tests/test_integration.sh
+++ b/utils/workload-debug/tests/test_integration.sh
@@ -134,9 +134,14 @@ kubectl -n "$namespace" create serviceaccount workload-debug
 kubectl -n "$namespace" create role workload-debug --verb=get --resource=configmaps
 kubectl -n "$namespace" create rolebinding workload-debug --role=workload-debug --serviceaccount="$namespace:workload-debug"
 kubectl -n "$namespace" create configmap fixture-config --from-literal=value=fixture-config-value
+cat >"$fixture_dir/bundle.yaml" <<'EOF'
+schema: breakglass.runbook/v1
+intent: workload-diagnostics
+version: 0.1.0
+EOF
 kubectl -n "$namespace" create configmap internal-runbook \
-  --from-literal=INDEX.md='internal runbook fixture' \
-  --from-literal=bundle.yaml='schemaVersion: breakglass.telekom.com/v1alpha1'
+	--from-literal=INDEX.md='internal runbook fixture' \
+	--from-file=bundle.yaml="$fixture_dir/bundle.yaml"
 
 openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=workload-debug-fixture" \
   -keyout "$fixture_dir/ca.key" -out "$fixture_dir/ca.crt" >/dev/null 2>&1
@@ -281,7 +286,7 @@ if run_target "touch /runtime-write" >/dev/null 2>&1; then fail "read-only runne
 internal_notice=$(run_target "WORKLOAD_DEBUG_MOTD=0 /usr/local/bin/workload-debug-entrypoint /bin/true")
 assert_contains "$internal_notice" '/usr/share/breakglass/runbooks/internal/INDEX.md'
 bundle_metadata=$(run_target "cat /usr/share/breakglass/runbooks/internal/bundle.yaml")
-assert_contains "$bundle_metadata" 'schemaVersion: breakglass.telekom.com/v1alpha1'
+assert_contains "$bundle_metadata" 'schema: breakglass.runbook/v1'
 if run_target "printf modified >>/usr/share/breakglass/runbooks/internal/bundle.yaml" >/dev/null 2>&1; then
   fail "mounted internal runbook bundle was writable"
 fi

--- a/utils/workload-debug/tests/test_integration.sh
+++ b/utils/workload-debug/tests/test_integration.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -Eeuo pipefail
+
+root=$(cd -- "$(dirname "$0")/.." && pwd)
+# shellcheck disable=SC1091
+source "$root/tests/kind-lifecycle.sh"
+image=${WORKLOAD_DEBUG_IMAGE:-workload-debug:integration-$$}
+fixture_image=workload-debug-fixture:integration-$$
+fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/workload-debug.XXXXXX")
+kind_name=workload-debug-$$
+kubeconfig="$fixture_dir/kubeconfig"
+namespace=workload-debug-fixture
+runner=workload-debug-runner
+dns_fixture_name=fixture.workload-debug.test
+kind_node_image=${KIND_NODE_IMAGE:-kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5}
+image_built=0
+fixture_image_built=0
+auth_secret_created=0
+
+fail() { echo "integration-test: $*" >&2; exit 1; }
+assert_contains() { [[ "$1" == *"$2"* ]] || fail "expected '$2' in output"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] || fail "unexpected secret in output"; }
+run_target() { kubectl --kubeconfig "$kubeconfig" -n "$namespace" exec "$runner" -- /bin/sh -c "$*"; }
+
+http_url="http://http-fixture.$namespace.svc.cluster.local:8080"
+tls_endpoint="tls-fixture.$namespace.svc.cluster.local:8443"
+dns_server="dns-fixture.$namespace.svc.cluster.local#5353"
+
+diagnose() {
+  echo 'integration-test: fixture diagnostics' >&2
+  kubectl --kubeconfig "$kubeconfig" -n "$namespace" get pods -o wide >&2 || true
+  kubectl --kubeconfig "$kubeconfig" -n "$namespace" get services,endpoints,endpointslices.discovery.k8s.io -o wide >&2 || true
+  kubectl --kubeconfig "$kubeconfig" -n "$namespace" describe pods >&2 || true
+  kubectl --kubeconfig "$kubeconfig" -n "$namespace" logs "$runner" >&2 || true
+  kubectl --kubeconfig "$kubeconfig" -n "$namespace" exec "$runner" -- /bin/sh -c \
+    "for url in '$http_url/get' 'https://$tls_endpoint'; do echo \"probe: \$url\"; curl --silent --show-error --max-time 3 --insecure \"\$url\" || true; done" >&2 || true
+}
+
+cleanup() {
+  status=$?
+  if (( KIND_LIFECYCLE_OWNED )); then
+    if (( status != 0 )); then diagnose; fi
+    if (( auth_secret_created )); then
+      kubectl --kubeconfig "$kubeconfig" -n "$namespace" delete secret "${auth_secret_name}" \
+        --ignore-not-found >/dev/null 2>&1 || status=1
+    fi
+    kind_lifecycle_cleanup "$kind_name" "$kubeconfig" || status=1
+  fi
+  if (( image_built )); then
+    docker image rm "$image" >/dev/null 2>&1 || status=1
+    if docker image inspect "$image" >/dev/null 2>&1; then
+      echo "integration-test: built image tag still exists after cleanup: $image" >&2
+      status=1
+    fi
+    if [ -n "${image_id:-}" ] && docker image inspect "$image_id" >/dev/null 2>&1; then
+      echo "integration-test: built image ID still exists after cleanup: $image_id" >&2
+      status=1
+    fi
+  fi
+  if (( fixture_image_built )); then
+    docker image rm "$fixture_image" >/dev/null 2>&1 || status=1
+    if docker image inspect "$fixture_image" >/dev/null 2>&1; then
+      echo "integration-test: fixture image tag still exists after cleanup: $fixture_image" >&2
+      status=1
+    fi
+    if [ -n "${fixture_image_id:-}" ] && docker image inspect "$fixture_image_id" >/dev/null 2>&1; then
+      echo "integration-test: fixture image ID still exists after cleanup: $fixture_image_id" >&2
+      status=1
+    fi
+  fi
+  rm -rf -- "$fixture_dir"
+  [[ ! -e "$fixture_dir" ]] || status=1
+  exit "$status"
+}
+trap cleanup EXIT
+
+for command in docker kind kubectl go openssl jq; do
+  command -v "$command" >/dev/null 2>&1 || fail "required tool '$command' is unavailable; install it (integration proof does not skip)"
+done
+docker info >/dev/null 2>&1 || fail "Docker daemon is unavailable"
+
+if [[ -z "${WORKLOAD_DEBUG_IMAGE:-}" ]]; then
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    fail "generated workload-debug image tag already exists: $image"
+  fi
+  image_built=1
+  docker build --pull=false --tag "$image" "$root"
+  image_id=$(docker image inspect --format '{{.Id}}' "$image") || fail "unable to record built image ID"
+else
+  docker image inspect "$image" >/dev/null 2>&1 || fail "WORKLOAD_DEBUG_IMAGE '$image' is not available"
+fi
+
+GOOS=linux CGO_ENABLED=0 go build -trimpath -o "$fixture_dir/fixture-server" "$root/tests/fixture-server.go"
+
+# The fixture must reject an arbitrary token-file path rather than following
+# an environment-controlled path outside its fixed Secret mount.
+if EXPECTED_AUTH_TOKEN_FILE="$fixture_dir/../outside-token" \
+  "$fixture_dir/fixture-server" --mode=http --listen=127.0.0.1:0 >/dev/null 2>&1; then
+  fail "HTTP fixture accepted a token-file traversal path"
+fi
+
+cat >"$fixture_dir/Dockerfile" <<'EOF'
+FROM scratch
+COPY fixture-server /fixture-server
+USER 65532:65532
+ENTRYPOINT ["/fixture-server"]
+EOF
+if docker image inspect "$fixture_image" >/dev/null 2>&1; then
+  fail "generated fixture image tag already exists: $fixture_image"
+fi
+fixture_image_built=1
+docker build --pull=false --tag "$fixture_image" "$fixture_dir"
+fixture_image_id=$(docker image inspect --format '{{.Id}}' "$fixture_image") || fail "unable to record fixture image ID"
+
+kind_lifecycle_create "$kind_name" "$kind_node_image" "$kubeconfig" || \
+  fail "unable to create disposable kind cluster '$kind_name'"
+export KUBECONFIG="$kubeconfig"
+kind load docker-image "$image" --name "$kind_name"
+kind load docker-image "$fixture_image" --name "$kind_name"
+
+kubectl create namespace "$namespace"
+kubectl -n "$namespace" create serviceaccount workload-debug
+kubectl -n "$namespace" create role workload-debug --verb=get --resource=configmaps
+kubectl -n "$namespace" create rolebinding workload-debug --role=workload-debug --serviceaccount="$namespace:workload-debug"
+kubectl -n "$namespace" create configmap fixture-config --from-literal=value=fixture-config-value
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=workload-debug-fixture" \
+  -keyout "$fixture_dir/ca.key" -out "$fixture_dir/ca.crt" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -subj "/CN=tls-fixture" \
+  -keyout "$fixture_dir/server.key" -out "$fixture_dir/server.csr" >/dev/null 2>&1
+openssl x509 -req -days 1 -in "$fixture_dir/server.csr" -CA "$fixture_dir/ca.crt" -CAkey "$fixture_dir/ca.key" \
+  -CAcreateserial -out "$fixture_dir/server.crt" -extfile <(printf 'subjectAltName=DNS:tls-fixture.%s.svc.cluster.local\n' "$namespace") >/dev/null 2>&1
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=wrong-ca" \
+  -keyout "$fixture_dir/wrong.key" -out "$fixture_dir/wrong.crt" >/dev/null 2>&1
+kubectl -n "$namespace" create secret generic tls-fixture --from-file=server.crt="$fixture_dir/server.crt" --from-file=server.key="$fixture_dir/server.key"
+kubectl -n "$namespace" create configmap fixture-ca --from-file=ca.crt="$fixture_dir/ca.crt" --from-file=wrong.crt="$fixture_dir/wrong.crt"
+
+cat >"$fixture_dir/runner.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $runner
+spec:
+  serviceAccountName: workload-debug
+  automountServiceAccountToken: true
+  containers:
+  - name: workload-debug
+    image: $image
+    command: ["/bin/sh", "-c", "exec sleep 600"]
+    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+    volumeMounts: [{name: ca, mountPath: /fixture-ca, readOnly: true}]
+  volumes: [{name: ca, configMap: {name: fixture-ca}}]
+EOF
+# Create the runner first so the HTTP fixture is pinned to this invocation's
+# exact projected token, rather than independently projecting another token.
+kubectl -n "$namespace" apply -f "$fixture_dir/runner.yaml"
+kubectl -n "$namespace" wait --for=condition=Ready pod/$runner --timeout=120s
+
+runner_token_file="$fixture_dir/runner-token"
+(umask 077; kubectl -n "$namespace" exec "$runner" -- /bin/sh -c \
+  'cat /var/run/secrets/kubernetes.io/serviceaccount/token' >"$runner_token_file")
+chmod 600 "$runner_token_file"
+[[ -s "$runner_token_file" ]] || fail "runner service-account token is empty"
+auth_secret_name=http-fixture-auth
+kubectl -n "$namespace" create secret generic "$auth_secret_name" --from-file=token="$runner_token_file"
+auth_secret_created=1
+
+cat >"$fixture_dir/fixtures.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-fixture
+  labels: {app: http-fixture}
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - name: fixture
+    image: $fixture_image
+    args: ["--mode=http", "--listen=:8080"]
+    env:
+    - name: EXPECTED_AUTH_TOKEN_FILE
+      value: /var/run/secrets/workload-debug/token
+    volumeMounts:
+    - name: auth-token
+      mountPath: /var/run/secrets/workload-debug
+      readOnly: true
+    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+  securityContext:
+    fsGroup: 65532
+    fsGroupChangePolicy: OnRootMismatch
+  volumes:
+  - name: auth-token
+    secret:
+      secretName: $auth_secret_name
+      defaultMode: 0440
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-fixture
+spec:
+  selector: {app: http-fixture}
+  ports: [{name: http, port: 8080, targetPort: 8080}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tls-fixture
+  labels: {app: tls-fixture}
+spec:
+  containers:
+  - name: fixture
+    image: $fixture_image
+    args: ["--mode=tls", "--listen=:8443", "--cert=/tls/server.crt", "--key=/tls/server.key"]
+    volumeMounts: [{name: tls, mountPath: /tls, readOnly: true}]
+    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+  volumes: [{name: tls, secret: {secretName: tls-fixture}}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-fixture
+spec:
+  selector: {app: tls-fixture}
+  ports: [{name: https, port: 8443, targetPort: 8443}]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-fixture
+  labels: {app: dns-fixture}
+spec:
+  containers:
+  - name: fixture
+    image: $fixture_image
+    args: ["--mode=dns", "--listen=:5353", "--name=$dns_fixture_name", "--address=203.0.113.7"]
+    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-fixture
+spec:
+  selector: {app: dns-fixture}
+  ports: [{name: dns, port: 5353, targetPort: 5353, protocol: UDP}]
+EOF
+# All namespaced fixtures, including the runner's ConfigMap volume, belong to
+# the same namespace as the service account created above.
+kubectl -n "$namespace" apply -f "$fixture_dir/fixtures.yaml"
+kubectl -n "$namespace" wait --for=condition=Ready pod/http-fixture pod/tls-fixture pod/dns-fixture --timeout=120s
+
+security=$(kubectl -n "$namespace" get pod "$runner" -o json | jq -c '.spec.containers[0].securityContext')
+[[ "$(jq -r '.runAsUser' <<<"$security")" == 65532 ]] || fail "runner is not UID 65532"
+[[ "$(jq -r '.readOnlyRootFilesystem' <<<"$security")" == true ]] || fail "runner is writable"
+[[ "$(jq -r '.allowPrivilegeEscalation' <<<"$security")" == false ]] || fail "privilege escalation is enabled"
+[[ "$(jq -c '.capabilities' <<<"$security")" == '{"drop":["ALL"]}' ]] || fail "runner capabilities are not dropped"
+if run_target "touch /runtime-write" >/dev/null 2>&1; then fail "read-only runner allowed a filesystem write"; fi
+
+http_security=$(kubectl -n "$namespace" get pod http-fixture -o json)
+[[ "$(jq -r '.spec.automountServiceAccountToken' <<<"$http_security")" == false ]] || fail "HTTP fixture has a service-account token"
+[[ "$(jq -r '.spec.securityContext.fsGroup' <<<"$http_security")" == 65532 ]] || fail "HTTP fixture Secret group is not restricted"
+[[ "$(jq -r '.spec.securityContext.fsGroupChangePolicy' <<<"$http_security")" == OnRootMismatch ]] || fail "HTTP fixture Secret group policy is not bounded"
+[[ "$(jq -r '.spec.containers[0].securityContext.runAsUser' <<<"$http_security")" == 65532 ]] || fail "HTTP fixture is not UID 65532"
+[[ "$(jq -r '.spec.containers[0].securityContext.readOnlyRootFilesystem' <<<"$http_security")" == true ]] || fail "HTTP fixture is writable"
+[[ "$(jq -r '.spec.containers[0].volumeMounts[] | select(.name == "auth-token") | .readOnly' <<<"$http_security")" == true ]] || fail "HTTP fixture Secret mount is writable"
+[[ "$(jq -r '.spec.volumes[] | select(.name == "auth-token") | .secret.defaultMode' <<<"$http_security")" == 288 ]] || fail "HTTP fixture Secret mode is not 0440"
+
+dns_ready=0
+dns_output=
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  if dns_output=$(run_target "debug-dns --server '$dns_server' '$dns_fixture_name'" 2>/dev/null); then
+    dns_ready=1
+    break
+  fi
+  sleep 1
+done
+[[ "$dns_ready" -eq 1 ]] || fail "DNS fixture did not become reachable from the runner"
+assert_contains "$dns_output" "203.0.113.7"
+run_target "debug-tls --ca /fixture-ca/ca.crt '$tls_endpoint'" >/dev/null
+if run_target "debug-tls --ca /fixture-ca/wrong.crt '$tls_endpoint'" >/dev/null 2>&1; then fail "wrong TLS CA was accepted"; fi
+if run_target "debug-tls --timeout 1 'tls-fixture.$namespace.svc.cluster.local:1'" >/dev/null 2>&1; then fail "unavailable TLS endpoint was accepted"; fi
+
+http_ready=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  if run_target "curl --silent --show-error --fail --max-time 2 '$http_url/get'" >/dev/null 2>&1; then
+    http_ready=1
+    break
+  fi
+  sleep 1
+done
+[[ "$http_ready" -eq 1 ]] || fail "HTTP fixture did not become reachable from the runner"
+http_output=
+http_attempt=0
+while [ "$http_attempt" -lt 5 ]; do
+  if http_output=$(run_target "debug-http --method GET --timeout 3 '$http_url/get'"); then break; fi
+  http_attempt=$((http_attempt + 1))
+  sleep 1
+done
+[[ "$http_attempt" -lt 5 ]] || fail "HTTP helper could not read the reachable fixture"
+assert_contains "$http_output" "fixture-get"
+run_target "debug-http --method HEAD '$http_url/head'" >/dev/null
+run_target "debug-http --method OPTIONS '$http_url/get'" >/dev/null
+redirect=$(run_target "debug-http --method GET '$http_url/redirect'")
+assert_contains "$redirect" "HTTP/1.1 302"
+if run_target "WORKLOAD_DEBUG_MAX_BYTES=64 debug-http --method GET '$http_url/large'" >/dev/null 2>&1; then fail "large response exceeded max-bytes"; fi
+if run_target "WORKLOAD_DEBUG_MAX_BYTES=64 debug-http --method GET '$http_url/chunked'" >/dev/null 2>&1; then fail "chunked response exceeded max-bytes"; fi
+oversized_headers_output="$fixture_dir/oversized-headers.out"
+if run_target "WORKLOAD_DEBUG_MAX_BYTES=64 debug-http --method GET '$http_url/oversized-headers'" >"$oversized_headers_output" 2>/dev/null; then
+  fail "oversized response headers were accepted"
+fi
+[[ ! -s "$oversized_headers_output" ]] || fail "oversized response headers were emitted"
+if run_target "debug-http --method GET --timeout 1 '$http_url/slow'" >/dev/null 2>&1; then fail "slow response exceeded timeout"; fi
+if run_target "debug-http --method POST '$http_url/get'" >/dev/null 2>&1; then fail "unsupported method was accepted"; fi
+if run_target "debug-http --method GET '$http_url/missing'" >/dev/null 2>&1; then fail "404 response was accepted"; fi
+if run_target "debug-http --method GET '$http_url/unknown'" >/dev/null 2>&1; then fail "unknown fixture path was accepted"; fi
+
+kube_path="/api/v1/namespaces/$namespace/configmaps/fixture-config"
+token=$(<"$runner_token_file")
+kube_output=$(run_target "debug-kube-api '$kube_path'")
+assert_contains "$kube_output" "fixture-config-value"
+if run_target "debug-kube-api '/api/v1/namespaces/$namespace/secrets/$auth_secret_name'" >/dev/null 2>&1; then
+  fail "runner service account can read the HTTP fixture Secret"
+fi
+
+# The fixture validates the exact projected service-account token, rather than
+# merely checking that some Authorization header exists. The successful body
+# proves that debug-kube-api supplied the real bearer credential.
+kube_auth_output=$(run_target "debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth")
+assert_contains "$kube_auth_output" "authenticated"
+assert_not_contains "$kube_auth_output" "$token"
+
+# The token-authenticated branch must use the same bounded streaming path as
+# unauthenticated requests. The fixture requires an Authorization header and
+# deliberately sends an unknown-length chunked response, so a direct curl
+# invocation would both authenticate successfully and exceed the limit.
+kube_chunked_output="$fixture_dir/kube-chunked.out"
+kube_chunked_error="$fixture_dir/kube-chunked.err"
+if kubectl --kubeconfig "$kubeconfig" -n "$namespace" exec "$runner" -- /bin/sh -c \
+  "WORKLOAD_DEBUG_MAX_BYTES=64 debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth-chunked" \
+  >"$kube_chunked_output" 2>"$kube_chunked_error"; then
+  fail "token-authenticated chunked response exceeded max-bytes"
+fi
+chunked_output_bytes=$(wc -c <"$kube_chunked_output")
+if [[ "$chunked_output_bytes" -le 64 || "$chunked_output_bytes" -ge 1024 ]]; then
+  fail "token-authenticated chunked output was not bounded: $chunked_output_bytes bytes"
+fi
+assert_contains "$(cat "$kube_chunked_output")" "HTTP/1.1 200 OK"
+
+kube_oversized_output="$fixture_dir/kube-oversized-headers.out"
+if kubectl --kubeconfig "$kubeconfig" -n "$namespace" exec "$runner" -- /bin/sh -c \
+  "WORKLOAD_DEBUG_MAX_BYTES=64 debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth-oversized-headers" \
+  >"$kube_oversized_output" 2>/dev/null; then
+  fail "token-authenticated oversized response headers were accepted"
+fi
+[[ ! -s "$kube_oversized_output" ]] || fail "token-authenticated oversized response headers were emitted"
+
+report_a=$(run_target "debug-report --json --dns '$dns_fixture_name' --dns-server '$dns_server' --tls '$tls_endpoint' --tls-ca /fixture-ca/ca.crt --http '$http_url/get' --kube '$kube_path'")
+report_b=$(run_target "debug-report --json --dns '$dns_fixture_name' --dns-server '$dns_server' --tls '$tls_endpoint' --tls-ca /fixture-ca/ca.crt --http '$http_url/get' --kube '$kube_path'")
+[[ "$report_a" == "$report_b" ]] || fail "readiness report is not deterministic"
+[[ "$(jq -r '.status' <<<"$report_a")" == ready ]] || fail "successful report is not ready"
+[[ "$(jq -r '.checks_failed' <<<"$report_a")" == 0 ]] || fail "successful report has failures"
+[[ "$(jq '.checks | length' <<<"$report_a")" == 4 ]] || fail "report check count changed"
+[[ "$(jq '[.checks[].success] | all' <<<"$report_a")" == true ]] || fail "report has unsuccessful check"
+failed_report=$(run_target "debug-report --json --http '$http_url/missing'")
+[[ "$(jq -r '.status' <<<"$failed_report")" == not-ready ]] || fail "failed report is not not-ready"
+[[ "$(jq -r '.checks_failed' <<<"$failed_report")" == 1 ]] || fail "failed report count is wrong"
+
+secret_probe=$(kubectl -n "$namespace" exec "$runner" -- /bin/sh -c "WORKLOAD_DEBUG_TIMEOUT=5 debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth-chunked >/dev/null 2>/tmp/auth-stderr & p=\$!; observed=0; for _ in 1 2 3 4 5 6 7 8 9 10; do if kill -0 \$p 2>/dev/null; then observed=1; tr '\\000' ' ' < /proc/\$p/cmdline; fi; sleep .2; done; wait \$p || true; cat /tmp/auth-stderr; rm -f /tmp/auth-stderr; [ \$observed -eq 1 ] || { echo 'could not observe helper process' >&2; exit 1; }")
+assert_not_contains "$secret_probe" "$token"
+logs=$(kubectl -n "$namespace" logs "$runner")
+assert_not_contains "$logs" "$token"
+echo "workload-debug integration proof passed"

--- a/utils/workload-debug/tests/test_integration.sh
+++ b/utils/workload-debug/tests/test_integration.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 root=$(cd -- "$(dirname "$0")/.." && pwd)
 # shellcheck disable=SC1091
 source "$root/tests/kind-lifecycle.sh"
-image=${WORKLOAD_DEBUG_IMAGE:-workload-debug:integration-$$}
+image=${WORKLOAD_DEBUG_IMAGE:-ghcr.io/telekom/k8s-breakglass/utils/workload-debug:integration-$$}
 fixture_image=workload-debug-fixture:integration-$$
 fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/workload-debug.XXXXXX")
 kind_name=workload-debug-$$

--- a/utils/workload-debug/tests/test_integration.sh
+++ b/utils/workload-debug/tests/test_integration.sh
@@ -125,6 +125,7 @@ kubectl -n "$namespace" create serviceaccount workload-debug
 kubectl -n "$namespace" create role workload-debug --verb=get --resource=configmaps
 kubectl -n "$namespace" create rolebinding workload-debug --role=workload-debug --serviceaccount="$namespace:workload-debug"
 kubectl -n "$namespace" create configmap fixture-config --from-literal=value=fixture-config-value
+kubectl -n "$namespace" create configmap internal-runbook --from-literal=INDEX.md='internal runbook fixture'
 
 openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj "/CN=workload-debug-fixture" \
   -keyout "$fixture_dir/ca.key" -out "$fixture_dir/ca.crt" >/dev/null 2>&1
@@ -149,9 +150,17 @@ spec:
   - name: workload-debug
     image: $image
     command: ["/bin/sh", "-c", "exec sleep 600"]
-    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
-    volumeMounts: [{name: ca, mountPath: /fixture-ca, readOnly: true}]
-  volumes: [{name: ca, configMap: {name: fixture-ca}}]
+    securityContext: {runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}, seccompProfile: {type: RuntimeDefault}}
+    volumeMounts:
+    - {name: ca, mountPath: /fixture-ca, readOnly: true}
+    - {name: ephemeral, mountPath: /workload-debug-tmp}
+    - {name: internal-runbooks, mountPath: /usr/share/breakglass/runbooks/internal, readOnly: true}
+  volumes:
+  - {name: ca, configMap: {name: fixture-ca}}
+  - name: ephemeral
+    emptyDir: {medium: Memory, sizeLimit: 1Mi}
+  - name: internal-runbooks
+    configMap: {name: internal-runbook, defaultMode: 0444}
 EOF
 # Create the runner first so the HTTP fixture is pinned to this invocation's
 # exact projected token, rather than independently projecting another token.
@@ -256,7 +265,10 @@ security=$(kubectl -n "$namespace" get pod "$runner" -o json | jq -c '.spec.cont
 [[ "$(jq -r '.readOnlyRootFilesystem' <<<"$security")" == true ]] || fail "runner is writable"
 [[ "$(jq -r '.allowPrivilegeEscalation' <<<"$security")" == false ]] || fail "privilege escalation is enabled"
 [[ "$(jq -c '.capabilities' <<<"$security")" == '{"drop":["ALL"]}' ]] || fail "runner capabilities are not dropped"
+[[ "$(jq -r '.seccompProfile.type' <<<"$security")" == RuntimeDefault ]] || fail "runner does not use RuntimeDefault seccomp"
 if run_target "touch /runtime-write" >/dev/null 2>&1; then fail "read-only runner allowed a filesystem write"; fi
+internal_notice=$(run_target "WORKLOAD_DEBUG_MOTD=0 /usr/local/bin/workload-debug-entrypoint /bin/true")
+assert_contains "$internal_notice" '/usr/share/breakglass/runbooks/internal/INDEX.md'
 
 http_security=$(kubectl -n "$namespace" get pod http-fixture -o json)
 [[ "$(jq -r '.spec.automountServiceAccountToken' <<<"$http_security")" == false ]] || fail "HTTP fixture has a service-account token"
@@ -324,6 +336,15 @@ if run_target "debug-kube-api '/api/v1/namespaces/$namespace/secrets/$auth_secre
   fail "runner service account can read the HTTP fixture Secret"
 fi
 
+# An explicitly overridden server must not receive the projected in-cluster
+# token. The authenticated fixture returns 401 when no Authorization header is
+# sent, which proves the request reached it without implicit credentials.
+kube_no_auth_output=
+if kube_no_auth_output=$(run_target "debug-kube-api --server '$http_url' /auth"); then
+  fail "debug-kube-api sent an implicit token to an overridden server"
+fi
+assert_contains "$kube_no_auth_output" "authorization-required"
+
 # The fixture validates the exact projected service-account token, rather than
 # merely checking that some Authorization header exists. The successful body
 # proves that debug-kube-api supplied the real bearer credential.
@@ -367,7 +388,8 @@ failed_report=$(run_target "debug-report --json --http '$http_url/missing'")
 [[ "$(jq -r '.status' <<<"$failed_report")" == not-ready ]] || fail "failed report is not not-ready"
 [[ "$(jq -r '.checks_failed' <<<"$failed_report")" == 1 ]] || fail "failed report count is wrong"
 
-secret_probe=$(kubectl -n "$namespace" exec "$runner" -- /bin/sh -c "WORKLOAD_DEBUG_TIMEOUT=5 debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth-chunked >/dev/null 2>/tmp/auth-stderr & p=\$!; observed=0; for _ in 1 2 3 4 5 6 7 8 9 10; do if kill -0 \$p 2>/dev/null; then observed=1; tr '\\000' ' ' < /proc/\$p/cmdline; fi; sleep .2; done; wait \$p || true; cat /tmp/auth-stderr; rm -f /tmp/auth-stderr; [ \$observed -eq 1 ] || { echo 'could not observe helper process' >&2; exit 1; }")
+secret_probe=$(kubectl -n "$namespace" exec "$runner" -- /bin/sh -c "TMPDIR=/workload-debug-tmp WORKLOAD_DEBUG_TIMEOUT=5 debug-kube-api --server '$http_url' --token /var/run/secrets/kubernetes.io/serviceaccount/token /auth-chunked >/dev/null 2>/workload-debug-tmp/auth-stderr & p=\$!; observed=0; for _ in 1 2 3 4 5 6 7 8 9 10; do if kill -0 \$p 2>/dev/null; then observed=1; tr '\\000' ' ' < /proc/\$p/cmdline; fi; sleep .2; done; wait \$p || { echo 'authenticated helper failed' >&2; exit 1; }; grep -F 'response' /workload-debug-tmp/auth-stderr >/dev/null && { echo 'authenticated helper emitted an unexpected error' >&2; exit 1; } || true; rm -f /workload-debug-tmp/auth-stderr; [ \$observed -eq 1 ] || { echo 'could not observe helper process' >&2; exit 1; }; echo helper-executed")
+assert_contains "$secret_probe" 'helper-executed'
 assert_not_contains "$secret_probe" "$token"
 logs=$(kubectl -n "$namespace" logs "$runner")
 assert_not_contains "$logs" "$token"

--- a/utils/workload-debug/tests/test_kind_lifecycle.sh
+++ b/utils/workload-debug/tests/test_kind_lifecycle.sh
@@ -28,9 +28,11 @@ create)
         esac
     done
     [ -n "$name" ] && [ -n "$kubeconfig" ]
-    if [ "${KIND_CREATE_MODE:-success}" = partial ]; then
+    if [ "${KIND_CREATE_MODE:-success}" = partial ] || [ "${KIND_CREATE_MODE:-success}" = partial-no-kubeconfig ]; then
         printf '%s\n' "$name" >"$state"
-        : >"$kubeconfig"
+        if [ "${KIND_CREATE_MODE:-success}" != partial-no-kubeconfig ]; then
+            : >"$kubeconfig"
+        fi
         exit 42
     fi
     printf '%s\n' "$name" >"$state"
@@ -98,6 +100,31 @@ kind_lifecycle_cleanup partial-owned "$fixture/partial.kubeconfig"
 }
 grep -Fx 'partial-owned' "$KIND_DELETE_LOG" >/dev/null || {
     printf '%s\n' 'owned partial cluster was not deleted' >&2
+    exit 1
+}
+
+# A failed create can register the cluster before writing its kubeconfig. It
+# is still owned by this invocation and must be deleted without that file.
+: >"$KIND_STATE"
+export KIND_CREATE_MODE=partial-no-kubeconfig
+KIND_LIFECYCLE_OWNED=0
+partial_without_config_status=0
+kind_lifecycle_create partial-no-config kind-node:dev "$fixture/no-config.kubeconfig" || partial_without_config_status=$?
+[ "$partial_without_config_status" -eq 42 ] || {
+    printf 'partial no-config create returned status %s, expected 42\n' "$partial_without_config_status" >&2
+    exit 1
+}
+[ "$KIND_LIFECYCLE_OWNED" -eq 1 ] || {
+    printf '%s\n' 'partial cluster without kubeconfig was not marked as owned' >&2
+    exit 1
+}
+kind_lifecycle_cleanup partial-no-config "$fixture/no-config.kubeconfig"
+[ ! -s "$KIND_STATE" ] || {
+    printf '%s\n' 'partial cluster without kubeconfig remained after cleanup' >&2
+    exit 1
+}
+grep -Fx 'partial-no-config' "$KIND_DELETE_LOG" >/dev/null || {
+    printf '%s\n' 'owned partial cluster without kubeconfig was not deleted' >&2
     exit 1
 }
 

--- a/utils/workload-debug/tests/test_kind_lifecycle.sh
+++ b/utils/workload-debug/tests/test_kind_lifecycle.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+set -Eeuo pipefail
+
+root=$(cd -- "$(dirname "$0")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf -- "$fixture"' EXIT HUP INT TERM
+
+cat >"$fixture/kind" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+state=${KIND_STATE:?}
+delete_log=${KIND_DELETE_LOG:?}
+case "${1:-}" in
+get)
+    [ "${2:-}" = clusters ] || exit 2
+    cat "$state"
+    ;;
+create)
+    name=
+    kubeconfig=
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --name) name=$2; shift 2 ;;
+        --kubeconfig) kubeconfig=$2; shift 2 ;;
+        *) shift ;;
+        esac
+    done
+    [ -n "$name" ] && [ -n "$kubeconfig" ]
+    if [ "${KIND_CREATE_MODE:-success}" = partial ]; then
+        printf '%s\n' "$name" >"$state"
+        : >"$kubeconfig"
+        exit 42
+    fi
+    printf '%s\n' "$name" >"$state"
+    : >"$kubeconfig"
+    ;;
+delete)
+    name=
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --name) name=$2; shift 2 ;;
+        *) shift ;;
+        esac
+    done
+    printf '%s\n' "$name" >>"$delete_log"
+    : >"$state"
+    ;;
+*) exit 2 ;;
+esac
+EOF
+chmod +x "$fixture/kind"
+
+# shellcheck disable=SC1091
+source "$root/tests/kind-lifecycle.sh"
+export PATH="$fixture:$PATH"
+export KIND_STATE="$fixture/clusters"
+export KIND_DELETE_LOG="$fixture/deletes"
+: >"$KIND_DELETE_LOG"
+
+# A caller-owned name is rejected during preflight and is never deleted.
+printf '%s\n' caller-owned >"$KIND_STATE"
+KIND_LIFECYCLE_OWNED=0
+collision_status=0
+kind_lifecycle_create caller-owned kind-node:dev "$fixture/caller.kubeconfig" || collision_status=$?
+[ "$collision_status" -eq 3 ] || {
+    printf 'collision returned status %s, expected 3\n' "$collision_status" >&2
+    exit 1
+}
+[ "$KIND_LIFECYCLE_OWNED" -eq 0 ] || {
+    printf '%s\n' 'collision was incorrectly marked as owned' >&2
+    exit 1
+}
+[ ! -s "$KIND_DELETE_LOG" ] || {
+    printf '%s\n' 'caller-owned collision was deleted' >&2
+    exit 1
+}
+
+# A failed create that leaves a cluster is owned and removed by cleanup.
+: >"$KIND_STATE"
+export KIND_CREATE_MODE=partial
+KIND_LIFECYCLE_OWNED=0
+partial_status=0
+kind_lifecycle_create partial-owned kind-node:dev "$fixture/partial.kubeconfig" || partial_status=$?
+[ "$partial_status" -eq 42 ] || {
+    printf 'partial create returned status %s, expected 42\n' "$partial_status" >&2
+    exit 1
+}
+[ "$KIND_LIFECYCLE_OWNED" -eq 1 ] || {
+    printf '%s\n' 'partial cluster was not marked as owned' >&2
+    exit 1
+}
+kind_lifecycle_cleanup partial-owned "$fixture/partial.kubeconfig"
+[ ! -s "$KIND_STATE" ] || {
+    printf '%s\n' 'partial cluster remained after owned cleanup' >&2
+    exit 1
+}
+grep -Fx 'partial-owned' "$KIND_DELETE_LOG" >/dev/null || {
+    printf '%s\n' 'owned partial cluster was not deleted' >&2
+    exit 1
+}
+
+printf '%s\n' 'kind lifecycle ownership tests passed'

--- a/utils/workload-debug/tool-contract.json
+++ b/utils/workload-debug/tool-contract.json
@@ -13,6 +13,8 @@
     "redirects": false,
     "max_timeout_seconds": 300,
     "max_response_bytes": 10485760,
+    "max_diagnostic_output_bytes": 1048576,
+    "default_diagnostic_output_bytes": 65536,
     "implicit_credentials": false,
     "filesystem_writes": false
   },

--- a/utils/workload-debug/tool-contract.json
+++ b/utils/workload-debug/tool-contract.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "intent": "workload-diagnostics",
+  "image_role": "debug-workload",
+  "commands": {
+    "dns": {"binary": "debug-dns", "operations": ["resolve"]},
+    "tls": {"binary": "debug-tls", "operations": ["handshake", "verify"]},
+    "http": {"binary": "debug-http", "operations": ["GET", "HEAD", "OPTIONS"]},
+    "kube-api": {"binary": "debug-kube-api", "operations": ["read-only GET"]},
+    "report": {"binary": "debug-report", "operations": ["summarize"]}
+  },
+  "boundaries": {
+    "redirects": false,
+    "max_timeout_seconds": 300,
+    "max_response_bytes": 10485760,
+    "implicit_credentials": false,
+    "filesystem_writes": false
+  },
+  "report": {
+    "schema_version": 1,
+    "statuses": ["ready", "not-ready"],
+    "deterministic": true,
+    "lifecycle": ["one-time", "post-upgrade"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a standalone `workload-debug` image for short-lived workload diagnostics. It provides bounded helpers for DNS, TLS, HTTP, read-only Kubernetes API requests, and deterministic readiness reports while remaining usable as an interactive non-root toolbox.

## Security and lifecycle contract

- Runs as UID/GID 65532 with a read-only root filesystem, `RuntimeDefault` seccomp, no privilege escalation, and all capabilities dropped.
- HTTP and Kubernetes API helpers accept only `GET`, `HEAD`, and `OPTIONS`, do not follow redirects, and bound time, headers, bodies, and temporary storage.
- An overridden API server never receives the projected service-account token unless the caller explicitly supplies `--token`.
- Authentication material is kept out of process arguments and removed on every exit path.
- The interactive shell can invoke packaged tools directly, so helper allowlists are not an authorization boundary. Provider-owned RBAC, NetworkPolicy, immutable runtime fields, credentials, and session lifetime must enforce the selected intent.
- Generic runbooks ship under `/usr/share/breakglass/runbooks/upstream/workload-debug`.
- A deployment may mount one digest-pinned documentation bundle read-only at `/usr/share/breakglass/runbooks/internal`, without `subPath`; bundle content is never sourced or executed.

## Behavioral verification

- Fast helper and Kind lifecycle ownership tests.
- ShellCheck, Hadolint, REUSE compliance, workflow parsing, and diff validation.
- Full disposable Kind proof using real DNS, TLS, HTTP, Kubernetes API, projected-token, RBAC-denial, output-bound, timeout, read-only filesystem, mounted-runbook, and cleanup behavior.
- The integration suite proves exact projected-token authentication, no implicit token forwarding to another server, token absence from process arguments and logs, and removal of the owned Kind cluster and image fixtures.

## Limitations

This image does not grant access by itself. Kubernetes API operations remain limited by the session ServiceAccount, and network probes remain limited by NetworkPolicy and reachable endpoints. It does not provide host namespaces, packet capture, `pwru`, node repair, storage-class validation, or crashdump collection; those belong to separate intent profiles.

Tracking: TCAAS-1551 / TCAAS-1617.
