### PR TITLE
test(e2e): make OIDC reload and recovery deterministic

### DIFF
--- a/e2e/api/config_hot_reload_test.go
+++ b/e2e/api/config_hot_reload_test.go
@@ -469,7 +469,11 @@ func TestAPIReloadsDuringLiveTraffic(t *testing.T) {
 		err = helpers.WaitForCondition(ctx, func() (bool, error) {
 			var reloaded breakglassv1alpha1.IdentityProvider
 			if err := cli.Get(ctx, types.NamespacedName{Name: testIDP.Name}, &reloaded); err != nil {
-				return false, err
+				// The API cache/server can transiently reject a read while the
+				// controller is reconciling. Treat that as not-ready and let the
+				// bounded poll retry; WaitForCondition still observes ctx
+				// cancellation and terminates the poll promptly.
+				return false, nil
 			}
 			if reloaded.Status.ObservedGeneration < targetGeneration {
 				return false, nil

--- a/e2e/api/config_hot_reload_test.go
+++ b/e2e/api/config_hot_reload_test.go
@@ -421,44 +421,78 @@ func TestAPIReloadsDuringLiveTraffic(t *testing.T) {
 			return
 		}
 
-		originalClientID := testIDP.Spec.OIDC.ClientID
-		originalExpectedAudience := testIDP.Spec.OIDC.ExpectedAudience
+		originalDisplayName := testIDP.Spec.DisplayName
 
-		// Ensure we restore the original client ID at the end
-		defer func() {
-			// Re-fetch to get latest version to avoid conflict
-			_ = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
-				idp.Spec.OIDC.ClientID = originalClientID
-				idp.Spec.OIDC.ExpectedAudience = originalExpectedAudience
+		// Updating clientID or expectedAudience changes the authentication contract
+		// for the token that drives this test. That cannot prove hot reload under
+		// live traffic: it deliberately makes the in-flight token invalid and then
+		// leaks 401s into the rest of this serial E2E package. DisplayName is still
+		// part of the provider spec, so it causes the real provider reconciler and
+		// its runtime reload path to run without changing the token contract.
+		// Always restore it, including if an assertion below fails, so this test
+		// cannot contaminate subsequent authenticated tests.
+		restored := false
+		t.Cleanup(func() {
+			if restored {
+				return
+			}
+
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cleanupCancel()
+			restoreIDP := &breakglassv1alpha1.IdentityProvider{ObjectMeta: metav1.ObjectMeta{Name: testIDP.Name}}
+			if err := helpers.UpdateWithRetry(cleanupCtx, cli, restoreIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
+				idp.Spec.DisplayName = originalDisplayName
 				return nil
-			})
-		}()
+			}); err != nil {
+				t.Errorf("failed to restore IdentityProvider display name: %v", err)
+			}
+		})
 
 		err = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
-			temporaryClientID := "temporary-client-id-" + helpers.GenerateUniqueName("")
-			idp.Spec.OIDC.ClientID = temporaryClientID
-			idp.Spec.OIDC.ExpectedAudience = temporaryClientID
+			idp.Spec.DisplayName = "E2E reload " + helpers.GenerateUniqueName("")
 			return nil
 		})
 		require.NoError(t, err, "Failed to update test IDP")
 
+		var updatedIDP breakglassv1alpha1.IdentityProvider
+		err = cli.Get(ctx, types.NamespacedName{Name: testIDP.Name}, &updatedIDP)
+		require.NoError(t, err, "Failed to read updated test IDP")
+		targetGeneration := updatedIDP.Generation
+
 		for i := 0; i < 5; i++ {
 			sessions, err := apiClient.ListSessions(ctx)
-			if err != nil {
-				t.Logf("Request %d during update: error=%v", i+1, err)
-			} else {
-				t.Logf("Request %d during update: success, sessions=%d", i+1, len(sessions))
-			}
+			require.NoErrorf(t, err, "request %d during IdentityProvider reload must retain valid authentication", i+1)
+			t.Logf("Request %d during update: success, sessions=%d", i+1, len(sessions))
 			time.Sleep(500 * time.Millisecond)
 		}
 
-		// Explicitly restore (defer will handle it if this fails, but good to be explicit for the test flow)
+		err = helpers.WaitForCondition(ctx, func() (bool, error) {
+			var reloaded breakglassv1alpha1.IdentityProvider
+			if err := cli.Get(ctx, types.NamespacedName{Name: testIDP.Name}, &reloaded); err != nil {
+				return false, err
+			}
+			if reloaded.Status.ObservedGeneration < targetGeneration {
+				return false, nil
+			}
+			for _, condition := range reloaded.Status.Conditions {
+				if condition.Type == string(breakglassv1alpha1.IdentityProviderConditionReady) &&
+					condition.Status == metav1.ConditionTrue &&
+					condition.ObservedGeneration >= targetGeneration {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, helpers.WaitForStateTimeout, 200*time.Millisecond)
+		require.NoError(t, err, "IdentityProvider update was not reconciled after live API traffic")
+
+		// Explicitly restore so the succeeding request verifies the post-reload
+		// state as well. t.Cleanup remains the fail-safe for an earlier failure.
 		err = helpers.UpdateWithRetry(ctx, cli, testIDP, func(idp *breakglassv1alpha1.IdentityProvider) error {
-			idp.Spec.OIDC.ClientID = originalClientID
-			idp.Spec.OIDC.ExpectedAudience = originalExpectedAudience
+			idp.Spec.DisplayName = originalDisplayName
 			return nil
 		})
 		require.NoError(t, err, "Failed to restore test IDP")
+		restored = true
 
 		sessions, err = apiClient.ListSessions(ctx)
 		require.NoError(t, err, "API should work after config update")

--- a/e2e/api/oidc_modes_comprehensive_test.go
+++ b/e2e/api/oidc_modes_comprehensive_test.go
@@ -118,6 +118,61 @@ func waitForClusterConfigNotReady(t *testing.T, ctx context.Context, cli client.
 	return nil //nolint:govet // unreachable
 }
 
+// waitForClusterConfigGenerationCondition proves that the controller reconciled
+// one particular ClusterConfig generation. A plain Ready/NotReady check is not
+// sufficient for recovery tests: a condition from an older generation can make
+// a newly committed spec update look successful (or broken) before the
+// reconciler has seen it.
+func waitForClusterConfigGenerationCondition(
+	t *testing.T,
+	ctx context.Context,
+	cli client.Client,
+	name, namespace string,
+	expectedGeneration int64,
+	expectedReady metav1.ConditionStatus,
+	timeout time.Duration,
+) *breakglassv1alpha1.ClusterConfig {
+	t.Helper()
+
+	var latest breakglassv1alpha1.ClusterConfig
+	var lastGetErr error
+	found := false
+	err := helpers.WaitForCondition(ctx, func() (bool, error) {
+		var observed breakglassv1alpha1.ClusterConfig
+		if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &observed); err != nil {
+			lastGetErr = err
+			return false, nil
+		}
+
+		found = true
+		lastGetErr = nil
+		latest = observed
+		if observed.Generation != expectedGeneration || observed.Status.ObservedGeneration != expectedGeneration {
+			return false, nil
+		}
+
+		for _, condition := range observed.Status.Conditions {
+			if condition.Type == string(breakglassv1alpha1.ClusterConfigConditionReady) &&
+				condition.Status == expectedReady &&
+				condition.ObservedGeneration == expectedGeneration {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, timeout, 200*time.Millisecond)
+	if err != nil {
+		if found {
+			logClusterConfigConditions(t, &latest)
+		} else if lastGetErr != nil {
+			t.Logf("never observed ClusterConfig %s/%s: %v", namespace, name, lastGetErr)
+		}
+		t.Fatalf("timed out waiting for ClusterConfig %s/%s generation %d to report Ready=%s with the same observed generation: %v",
+			namespace, name, expectedGeneration, expectedReady, err)
+	}
+
+	return &latest
+}
+
 // ---------------------------------------------------------------------------
 // setupOIDCContext returns common OIDC-related values used across tests.
 // ---------------------------------------------------------------------------
@@ -649,9 +704,20 @@ func TestOIDC_RecoveryAfterFixingConfig(t *testing.T) {
 	err := cli.Create(ctx, cc)
 	require.NoError(t, err)
 
-	// Wait for not-Ready
-	result := waitForClusterConfigNotReady(t, ctx, cli, ccName, namespace, 60*time.Second)
-	assert.False(t, isClusterConfigReady(result), "CC with wrong secret should not be Ready")
+	// Record the persisted generation before making the negative assertion. A
+	// failed GET or an empty status is not evidence that the bad credential was
+	// processed; require the controller to publish Ready=False for this exact
+	// generation first.
+	var badConfig breakglassv1alpha1.ClusterConfig
+	err = cli.Get(ctx, types.NamespacedName{Name: ccName, Namespace: namespace}, &badConfig)
+	require.NoError(t, err, "bad-secret ClusterConfig must exist before waiting for reconciliation")
+	badGeneration := badConfig.Generation
+	require.Positive(t, badGeneration, "bad-secret ClusterConfig must have a persisted generation")
+
+	result := waitForClusterConfigGenerationCondition(
+		t, ctx, cli, ccName, namespace, badGeneration, metav1.ConditionFalse, 60*time.Second,
+	)
+	assert.False(t, isClusterConfigReady(result), "CC with wrong secret should report Ready=False")
 	t.Log("Step 1: CC is not Ready (expected)")
 
 	// Step 2: Create a correct secret and update the CC to reference it
@@ -675,14 +741,28 @@ func TestOIDC_RecoveryAfterFixingConfig(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	t.Log("Step 2: Updated CC to use correct secret")
 
-	// Step 3: CC should recover and become Ready
-	err = waitForClusterConfigConditionReady(t, ctx, cli, ccName, namespace, 90*time.Second)
-	require.NoError(t, err, "CC should recover after fixing client secret")
+	// Capture the committed resource after the conflict-aware write. This
+	// fences recovery to the successful spec generation rather than accepting a
+	// stale Ready condition left by the failed bad-secret generation.
+	var committed breakglassv1alpha1.ClusterConfig
+	err = cli.Get(ctx, types.NamespacedName{Name: ccName, Namespace: namespace}, &committed)
+	require.NoError(t, err, "failed to read committed ClusterConfig update")
+	committedGeneration := committed.Generation
+	require.Greater(t, committedGeneration, badGeneration, "correct-secret update must create a newer generation")
+	require.NotNil(t, committed.Spec.OIDCAuth.ClientSecretRef, "committed ClusterConfig must retain OIDC client secret reference")
+	require.Equal(t, goodSecretName, committed.Spec.OIDCAuth.ClientSecretRef.Name,
+		"committed ClusterConfig must reference the correct client secret")
+	t.Logf("Step 2: Updated CC to use correct secret at generation %d", committedGeneration)
 
-	recovered := getClusterConfigWithRetry(t, ctx, cli, ccName, namespace)
-	assertClusterConfigReady(t, &recovered)
+	// Step 3: CC must publish Ready=True for the committed update generation.
+	// The helper requires status.observedGeneration and the Ready condition's
+	// observedGeneration to equal that current generation, so stale state cannot
+	// satisfy the recovery proof.
+	recovered := waitForClusterConfigGenerationCondition(
+		t, ctx, cli, ccName, namespace, committedGeneration, metav1.ConditionTrue, 90*time.Second,
+	)
+	assertClusterConfigReady(t, recovered)
 
 	t.Log("=== CC-OIDC-COMP-010: Pass — CC recovered after fix ===")
 }

--- a/e2e/api/oidc_modes_comprehensive_test.go
+++ b/e2e/api/oidc_modes_comprehensive_test.go
@@ -658,17 +658,22 @@ func TestOIDC_RecoveryAfterFixingConfig(t *testing.T) {
 	goodSecretName := helpers.GenerateUniqueName("comp010-good")
 	createClientSecret(t, ctx, cli, cleanup, goodSecretName, namespace, oc.saSecret)
 
-	// Re-fetch and update
+	// The controller records the failed OIDC probe in status after Step 1. That
+	// status write can race a spec update, so apply the desired reference through
+	// the shared conflict-aware helper. The helper re-reads before every retry;
+	// the final Ready assertion below proves the desired configuration—not merely
+	// that an update request happened—was accepted and reconciled.
 	var current breakglassv1alpha1.ClusterConfig
-	err = cli.Get(ctx, types.NamespacedName{Name: ccName, Namespace: namespace}, &current)
-	require.NoError(t, err)
-
-	current.Spec.OIDCAuth.ClientSecretRef = &breakglassv1alpha1.SecretKeyReference{
-		Name:      goodSecretName,
-		Namespace: namespace,
-		Key:       "client-secret",
-	}
-	err = cli.Update(ctx, &current)
+	current.Name = ccName
+	current.Namespace = namespace
+	err = helpers.UpdateWithRetry(ctx, cli, &current, func(updated *breakglassv1alpha1.ClusterConfig) error {
+		updated.Spec.OIDCAuth.ClientSecretRef = &breakglassv1alpha1.SecretKeyReference{
+			Name:      goodSecretName,
+			Namespace: namespace,
+			Key:       "client-secret",
+		}
+		return nil
+	})
 	require.NoError(t, err)
 	t.Log("Step 2: Updated CC to use correct secret")
 


### PR DESCRIPTION
## Outcome

Make the Single-Cluster/OIDC E2E suite prove configuration reload and recovery
without invalidating its own bearer token or accepting stale controller status.
This is a test-correctness fix discovered by the exact-main post-merge run for
#1269; it does not change production code.

Exact signed head: `4497f079a93218eb4cd373f1a6cec4f02d4c3507`.

## Root causes and fixes

| Failure | Root cause | Behavioral correction |
| --- | --- | --- |
| Live-traffic reload returned 401 and contaminated later API tests | The test changed the active IdentityProvider client ID and expected audience, making its own existing token invalid. | Change `spec.displayName`, which still drives the real IdentityProvider reconcile/server reload path without changing the token contract. Require all five in-flight authenticated requests to succeed, require the updated generation to become Ready, and restore through failure-safe cleanup. |
| OIDC recovery hit a resource-version conflict | The test updated ClusterConfig spec while the controller was writing failure status. | Use the repository's bounded conflict-aware update helper. |
| Recovery could false-green on stale Ready state | Existing helpers did not bind Ready to the generation containing the corrected secret. | Require the bad-secret generation to reach observed `Ready=False`, then require a strictly newer persisted generation with the correct secret and exact observed-generation `Ready=True`. Transient GET errors and absent objects remain not-ready and retry within the bounded wait; they are never treated as state evidence. |

## Verification

- All three commits are validly SSH-signed with the repository-configured key and are patch-equivalent after the one-time restack onto current `main` (`b1aaf1392756d57a56ecb786f250bec53068a95a`).
- `make test` passed for the exact final child during independent review.
- The modified E2E package compiles after the generation-fencing child.
- `gofmt` and `git diff --check` pass.
- Independent adversarial review: SAFE for the implementation and state proof.

The real acceptance gate is this exact head's complete upstream CI, especially
Single-Cluster API E2E. No local Kind result is claimed. This PR remains Draft
until every applicable exact-head job and a fresh formal review are clean.

Tracking: TCAAS-1551.
