### PR TITLE
docs(debug): define OCI runbook bundle contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OCI runbook bundle contract**: Documented the generic, additive contract for
+  mounting signed, digest-pinned documentation bundles into approved debug
+  templates through Kubernetes image volumes. The controller continues to use
+  the built-in runbooks when an optional bundle is absent and leaves capability,
+  signature, and provenance enforcement to the platform admission pipeline.
+
 ## [0.1.0-rc.8] - 2026-08-22
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Complete documentation for the breakglass privilege escalation system.
 - **[BreakglassEscalation](./breakglass-escalation.md)** - Define privilege escalation policies
 - **[BreakglassSession](./breakglass-session.md)** - Active escalation sessions
 - **[Debug Session](./debug-session.md)** - Debug pod deployments and kubectl debug access
+- **[OCI runbook bundles](./runbook-bundle-contract.md)** - Additive, digest-pinned documentation image volumes for debug templates
 - **[Debug Session Cluster Bindings](./debug-session-cluster-binding.md)** - Delegate template access to teams and clusters
 - **[Breakglass user-flow recording](./demos/breakglass-user-flow.md)** - Asciinema demo of denial, approval, API access, and DebugSession
 - **[Extra Deploy Variables](./extra-deploy-variables.md)** - User-provided variables for customizable templates

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -180,6 +180,9 @@ The `templateString` supports all session context variables (`.session`, `.targe
 
 > **Note:** `template` and `templateString` are mutually exclusive. The webhook will reject DebugPodTemplates with both fields set.
 
+For additive operator-owned documentation supplied through a digest-pinned
+OCI image volume, see the [OCI runbook bundle contract](./runbook-bundle-contract.md).
+
 #### Multi-Document YAML in Pod Templates
 
 When using `templateString`, you can use multi-document YAML (documents separated by `---`) to define the PodSpec AND additional supporting Kubernetes resources that should be created alongside the debug pod.

--- a/docs/runbook-bundle-contract.md
+++ b/docs/runbook-bundle-contract.md
@@ -1,0 +1,186 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# OCI runbook bundles
+
+This document defines the portable contract for adding operator-owned runbooks
+to a Breakglass debug utility pod. It is deliberately independent of a
+registry, a platform distribution, or a particular utility image. A platform
+may use it to publish a more detailed, internal runbook bundle without
+changing the upstream utility image.
+
+## Two documentation trees
+
+Every utility image should ship generic documentation at
+`/usr/share/breakglass/runbooks/upstream`. An approved platform may add an
+OCI artifact as a Kubernetes [image volume][k8s-image-volume], mounted
+read-only at `/usr/share/breakglass/runbooks/internal`.
+
+The two trees are additive. The internal tree may provide more detailed
+operational context, but it must not replace or override the upstream
+description of commands, security boundaries, required capabilities, limits,
+or cleanup. Utilities and entrypoints MUST NOT source, execute, or dynamically
+load files from either tree. A missing internal tree therefore leaves the
+generic workflow usable.
+
+The mount is intentionally at the bundle root. Consumers MUST NOT use
+`subPath`, user-provided mount paths, or a writable mount. The controller does
+not copy the bundle into a writable volume and does not interpret its files as
+configuration.
+
+## `bundle.yaml`
+
+The artifact root MUST contain `bundle.yaml` and `INDEX.md`. `bundle.yaml` is
+metadata, not executable configuration. The following schema is normative;
+unknown fields SHOULD be rejected by the publishing pipeline so typos cannot
+silently change the contract:
+
+The machine-readable form is [`runbook-bundle.schema.yaml`](./runbook-bundle.schema.yaml).
+It is a JSON Schema document represented as YAML so it can be consumed by
+standard JSON Schema tooling after YAML parsing.
+
+```yaml
+schema: breakglass.runbook/v1
+intent: network-diagnostics
+version: 2026.08.0
+image:
+  name: example/network-debug
+  digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  architectures:
+    - amd64
+    - arm64
+compatibility:
+  kubernetes: ">=1.36.0"
+  utility: network-debug
+  utilityVersions: ["1.x"]
+index:
+  - id: network-overview
+    title: Network overview
+    path: runbooks/network-overview.md
+    summary: Collect bounded, read-only network evidence.
+    security: No host namespaces, credentials, or network mutation.
+source:
+  repository: https://example.invalid/operations/runbooks
+  revision: 0123456789abcdef0123456789abcdef01234567
+  generatedAt: "2026-08-01T12:00:00Z"
+```
+
+Required fields are `schema`, `intent`, `version`, `image.name`,
+`image.digest`, `compatibility`, `index`, and `source`. `image.digest` MUST be
+an OCI manifest digest (`sha256:` followed by exactly 64 hexadecimal digits),
+not a tag or a layer digest. `version` is the bundle version and `source` is
+the provenance of the content; neither grants access or changes the image
+being run.
+
+`intent` names the diagnostic outcome, for example `workload-diagnostics`,
+`network-diagnostics`, `storage-diagnostics`, or
+`diagnostic-artifact-collection`. It is an inventory key, not an RBAC role.
+The same intent can have several bundle versions, but one selected
+DebugSession must use one complete bundle and one utility image digest.
+
+Each `index[].path` MUST be relative to the artifact root, use `/` as its
+separator, and resolve to a regular UTF-8 Markdown file. Paths MUST NOT be
+absolute, contain `..`, or point through symlinks. `INDEX.md` MUST link to all
+entries and identify the intent, bundle version, utility image digest, source
+revision, prerequisites, limits, evidence, security boundary, failure modes,
+and cleanup procedure. The source repository and revision are informational
+provenance and must not be fetched at runtime.
+
+Bundles contain documentation and data only. They MUST NOT contain scripts,
+ELF or other binaries, credentials, tokens, private keys, certificates with
+private material, setuid/setgid files, device nodes, sockets, or symlinks.
+Publishing CI should inspect the assembled artifact, validate the schema and
+paths, generate an SBOM and provenance attestation, and sign the immutable OCI
+manifest. Admission policy should verify the signature and attestations before
+allowing the reference in a debug workload.
+
+## DebugPodTemplate usage
+
+The upstream API already carries the Kubernetes `corev1.Volume` and
+`VolumeMount` structures through `DebugPodTemplate`. An administrator-owned
+template can use the image volume as follows (the digest below is illustrative
+and must be replaced by the reviewed bundle digest):
+
+```yaml
+apiVersion: breakglass.t-caas.telekom.com/v1alpha1
+kind: DebugPodTemplate
+metadata:
+  name: network-diagnostics
+spec:
+  template:
+    spec:
+      containers:
+        - name: debug
+          image: example/network-debug@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: internal-runbooks
+              mountPath: /usr/share/breakglass/runbooks/internal
+              readOnly: true
+      volumes:
+        - name: internal-runbooks
+          image:
+            reference: example/runbooks/network-diagnostics@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            pullPolicy: IfNotPresent
+```
+
+The template owner, not the session requester, chooses the reference, volume
+name, and mount path. A platform may generate this part of the template from
+its own profile catalogue, but user variables MUST NOT control any of these
+values. The image reference must be allowlisted, digest-pinned, signed, and
+available to the target nodes using the normal image-pull-secret mechanism.
+
+`IfNotPresent` is appropriate for an immutable digest and allows nodes to use
+their cached copy. `Always` is also valid when the platform requires a fresh
+signature check at every pod start. Mutable tags are not valid for a runbook
+bundle. The volume is read-only by Kubernetes; callers must still use a
+read-only `volumeMount` and a read-only security context.
+
+Image volumes are resolved by the target kubelet and runtime, not by the
+Breakglass controller. The target cluster must support the ImageVolume API,
+its kubelet and CRI must support image volumes, and registry credentials and
+egress must be configured. The controller or platform integration MUST fail
+closed when the capability is explicitly required: it must not silently omit
+the internal bundle or replace it with an init-container copy. Clusters where
+the capability is unavailable may run the built-in upstream documentation
+only, if the selected profile declares the internal bundle optional.
+
+The Kubernetes image-volume cache can remain on a node after a Pod is deleted.
+Session cleanup deletes the Pod and its owned resources; it does not promise
+node cache eviction. Consequently bundles must never contain secrets or
+incident evidence. Pull failures surface as Pod startup failures and are
+handled as an unmet prerequisite, not as a successful run with reduced docs.
+
+## Review and test requirements
+
+The publishing and platform pipelines should prove behavior, not just inspect
+YAML strings:
+
+1. Build the bundle as an OCI artifact, inspect its manifest digest, verify its
+   signature, SBOM, provenance, schema, paths, file modes, and absence of
+   executable or secret material.
+2. Render the administrator-owned DebugPodTemplate and create it in a cluster
+   with image-volume support. Start a disposable debug Pod using a local
+   registry fixture and verify that `bundle.yaml`, `INDEX.md`, and an indexed
+   document are readable by the utility's runtime UID.
+3. Verify the mount is read-only by attempting a write and checking the
+   operation is rejected. Verify the utility still runs its built-in command
+   when no internal volume is selected.
+4. Delete the DebugSession and verify the Pod and session-owned resources are
+   gone. Record separately that node-local image cache eviction is outside the
+   session cleanup contract.
+5. Exercise negative cases: tag references, unapproved registries, missing
+   digests, invalid paths, duplicate index IDs, unsupported cluster
+   capability, failed pulls, and signature/provenance failures must all fail
+   closed for a required bundle.
+
+The Breakglass controller does not verify OCI signatures itself and does not
+claim support for image volumes on clusters whose Kubernetes components lack
+the feature. Those checks belong to the platform admission and release
+pipeline, while this document defines the interface they must implement.
+
+[k8s-image-volume]: https://kubernetes.io/docs/concepts/storage/volumes/#image

--- a/docs/runbook-bundle-contract.md
+++ b/docs/runbook-bundle-contract.md
@@ -13,8 +13,8 @@ changing the upstream utility image.
 
 ## Two documentation trees
 
-Every utility image should ship generic documentation at
-`/usr/share/breakglass/runbooks/upstream`. An approved platform may add an
+Every utility image should ship generic documentation below
+`/usr/share/breakglass/runbooks/upstream/<utility-or-intent>`. An approved platform may add an
 OCI artifact as a Kubernetes [image volume][k8s-image-volume], mounted
 read-only at `/usr/share/breakglass/runbooks/internal`.
 
@@ -135,10 +135,25 @@ values. The image reference must be allowlisted, digest-pinned, signed, and
 available to the target nodes using the normal image-pull-secret mechanism.
 
 `IfNotPresent` is appropriate for an immutable digest and allows nodes to use
-their cached copy. `Always` is also valid when the platform requires a fresh
-signature check at every pod start. Mutable tags are not valid for a runbook
-bundle. The volume is read-only by Kubernetes; callers must still use a
-read-only `volumeMount` and a read-only security context.
+their cached copy. `Always` is also valid when the platform accepts registry
+availability as a startup dependency. `Never` and mutable tags are not valid
+for a production runbook bundle. The volume is read-only by Kubernetes;
+callers must still use a read-only `volumeMount` and a read-only security
+context. `AlwaysPullImages` applies to image volumes too.
+
+Image-volume support depends on the cluster version and components:
+
+| Kubernetes version | Required platform decision |
+| --- | --- |
+| Before 1.31 | Unsupported; omit the optional bundle. |
+| 1.31–1.34 | Enable the `ImageVolume` feature gate on the API server and every eligible kubelet, and prove CRI support before selecting the bundle. |
+| 1.35 | The beta feature is enabled by default; still prove the actual kubelet/runtime path. |
+| 1.36 and later | The API is GA and always enabled; CRI support and registry access remain prerequisites. |
+
+`subPath` is intentionally excluded even where the cluster version supports
+it. Do not depend on image-volume digest reporting in Pod status; that is a
+separate feature and the immutable reference in the administrator-owned
+template remains the source of truth.
 
 Image volumes are resolved by the target kubelet and runtime, not by the
 Breakglass controller. The target cluster must support the ImageVolume API,
@@ -152,7 +167,9 @@ only, if the selected profile declares the internal bundle optional.
 The Kubernetes image-volume cache can remain on a node after a Pod is deleted.
 Session cleanup deletes the Pod and its owned resources; it does not promise
 node cache eviction. Consequently bundles must never contain secrets or
-incident evidence. Pull failures surface as Pod startup failures and are
+incident evidence. Image-volume mounts cannot currently be made `noexec`, so
+publishers must reject executable modes and utility images must never execute
+bundle content. Pull failures surface as Pod startup failures and are
 handled as an unmet prerequisite, not as a successful run with reduced docs.
 
 ## Review and test requirements
@@ -162,7 +179,9 @@ YAML strings:
 
 1. Build the bundle as an OCI artifact, inspect its manifest digest, verify its
    signature, SBOM, provenance, schema, paths, file modes, and absence of
-   executable or secret material.
+   executable or secret material. Do not assume that an admission rule which
+   verifies container images also examines `volumes[*].image.reference`;
+   release or admission CI must prove that coverage before relying on it.
 2. Render the administrator-owned DebugPodTemplate and create it in a cluster
    with image-volume support. Start a disposable debug Pod using a local
    registry fixture and verify that `bundle.yaml`, `INDEX.md`, and an indexed

--- a/docs/runbook-bundle.schema.yaml
+++ b/docs/runbook-bundle.schema.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# JSON Schema for the OCI runbook bundle.yaml contract. It is YAML so it can be
+# read by the same tooling used for bundle metadata.
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Breakglass OCI runbook bundle
+type: object
+additionalProperties: false
+required:
+  - schema
+  - intent
+  - version
+  - image
+  - compatibility
+  - index
+  - source
+properties:
+  schema:
+    const: breakglass.runbook/v1
+  intent:
+    type: string
+    pattern: '^[a-z][a-z0-9-]{1,62}$'
+  version:
+    type: string
+    minLength: 1
+    maxLength: 128
+  image:
+    type: object
+    additionalProperties: false
+    required: [name, digest]
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 255
+        pattern: '^[a-z0-9]+([._/-][a-z0-9]+)*$'
+      digest:
+        type: string
+        pattern: '^sha256:[0-9a-f]{64}$'
+      architectures:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+          enum: [amd64, arm64, arm, ppc64le, s390x, riscv64]
+  compatibility:
+    type: object
+    additionalProperties: false
+    required: [kubernetes, utility, utilityVersions]
+    properties:
+      kubernetes:
+        type: string
+        minLength: 1
+        maxLength: 128
+      utility:
+        type: string
+        pattern: '^[a-z][a-z0-9-]{1,62}$'
+      utilityVersions:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 128
+  index:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required: [id, title, path, summary, security]
+      properties:
+        id:
+          type: string
+          pattern: '^[a-z][a-z0-9-]{1,62}$'
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        path:
+          type: string
+          pattern: '^(?!/)(?!.*(?:^|/)\.\.(?:/|$))(?!.*\\)(?!.*//)[^\\x00]+$'
+        summary:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        security:
+          type: string
+          minLength: 1
+          maxLength: 2000
+  source:
+    type: object
+    additionalProperties: false
+    required: [repository, revision, generatedAt]
+    properties:
+      repository:
+        type: string
+        format: uri-reference
+        minLength: 1
+        maxLength: 2000
+      revision:
+        type: string
+        pattern: '^[0-9a-f]{40,64}$'
+      generatedAt:
+        type: string
+        format: date-time

--- a/pkg/breakglass/debug/debug_session_reconciler_test.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_test.go
@@ -3862,6 +3862,40 @@ func TestConvertDebugPodSpec(t *testing.T) {
 		assert.Equal(t, "config", spec.Volumes[0].Name)
 	})
 
+	t.Run("preserves an immutable image volume for a runbook bundle", func(t *testing.T) {
+		dps := breakglassv1alpha1.DebugPodSpecInner{
+			Containers: []corev1.Container{
+				{
+					Name:  "debug",
+					Image: "example/network-debug@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "internal-runbooks", MountPath: "/usr/share/breakglass/runbooks/internal", ReadOnly: true},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "internal-runbooks",
+					VolumeSource: corev1.VolumeSource{
+						Image: &corev1.ImageVolumeSource{
+							Reference:  "example/runbooks/network-diagnostics@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+							PullPolicy: corev1.PullIfNotPresent,
+						},
+					},
+				},
+			},
+		}
+
+		spec := ctrl.convertDebugPodSpec(dps)
+		require.Len(t, spec.Volumes, 1)
+		require.NotNil(t, spec.Volumes[0].Image)
+		assert.Equal(t, "example/runbooks/network-diagnostics@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", spec.Volumes[0].Image.Reference)
+		assert.Equal(t, corev1.PullIfNotPresent, spec.Volumes[0].Image.PullPolicy)
+		require.Len(t, spec.Containers[0].VolumeMounts, 1)
+		assert.Equal(t, "/usr/share/breakglass/runbooks/internal", spec.Containers[0].VolumeMounts[0].MountPath)
+		assert.True(t, spec.Containers[0].VolumeMounts[0].ReadOnly)
+	})
+
 	t.Run("converts pod spec with node selector", func(t *testing.T) {
 		dps := breakglassv1alpha1.DebugPodSpecInner{
 			Containers: []corev1.Container{


### PR DESCRIPTION
## Summary

Defines a generic contract for adding deployment-specific documentation to debug utility pods through Kubernetes OCI image volumes, without baking private runbooks into public utility images.

The contract reserves two additive paths:

- generic image-owned documentation below `/usr/share/breakglass/runbooks/upstream/<utility-or-intent>`;
- one optional bundle mounted read-only at `/usr/share/breakglass/runbooks/internal`.

The bundle root contains `bundle.yaml` and `INDEX.md`. A machine-readable JSON Schema defines intent, version, utility-image compatibility, immutable digest, indexed documents, and source metadata.

## Security and compatibility

- The administrator-owned template chooses the bundle reference and mount; session input cannot choose a registry, tag, path, volume, or `subPath`.
- Production references are signed immutable digests. Bundles contain documentation/data only and may not contain credentials, binaries, executable modes, devices, sockets, or symlinks.
- Utilities never source or execute bundle content. Internal guidance supplements and cannot override upstream security limits.
- Unsupported clusters retain built-in generic runbooks; a profile which requires an internal bundle fails closed instead of copying it through an init container.
- Kubernetes 1.31–1.34 requires an explicitly enabled `ImageVolume` gate and compatible kubelets/runtime, 1.35 enables the beta feature by default, and 1.36 makes the API GA. Runtime support and registry access remain prerequisites.
- Session cleanup removes the Pod and mounts but does not claim node image-cache eviction.
- Admission/release tests must prove coverage of `volumes[*].image.reference`; container-image verification must not be assumed to cover image volumes.

See the Kubernetes [image-volume documentation](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).

## Behavioral verification

- `make test`
- `make lint`
- `make verify-docs-snippets`
- REUSE compliance and schema YAML parsing
- controller unit behavior proving the immutable image-volume reference, pull policy, fixed mount path, and read-only flag survive `DebugPodSpec` conversion

The downstream acceptance layer must additionally pull a real digest-pinned bundle, mount it through an image volume, prove its files are read-only and non-executable, reject invalid/unsigned content, and prove session cleanup. This contract PR does not claim that downstream behavior.

## Non-goals

This PR does not publish a bundle, select a private registry, add platform profiles, change CRDs/controllers, or claim that every admission engine already verifies image-volume signatures. Those remain deployment-owned and require real cluster E2E proof.

Tracking: TCAAS-1551 / TCAAS-1609.
