### PR TITLE
docs: harden PR readiness evidence gate

### DIFF
--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -217,7 +217,10 @@ active `pull_request`, `required_signatures`, `workflows`,
 `required_deployments`, and `code_scanning` rules. The effective ruleset pages
 and classic branch-protection requirements form one inventory: a repository
 with no rulesets but an App-bound classic required check is supported, while a
-repository with neither fails closed. A merge queue,
+repository with neither fails closed. Classic `required_linear_history` and
+every other enabled classic control without an explicit verifier are synthesized
+into that inventory and fail closed with their exact payload; malformed known
+ruleset/classic schemas fail before validation. A merge queue,
 linear-history rule, or any unrecognised active type fails closed with the
 server-provided type/parameters in the error: extend the verifier for that
 type, or remove/replace the rule before using this ready/merge gate. It never
@@ -403,12 +406,19 @@ collect_policy_inventory() {
     "$gate_dir/effective-rules.json" >/dev/null ||
     fail "missing or malformed effective branch rules"
 
-  # A failed request is not evidence that protection is absent. Repositories
-  # using rulesets-only protection need a captured `{}` response produced by a
-  # separate, authenticated 404-aware collector; otherwise stop here.
-  gh_api "repos/$base_repo/branches/$base_ref/protection" \
-    >"$gate_dir/branch-protection.json" ||
-    fail "could not capture branch protection (do not substitute an empty object after an API failure)"
+  # Capture the authenticated HTTP response even when `gh` returns non-zero.
+  # The contract accepts only a final HTTP 200 object or an authenticated 404
+  # (which conclusively means this branch has no classic protection); 401/403,
+  # 5xx, malformed headers/body, and every other status remain fatal.
+  protection_http="$gate_dir/branch-protection.http"
+  if gh_api --include "repos/$base_repo/branches/$base_ref/protection" \
+    >"$protection_http"; then
+    :
+  else
+    : # normalize-branch-protection-http validates the final HTTP status below.
+  fi
+  "$contract" normalize-branch-protection-http "$protection_http" \
+    "$gate_dir/branch-protection.json"
   jq -e 'type == "object"' "$gate_dir/branch-protection.json" >/dev/null ||
     fail "malformed branch protection"
 

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -521,9 +521,11 @@ capture the **entire** evidence set again and compare the two manifests:
 ```bash
 manifest_snapshot() {
   snapshot="$1"
-  # JSON files are canonicalized; every other captured artifact (including
-  # `.http` response evidence) is represented by its SHA-256. The helper
-  # rejects malformed JSON and omits only the manifest it is writing.
+  # JSON files are canonicalized. HTTP responses are parsed and validated,
+  # then represented by final status, stable headers, and canonical body;
+  # GitHub's volatile Date/request-ID/rate-limit transport metadata is
+  # deliberately excluded only after validation. Other artifacts use SHA-256.
+  # The helper omits only the manifest it is writing.
   "$contract" manifest-evidence "$snapshot" "$snapshot/gate.jsonl"
 }
 

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -23,13 +23,17 @@ The comment invokes the coding agent and is not a pull-request review request.
 gh pr edit PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
 ```
 
+For the fail-closed gate below, use the equivalent REST reviewer request with
+the configured bot login because its successful response carries GitHub's
+server `Date` boundary. Do not substitute a local clock or a comment.
+
 Use the known, repository-configured Copilot reviewer login, never a display
 name or similarly named account. The selected review must be the newest review
 from that exact login with all of these properties:
 
 - `state` is `COMMENTED`, not dismissed;
 - `submittedAt` is non-null and provably later than the recorded
-  high-resolution review-request completion time;
+  GitHub server-derived review-request completion time;
 - `commit.oid` equals the captured PR `headRefOid`.
 
 Copilot does not re-review every push unless the repository explicitly
@@ -68,12 +72,13 @@ case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
 gate_root="$(mktemp -d)"
 trap 'rm -rf "$gate_root"' EXIT
 observed="$gate_root/observed.json"
-expected_inventory="${expected_inventory-}"
-ruleset_evidence="${ruleset_evidence-}"
-expected_inventory_validator="${expected_inventory_validator-}"
 copilot_reviewer_login="${copilot_reviewer_login-}"
 : "${copilot_reviewer_login:?set the repository-configured Copilot reviewer login}"
-case "$copilot_reviewer_login" in *[!A-Za-z0-9-]*)
+case "$copilot_reviewer_login" in
+  *'[bot]') copilot_login_core="${copilot_reviewer_login%?????}";;
+  *) copilot_login_core="$copilot_reviewer_login";;
+esac
+case "$copilot_login_core" in ''|*[!A-Za-z0-9-]*|-*|*-)
   fail "invalid Copilot reviewer login";;
 esac
 
@@ -95,6 +100,52 @@ capture_identity() {
   ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr"
 }
 
+# No workstation clock participates in review freshness. GitHub's HTTP Date is
+# the server-derived completion boundary; strict greater-than deliberately
+# rejects same-second review timestamps.
+server_date_to_ns() {
+  command -v ruby >/dev/null || return 1
+  # shellcheck disable=SC2016
+  ruby -r time -e '
+    s = ARGV.fetch(0); t = Time.httpdate(s).utc
+    abort unless t.utc? && s.match?(/\A(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), /)
+    puts (t.to_r * 1_000_000_000).to_i
+  ' "$1"
+}
+
+review_timestamp_to_ns() {
+  command -v ruby >/dev/null || return 1
+  # shellcheck disable=SC2016
+  ruby -r time -e '
+    s = ARGV.fetch(0)
+    abort unless s.match?(/\A\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z\z/)
+    t = Time.iso8601(s).utc; abort unless t.utc?
+    puts (t.to_r * 1_000_000_000).to_i
+  ' "$1"
+}
+
+request_formal_review() {
+  review_request_http="$gate_root/review-request.http"
+  # REST is the formal reviewer API equivalent of `gh pr edit --add-reviewer`.
+  # --include preserves the GitHub server Date header with the successful POST.
+  gh api --include -X POST "repos/$base_repo/pulls/$pr/requested_reviewers" \
+    -f "reviewers[]=$copilot_reviewer_login" >"$review_request_http"
+  request_server_date="$(awk '
+    tolower($1) == "date:" { $1=""; sub(/^[[:space:]]+/, ""); print; exit }
+    /^[[:space:]]*$/ { exit }
+  ' "$review_request_http")"
+  test -n "$request_server_date" || fail "GitHub review request omitted Date"
+  request_server_ns="$(server_date_to_ns "$request_server_date")" ||
+    fail "ambiguous GitHub review-request Date"
+  case "$request_server_ns" in ''|*[!0-9]*)
+    fail "invalid GitHub review-request boundary";;
+  esac
+  jq -n --arg serverDate "$request_server_date" \
+    --arg requestServerNanoseconds "$request_server_ns" \
+    '{serverDate: $serverDate, requestServerNanoseconds: $requestServerNanoseconds}' \
+    >"$gate_root/review-request.json"
+}
+
 # Observe the source/base before requesting a fresh review.
 capture_identity >"$observed"
 jq -e '((.errors // []) | length) == 0 and .data != null and
@@ -103,18 +154,7 @@ jq -e '((.errors // []) | length) == 0 and .data != null and
        .data.repository.pullRequest.baseRefOid and
        .data.repository.pullRequest.headRepository.nameWithOwner' \
   "$observed" >/dev/null || fail "incomplete PR identity"
-
-gh pr edit "$pr" --repo "$base_repo" --add-reviewer @copilot
-request_after_ns="$(date -u +%s%N 2>/dev/null || true)"
-case "$request_after_ns" in *N*|*[!0-9]*)
-  command -v ruby >/dev/null ||
-    fail "no high-resolution UTC clock; re-request/wait rather than guessing freshness"
-  request_after_ns="$(ruby -e \
-    'puts Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)')";;
-esac
-jq -n --arg requestAfterUnixNanoseconds "$request_after_ns" \
-  '{requestAfterUnixNanoseconds: $requestAfterUnixNanoseconds}' \
-  >"$gate_root/review-request.json"
+base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' "$observed")"
 ```
 
 Do not infer a merge-queue commit SHA from `mergeQueueEntry.id`. This workflow
@@ -146,19 +186,18 @@ Capture every page of each connection. A complete snapshot contains:
 | Evidence | Required fields and decision |
 | --- | --- |
 | PR identity | `headRefOid`, `baseRefOid`, head repository/ref, base ref, test-merge SHA, `reviewDecision` |
-| Formal reviews | review ID, configured reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review provably after `request_after_ns` |
+| Formal reviews | review ID, configured reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review strictly after GitHub's `request_server_ns` response boundary |
 | Human approval | `reviewDecision` and current branch-ruleset/code-owner evidence for the pair; Copilot does not satisfy this row |
 | Threads and comments | every thread ID/resolution/outdated state and every comment ID, minimized state/reason, author, path, line, and timestamp |
 | Checks | complete expected inventory, result, `head_sha`, check-suite ID, and `CheckRun.app.owner.login`, `CheckRun.app.slug`, and `CheckRun.app.id` |
-| Legacy statuses | every context, state, target URL, and `creator.login`/`creator.id`; compare to the expected status provider inventory |
+| Legacy statuses | every context, state, target URL, and `creator.login`/`creator.id`; reject a status that attempts to satisfy a required context because GitHub rules do not bind its creator |
 | Check suites | suite ID, `head_sha`, app/provider identity, and each associated PR's repository, head SHA/ref, and base SHA/ref |
 
-Use repository rules/required-workflow configuration as the source of the full
-expected inventory and allowed provider identities. For this task every
-expected job must conclude `SUCCESS`. `NEUTRAL` or `SKIPPED` is acceptable only
-when the current rules explicitly name that exact job and provider as an
-intentional exception; record the rule source and reason. Never silently turn a
-non-success result into a pass.
+Fetch GitHub's effective branch rules and branch-protection object into every
+snapshot. They are the complete expected check/provider inventory: every
+required job must have one exact app ID and conclude `SUCCESS`. The gate rejects
+an empty, partial, legacy-only, or changed inventory; it does not accept a
+caller-provided “expected” list, `NEUTRAL`, or `SKIPPED` as a substitute.
 
 The following commands provide the raw, paginated review/thread/check material.
 Save each response under the gate directory and normalize it with sorted JSON
@@ -199,15 +238,20 @@ jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" '
   [ .[] | .data.repository.pullRequest.reviews.nodes[] |
     select(.author.login == $login) ] |
   if length == 0 then false else max_by(.submittedAt) |
-    (.id != null and .state == "COMMENTED" and .submittedAt != null and
-     .commit.oid == $head)
+    if (.id != null and .state == "COMMENTED" and .submittedAt != null and
+        .commit.oid == $head) then . else false end
   end
-' "$gate_dir/reviews.json" >/dev/null || fail "missing current formal Copilot review"
+' "$gate_dir/reviews.json" >"$gate_dir/copilot-review.json" ||
+  fail "missing current formal Copilot review"
 
-# GitHub review timestamps are normally second-resolution. The gate verifier
-# must parse submittedAt to UTC nanoseconds and prove it is strictly greater
-# than request_after_ns. Same-second, missing, rounded, or ambiguous data fails:
-# re-request and wait for an unambiguous fresh review.
+review_submitted_at="$(jq -r .submittedAt "$gate_dir/copilot-review.json")"
+review_submitted_ns="$(review_timestamp_to_ns "$review_submitted_at")" ||
+  fail "invalid formal Copilot submittedAt"
+case "$review_submitted_ns:$request_server_ns" in :*|*:|*[!0-9:]*|*:*:*)
+  fail "ambiguous formal-review freshness boundary";;
+esac
+test "$review_submitted_ns" -gt "$request_server_ns" ||
+  fail "formal Copilot review is not after GitHub request completion"
 
   # All review threads. Paginate every returned thread's comments separately.
   # shellcheck disable=SC2016
@@ -274,20 +318,21 @@ Resolve a thread only after its fix is present in the current head.
 collect_ci_and_statuses() {
   gate_dir="$1"
   # REST carries check runs, suites, and legacy statuses; its full path scopes gh api.
-  for oid in "$head_oid" "$candidate_oid"; do
-  gh api --paginate --slurp \
-    "repos/$base_repo/commits/$oid/check-runs?per_page=100" \
-    >"$gate_dir/check-runs-$oid.json"
-  gh api --paginate --slurp \
-    "repos/$base_repo/commits/$oid/check-suites?per_page=100" \
-    >"$gate_dir/check-suites-$oid.json"
+  oid_list=("$head_oid")
+  test "$candidate_oid" = "$head_oid" || oid_list+=("$candidate_oid")
+  for oid in "${oid_list[@]}"; do
+    gh api --paginate --slurp \
+      "repos/$base_repo/commits/$oid/check-runs?per_page=100" \
+      >"$gate_dir/check-runs-$oid.json"
+    gh api --paginate --slurp \
+      "repos/$base_repo/commits/$oid/check-suites?per_page=100" \
+      >"$gate_dir/check-suites-$oid.json"
     gh api --paginate --slurp \
       "repos/$base_repo/commits/$oid/status?per_page=100" \
       >"$gate_dir/status-contexts-$oid.json"
 
     # A successful HTTP response is not enough: reject incomplete, malformed,
-    # or unexpectedly unpaginated payloads before the inventory validator sees
-    # them. Provider and result matching remains the validator's fail-closed job.
+    # or unexpectedly unpaginated payloads before direct inventory validation.
     jq -e 'type == "array" and length > 0 and
       all(.[]; (.check_runs | type) == "array")' \
       "$gate_dir/check-runs-$oid.json" >/dev/null ||
@@ -300,30 +345,136 @@ collect_ci_and_statuses() {
       all(.[]; (.state | type) == "string" and (.statuses | type) == "array")' \
       "$gate_dir/status-contexts-$oid.json" >/dev/null ||
       fail "invalid legacy-status response for $oid"
+
+    jq --arg oid "$oid" '[.[] | .check_runs[]? | . + {observedOid: $oid}]' \
+      "$gate_dir/check-runs-$oid.json" >"$gate_dir/runs-$oid.json"
+    jq --arg oid "$oid" '[.[] | .check_suites[]? | . + {observedOid: $oid}]' \
+      "$gate_dir/check-suites-$oid.json" >"$gate_dir/suites-$oid.json"
+    jq --arg oid "$oid" '[.[] | .statuses[]? | . + {observedOid: $oid}]' \
+      "$gate_dir/status-contexts-$oid.json" >"$gate_dir/statuses-$oid.json"
   done
+
+  jq -s 'add' "$gate_dir"/runs-*.json >"$gate_dir/check-runs-normalized.json"
+  jq -s 'add' "$gate_dir"/suites-*.json >"$gate_dir/check-suites-normalized.json"
+  jq -s 'add' "$gate_dir"/statuses-*.json >"$gate_dir/status-contexts-normalized.json"
 }
 ```
 
-Join each expected check run to its suite. The suite's associated PR must name
-the captured repository, `head_oid`/head ref, and `base_oid`/base ref. A run on
-`candidate_oid` is valid only with that exact association; an unrelated green
-run, a run for an earlier head, or one for a different base fails. Validate
-legacy status contexts with the same strict expected inventory: each context's
-creator login/ID and allowed state must match its configured provider; an
-unknown, missing, or non-success required context fails.
-
-The caller must provide a reviewed expected-inventory validator. It receives
-the complete raw snapshot, the actual branch-ruleset/required-workflow evidence,
-and the high-resolution review completion timestamp; it must enforce every row
-in the table rather than treating an unrecognized result as optional.
+The expected inventory is built from GitHub's effective rules for the captured
+base ref and its branch-protection object—not from a caller file. The collector
+refuses an empty inventory, a legacy required context
+without an integration ID, a duplicate context, or an unsupported provider
+binding. GitHub does not bind a legacy status context to a creator; therefore a
+legacy status can never satisfy a required check in this gate. This is a
+deliberate fail-closed limitation, not a reason to treat an unknown context as
+green.
 
 ```bash
+collect_policy_inventory() {
+  gate_dir="$1"
+  gh api --paginate --slurp \
+    "repos/$base_repo/rules/branches/$base_ref" \
+    >"$gate_dir/effective-rules.json"
+  jq -e 'type == "array" and length > 0 and all(.[]; type == "array")' \
+    "$gate_dir/effective-rules.json" >/dev/null ||
+    fail "missing or malformed effective branch rules"
+  gh api "repos/$base_repo/branches/$base_ref/protection" \
+    >"$gate_dir/branch-protection.json"
+  jq -e 'type == "object" and (.url | type) == "string"' \
+    "$gate_dir/branch-protection.json" >/dev/null ||
+    fail "missing or malformed branch protection"
+
+  jq -n --arg repository "$base_repo" --arg baseRef "$base_ref" \
+    --slurpfile effective "$gate_dir/effective-rules.json" \
+    --slurpfile protection "$gate_dir/branch-protection.json" '
+    def effective: ($effective[0] | add);
+    def ruleChecks:
+      [effective[] | select(.type == "required_status_checks") |
+       (.parameters.required_status_checks // [])[]? |
+       {context: (.context // ""), appId: (.integration_id // .app_id)}];
+    def protectionChecks:
+      [($protection[0].required_status_checks.checks // [])[] |
+       {context: (.context // ""), appId: (.app_id // .integration_id)}];
+    def legacyContexts:
+      ($protection[0].required_status_checks.contexts // []);
+    (ruleChecks + protectionChecks) as $checks |
+    ([ $checks[] | .context ] | unique) as $names |
+    ([ $checks[] | .context ] | unique) as $boundLegacy |
+    legacyContexts as $legacy |
+    if ($checks | length) == 0 then
+      error("no server-required checks; refusing a no-op inventory")
+    elif any($checks[]; (.context | type) != "string" or .context == "" or
+                       (.appId | type) != "number" or .appId <= 0) then
+      error("required check lacks an exact integration ID")
+    elif ($names | length) != ($checks | length) then
+      error("duplicate required check context")
+    elif (($legacy - $boundLegacy) | length) != 0 then
+      error("legacy required status lacks an app/provider binding")
+    else {
+      schema: 1,
+      repository: $repository,
+      baseRef: $baseRef,
+      effectiveRules: effective,
+      branchProtection: $protection[0],
+      requiredCheckRuns: ($checks | unique_by([.context, .appId]) |
+                          sort_by(.context, .appId)),
+      legacyStatusPolicy: "reject-required-contexts-without-provider-binding"
+    } end
+  ' >"$gate_dir/expected-inventory.json" ||
+    fail "could not build exact expected check/provider inventory"
+}
+
+validate_exact_inventory() {
+  snapshot="$1"
+  jq -e '.schema == 1 and (.requiredCheckRuns | type) == "array" and
+    (.requiredCheckRuns | length) > 0 and
+    all(.requiredCheckRuns[]; (.context | type) == "string" and
+      (.appId | type) == "number" and .appId > 0)' \
+    "$snapshot/expected-inventory.json" >/dev/null ||
+    fail "invalid or no-op expected inventory"
+  jq -e --arg repository "$base_repo" --arg head "$head_oid" \
+    --arg base "$base_oid" --arg baseRef "$base_ref" --arg candidate "$candidate_oid" \
+    --slurpfile expected "$snapshot/expected-inventory.json" \
+    --slurpfile runs "$snapshot/check-runs-normalized.json" \
+    --slurpfile suites "$snapshot/check-suites-normalized.json" \
+    --slurpfile statuses "$snapshot/status-contexts-normalized.json" '
+    $expected[0].requiredCheckRuns as $required |
+    def associated_suite($run):
+      [ $suites[0][] |
+        select(.id == $run.check_suite.id and .head_sha == $candidate and
+               .app.id == $run.app.id) |
+        .pull_requests[]? |
+        select(.head.sha == $head and .base.sha == $base and
+               .base.ref == $baseRef and
+               .base.repo.url == ("https://api.github.com/repos/" + $repository))
+      ] | length > 0;
+    def successful_required_run($need):
+      [ $runs[0][] |
+        select(.observedOid == $candidate and .head_sha == $candidate and
+               .name == $need.context and .app.id == $need.appId and
+               (.app.owner.login | type) == "string" and
+               (.app.slug | type) == "string" and .status == "completed" and
+               (.conclusion | ascii_upcase) == "SUCCESS" and associated_suite(.))
+      ] | length == 1;
+    ($required | length) > 0 and
+    all($required[]; successful_required_run(.)) and
+    ([ $statuses[0][] | select(.context as $context |
+       ($required | map(.context) | index($context)) != null) ] | length == 0)
+  ' "$snapshot/expected-inventory.json" >/dev/null ||
+    fail "required check/provider/suite result or legacy-status binding is invalid"
+}
+
+# Bind policy to the observed base before asking for review. A policy change
+# later invalidates the request and the two snapshots must remain byte-identical.
+mkdir -p "$gate_root/observed-policy"
+collect_policy_inventory "$gate_root/observed-policy"
+request_formal_review
+
 capture_snapshot() {
   gate_dir="$1"
   mkdir -p "$gate_dir"
   cp "$gate_root/review-request.json" "$gate_dir/review-request.json"
-  cp "$expected_inventory" "$gate_dir/expected-inventory.json"
-  cp "$ruleset_evidence" "$gate_dir/ruleset-evidence.json"
+  cp "$gate_root/review-request.http" "$gate_dir/review-request.http"
   capture_identity >"$gate_dir/identity.json"
   jq -e '((.errors // []) | length) == 0 and
     .data != null and .data.repository.pullRequest != null and
@@ -339,6 +490,10 @@ capture_snapshot() {
   candidate_oid="$(jq -r \
     '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
     "$gate_dir/identity.json")"
+  collect_policy_inventory "$gate_dir"
+  cmp -s "$gate_root/observed-policy/expected-inventory.json" \
+    "$gate_dir/expected-inventory.json" ||
+    fail "effective rules/check/provider inventory changed; restart and re-request Copilot"
   collect_reviews_and_threads "$gate_dir"
   collect_ci_and_statuses "$gate_dir"
 }
@@ -350,20 +505,8 @@ validate_snapshot() {
   jq -e '[.[] | .data.repository.pullRequest.reviewThreads.nodes[] |
     select(.isResolved != true)] | length == 0' \
     "$snapshot/threads.json" >/dev/null || fail "unresolved review thread"
-  test -x "$expected_inventory_validator" ||
-    fail "missing reviewed expected-inventory validator"
-  "$expected_inventory_validator" \
-    --snapshot "$snapshot" \
-    --expected "$snapshot/expected-inventory.json" \
-    --rules "$snapshot/ruleset-evidence.json" \
-    --review-after-ns "$request_after_ns"
+  validate_exact_inventory "$snapshot"
 }
-
-: "${expected_inventory:?capture the current expected check/status provider inventory}"
-: "${ruleset_evidence:?capture current ruleset/code-owner evidence}"
-: "${expected_inventory_validator:?set the reviewed gate validator path}"
-test -s "$expected_inventory" && test -s "$ruleset_evidence" ||
-  fail "missing expected inventory or ruleset evidence"
 
 # First complete collection and validation, followed by the complete final rerun.
 capture_snapshot "$gate_root/verified"
@@ -373,8 +516,8 @@ validate_snapshot "$gate_root/final"
 ```
 
 Before marking ready or merging, create a normalized, sorted manifest from all
-the files above plus the expected-check inventory and ruleset evidence. Validate
-the formal-Copilot predicate, human/code-owner approval, zero unpermitted
+the files above, including the server-fetched effective rules and protection.
+Validate the formal-Copilot predicate, human/code-owner approval, zero unpermitted
 unresolved threads, and every expected check/provider/suite association. Then
 capture the **entire** evidence set again and compare the two manifests:
 
@@ -499,20 +642,71 @@ on PR number order or a manually remembered stack. Rebase in dependency order
 from parent to child, then run a fresh review and complete gate for **each** PR.
 
 ```bash
-gh pr list --repo "$base_repo" --state open --limit 100 \
-  --json number,headRefName,baseRefName,url >"$gate_root/open-prs.json"
+# `gh pr list --limit 100` is not a stack inventory. GraphQL pagination captures
+# every open PR and includes the source repository needed to reject forks.
+stack_root_base=STACK_ROOT_BASE_REF
+git check-ref-format --branch "$stack_root_base" >/dev/null
+# shellcheck disable=SC2016
+# GraphQL variables must reach gh unchanged.
+gh api graphql --paginate --slurp -f query='
+  query($owner:String!, $repo:String!, $endCursor:String) {
+    repository(owner:$owner, name:$repo) {
+      pullRequests(first:100, states:OPEN, after:$endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { number url headRefName baseRefName headRepository { nameWithOwner } }
+      }
+    }
+  }
+' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F endCursor=null \
+  >"$gate_root/open-pr-pages.json"
+require_graphql_pages "$gate_root/open-pr-pages.json"
+jq -e 'all(.[]; .data.repository.pullRequests.pageInfo != null and
+  .data.repository.pullRequests.nodes != null) and
+  .[-1].data.repository.pullRequests.pageInfo.hasNextPage == false' \
+  "$gate_root/open-pr-pages.json" >/dev/null || fail "incomplete open-PR pagination"
 
-# A child has baseRefName equal to its parent's headRefName. Build the directed
-# graph from this data, topologically order it parent -> child, and stop on a
-# cycle, missing parent, duplicate source branch, fork, or truncated listing.
-jq -r '.[] | [.number, .baseRefName, .headRefName, .url] | @tsv' \
-  "$gate_root/open-prs.json"
+# Build and validate the complete graph. The emitted order is the requested
+# stack only, topologically ordered parent -> child; every open-PR cycle is
+# rejected, and a selected chain may end only at the caller-approved root base.
+ruby -r json -e '
+  pages = JSON.parse(File.read(ARGV.fetch(0)))
+  repo, target, root = ARGV.fetch(1), Integer(ARGV.fetch(2)), ARGV.fetch(3)
+  prs = pages.flat_map { |page| page.dig("data", "repository", "pullRequests", "nodes") || abort("missing PR nodes") }
+  abort("duplicate PR number") unless prs.map { |p| p.fetch("number") }.uniq.length == prs.length
+  abort("fork or missing head repository") unless prs.all? { |p| p.dig("headRepository", "nameWithOwner") == repo }
+  heads = prs.map { |p| p.fetch("headRefName") }
+  abort("duplicate source branch") unless heads.uniq.length == heads.length
+  by_head = prs.to_h { |p| [p.fetch("headRefName"), p] }
+  visiting, visited = {}, {}
+  visit = lambda do |node|
+    key = node.fetch("headRefName"); abort("stack cycle") if visiting[key]
+    return if visited[key]
+    visiting[key] = true
+    parent = by_head[node.fetch("baseRefName")]
+    visit.call(parent) if parent
+    visiting.delete(key); visited[key] = true
+  end
+  prs.each { |node| visit.call(node) }
+  node = prs.select { |p| p.fetch("number") == target }
+  abort("requested PR absent from complete open-PR graph") unless node.length == 1
+  chain, seen = [], {}
+  node = node.fetch(0)
+  loop do
+    key = node.fetch("headRefName"); abort("selected stack cycle") if seen[key]
+    seen[key] = true; chain << node
+    parent_ref = node.fetch("baseRefName")
+    break if parent_ref == root
+    node = by_head[parent_ref] or abort("selected stack parent missing")
+  end
+  puts chain.reverse.map { |p| p.fetch("number") }
+' "$gate_root/open-pr-pages.json" "$base_repo" "$pr" "$stack_root_base" \
+  >"$gate_root/stack-order.txt"
 ```
 
-After a parent moves, re-fetch each child, verify its live head/base and one
-push endpoint using the rebase protocol above, rebase it onto the moved parent,
-and re-gate it. A parent review, approval, check, or manifest never approves a
-child; a child may not be pushed before its parent dependency is current.
+For each PR number in `stack-order.txt`, re-fetch its live head/base, run the
+guarded rebase protocol, then request a new Copilot review and run the complete
+two-snapshot gate. A parent review, approval, check, or manifest never approves
+a child; a child may not be pushed before its parent dependency is current.
 
 ## PR descriptions and draft lifecycle
 

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -11,41 +11,60 @@ rebasing, squashing, writing descriptions, and interacting with CI.
 
 ## Exact-Head Gate
 
-Treat the commit currently at the PR head as the unit of approval. A green
-check or review on an earlier commit does not approve a later push.
+Treat the current PR head **and base** as the unit of approval. A green check
+or review from an earlier source/base pair does not approve a later push.
 
 After **every** push, record the new head and do not mark the PR ready until
 all of the following apply to that exact object ID:
 
-1. Every required CI check has completed successfully for the current head.
-   Inspect the expected check inventory as well as its conclusion; a single
-   unrelated successful check is not sufficient.
-2. The latest formal Copilot review was submitted for that same head (if
-   Copilot review is required for the repository).
+1. Every required CI check has completed successfully for the current
+   head/base pair. Inspect the expected check inventory as well as its
+   conclusion; a single unrelated successful check is not sufficient.
+2. The latest formal Copilot review is a submitted, non-dismissed `COMMENTED`
+   review from the configured Copilot reviewer identity for that exact head.
 3. Suppressed/minimized review comments have been inspected, and every
-   non-outdated unresolved review thread has either been fixed and resolved or
-   has an explicit, documented disposition.
+   unresolved review conversation has been resolved. Do not waive a thread
+   merely by documenting a disposition unless the current repository ruleset
+   explicitly permits that specific exception.
 
 ```bash
-# Save this value before inspecting checks and reviews. Re-run it after each
-# push; never reuse an OID recorded for an earlier head.
-head_oid="$(gh pr view PR_NUMBER --json headRefOid --jq .headRefOid)"
-printf '%s\n' "$head_oid"
+# Snapshot these values before inspecting checks and reviews. Re-run the
+# complete gate if the final snapshot differs.
+pr_snapshot() {
+  gh pr view PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY \
+    --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository
+}
+before_snapshot="$(pr_snapshot)"
+printf '%s\n' "$before_snapshot"
 
-# CI status is useful only after comparing its commit to head_oid.
+# CI output must be associated with the snapshot; see the CI rules below.
 gh pr checks PR_NUMBER --watch --required
+
+# Read head and base again after CI, reviews, and threads have been examined.
+after_snapshot="$(pr_snapshot)"
+test "$before_snapshot" = "$after_snapshot" || {
+  echo "PR head/base changed; restart the complete exact-head gate" >&2
+  exit 1
+}
 ```
 
-For automated gates, query the PR's `headRefOid`, required check runs, formal
-reviews (including each review's `commit.oid`), review threads, and minimized
-comments through GitHub GraphQL. Paginate each connection until `hasNextPage`
-is false. Fail the gate unless the selected Copilot review's `commit.oid`
-equals `headRefOid`, all required checks apply to that OID and succeeded, and
-there are no unreviewed minimized comments or non-outdated unresolved threads.
+For automated gates, query the PR's `headRefOid`, `baseRefOid`, required check
+runs, formal reviews (including each review's `commit.oid`), review threads,
+and minimized comments through GitHub GraphQL. Paginate every connection until
+`hasNextPage` is false. Repeat the complete snapshot after gathering the data;
+if either head or base changed, discard the result and restart the gate.
+
+GitHub may run `pull_request` workflows on a synthetic test-merge SHA, and
+merge-queue workflows can run on a merge-queue candidate SHA. Therefore, do
+not require every check-run SHA to equal `headRefOid`. Instead, verify each
+required run/check is associated with the captured source `headRefOid` **and**
+`baseRefOid`, then accept its selected synthetic merge or merge-queue SHA only
+when that association is exact. A check for a different base, an earlier head,
+or an unrelated successful run fails the gate.
 
 For example, enumerate formal reviews with a separate paginated query, then
-select the latest submitted Copilot reviewer result rather than a coding-agent
-comment:
+select the latest submitted result from the repository-configured exact Copilot
+reviewer login rather than a coding-agent comment:
 
 ```bash
 gh api graphql -f query='
@@ -68,9 +87,13 @@ gh api graphql -f query='
 ' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
 ```
 
-Compare the formal review's `commit.oid` to the displayed `headRefOid` exactly;
-an older matching review state is insufficient. Repeat with `cursor` set to
-`endCursor` until all review pages have been inspected.
+Set `copilot_reviewer_login` to the known, repository-configured bot login; do
+not identify Copilot from a display name, an `@copilot` mention, or a similarly
+named account. The selected review must have that exact `author.login`,
+`state: COMMENTED`, a non-null `submittedAt`, no dismissed state, and a
+`commit.oid` exactly equal to the captured `headRefOid`. An older matching
+state is insufficient. Repeat with `cursor` set to `endCursor` until all review
+pages have been inspected.
 
 ## Requesting a Formal Copilot Review
 
@@ -108,7 +131,9 @@ gh api graphql -f query='
             isResolved
             isOutdated
             comments(first:100) {
+              pageInfo { hasNextPage endCursor }
               nodes {
+                id
                 body
                 author { login }
                 path
@@ -126,11 +151,39 @@ gh api graphql -f query='
 ' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
 ```
 
-Repeat the query with `cursor` set to `endCursor` until `hasNextPage` is
-false. Inspect minimized comments as deliberately as visible ones: minimizing
-is not a resolution or a waiver. Only unresolved threads with
-`isOutdated: false` block the ready gate, but outdated threads still deserve a
-documented decision when they raise a safety concern.
+Repeat the thread query with `cursor` set to `endCursor` until the thread
+`hasNextPage` is false. Each thread's comments have a separate cursor: when a
+thread's `comments.pageInfo.hasNextPage` is true, page that thread by its
+returned thread ID before deciding the conversation is complete.
+
+```bash
+gh api graphql -f query='
+  query($thread:ID!, $cursor:String) {
+    node(id:$thread) {
+      ... on PullRequestReviewThread {
+        comments(first:100, after:$cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            body
+            author { login }
+            path
+            line
+            createdAt
+            isMinimized
+            minimizedReason
+          }
+        }
+      }
+    }
+  }
+' -F thread=THREAD_ID -F cursor=null
+```
+
+Inspect minimized comments as deliberately as visible ones: minimizing is not
+a resolution or a waiver. Every unresolved review thread, including an outdated
+one, blocks the ready gate unless an applicable current repository ruleset
+explicitly permits the exception.
 
 ## Resolving Review Threads
 
@@ -162,24 +215,94 @@ rebase only when a current base is actually required. Before rewriting a
 published branch, fetch it, capture the exact remote branch OID, and make sure
 the rewrite is authorized for that branch.
 
+This repository's policy is same-repository PRs only. Refuse to push a fork
+branch; never guess that `origin`, `main`, or the checked-out branch is the PR
+source. Derive the live PR head repository/ref and base repository/ref first,
+then select exactly one verified local remote for that head repository.
+
 ```bash
-git fetch origin main
-branch="$(git branch --show-current)"
-remote_head="$(git rev-parse "origin/$branch")"
-git rebase --gpg-sign origin/main
+# Start from the actual target PR URL, not a branch name or local remote.
+pr_url="https://github.example/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
+pr_url="$(gh pr view "$pr_url" --json url --jq .url)"
+base_repo="$(printf '%s\n' "$pr_url" | awk -F/ '{print $(NF-3) "/" $(NF-2)}')"
+pr="$(printf '%s\n' "$pr_url" | awk -F/ '{print $NF}')"
+case "$base_repo" in */*) ;; *) echo "invalid PR URL" >&2; exit 1;; esac
+pr_data="$(gh pr view "$pr" --repo "$base_repo" \
+  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
+base_ref="$(jq -r .baseRefName <<<"$pr_data")"
+base_oid="$(jq -r .baseRefOid <<<"$pr_data")"
+head_ref="$(jq -r .headRefName <<<"$pr_data")"
+head_oid="$(jq -r .headRefOid <<<"$pr_data")"
+head_repo="$(jq -r .headRepository.nameWithOwner <<<"$pr_data")"
+
+# The current policy does not authorize pushes to forks.
+test "$head_repo" = "$base_repo" || {
+  echo "refusing to rewrite or push fork PR $head_repo" >&2
+  exit 1
+}
+
+# Match a configured remote to the actual PR head repository, rather than
+# assuming that a remote named origin is safe. Refuse ambiguity.
+push_remote=""
+for candidate in $(git remote); do
+  candidate_repo="$(gh repo view "$(git remote get-url "$candidate")" \
+    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+  test "$candidate_repo" = "$head_repo" || continue
+  test -z "$push_remote" || {
+    echo "multiple remotes resolve to PR head repository" >&2
+    exit 1
+  }
+  push_remote="$candidate"
+done
+test -n "$push_remote" || {
+  echo "no configured remote matches PR head repository" >&2
+  exit 1
+}
+
+git fetch "$push_remote" \
+  "refs/heads/$base_ref:refs/remotes/$push_remote/$base_ref" \
+  "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
+test "$(git rev-parse "$push_remote/$base_ref")" = "$base_oid" || {
+  echo "PR base changed; refresh PR metadata before rebasing" >&2
+  exit 1
+}
+remote_head="$(git rev-parse "$push_remote/$head_ref")"
+test "$remote_head" = "$head_oid" || {
+  echo "PR head changed; refresh PR metadata before rebasing" >&2
+  exit 1
+}
+local_branch="$(git branch --show-current)"
+test "$local_branch" = "$head_ref" || {
+  echo "checked-out branch is not the PR head ref" >&2
+  exit 1
+}
+test -z "$(git status --porcelain)" || {
+  echo "refusing to rebase a dirty worktree" >&2
+  exit 1
+}
+git rebase --gpg-sign "$push_remote/$base_ref"
 
 # If conflicts arise, resolve them and continue:
-git add -A
+git add -- path/to/resolved-conflict.go path/to/other-resolved-file.yaml
 git rebase --continue
 
 # --gpg-sign preserves signing for rewritten commits. Configure a suitable
 # signing key in advance; do not disable signing to bypass a local setup
 # problem. Check every rewritten commit before pushing.
-git log --show-signature --format=fuller origin/main..HEAD
+git log --show-signature --format=fuller "$push_remote/$base_ref..HEAD"
 
 # Only after the rebase is verified, update this personal branch without
-# overwriting a collaborator's intervening push.
-git push --force-with-lease="refs/heads/$branch:$remote_head" origin "$branch"
+# overwriting a collaborator's intervening push. Re-read the live PR metadata
+# immediately before this command and stop if head/base repository, ref, or OID
+# changed from pr_data.
+current_pr_data="$(gh pr view "$pr" --repo "$base_repo" \
+  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
+test "$current_pr_data" = "$pr_data" || {
+  echo "PR metadata changed; refresh and restart before pushing" >&2
+  exit 1
+}
+git push --force-with-lease="refs/heads/$head_ref:$remote_head" \
+  "$push_remote" "HEAD:refs/heads/$head_ref"
 ```
 
 Do not use a broad `--force`. If the lease no longer matches, stop, fetch, and
@@ -214,10 +337,12 @@ gh pr checks PR_NUMBER --watch
 gh run view RUN_ID --log-failed
 ```
 
-Before accepting the result, compare the CI run's head SHA and every required
-check run's SHA to the `head_oid` recorded in the exact-head gate. Re-run the
-gate after any branch update, including an automatic rebase or a merge from
-main.
+Before accepting the result, compare every required run/check's PR association
+to the captured `headRefOid` and `baseRefOid`. Its SHA can equal the source
+head only for head-based workflows; for pull-request test merges or merge
+queues, validate the selected synthetic candidate for that same source/base
+pair instead. Re-run the complete gate after any branch or base update,
+including an automatic rebase or a merge into the base branch.
 
 ## Adding PR Comments
 
@@ -246,6 +371,11 @@ Markdown, backticks, variables, or escaped newlines through an inline
 ```bash
 # Edit a real temporary Markdown file using an editor or a repository template.
 body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
+"${EDITOR:?set EDITOR to populate the PR description}" "$body_file"
+test -s "$body_file" || {
+  echo "refusing to create or edit a PR with an empty description" >&2
+  exit 1
+}
 
 gh pr create \
   --title "feat: description" \
@@ -258,13 +388,26 @@ gh pr edit PR_NUMBER --body-file "$body_file"
 # Read the stored body back and inspect the rendered PR to confirm headings,
 # newlines, links, dependency heads, scope, limitations, and test evidence.
 gh pr view PR_NUMBER --json body --jq .body
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) { bodyHTML }
+    }
+  }
+' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER --jq \
+  .data.repository.pullRequest.bodyHTML
+gh pr view PR_NUMBER --web
 ```
+
+Compare the raw body to the source file, inspect `bodyHTML`, and verify the
+rendered web page before relying on the description. The raw API body alone
+does not prove Markdown rendered as intended.
 
 ## Workflow Tips
 
-1. **Gate each pushed head** — collect its exact OID, required CI result,
-   formal-review commit OID, minimized comments, and unresolved current
-   threads. Copilot does not inherently review every push.
+1. **Gate each pushed head/base pair** — collect exact OIDs, required CI
+   association, formal-review commit OID, minimized comments, and every
+   unresolved thread. Copilot does not inherently review every push.
 2. **Resolve threads only after fixing** — don't resolve a thread until the
    code change is pushed and the new head has been checked.
 3. **Batch GraphQL mutations** — resolve multiple threads in one API call

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -406,8 +406,13 @@ green.
 ```bash
 collect_policy_inventory() {
   gate_dir="$1"
+  # Branch refs are one REST path segment. Encode every byte outside the URI
+  # unreserved set so refs such as `feature/review` cannot change the endpoint
+  # path (and spaces, `%`, or `+` cannot be interpreted by a proxy).
+  encoded_base_ref="$(jq -nr --arg ref "$base_ref" '$ref | @uri')"
+  test -n "$encoded_base_ref" || fail "could not URL-encode base ref"
   gh_api --paginate --slurp \
-    "repos/$base_repo/rules/branches/$base_ref" \
+    "repos/$base_repo/rules/branches/$encoded_base_ref" \
     >"$gate_dir/effective-rules.json"
   # `--slurp` yields an array of arrays, one per pagination page. Empty
   # ruleset pages are valid; the contract combines them with classic branch
@@ -424,7 +429,7 @@ collect_policy_inventory() {
   # empty, non-JSON, malformed, 401/403, 5xx, and every other response remain
   # fatal.
   protection_http="$gate_dir/branch-protection.http"
-  if gh_api --include "repos/$base_repo/branches/$base_ref/protection" \
+  if gh_api --include "repos/$base_repo/branches/$encoded_base_ref/protection" \
     >"$protection_http"; then
     :
   else

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -25,7 +25,8 @@ Treat a PR as approved only when one complete, current evidence snapshot passes.
 
   The prompt uses [`.github/scripts/pr-gate-contract.sh`](../scripts/pr-gate-contract.sh)
   as the executable reference for URL parsing, conservative review freshness,
-  policy inventory, and exact check-suite evidence. It tests API-shaped
+  complete evidence manifests, draft binding, policy inventory, and exact
+  check-suite evidence. It tests API-shaped
   fixtures, including a synthetic merge candidate that differs from the source
   head and attacker-controlled suite/status cases; it does not test for text
   in this document.
@@ -36,7 +37,7 @@ Request a formal Copilot review; do not write an `@copilot review` comment.
 The comment invokes the coding agent and is not a pull-request review request.
 
 ```bash
-GH_HOST=HOST gh pr edit PR_NUMBER --repo HOST/BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
+env GH_HOST="$github_host" gh pr edit "$pr" --repo "$hosted_repo" --add-reviewer @copilot
 ```
 
 For the fail-closed gate below, use the equivalent REST reviewer request with
@@ -90,6 +91,8 @@ EOF
 hosted_repo="$github_host/$base_repo"
 gh_api() { env GH_HOST="$github_host" gh api --hostname "$github_host" "$@"; }
 gh_pr() { env GH_HOST="$github_host" gh pr "$@"; }
+gh auth status --hostname "$github_host" >/dev/null ||
+  fail "no authenticated gh session for the pinned GitHub host"
 case "$base_repo" in */*) ;; *) fail "invalid PR repository";; esac
 case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
 
@@ -226,6 +229,18 @@ server-provided type/parameters in the error: extend the verifier for that
 type, or remove/replace the rule before using this ready/merge gate. It never
 silently ignores a rule, accepts `NEUTRAL`/`SKIPPED`, or accepts a legacy
 required status, whose `creator` cannot prove a GitHub App integration.
+
+The policy verifier accepts only the documented payloads it can enforce:
+`pull_request` requires every review boolean and an integer approval count;
+`required_status_checks` requires its strict flag and a nonempty list of
+positive App integration IDs; workflow entries require an integer
+`repository_id`, path, and immutable SHA; and code-scanning thresholds must be
+GitHub's documented enum values. Classic status policy requires `strict`,
+`contexts`, and `checks`; classic reviews require their dismissal, code-owner,
+stale-review, last-push, and approval fields with their documented types. An
+empty active status-check list, a malformed payload, or an enabled control the
+contract does not model is fatal. A classic context that is also present in an
+exact App-bound classic check is permitted; any unbound context is rejected.
 
 The following commands provide the raw, paginated review/thread/check material.
 Save each response under the gate directory and normalize it with sorted JSON
@@ -408,8 +423,11 @@ collect_policy_inventory() {
 
   # Capture the authenticated HTTP response even when `gh` returns non-zero.
   # The contract accepts only a final HTTP 200 object or an authenticated 404
-  # (which conclusively means this branch has no classic protection); 401/403,
-  # 5xx, malformed headers/body, and every other status remain fatal.
+  # (which conclusively means this branch has no classic protection). A 404 is
+  # accepted only with one valid Date, a GitHub request ID, JSON content type,
+  # and GitHub's `Branch not protected` JSON error/documentation URL/status;
+  # empty, non-JSON, malformed, 401/403, 5xx, and every other response remain
+  # fatal.
   protection_http="$gate_dir/branch-protection.http"
   if gh_api --include "repos/$base_repo/branches/$base_ref/protection" \
     >"$protection_http"; then
@@ -503,12 +521,10 @@ capture the **entire** evidence set again and compare the two manifests:
 ```bash
 manifest_snapshot() {
   snapshot="$1"
-  find "$snapshot" -type f -name '*.json' -print | LC_ALL=C sort |
-    while IFS= read -r json; do
-      relative="${json#"$snapshot"/}"
-      printf '%s\t' "$relative"
-      jq -S -c . "$json"
-    done >"$snapshot/gate.jsonl"
+  # JSON files are canonicalized; every other captured artifact (including
+  # `.http` response evidence) is represented by its SHA-256. The helper
+  # rejects malformed JSON and omits only the manifest it is writing.
+  "$contract" manifest-evidence "$snapshot" "$snapshot/gate.jsonl"
 }
 
 # Both snapshots were collected and validated above. Reject any changed raw or
@@ -735,6 +751,9 @@ test "$parsed_host" = "$github_host" && test "$parsed_repo" = "$base_repo" || {
 hosted_repo="$github_host/$base_repo"
 gh_pr() { env GH_HOST="$github_host" gh pr "$@"; }
 gh_api() { env GH_HOST="$github_host" gh api --hostname "$github_host" "$@"; }
+gh auth status --hostname "$github_host" >/dev/null || {
+  echo "no authenticated gh session for the pinned GitHub host" >&2; exit 1;
+}
 git check-ref-format --branch "$base_ref" >/dev/null
 head_ref="$(git branch --show-current)"
 git check-ref-format --branch "$head_ref" >/dev/null
@@ -787,12 +806,10 @@ test "$created_host" = "$github_host" && test "$created_repo" = "$base_repo" || 
   echo "PR creation returned a different GitHub host or repository" >&2; exit 1;
 }
 gh_pr view "$pr" --repo "$hosted_repo" \
-  --json headRefName,headRefOid,headRepository,baseRefName,baseRefOid,baseRepository \
-  | jq -e --arg repo "$base_repo" --arg head "$head_ref" --arg headOid "$source_oid" \
-      --arg base "$base_ref" --arg baseOid "$base_oid" '
-      .headRepository.nameWithOwner == $repo and .headRefName == $head and .headRefOid == $headOid and
-      .baseRepository.nameWithOwner == $repo and .baseRefName == $base and .baseRefOid == $baseOid
-    ' >/dev/null || { echo "created PR source/base does not match verified refs" >&2; exit 1; }
+  --json isDraft,headRefName,headRefOid,headRepository,baseRefName,baseRefOid,baseRepository \
+  >"$gate_root/created-pr.json"
+"$contract" verify-created-draft "$gate_root/created-pr.json" "$base_repo" \
+  "$head_ref" "$source_oid" "$base_ref" "$base_oid"
 
 # Use the same file-only rule for an existing PR description.
 gh_pr edit "$pr" --repo "$hosted_repo" --body-file "$body_file"

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -1,249 +1,289 @@
 # GitHub PR Management
 
-Use this prompt when managing pull requests: reviewing, resolving threads,
-rebasing, squashing, writing descriptions, and interacting with CI.
+Use this prompt to create, update, review, rebase, and ready a pull request.
+Treat a PR as approved only when one complete, current evidence snapshot passes.
 
-## Prerequisites
+## Repository and command scope
 
-- GitHub CLI (`gh`) must be authenticated
-- EMU (Enterprise Managed User) accounts cannot use GitHub MCP API for
-  write operations — always use `gh` CLI instead
-- Pass `--repo BASE_OWNER/BASE_REPOSITORY` to every `gh pr` and `gh run`
-  command. The installed `gh api` command has no `--repo` flag, so every REST
-  path and GraphQL `owner`/`repo` value below names the target repository
-  explicitly instead of relying on the current directory.
+- Use `--repo BASE_OWNER/BASE_REPOSITORY` with every `gh pr` and `gh run`
+  command. Do not rely on the checked-out repository or a remote named
+  `origin`.
+- This task's user-directed policy permits direct same-repository branches
+  only. Refuse fork pushes; do not repurpose this policy as a repository rule.
+- The installed `gh api` has no `--repo` flag. Its REST paths must include
+  `repos/$base_repo/...`; its GraphQL calls must include explicit `owner` and
+  `repo` variables.
 
-## Exact-Head Gate
+## Formal review requirements
 
-Treat the current PR head **and base** as the unit of approval. A green check
-or review from an earlier source/base pair does not approve a later push.
-
-After **every** push, record the new head and do not mark the PR ready until
-all of the following apply to that exact object ID:
-
-1. Every required CI check has completed successfully for the current
-   head/base pair. Inspect the expected check inventory as well as its
-   conclusion; a single unrelated successful check is not sufficient.
-2. The latest formal Copilot review is a submitted, non-dismissed `COMMENTED`
-   review from the configured Copilot reviewer identity for that exact head.
-3. Suppressed/minimized review comments have been inspected, and every
-   unresolved review conversation has been resolved. Do not waive a thread
-   merely by documenting a disposition unless the current repository ruleset
-   explicitly permits that specific exception.
-
-```bash
-# Snapshot these values before inspecting checks and reviews. Re-run the
-# complete gate if the final snapshot differs.
-pr_snapshot() {
-  gh pr view PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY \
-    --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository,reviewDecision
-}
-before_snapshot="$(pr_snapshot)"
-printf '%s\n' "$before_snapshot"
-
-# CI output must be associated with the snapshot; see the CI rules below.
-gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --watch --required
-
-# Read head and base again after CI, reviews, and threads have been examined.
-after_snapshot="$(pr_snapshot)"
-test "$before_snapshot" = "$after_snapshot" || {
-  echo "PR head/base changed; restart the complete exact-head gate" >&2
-  exit 1
-}
-```
-
-For automated gates, query the PR's `headRefOid`, `baseRefOid`, required check
-runs, formal reviews (including each review's `commit.oid`), review threads,
-and minimized comments through GitHub GraphQL. Paginate every connection until
-`hasNextPage` is false. Repeat the complete snapshot after gathering the data;
-if either head or base changed, discard the result and restart the gate.
-
-Base movement invalidates the previous gate just as head movement does. When
-either OID changes, request a fresh formal Copilot review (unless an explicit,
-verified repository automation has already produced one for the new pair),
-repeat the human/code-owner approval check, and rerun CI/thread inspection.
-
-GitHub may run `pull_request` workflows on a synthetic test-merge SHA, and
-merge-queue workflows can run on a merge-queue candidate SHA. Therefore, do
-not require every check-run SHA to equal `headRefOid`. Instead, verify each
-required run/check is associated with the captured source `headRefOid` **and**
-`baseRefOid`, then accept its selected synthetic merge or merge-queue SHA only
-when that association is exact. A check for a different base, an earlier head,
-or an unrelated successful run fails the gate.
-
-For example, enumerate formal reviews with a separate paginated query, then
-select the latest submitted result from the repository-configured exact Copilot
-reviewer login rather than a coding-agent comment:
-
-```bash
-gh api graphql -f query='
-  query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
-    repository(owner:$owner, name:$repo) {
-      pullRequest(number:$pr) {
-        headRefOid
-        baseRefOid
-        reviewDecision
-        reviews(first:100, after:$cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            author { login }
-            state
-            submittedAt
-            commit { oid }
-          }
-        }
-      }
-    }
-  }
-' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F cursor=null
-```
-
-Set `copilot_reviewer_login` to the known, repository-configured bot login; do
-not identify Copilot from a display name, an `@copilot` mention, or a similarly
-named account. The selected review must have that exact `author.login`,
-`state: COMMENTED`, a non-null `submittedAt`, no dismissed state, and a
-`commit.oid` exactly equal to the captured `headRefOid`. An older matching
-state is insufficient. Repeat with `cursor` set to `endCursor` until all review
-pages have been inspected.
-
-Copilot's `COMMENTED` review is distinct from human approval. Read
-`reviewDecision` and the actual branch ruleset/code-owner requirement for the
-captured head/base pair; require the current human and code-owner approvals
-that those rules demand. A current human approval cannot be replaced by a
-Copilot comment, and a Copilot comment cannot be replaced by a green check.
-
-## Requesting a Formal Copilot Review
-
-Request Copilot as a PR reviewer; do **not** use an `@copilot review` comment.
-That comment invokes the coding agent and is not a formal pull-request review
-request.
+Request a formal Copilot review; do not write an `@copilot review` comment.
+The comment invokes the coding agent and is not a pull-request review request.
 
 ```bash
 gh pr edit PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
 ```
 
-The equivalent is GitHub's requested-reviewers REST endpoint with the Copilot
-reviewer account. Use it only where the repository's GitHub configuration
-supports that bot reviewer.
+Use the known, repository-configured Copilot reviewer login, never a display
+name or similarly named account. The selected review must be the newest review
+from that exact login with all of these properties:
 
-Copilot does not automatically re-review every pushed commit unless the
-repository has explicitly configured automatic re-reviews. After each pushed
-head **or base OID change**, request another formal review when necessary and
-verify the resulting review commit OID against the new PR head. Never infer a
-new review from an older review, a comment, or the absence of new threads.
+- `state` is `COMMENTED`, not dismissed;
+- `submittedAt` is non-null and later than the recorded review-request time;
+- `commit.oid` equals the captured PR `headRefOid`.
 
-## Checking PR Review Threads
+Copilot does not re-review every push unless the repository explicitly
+configures it. A head or base OID change restarts the gate and requires a fresh
+formal Copilot request/review. Its `COMMENTED` review is not a human approval:
+the captured `reviewDecision` and the actual branch ruleset/code-owner policy
+must independently show the current human and code-owner approvals required for
+that same head/base pair. A review commit OID does not bind the base: the review
+request timestamp is recorded after observing the pair, and final identity
+comparison provides the required base binding.
 
-Use this GraphQL query to list all review threads and their resolution status:
+## Fail-closed exact-head/base gate
+
+Required CI may run directly on the source head, on GitHub's synthetic PR test
+merge, or on a merge-queue candidate. Never accept a check merely because its
+SHA equals the source head. It must be associated with the exact captured
+head/base pair and the selected candidate, where applicable.
+
+The gate is fail-closed. Start its shell with `set -euo pipefail`; any API,
+pagination, validation, or comparison failure means **restart**, not ready or
+merge. Capture and retain all raw JSON in a private temporary directory for the
+gate run; do not use a green result from an earlier run.
 
 ```bash
-gh api graphql -f query='
-  query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
+set -euo pipefail
+
+fail() { printf '%s\n' "$*" >&2; exit 1; }
+
+# Derive both target repository and number from the actual PR URL.
+pr_url="https://github.example/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
+base_repo="$(printf '%s\n' "$pr_url" | awk -F/ '{print $(NF-3) "/" $(NF-2)}')"
+pr="$(printf '%s\n' "$pr_url" | awk -F/ '{print $NF}')"
+case "$base_repo" in */*) ;; *) fail "invalid PR URL";; esac
+case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
+
+gate_root="$(mktemp -d)"
+trap 'rm -rf "$gate_root"' EXIT
+observed="$gate_root/observed.json"
+
+capture_identity() {
+  gh api graphql -f query='
+    query($owner:String!, $repo:String!, $pr:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$pr) {
+          headRefName headRefOid baseRefName baseRefOid
+          headRepository { nameWithOwner }
+          reviewDecision
+          potentialMergeCommit { oid }
+          mergeQueueEntry { id }
+        }
+      }
+    }
+  ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr"
+}
+
+# Observe the source/base before requesting a fresh review.
+capture_identity >"$observed"
+jq -e '.data.repository.pullRequest.headRefOid and
+       .data.repository.pullRequest.baseRefOid and
+       .data.repository.pullRequest.headRepository.nameWithOwner' \
+  "$observed" >/dev/null || fail "incomplete PR identity"
+
+request_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n --arg requestAt "$request_at" '{requestAt: $requestAt}' \
+  >"$gate_root/review-request.json"
+gh pr edit "$pr" --repo "$base_repo" --add-reviewer @copilot
+```
+
+Do not infer a merge-queue commit SHA from `mergeQueueEntry.id`. This workflow
+does not have a reliable API binding from that ID to the merge-group commit, so
+it stops rather than overclaims merge-queue evidence:
+
+```bash
+jq -e '.data.repository.pullRequest.mergeQueueEntry == null' \
+  "$observed" >/dev/null || \
+  fail "merge queue active: no reliable candidate SHA; do not ready or merge"
+
+head_oid="$(jq -r '.data.repository.pullRequest.headRefOid' "$observed")"
+base_oid="$(jq -r '.data.repository.pullRequest.baseRefOid' "$observed")"
+candidate_oid="$(jq -r \
+  '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
+  "$observed")"
+```
+
+Once the requested review and required CI are complete, take the first complete
+evidence capture in `$gate_root/verified`. Its `identity.json` must byte-match
+`observed.json` before using it. Validate the evidence, then repeat the *same*
+collection into `$gate_root/final` immediately before ready/merge. Both captures
+must use the same filenames and include a fresh `identity.json`.
+
+```bash
+gate_dir="$gate_root/verified"
+mkdir -p "$gate_dir"
+cp "$gate_root/review-request.json" "$gate_dir/review-request.json"
+capture_identity >"$gate_dir/identity.json"
+cmp -s "$observed" "$gate_dir/identity.json" || \
+  fail "PR head/base or candidate changed; restart the complete gate"
+head_oid="$(jq -r '.data.repository.pullRequest.headRefOid' "$gate_dir/identity.json")"
+base_oid="$(jq -r '.data.repository.pullRequest.baseRefOid' "$gate_dir/identity.json")"
+candidate_oid="$(jq -r \
+  '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
+  "$gate_dir/identity.json")"
+```
+
+### Evidence that one gate snapshot must contain
+
+Capture every page of each connection. A complete snapshot contains:
+
+| Evidence | Required fields and decision |
+| --- | --- |
+| PR identity | `headRefOid`, `baseRefOid`, head repository/ref, base ref, test-merge SHA, `reviewDecision` |
+| Formal reviews | reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review after `request_at` |
+| Human approval | `reviewDecision` and current branch-ruleset/code-owner evidence for the pair; Copilot does not satisfy this row |
+| Threads and comments | every thread ID/resolution/outdated state and every comment ID, minimized state/reason, author, path, line, and timestamp |
+| Checks | complete expected inventory, result, `head_sha`, check-suite ID, and `CheckRun.app.owner.login`, `CheckRun.app.slug`, and `CheckRun.app.id` |
+| Check suites | suite ID, `head_sha`, app/provider identity, and each associated PR's repository, head SHA/ref, and base SHA/ref |
+
+Use repository rules/required-workflow configuration as the source of the full
+expected inventory and allowed provider identities. For this task every
+expected job must conclude `SUCCESS`. `NEUTRAL` or `SKIPPED` is acceptable only
+when the current rules explicitly name that exact job and provider as an
+intentional exception; record the rule source and reason. Never silently turn a
+non-success result into a pass.
+
+The following commands provide the raw, paginated review/thread/check material.
+Save each response under the gate directory and normalize it with sorted JSON
+before comparing snapshots.
+
+```bash
+# Formal reviews; evaluate the exact-login/latest/COMMENTED/time/head predicate.
+gh api graphql --paginate --slurp -f query='
+  query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
-        reviewThreads(first:100, after:$cursor) {
+        reviews(first:100, after:$endCursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes { author { login } state submittedAt commit { oid } }
+        }
+      }
+    }
+  }
+' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr" \
+  -F endCursor=null >"$gate_dir/reviews.json"
+
+copilot_reviewer_login=REPOSITORY_CONFIGURED_COPILOT_LOGIN
+jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" \
+  --arg requested "$request_at" '
+  [ .[] | .data.repository.pullRequest.reviews.nodes[] |
+    select(.author.login == $login) ] |
+  if length == 0 then false else max_by(.submittedAt) |
+    (.state == "COMMENTED" and .submittedAt != null and
+     .submittedAt >= $requested and .commit.oid == $head)
+  end
+' "$gate_dir/reviews.json" >/dev/null || fail "missing current formal Copilot review"
+
+# All review threads. Paginate every returned thread's comments separately.
+gh api graphql --paginate --slurp -f query='
+  query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100, after:$endCursor) {
           pageInfo { hasNextPage endCursor }
           nodes {
-            id
-            isResolved
-            isOutdated
+            id isResolved isOutdated
             comments(first:100) {
               pageInfo { hasNextPage endCursor }
-              nodes {
-                id
-                body
-                author { login }
-                path
-                line
-                createdAt
-                isMinimized
-                minimizedReason
-              }
+              nodes { id body author { login } path line createdAt isMinimized minimizedReason }
             }
           }
         }
       }
     }
   }
-' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F cursor=null
-```
+' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr" \
+  -F endCursor=null >"$gate_dir/threads.json"
 
-Repeat the thread query with `cursor` set to `endCursor` until the thread
-`hasNextPage` is false. Each thread's comments have a separate cursor: when a
-thread's `comments.pageInfo.hasNextPage` is true, page that thread by its
-returned thread ID before deciding the conversation is complete.
-
-```bash
-gh api graphql -f query='
-  query($thread:ID!, $cursor:String) {
-    node(id:$thread) {
-      ... on PullRequestReviewThread {
-        comments(first:100, after:$cursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            id
-            body
-            author { login }
-            path
-            line
-            createdAt
-            isMinimized
-            minimizedReason
+thread_number=0
+jq -r '.[].data.repository.pullRequest.reviewThreads.nodes[].id' \
+  "$gate_dir/threads.json" | while IFS= read -r thread_id; do
+    thread_number=$((thread_number + 1))
+    gh api graphql --paginate --slurp -f query='
+      query($thread:ID!, $endCursor:String) {
+        node(id:$thread) {
+          ... on PullRequestReviewThread {
+            comments(first:100, after:$endCursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes { id body author { login } path line createdAt isMinimized minimizedReason }
+            }
           }
         }
       }
-    }
-  }
-' -F thread=THREAD_ID -F cursor=null
+    ' -F thread="$thread_id" -F endCursor=null \
+      >"$gate_dir/thread-comments-$thread_number.json"
+  done
 ```
 
-Inspect minimized comments as deliberately as visible ones: minimizing is not
-a resolution or a waiver. Every unresolved review thread, including an outdated
-one, blocks the ready gate unless an applicable current repository ruleset
-explicitly permits the exception.
-
-## Resolving Review Threads
-
-After fixing an issue raised in a review thread, resolve it:
+Every unresolved thread blocks the gate, including an outdated thread, unless
+the current ruleset expressly permits that precise exception. Minimized is not
+resolved. Resolve a thread only after its fix is present in the current head.
 
 ```bash
-# Single thread
-gh api graphql -f query='
-  mutation {
-    resolveReviewThread(input: {threadId: "THREAD_ID"}) {
-      thread { isResolved }
-    }
-  }
-'
-
-# Multiple threads at once (use aliases)
-gh api graphql -f query='
-  mutation {
-    t1: resolveReviewThread(input: {threadId: "ID_1"}) { thread { isResolved } }
-    t2: resolveReviewThread(input: {threadId: "ID_2"}) { thread { isResolved } }
-  }
-'
+# REST carries check runs and suites; its full path scopes gh api explicitly.
+for oid in "$head_oid" "$candidate_oid"; do
+  gh api --paginate --slurp \
+    "repos/$base_repo/commits/$oid/check-runs?per_page=100" \
+    >"$gate_dir/check-runs-$oid.json"
+  gh api --paginate --slurp \
+    "repos/$base_repo/commits/$oid/check-suites?per_page=100" \
+    >"$gate_dir/check-suites-$oid.json"
+done
 ```
 
-## Rebasing on the PR Base
+Join each expected check run to its suite. The suite's associated PR must name
+the captured repository, `head_oid`/head ref, and `base_oid`/base ref. A run on
+`candidate_oid` is valid only with that exact association; an unrelated green
+run, a run for an earlier head, or one for a different base fails.
 
-Prefer a short, signed stack: put follow-up fixes in signed child commits and
-rebase only when a current base is actually required. Before rewriting a
-published branch, fetch it, capture the exact remote branch OID, and make sure
-the rewrite is authorized for that branch.
-
-This task's user-directed policy permits direct same-repository branches only.
-Refuse to push a fork branch; never guess that `origin`, `main`, or the
-checked-out branch is the PR source. Derive the live PR head repository/ref and
-base repository/ref first, then select exactly one verified local remote for
-that head repository.
+Before marking ready or merging, create a normalized, sorted manifest from all
+the files above plus the expected-check inventory and ruleset evidence. Validate
+the formal-Copilot predicate, human/code-owner approval, zero unpermitted
+unresolved threads, and every expected check/provider/suite association. Then
+capture the **entire** evidence set again and compare the two manifests:
 
 ```bash
-# Start from the actual target PR URL, not a branch name or local remote.
-pr_url="https://github.example/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
-base_repo="$(printf '%s\n' "$pr_url" | awk -F/ '{print $(NF-3) "/" $(NF-2)}')"
-pr="$(printf '%s\n' "$pr_url" | awk -F/ '{print $NF}')"
-case "$base_repo" in */*) ;; *) echo "invalid PR URL" >&2; exit 1;; esac
+manifest_snapshot() {
+  snapshot="$1"
+  find "$snapshot" -type f -name '*.json' -print | LC_ALL=C sort |
+    while IFS= read -r json; do
+      relative="${json#"$snapshot"/}"
+      printf '%s\t' "$relative"
+      jq -S -c . "$json"
+    done >"$snapshot/gate.jsonl"
+}
+
+# After validating verified/, run every identity/review/thread/check collector
+# above again with gate_dir="$gate_root/final". Include expected inventory and
+# ruleset evidence JSON in both directories, then reject any change.
+manifest_snapshot "$gate_root/verified"
+manifest_snapshot "$gate_root/final"
+cmp -s "$gate_root/verified/gate.jsonl" "$gate_root/final/gate.jsonl" || \
+  fail "gate evidence changed; restart from identity and request a new review"
+```
+
+The final capture must still have the observed head/base pair. A changed head or
+base invalidates Copilot, human approval, checks, and threads; restart rather
+than carrying any evidence forward.
+
+## Rebasing a same-repository PR safely
+
+Use signed child commits where possible. Rewrite only an authorized direct PR
+branch, and only after deriving its live source and base from the PR URL.
+
+```bash
+set -euo pipefail
+
 pr_data="$(gh pr view "$pr" --repo "$base_repo" \
   --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
 base_ref="$(jq -r .baseRefName <<<"$pr_data")"
@@ -251,298 +291,120 @@ base_oid="$(jq -r .baseRefOid <<<"$pr_data")"
 head_ref="$(jq -r .headRefName <<<"$pr_data")"
 head_oid="$(jq -r .headRefOid <<<"$pr_data")"
 head_repo="$(jq -r .headRepository.nameWithOwner <<<"$pr_data")"
+test "$head_repo" = "$base_repo" || { echo "refusing fork push" >&2; exit 1; }
 
-# The current user-directed policy does not authorize pushes to forks.
-test "$head_repo" = "$base_repo" || {
-  echo "refusing to rewrite or push fork PR $head_repo" >&2
-  exit 1
-}
-
-# Match a configured remote's fetch and push URLs to the actual PR head
-# repository, rather than assuming that a remote named origin is safe. Refuse
-# ambiguity or a distinct push target.
+# A selected remote must have exactly one push URL, and both its fetch and push
+# targets must resolve to the current PR head repository.
 push_remote=""
 for candidate in $(git remote); do
-  candidate_fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
-    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
-  candidate_push_repo="$(gh repo view "$(git remote get-url --push "$candidate")" \
-    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
-  test "$candidate_fetch_repo" = "$head_repo" || continue
-  test "$candidate_push_repo" = "$head_repo" || continue
-  test -z "$push_remote" || {
-    echo "multiple remotes resolve to PR head repository" >&2
-    exit 1
-  }
+  fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
+    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || :)"
+  push_urls="$(git remote get-url --push --all "$candidate")"
+  push_count="$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')"
+  test "$push_count" = 1 || continue
+  push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
+  push_repo="$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner \
+    2>/dev/null || :)"
+  test "$fetch_repo" = "$head_repo" || continue
+  test "$push_repo" = "$head_repo" || continue
+  test -z "$push_remote" || { echo "ambiguous verified remotes" >&2; exit 1; }
   push_remote="$candidate"
 done
-test -n "$push_remote" || {
-  echo "no configured remote matches PR head repository" >&2
-  exit 1
-}
+test -n "$push_remote" || { echo "no single verified push target" >&2; exit 1; }
 
 git fetch "$push_remote" \
   "refs/heads/$base_ref:refs/remotes/$push_remote/$base_ref" \
   "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
-test "$(git rev-parse "$push_remote/$base_ref")" = "$base_oid" || {
-  echo "PR base changed; refresh PR metadata before rebasing" >&2
-  exit 1
-}
+test "$(git rev-parse "$push_remote/$base_ref")" = "$base_oid"
 remote_head="$(git rev-parse "$push_remote/$head_ref")"
-test "$remote_head" = "$head_oid" || {
-  echo "PR head changed; refresh PR metadata before rebasing" >&2
-  exit 1
-}
-test "$(git rev-parse HEAD)" = "$head_oid" || {
-  echo "local checkout is stale or is not the captured PR head" >&2
-  exit 1
-}
-local_branch="$(git branch --show-current)"
-test "$local_branch" = "$head_ref" || {
-  echo "checked-out branch is not the PR head ref" >&2
-  exit 1
-}
-test -z "$(git status --porcelain)" || {
-  echo "refusing to rebase a dirty worktree" >&2
-  exit 1
-}
+test "$remote_head" = "$head_oid"
+test "$(git rev-parse HEAD)" = "$head_oid" || { echo "stale checkout" >&2; exit 1; }
+test "$(git branch --show-current)" = "$head_ref"
+test -z "$(git status --porcelain)" || { echo "dirty worktree" >&2; exit 1; }
+
 if ! git rebase --gpg-sign "$push_remote/$base_ref"; then
   echo "rebase stopped; do not push" >&2
   git status --short
-  echo "resolve only named conflict paths and continue, or run git rebase --abort" >&2
+  exit 1
+fi
+git rebase --show-current-patch >/dev/null 2>&1 && { echo "rebase remains" >&2; exit 1; }
+test -z "$(git status --porcelain)" || { echo "dirty after rebase" >&2; exit 1; }
+test "$(git merge-base HEAD "$push_remote/$base_ref")" = \
+  "$(git rev-parse "$push_remote/$base_ref")"
+
+signature_statuses="$(git log --format='%G?' "$push_remote/$base_ref..HEAD")"
+printf '%s\n' "$signature_statuses"
+if printf '%s\n' "$signature_statuses" | grep -Eq '[^G]'; then
+  echo "rewritten commits are not all validly signed" >&2
   exit 1
 fi
 
-# --gpg-sign preserves signing for rewritten commits. Configure a suitable
-# signing key in advance; do not disable signing to bypass a local setup
-# problem. Check every rewritten commit before pushing.
-git rebase --show-current-patch >/dev/null 2>&1 && {
-  echo "rebase state remains; do not push" >&2
-  exit 1
-}
-test -z "$(git status --porcelain)" || {
-  echo "worktree is not clean after rebase; do not push" >&2
-  exit 1
-}
-test "$(git merge-base HEAD "$push_remote/$base_ref")" = \
-  "$(git rev-parse "$push_remote/$base_ref")" || {
-  echo "rebased HEAD is not based on the captured PR base" >&2
-  exit 1
-}
-git log --show-signature --format='%H %G?' "$push_remote/$base_ref..HEAD"
-test -z "$(git log --format='%G?' "$push_remote/$base_ref..HEAD" | grep -v '^G$')" || {
-  echo "rewritten commits are not all validly signed" >&2
-  exit 1
-}
-
-# Only after the rebase is verified, update this personal branch without
-# overwriting a collaborator's intervening push. Re-read the live PR metadata
-# immediately before this command and stop if head/base repository, ref, or OID
-# changed from pr_data.
-current_pr_data="$(gh pr view "$pr" --repo "$base_repo" \
-  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
-test "$current_pr_data" = "$pr_data" || {
-  echo "PR metadata changed; refresh and restart before pushing" >&2
-  exit 1
-}
+# Re-read live PR metadata; any movement means start over.
+test "$(gh pr view "$pr" --repo "$base_repo" \
+  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)" = "$pr_data"
 git push --force-with-lease="refs/heads/$head_ref:$remote_head" \
   "$push_remote" "HEAD:refs/heads/$head_ref"
 ```
 
-If the rebase stops, do not continue to the push block. Inspect its state,
-stage only the conflict paths that were actually resolved, and either continue
-or abandon the rebase. After a successful continuation, rerun every post-rebase
-guard above and re-read live PR metadata before considering a push.
+If a rebase stops, resolve and stage only the named conflict paths, then
+continue; otherwise run `git rebase --abort`. After either path, rerun every
+post-rebase guard before a push. Never use broad `--force`, reset-based squash,
+unsigned amend, or `git add -A`.
+
+## PR descriptions and draft lifecycle
+
+Prepare Markdown in a real file. Do not interpolate Markdown, backticks, or
+escaped newlines through `--body` or shell command substitution.
 
 ```bash
-# Resume only after resolving the named paths:
-git status --short
-git add -- path/to/resolved-conflict.go path/to/other-resolved-file.yaml
-git rebase --continue
-```
+set -euo pipefail
 
-```bash
-# Or, if the rebase should not proceed, discard only the rebase operation.
-git rebase --abort
-```
-
-Do not use a broad `--force`. If the lease no longer matches, stop, fetch, and
-reconcile the remote change before deciding whether to rebase again.
-
-## Signed Commit Hygiene
-
-Keep commits signed. Do not disable signing for rebases, squashes, or amends.
-If a PR needs a single commit, prefer GitHub's signed squash-merge policy or a
-carefully reviewed interactive rebase on an unpublished personal branch.
-
-```bash
-git commit -S -m "docs: describe the change"
-git commit --amend -S --no-edit
-```
-
-Do not use reset-based squashing. It discards the reviewed commit structure and
-makes a lease-safe, auditable update harder. For stacked PRs, rebase each child
-in dependency order and update only the affected personal branch with an
-explicit `--force-with-lease` after checking its recorded remote OID.
-
-## Checking CI Status
-
-```bash
-# List all CI checks for a PR
-gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --required
-
-# Watch CI in real-time
-gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --watch --required
-
-# Get detailed check run output
-gh run view RUN_ID --repo BASE_OWNER/BASE_REPOSITORY --log-failed
-```
-
-Get the expected check inventory and acceptable provider from the actual branch
-ruleset/required-workflow configuration for the captured base ref; do not infer
-them from whichever checks happened to appear in one run. For this task, every
-expected job must conclude `success`. `neutral` or `skipped` is acceptable only
-when the current rules explicitly name that exact job/provider as intentionally
-expected, and the gate records the rule source and reason; it is never silently
-treated as a pass.
-
-Use both check suites and check runs, and inspect the suite's associated PR
-objects. The REST commands deliberately carry the full repository path because
-`gh api` does not implement `--repo`:
-
-```bash
-# Record the PR source/base pair, test-merge candidate, merge-queue entry, and
-# GraphQL check-suite IDs. Paginate statusCheckRollup contexts when necessary.
-gh api graphql --paginate -f query='
-  query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
-    repository(owner:$owner, name:$repo) {
-      pullRequest(number:$pr) {
-        headRefOid
-        baseRefOid
-        potentialMergeCommit { oid }
-        mergeQueueEntry { id }
-        statusCheckRollup {
-          contexts(first:100, after:$endCursor) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              __typename
-              ... on CheckRun {
-                name
-                conclusion
-                detailsUrl
-                checkSuite { id }
-              }
-              ... on StatusContext { context state targetUrl }
-            }
-          }
-        }
-      }
-    }
-  }
-' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F endCursor=null
-```
-
-```bash
-base_repo=BASE_OWNER/BASE_REPOSITORY
-head_oid=CAPTURED_PR_HEAD_OID
-base_oid=CAPTURED_PR_BASE_OID
-candidate_oid=CAPTURED_TEST_MERGE_OR_MERGE_QUEUE_OID
-
-# Inspect the source head and, when GitHub selected one, its test-merge or
-# merge-queue candidate. Paginate all response pages.
-for oid in "$head_oid" "$candidate_oid"; do
-  test -n "$oid" || continue
-  gh api --paginate "repos/$base_repo/commits/$oid/check-suites?per_page=100"
-  gh api --paginate "repos/$base_repo/commits/$oid/check-runs?per_page=100"
-  gh api --paginate "repos/$base_repo/commits/$oid/pulls?per_page=100"
-done
-```
-
-For every expected check, verify the check run, its check suite, and the
-suite's associated pull request all identify the captured `head_oid`,
-`base_oid`, repository, and refs. A head-based workflow may run directly on
-`head_oid`; a `pull_request` test merge or merge queue may use `candidate_oid`
-only when the suite's PR association proves that exact source/base pair. Record
-the selected candidate from the workflow/merge-queue event metadata (for a
-regular PR, `potentialMergeCommit.oid` can supply the current test-merge
-candidate). Re-run the complete gate after any branch or base update.
-
-## Adding PR Comments
-
-```bash
-# General comment
-gh pr comment PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --body "Comment text"
-
-# gh api has no --repo flag. Use only IDs returned by the earlier GraphQL query
-# explicitly scoped to BASE_OWNER/BASE_REPOSITORY.
-# Reply to a review thread (use the thread's comment ID)
-gh api graphql -f query='
-  mutation {
-    addPullRequestReviewComment(input: {
-      pullRequestReviewId: "REVIEW_ID",
-      inReplyTo: "COMMENT_ID",
-      body: "Reply text"
-    }) { comment { id } }
-  }
-'
-```
-
-## Creating PRs
-
-Write the description into a real Markdown file. Do not interpolate complex
-Markdown, backticks, variables, or escaped newlines through an inline
-`--body` argument or shell command substitution.
-
-```bash
-# Select a known editor executable directly; do not evaluate a shell fragment
-# from EDITOR or interpolate Markdown through a shell command.
 body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
-vi "$body_file"
-test -s "$body_file" || {
-  echo "refusing to create or edit a PR with an empty description" >&2
-  exit 1
-}
+vi "$body_file"                         # a known executable, not an EDITOR shell fragment
+test -s "$body_file"
 
-# Derive the target's actual default base; do not hardcode main.
+# Use the actual intended base, not a hardcoded main. Resolve the default only
+# when that is the intended target; otherwise set and validate the release base.
 base_repo=BASE_OWNER/BASE_REPOSITORY
 base_ref="$(gh repo view "$base_repo" --json defaultBranchRef --jq .defaultBranchRef.name)"
+head_ref="$(git branch --show-current)"
 
-gh pr create --repo "$base_repo" \
-  --title "feat: description" \
-  --body-file "$body_file" \
-  --base "$base_ref"
+# The branch must already be pushed to one preverified same-repository target.
+push_remote=REMOTE_VERIFIED_FOR_THIS_BRANCH
+push_urls="$(git remote get-url --push --all "$push_remote")"
+test "$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')" = 1
+push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
+test "$(gh repo view "$(git remote get-url "$push_remote")" \
+  --json nameWithOwner --jq .nameWithOwner)" = "$base_repo"
+test "$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner)" = "$base_repo"
+git fetch "$push_remote" "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
+test "$(git rev-parse "$push_remote/$head_ref")" = "$(git rev-parse HEAD)"
 
-# The same rule applies to edits.
+pr_url="$(gh pr create --repo "$base_repo" --draft \
+  --head "$head_ref" --base "$base_ref" --title "feat: description" \
+  --body-file "$body_file")"
+printf '%s\n' "$pr_url"
+
+# Use the same file-only rule for an existing PR description.
 gh pr edit PR_NUMBER --repo "$base_repo" --body-file "$body_file"
+```
 
-# Read the stored body back and inspect the rendered PR to confirm headings,
-# newlines, links, dependency heads, scope, limitations, and test evidence.
+Read the stored raw body, inspect `bodyHTML`, and check the rendered web page
+for headings, newlines, links, dependency heads, scope, limitations, and test
+evidence. Mark a draft ready only after the complete gate passes.
+
+```bash
 gh pr view PR_NUMBER --repo "$base_repo" --json body --jq .body
 gh api graphql -f query='
   query($owner:String!, $repo:String!, $pr:Int!) {
-    repository(owner:$owner, name:$repo) {
-      pullRequest(number:$pr) { bodyHTML }
-    }
+    repository(owner:$owner, name:$repo) { pullRequest(number:$pr) { bodyHTML } }
   }
-' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER --jq \
-  .data.repository.pullRequest.bodyHTML
+' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr=PR_NUMBER \
+  --jq .data.repository.pullRequest.bodyHTML
 gh pr view PR_NUMBER --repo "$base_repo" --web
+gh pr ready PR_NUMBER --repo "$base_repo"
 ```
 
-Compare the raw body to the source file, inspect `bodyHTML`, and verify the
-rendered web page before relying on the description. The raw API body alone
-does not prove Markdown rendered as intended.
-
-## Workflow Tips
-
-1. **Gate each pushed head/base pair** — collect exact OIDs, required CI
-   association, formal-review commit OID, minimized comments, and every
-   unresolved thread. Copilot does not inherently review every push.
-2. **Resolve threads only after fixing** — don't resolve a thread until the
-   code change is pushed and the new head has been checked.
-3. **Batch GraphQL mutations** — resolve multiple threads in one API call
-   using aliases (`t1:`, `t2:`, etc.).
-4. **Prefer stacked signed commits** — rebase only when necessary, preserve
-   signatures, and use an explicit `--force-with-lease` only for an authorized
-   rewrite of the affected branch.
-5. **Verify the formal review** — a Copilot review must be a formal review on
-   the current head, not an `@copilot review` coding-agent comment.
+Do not run the final `gh pr ready` command until the full gate snapshot has
+passed unchanged. No successful check, review, or absence of new comments from
+an earlier head/base pair is reusable evidence.

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -1,7 +1,7 @@
 # GitHub PR Management
 
 Use this prompt when managing pull requests: reviewing, resolving threads,
-rebasing, squashing, and interacting with CI.
+rebasing, squashing, writing descriptions, and interacting with CI.
 
 ## Prerequisites
 
@@ -9,27 +9,113 @@ rebasing, squashing, and interacting with CI.
 - EMU (Enterprise Managed User) accounts cannot use GitHub MCP API for
   write operations — always use `gh` CLI instead
 
+## Exact-Head Gate
+
+Treat the commit currently at the PR head as the unit of approval. A green
+check or review on an earlier commit does not approve a later push.
+
+After **every** push, record the new head and do not mark the PR ready until
+all of the following apply to that exact object ID:
+
+1. Every required CI check has completed successfully for the current head.
+   Inspect the expected check inventory as well as its conclusion; a single
+   unrelated successful check is not sufficient.
+2. The latest formal Copilot review was submitted for that same head (if
+   Copilot review is required for the repository).
+3. Suppressed/minimized review comments have been inspected, and every
+   non-outdated unresolved review thread has either been fixed and resolved or
+   has an explicit, documented disposition.
+
+```bash
+# Save this value before inspecting checks and reviews. Re-run it after each
+# push; never reuse an OID recorded for an earlier head.
+head_oid="$(gh pr view PR_NUMBER --json headRefOid --jq .headRefOid)"
+printf '%s\n' "$head_oid"
+
+# CI status is useful only after comparing its commit to head_oid.
+gh pr checks PR_NUMBER --watch --required
+```
+
+For automated gates, query the PR's `headRefOid`, required check runs, formal
+reviews (including each review's `commit.oid`), review threads, and minimized
+comments through GitHub GraphQL. Paginate each connection until `hasNextPage`
+is false. Fail the gate unless the selected Copilot review's `commit.oid`
+equals `headRefOid`, all required checks apply to that OID and succeeded, and
+there are no unreviewed minimized comments or non-outdated unresolved threads.
+
+For example, enumerate formal reviews with a separate paginated query, then
+select the latest submitted Copilot reviewer result rather than a coding-agent
+comment:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        headRefOid
+        reviews(first:100, after:$cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            author { login }
+            state
+            submittedAt
+            commit { oid }
+          }
+        }
+      }
+    }
+  }
+' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
+```
+
+Compare the formal review's `commit.oid` to the displayed `headRefOid` exactly;
+an older matching review state is insufficient. Repeat with `cursor` set to
+`endCursor` until all review pages have been inspected.
+
+## Requesting a Formal Copilot Review
+
+Request Copilot as a PR reviewer; do **not** use an `@copilot review` comment.
+That comment invokes the coding agent and is not a formal pull-request review
+request.
+
+```bash
+gh pr edit PR_NUMBER --add-reviewer @copilot
+```
+
+The equivalent is GitHub's requested-reviewers REST endpoint with the Copilot
+reviewer account. Use it only where the repository's GitHub configuration
+supports that bot reviewer.
+
+Copilot does not automatically re-review every pushed commit unless the
+repository has explicitly configured automatic re-reviews. After each pushed
+head, request another formal review when necessary and verify the resulting
+review commit OID against the new PR head. Never infer a new review from an
+older review, a comment, or the absence of new threads.
+
 ## Checking PR Review Threads
 
 Use this GraphQL query to list all review threads and their resolution status:
 
 ```bash
 gh api graphql -f query='
-  query($owner:String!, $repo:String!, $pr:Int!) {
+  query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
-        reviewThreads(first:100) {
+        reviewThreads(first:100, after:$cursor) {
+          pageInfo { hasNextPage endCursor }
           nodes {
             id
             isResolved
             isOutdated
-            comments(first:1) {
+            comments(first:100) {
               nodes {
                 body
                 author { login }
                 path
                 line
                 createdAt
+                isMinimized
+                minimizedReason
               }
             }
           }
@@ -37,8 +123,14 @@ gh api graphql -f query='
       }
     }
   }
-' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER
+' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
 ```
+
+Repeat the query with `cursor` set to `endCursor` until `hasNextPage` is
+false. Inspect minimized comments as deliberately as visible ones: minimizing
+is not a resolution or a waiver. Only unresolved threads with
+`isOutdated: false` block the ready gate, but outdated threads still deserve a
+documented decision when they raise a safety concern.
 
 ## Resolving Review Threads
 
@@ -65,43 +157,49 @@ gh api graphql -f query='
 
 ## Rebasing on Main
 
+Prefer a short, signed stack: put follow-up fixes in signed child commits and
+rebase only when a current base is actually required. Before rewriting a
+published branch, fetch it, capture the exact remote branch OID, and make sure
+the rewrite is authorized for that branch.
+
 ```bash
 git fetch origin main
-git rebase origin/main
+branch="$(git branch --show-current)"
+remote_head="$(git rev-parse "origin/$branch")"
+git rebase --gpg-sign origin/main
 
 # If conflicts arise, resolve them and continue:
 git add -A
 git rebase --continue
 
-# Always use gpg-sign=false and skip editor:
-GIT_EDITOR=true git -c commit.gpgsign=false rebase --continue
+# --gpg-sign preserves signing for rewritten commits. Configure a suitable
+# signing key in advance; do not disable signing to bypass a local setup
+# problem. Check every rewritten commit before pushing.
+git log --show-signature --format=fuller origin/main..HEAD
+
+# Only after the rebase is verified, update this personal branch without
+# overwriting a collaborator's intervening push.
+git push --force-with-lease="refs/heads/$branch:$remote_head" origin "$branch"
 ```
 
-## Squashing Commits
+Do not use a broad `--force`. If the lease no longer matches, stop, fetch, and
+reconcile the remote change before deciding whether to rebase again.
 
-Squash all commits on a feature branch into one:
+## Signed Commit Hygiene
+
+Keep commits signed. Do not disable signing for rebases, squashes, or amends.
+If a PR needs a single commit, prefer GitHub's signed squash-merge policy or a
+carefully reviewed interactive rebase on an unpublished personal branch.
 
 ```bash
-# Count commits ahead of main
-COMMITS=$(git rev-list --count origin/main..HEAD)
-
-# Interactive rebase, squash all into first
-GIT_EDITOR="sed -i '' '2,\$s/^pick/squash/'" git -c commit.gpgsign=false rebase -i HEAD~$COMMITS
-
-# Or reset-based squash (simpler):
-git reset --soft origin/main
-git -c commit.gpgsign=false commit -m "feat: description (#PR)"
+git commit -S -m "docs: describe the change"
+git commit --amend -S --no-edit
 ```
 
-## Amending and Force-Pushing
-
-After fixing review comments, amend the squashed commit:
-
-```bash
-git add -A
-git -c commit.gpgsign=false commit --amend --no-edit
-git push --force-with-lease
-```
+Do not use reset-based squashing. It discards the reviewed commit structure and
+makes a lease-safe, auditable update harder. For stacked PRs, rebase each child
+in dependency order and update only the affected personal branch with an
+explicit `--force-with-lease` after checking its recorded remote OID.
 
 ## Checking CI Status
 
@@ -115,6 +213,11 @@ gh pr checks PR_NUMBER --watch
 # Get detailed check run output
 gh run view RUN_ID --log-failed
 ```
+
+Before accepting the result, compare the CI run's head SHA and every required
+check run's SHA to the `head_oid` recorded in the exact-head gate. Re-run the
+gate after any branch update, including an automatic rebase or a merge from
+main.
 
 ## Adding PR Comments
 
@@ -136,22 +239,38 @@ gh api graphql -f query='
 
 ## Creating PRs
 
+Write the description into a real Markdown file. Do not interpolate complex
+Markdown, backticks, variables, or escaped newlines through an inline
+`--body` argument or shell command substitution.
+
 ```bash
+# Edit a real temporary Markdown file using an editor or a repository template.
+body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
+
 gh pr create \
   --title "feat: description" \
-  --body "## Summary\n\nDescription\n\n## Changes\n\n- Change 1\n- Change 2" \
+  --body-file "$body_file" \
   --base main
+
+# The same rule applies to edits.
+gh pr edit PR_NUMBER --body-file "$body_file"
+
+# Read the stored body back and inspect the rendered PR to confirm headings,
+# newlines, links, dependency heads, scope, limitations, and test evidence.
+gh pr view PR_NUMBER --json body --jq .body
 ```
 
 ## Workflow Tips
 
-1. **Always check threads after push** — Copilot reviewer adds new threads
-   on every push. Run the thread-check query after each force-push.
+1. **Gate each pushed head** — collect its exact OID, required CI result,
+   formal-review commit OID, minimized comments, and unresolved current
+   threads. Copilot does not inherently review every push.
 2. **Resolve threads only after fixing** — don't resolve a thread until the
-   code change is pushed.
+   code change is pushed and the new head has been checked.
 3. **Batch GraphQL mutations** — resolve multiple threads in one API call
    using aliases (`t1:`, `t2:`, etc.).
-4. **Force-push with lease** — always use `--force-with-lease` to avoid
-   overwriting collaborators' changes.
-5. **Verify 0 unresolved** — before marking a PR ready, confirm all threads
-   are resolved.
+4. **Prefer stacked signed commits** — rebase only when necessary, preserve
+   signatures, and use an explicit `--force-with-lease` only for an authorized
+   rewrite of the affected branch.
+5. **Verify the formal review** — a Copilot review must be a formal review on
+   the current head, not an `@copilot review` coding-agent comment.

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -3,16 +3,32 @@
 Use this prompt to create, update, review, rebase, and ready a pull request.
 Treat a PR as approved only when one complete, current evidence snapshot passes.
 
-## Repository and command scope
+## Repository, host, and command scope
 
-- Use `--repo BASE_OWNER/BASE_REPOSITORY` with every `gh pr` and `gh run`
-  command. Do not rely on the checked-out repository or a remote named
-  `origin`.
+- Pin every GitHub operation to the HTTPS host embedded in the actual PR URL.
+  Do not rely on `GH_HOST`, the checked-out repository, a remote named
+  `origin`, or a Git URL rewrite. The reference helper below rejects HTTP,
+  credentials, ports, queries, fragments, malformed hosts, and malformed PR
+  paths before a network request is made.
+- Use `--repo HOST/BASE_OWNER/BASE_REPOSITORY` with every `gh pr` and `gh run`
+  command. REST and GraphQL requests must use `gh api --hostname HOST`; their
+  REST paths must include `repos/BASE_OWNER/BASE_REPOSITORY/...` and GraphQL
+  calls must include explicit `owner` and `repo` variables.
 - This task's user-directed policy permits direct same-repository branches
   only. Refuse fork pushes; do not repurpose this policy as a repository rule.
-- The installed `gh api` has no `--repo` flag. Its REST paths must include
-  `repos/$base_repo/...`; its GraphQL calls must include explicit `owner` and
-  `repo` variables.
+- Run the behavioural conformance suite before relying on a changed copy of
+  this procedure:
+
+  ```bash
+  ./.github/scripts/test-pr-gate-contract.sh
+  ```
+
+  The prompt uses [`.github/scripts/pr-gate-contract.sh`](../scripts/pr-gate-contract.sh)
+  as the executable reference for URL parsing, conservative review freshness,
+  policy inventory, and exact check-suite evidence. It tests API-shaped
+  fixtures, including a synthetic merge candidate that differs from the source
+  head and attacker-controlled suite/status cases; it does not test for text
+  in this document.
 
 ## Formal review requirements
 
@@ -20,7 +36,7 @@ Request a formal Copilot review; do not write an `@copilot review` comment.
 The comment invokes the coding agent and is not a pull-request review request.
 
 ```bash
-gh pr edit PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
+GH_HOST=HOST gh pr edit PR_NUMBER --repo HOST/BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
 ```
 
 For the fail-closed gate below, use the equivalent REST reviewer request with
@@ -63,10 +79,18 @@ set -euo pipefail
 fail() { printf '%s\n' "$*" >&2; exit 1; }
 
 # Derive both target repository and number from the actual PR URL.
-pr_url="https://github.example/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
-base_repo="$(printf '%s\n' "$pr_url" | awk -F/ '{print $(NF-3) "/" $(NF-2)}')"
-pr="$(printf '%s\n' "$pr_url" | awk -F/ '{print $NF}')"
-case "$base_repo" in */*) ;; *) fail "invalid PR URL";; esac
+# Supply the exact browser/API URL rather than a host placeholder. The parser
+# pins host/repository/number before any `gh` or Git network operation.
+pr_url="https://github.com/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
+contract="./.github/scripts/pr-gate-contract.sh"
+test -x "$contract" || fail "missing executable PR-gate contract helper"
+IFS=$'\t' read -r github_host base_repo pr <<EOF
+$($contract parse-pr-url "$pr_url")
+EOF
+hosted_repo="$github_host/$base_repo"
+gh_api() { env GH_HOST="$github_host" gh api --hostname "$github_host" "$@"; }
+gh_pr() { env GH_HOST="$github_host" gh pr "$@"; }
+case "$base_repo" in */*) ;; *) fail "invalid PR repository";; esac
 case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
 
 gate_root="$(mktemp -d)"
@@ -85,12 +109,13 @@ esac
 capture_identity() {
   # shellcheck disable=SC2016
   # GraphQL variables must reach gh unchanged.
-  gh api graphql -f query='
+  gh_api graphql -f query='
     query($owner:String!, $repo:String!, $pr:Int!) {
       repository(owner:$owner, name:$repo) {
         pullRequest(number:$pr) {
-          headRefName headRefOid baseRefName baseRefOid
-          headRepository { nameWithOwner }
+          headRefName headRefOid baseRefName baseRefOid isDraft mergeable mergeStateStatus
+          headRepository { id nameWithOwner }
+          baseRepository { id nameWithOwner }
           reviewDecision
           potentialMergeCommit { oid }
           mergeQueueEntry { id }
@@ -100,27 +125,17 @@ capture_identity() {
   ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr"
 }
 
-# No workstation clock participates in review freshness. GitHub's HTTP Date is
-# the server-derived completion boundary; strict greater-than deliberately
-# rejects same-second review timestamps.
-server_date_to_ns() {
-  command -v ruby >/dev/null || return 1
-  # shellcheck disable=SC2016
-  ruby -r time -e '
-    s = ARGV.fetch(0); t = Time.httpdate(s).utc
-    abort unless t.utc? && s.match?(/\A(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), /)
-    puts (t.to_r * 1_000_000_000).to_i
-  ' "$1"
-}
-
-review_timestamp_to_ns() {
-  command -v ruby >/dev/null || return 1
-  # shellcheck disable=SC2016
-  ruby -r time -e '
-    s = ARGV.fetch(0)
-    abort unless s.match?(/\A\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z\z/)
-    t = Time.iso8601(s).utc; abort unless t.utc?
-    puts (t.to_r * 1_000_000_000).to_i
+# `reviewDecision`, mergeability, and merge-state legitimately change while CI
+# and reviews complete. Bind only immutable source/base/candidate identity
+# across the review request; validate mutable policy state in each snapshot.
+identity_binding() {
+  jq -S '
+    .data.repository.pullRequest |
+    {headRefName, headRefOid, baseRefName, baseRefOid,
+     headRepository: {id: .headRepository.id, nameWithOwner: .headRepository.nameWithOwner},
+     baseRepository: {id: .baseRepository.id, nameWithOwner: .baseRepository.nameWithOwner},
+     potentialMergeCommit: (.potentialMergeCommit | if . == null then null else {oid} end),
+     mergeQueueEntry: (.mergeQueueEntry | if . == null then null else {id} end)}
   ' "$1"
 }
 
@@ -128,14 +143,11 @@ request_formal_review() {
   review_request_http="$gate_root/review-request.http"
   # REST is the formal reviewer API equivalent of `gh pr edit --add-reviewer`.
   # --include preserves the GitHub server Date header with the successful POST.
-  gh api --include -X POST "repos/$base_repo/pulls/$pr/requested_reviewers" \
+  gh_api --include -X POST "repos/$base_repo/pulls/$pr/requested_reviewers" \
     -f "reviewers[]=$copilot_reviewer_login" >"$review_request_http"
-  request_server_date="$(awk '
-    tolower($1) == "date:" { $1=""; sub(/^[[:space:]]+/, ""); print; exit }
-    /^[[:space:]]*$/ { exit }
-  ' "$review_request_http")"
-  test -n "$request_server_date" || fail "GitHub review request omitted Date"
-  request_server_ns="$(server_date_to_ns "$request_server_date")" ||
+  request_server_date="$($contract request-date "$review_request_http")" ||
+    fail "ambiguous GitHub review-request Date"
+  request_server_ns="$($contract request-date-to-ns "$review_request_http")" ||
     fail "ambiguous GitHub review-request Date"
   case "$request_server_ns" in ''|*[!0-9]*)
     fail "invalid GitHub review-request boundary";;
@@ -152,8 +164,10 @@ jq -e '((.errors // []) | length) == 0 and .data != null and
        .data.repository.pullRequest != null and
        .data.repository.pullRequest.headRefOid and
        .data.repository.pullRequest.baseRefOid and
-       .data.repository.pullRequest.headRepository.nameWithOwner' \
+       .data.repository.pullRequest.headRepository.nameWithOwner and
+       .data.repository.pullRequest.baseRepository.nameWithOwner' \
   "$observed" >/dev/null || fail "incomplete PR identity"
+identity_binding "$observed" >"$gate_root/observed-identity-binding.json"
 base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' "$observed")"
 ```
 
@@ -174,10 +188,12 @@ candidate_oid="$(jq -r \
 ```
 
 Once the requested review and required CI are complete, take the first complete
-evidence capture in `$gate_root/verified`. Its `identity.json` must byte-match
-`observed.json` before using it. Validate the evidence, then repeat the *same*
-collection into `$gate_root/final` immediately before ready/merge. Both captures
-must use the same filenames and include a fresh `identity.json`.
+evidence capture in `$gate_root/verified`. Its immutable source/base/candidate
+identity projection must byte-match the observed projection before use;
+approval/merge-state fields are deliberately re-read because they are expected
+to change while the review completes. Validate the evidence, then repeat the
+*same* collection into `$gate_root/final` immediately before ready/merge. Both
+captures must use the same filenames and include a fresh `identity.json`.
 
 ### Evidence that one gate snapshot must contain
 
@@ -185,19 +201,25 @@ Capture every page of each connection. A complete snapshot contains:
 
 | Evidence | Required fields and decision |
 | --- | --- |
-| PR identity | `headRefOid`, `baseRefOid`, head repository/ref, base ref, test-merge SHA, `reviewDecision` |
-| Formal reviews | review ID, configured reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review strictly after GitHub's `request_server_ns` response boundary |
-| Human approval | `reviewDecision` and current branch-ruleset/code-owner evidence for the pair; Copilot does not satisfy this row |
+| PR identity | pinned HTTPS host; `headRefOid`, `baseRefOid`, source/base repository and refs, test-merge SHA, `reviewDecision`, `mergeable`, `mergeStateStatus`, draft state |
+| Formal reviews | review ID, configured reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review no earlier than the first whole second after GitHub's server `Date` boundary |
+| Human approval | `reviewDecision == APPROVED`, zero unresolved threads, and the current `mergeable == MERGEABLE` / `mergeStateStatus == CLEAN` server predicate for the pair; Copilot does not satisfy this row |
 | Threads and comments | every thread ID/resolution/outdated state and every comment ID, minimized state/reason, author, path, line, and timestamp |
 | Checks | complete expected inventory, result, `head_sha`, check-suite ID, and `CheckRun.app.owner.login`, `CheckRun.app.slug`, and `CheckRun.app.id` |
 | Legacy statuses | every context, state, target URL, and `creator.login`/`creator.id`; reject a status that attempts to satisfy a required context because GitHub rules do not bind its creator |
-| Check suites | suite ID, `head_sha`, app/provider identity, and each associated PR's repository, head SHA/ref, and base SHA/ref |
+| Check suites | suite ID, `head_sha`, app/provider identity, suite repository identity/HTTPS URL, and each associated PR's source/base repository identity, refs, and SHAs |
 
 Fetch GitHub's effective branch rules and branch-protection object into every
-snapshot. They are the complete expected check/provider inventory: every
-required job must have one exact app ID and conclude `SUCCESS`. The gate rejects
-an empty, partial, legacy-only, or changed inventory; it does not accept a
-caller-provided “expected” list, `NEUTRAL`, or `SKIPPED` as a substitute.
+snapshot. Inventory **every active rule type and its parameters**, not only
+status checks. The contract validates App-bound required checks directly and
+uses GitHub's exact-PR final `MERGEABLE`/`CLEAN` predicate in addition for
+active `pull_request`, `required_signatures`, `required_workflows`,
+`required_deployments`, and `required_code_scanning` rules. A merge queue,
+linear-history rule, or any unrecognised active type fails closed with the
+server-provided type/parameters in the error: extend the verifier for that
+type, or remove/replace the rule before using this ready/merge gate. It never
+silently ignores a rule, accepts `NEUTRAL`/`SKIPPED`, or accepts a legacy
+required status, whose `creator` cannot prove a GitHub App integration.
 
 The following commands provide the raw, paginated review/thread/check material.
 Save each response under the gate directory and normalize it with sorted JSON
@@ -215,7 +237,7 @@ collect_reviews_and_threads() {
   # Formal reviews; evaluate the exact-login/latest/COMMENTED/time/head predicate.
   # shellcheck disable=SC2016
   # GraphQL variables must reach gh unchanged.
-  gh api graphql --paginate --slurp -f query='
+  gh_api graphql --paginate --slurp -f query='
   query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
@@ -245,18 +267,13 @@ jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" '
   fail "missing current formal Copilot review"
 
 review_submitted_at="$(jq -r .submittedAt "$gate_dir/copilot-review.json")"
-review_submitted_ns="$(review_timestamp_to_ns "$review_submitted_at")" ||
-  fail "invalid formal Copilot submittedAt"
-case "$review_submitted_ns:$request_server_ns" in :*|*:|*[!0-9:]*|*:*:*)
-  fail "ambiguous formal-review freshness boundary";;
-esac
-test "$review_submitted_ns" -gt "$request_server_ns" ||
-  fail "formal Copilot review is not after GitHub request completion"
+$contract verify-review-freshness "$gate_root/review-request.http" "$review_submitted_at" ||
+  fail "formal Copilot review is not provably after GitHub request completion"
 
   # All review threads. Paginate every returned thread's comments separately.
   # shellcheck disable=SC2016
   # GraphQL variables must reach gh unchanged.
-  gh api graphql --paginate --slurp -f query='
+  gh_api graphql --paginate --slurp -f query='
   query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
@@ -287,7 +304,7 @@ thread_number=0
     thread_number=$((thread_number + 1))
     # shellcheck disable=SC2016
     # GraphQL variables must reach gh unchanged.
-    gh api graphql --paginate --slurp -f query='
+    gh_api graphql --paginate --slurp -f query='
       query($thread:ID!, $endCursor:String) {
         node(id:$thread) {
           ... on PullRequestReviewThread {
@@ -317,17 +334,18 @@ Resolve a thread only after its fix is present in the current head.
 ```bash
 collect_ci_and_statuses() {
   gate_dir="$1"
-  # REST carries check runs, suites, and legacy statuses; its full path scopes gh api.
+  # REST carries check runs, suites, and legacy statuses. `filter=latest`
+  # avoids treating a superseded failed rerun as the current required run.
   oid_list=("$head_oid")
   test "$candidate_oid" = "$head_oid" || oid_list+=("$candidate_oid")
   for oid in "${oid_list[@]}"; do
-    gh api --paginate --slurp \
-      "repos/$base_repo/commits/$oid/check-runs?per_page=100" \
+    gh_api --paginate --slurp \
+      "repos/$base_repo/commits/$oid/check-runs?per_page=100&filter=latest" \
       >"$gate_dir/check-runs-$oid.json"
-    gh api --paginate --slurp \
+    gh_api --paginate --slurp \
       "repos/$base_repo/commits/$oid/check-suites?per_page=100" \
       >"$gate_dir/check-suites-$oid.json"
-    gh api --paginate --slurp \
+    gh_api --paginate --slurp \
       "repos/$base_repo/commits/$oid/status?per_page=100" \
       >"$gate_dir/status-contexts-$oid.json"
 
@@ -372,96 +390,33 @@ green.
 ```bash
 collect_policy_inventory() {
   gate_dir="$1"
-  gh api --paginate --slurp \
+  gh_api --paginate --slurp \
     "repos/$base_repo/rules/branches/$base_ref" \
     >"$gate_dir/effective-rules.json"
   jq -e 'type == "array" and length > 0 and all(.[]; type == "array")' \
     "$gate_dir/effective-rules.json" >/dev/null ||
     fail "missing or malformed effective branch rules"
-  gh api "repos/$base_repo/branches/$base_ref/protection" \
-    >"$gate_dir/branch-protection.json"
-  jq -e 'type == "object" and (.url | type) == "string"' \
-    "$gate_dir/branch-protection.json" >/dev/null ||
-    fail "missing or malformed branch protection"
 
-  jq -n --arg repository "$base_repo" --arg baseRef "$base_ref" \
-    --slurpfile effective "$gate_dir/effective-rules.json" \
-    --slurpfile protection "$gate_dir/branch-protection.json" '
-    def effective: ($effective[0] | add);
-    def ruleChecks:
-      [effective[] | select(.type == "required_status_checks") |
-       (.parameters.required_status_checks // [])[]? |
-       {context: (.context // ""), appId: (.integration_id // .app_id)}];
-    def protectionChecks:
-      [($protection[0].required_status_checks.checks // [])[] |
-       {context: (.context // ""), appId: (.app_id // .integration_id)}];
-    def legacyContexts:
-      ($protection[0].required_status_checks.contexts // []);
-    (ruleChecks + protectionChecks) as $checks |
-    ([ $checks[] | .context ] | unique) as $names |
-    ([ $checks[] | .context ] | unique) as $boundLegacy |
-    legacyContexts as $legacy |
-    if ($checks | length) == 0 then
-      error("no server-required checks; refusing a no-op inventory")
-    elif any($checks[]; (.context | type) != "string" or .context == "" or
-                       (.appId | type) != "number" or .appId <= 0) then
-      error("required check lacks an exact integration ID")
-    elif ($names | length) != ($checks | length) then
-      error("duplicate required check context")
-    elif (($legacy - $boundLegacy) | length) != 0 then
-      error("legacy required status lacks an app/provider binding")
-    else {
-      schema: 1,
-      repository: $repository,
-      baseRef: $baseRef,
-      effectiveRules: effective,
-      branchProtection: $protection[0],
-      requiredCheckRuns: ($checks | unique_by([.context, .appId]) |
-                          sort_by(.context, .appId)),
-      legacyStatusPolicy: "reject-required-contexts-without-provider-binding"
-    } end
-  ' >"$gate_dir/expected-inventory.json" ||
-    fail "could not build exact expected check/provider inventory"
+  # A failed request is not evidence that protection is absent. Repositories
+  # using rulesets-only protection need a captured `{}` response produced by a
+  # separate, authenticated 404-aware collector; otherwise stop here.
+  gh_api "repos/$base_repo/branches/$base_ref/protection" \
+    >"$gate_dir/branch-protection.json" ||
+    fail "could not capture branch protection (do not substitute an empty object after an API failure)"
+  jq -e 'type == "object"' "$gate_dir/branch-protection.json" >/dev/null ||
+    fail "malformed branch protection"
+
+  "$contract" inventory-policy "$github_host" "$base_repo" "$base_ref" \
+    "$gate_dir/effective-rules.json" "$gate_dir/branch-protection.json" \
+    "$gate_dir/expected-inventory.json"
 }
 
 validate_exact_inventory() {
   snapshot="$1"
-  jq -e '.schema == 1 and (.requiredCheckRuns | type) == "array" and
-    (.requiredCheckRuns | length) > 0 and
-    all(.requiredCheckRuns[]; (.context | type) == "string" and
-      (.appId | type) == "number" and .appId > 0)' \
-    "$snapshot/expected-inventory.json" >/dev/null ||
-    fail "invalid or no-op expected inventory"
-  jq -e --arg repository "$base_repo" --arg head "$head_oid" \
-    --arg base "$base_oid" --arg baseRef "$base_ref" --arg candidate "$candidate_oid" \
-    --slurpfile expected "$snapshot/expected-inventory.json" \
-    --slurpfile runs "$snapshot/check-runs-normalized.json" \
-    --slurpfile suites "$snapshot/check-suites-normalized.json" \
-    --slurpfile statuses "$snapshot/status-contexts-normalized.json" '
-    $expected[0].requiredCheckRuns as $required |
-    def associated_suite($run):
-      [ $suites[0][] |
-        select(.id == $run.check_suite.id and .head_sha == $candidate and
-               .app.id == $run.app.id) |
-        .pull_requests[]? |
-        select(.head.sha == $head and .base.sha == $base and
-               .base.ref == $baseRef and
-               .base.repo.url == ("https://api.github.com/repos/" + $repository))
-      ] | length > 0;
-    def successful_required_run($need):
-      [ $runs[0][] |
-        select(.observedOid == $candidate and .head_sha == $candidate and
-               .name == $need.context and .app.id == $need.appId and
-               (.app.owner.login | type) == "string" and
-               (.app.slug | type) == "string" and .status == "completed" and
-               (.conclusion | ascii_upcase) == "SUCCESS" and associated_suite(.))
-      ] | length == 1;
-    ($required | length) > 0 and
-    all($required[]; successful_required_run(.)) and
-    ([ $statuses[0][] | select(.context as $context |
-       ($required | map(.context) | index($context)) != null) ] | length == 0)
-  ' "$snapshot/expected-inventory.json" >/dev/null ||
-    fail "required check/provider/suite result or legacy-status binding is invalid"
+  "$contract" verify-checks "$snapshot/identity.json" \
+    "$snapshot/expected-inventory.json" "$snapshot/repository.json" \
+    "$snapshot/check-runs-normalized.json" "$snapshot/check-suites-normalized.json" \
+    "$snapshot/status-contexts-normalized.json" "$snapshot/check-verdict.json"
 }
 
 # Bind policy to the observed base before asking for review. A policy change
@@ -481,15 +436,23 @@ capture_snapshot() {
     .data.repository.pullRequest.headRefOid != null and
     .data.repository.pullRequest.baseRefOid != null and
     .data.repository.pullRequest.headRepository.nameWithOwner != null and
+    .data.repository.pullRequest.baseRepository.nameWithOwner != null and
     .data.repository.pullRequest.mergeQueueEntry == null' \
     "$gate_dir/identity.json" >/dev/null || fail "invalid final PR identity"
-  cmp -s "$observed" "$gate_dir/identity.json" ||
+  identity_binding "$gate_dir/identity.json" >"$gate_dir/identity-binding.json"
+  cmp -s "$gate_root/observed-identity-binding.json" "$gate_dir/identity-binding.json" ||
     fail "PR head/base/candidate changed; restart and re-request Copilot"
   head_oid="$(jq -r '.data.repository.pullRequest.headRefOid' "$gate_dir/identity.json")"
   base_oid="$(jq -r '.data.repository.pullRequest.baseRefOid' "$gate_dir/identity.json")"
   candidate_oid="$(jq -r \
     '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
     "$gate_dir/identity.json")"
+  gh_api "repos/$base_repo" >"$gate_dir/repository.json"
+  jq -e --arg host "$github_host" --arg repo "$base_repo" '
+    (.id | type) == "number" and .full_name == $repo and
+    .html_url == ("https://" + $host + "/" + $repo) and (.url | type) == "string"
+  ' "$gate_dir/repository.json" >/dev/null ||
+    fail "repository capture is not pinned to the HTTPS GitHub host"
   collect_policy_inventory "$gate_dir"
   cmp -s "$gate_root/observed-policy/expected-inventory.json" \
     "$gate_dir/expected-inventory.json" ||
@@ -541,7 +504,7 @@ cmp -s "$gate_root/verified/gate.jsonl" "$gate_root/final/gate.jsonl" || \
 
 # This is the only mutation in this block. Do not launch a browser or inspect
 # additional mutable state between the final manifest comparison and ready.
-gh pr ready "$pr" --repo "$base_repo"
+gh_pr ready "$pr" --repo "$hosted_repo"
 ```
 
 The final capture must still have the observed head/base pair. A changed head or
@@ -556,8 +519,9 @@ branch, and only after deriving its live source and base from the PR URL.
 ```bash
 set -euo pipefail
 
-pr_data="$(gh pr view "$pr" --repo "$base_repo" \
+pr_data="$(gh_pr view "$pr" --repo "$hosted_repo" \
   --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
+pr_identity="$(jq -S -c . <<<"$pr_data")"
 base_ref="$(jq -r .baseRefName <<<"$pr_data")"
 base_oid="$(jq -r .baseRefOid <<<"$pr_data")"
 head_ref="$(jq -r .headRefName <<<"$pr_data")"
@@ -572,12 +536,14 @@ if git config --get-regexp '^url\..*\.(insteadOf|pushInsteadOf)$' >/dev/null; th
   exit 1
 fi
 
-# A selected remote must have exactly one push URL, and both its fetch and push
-# targets must resolve to the current PR head repository.
+# A selected remote must have exactly one HTTPS fetch/push URL whose host and
+# repository exactly match the live same-repository PR source. Do not inspect
+# arbitrary SSH/custom URLs through `gh repo view`: that would make endpoint
+# verification depend on a second, unpinned host selection.
+expected_https_remote="https://$github_host/$head_repo.git"
 push_remote=""
 for candidate in $(git remote); do
-  fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
-    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || :)"
+  fetch_url="$(git remote get-url "$candidate")"
   push_urls="$(git remote get-url --push --all "$candidate")"
   push_count="$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')"
   if test "$push_count" != 1; then
@@ -585,10 +551,8 @@ for candidate in $(git remote); do
     continue
   fi
   push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
-  push_repo="$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner \
-    2>/dev/null || :)"
-  if test "$fetch_repo" != "$head_repo" || test "$push_repo" != "$head_repo"; then
-    printf 'rejecting remote %s: endpoint is not the PR head repository\n' "$candidate" >&2
+  if test "$fetch_url" != "$expected_https_remote" || test "$push_url" != "$expected_https_remote"; then
+    printf 'rejecting remote %s: endpoint is not the pinned HTTPS PR source\n' "$candidate" >&2
     continue
   fi
   test -z "$push_remote" || { echo "ambiguous verified remotes" >&2; exit 1; }
@@ -615,6 +579,8 @@ git rebase --show-current-patch >/dev/null 2>&1 && { echo "rebase remains" >&2; 
 test -z "$(git status --porcelain)" || { echo "dirty after rebase" >&2; exit 1; }
 test "$(git merge-base HEAD "$push_remote/$base_ref")" = \
   "$(git rev-parse "$push_remote/$base_ref")"
+rebased_head="$(git rev-parse HEAD)"
+git cat-file -e "$rebased_head^{commit}"
 
 signature_statuses="$(git log --format='%G?' "$push_remote/$base_ref..HEAD")"
 printf '%s\n' "$signature_statuses"
@@ -623,11 +589,25 @@ if printf '%s\n' "$signature_statuses" | grep -Eq '[^G]'; then
   exit 1
 fi
 
-# Re-read live PR metadata; any movement means start over.
-test "$(gh pr view "$pr" --repo "$base_repo" \
-  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)" = "$pr_data"
+# Re-read live PR metadata. Pin the immutable, verified post-rebase OID; any
+# source/base movement or local mutation means start over. The lease protects
+# the small interval between this read and the push.
+live_pr_data="$(gh_pr view "$pr" --repo "$hosted_repo" \
+  --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository)"
+test "$(jq -S -c . <<<"$live_pr_data")" = "$pr_identity" || {
+  echo "PR moved while rebasing; do not push" >&2; exit 1;
+}
+test "$(git rev-parse HEAD)" = "$rebased_head" || {
+  echo "post-rebase OID changed after verification; do not push" >&2; exit 1;
+}
 git push --force-with-lease="refs/heads/$head_ref:$remote_head" \
-  "$push_remote" "HEAD:refs/heads/$head_ref"
+  "$push_remote" "$rebased_head:refs/heads/$head_ref"
+test "$(git ls-remote "$expected_https_remote" "refs/heads/$head_ref" | awk '{print $1}')" = "$rebased_head" || {
+  echo "remote did not retain the verified post-rebase OID" >&2; exit 1;
+}
+test "$(gh_pr view "$pr" --repo "$hosted_repo" --json headRefOid --jq .headRefOid)" = "$rebased_head" || {
+  echo "GitHub PR source is not the verified post-rebase OID" >&2; exit 1;
+}
 ```
 
 If a rebase stops, resolve and stage only the named conflict paths, then
@@ -648,7 +628,7 @@ stack_root_base=STACK_ROOT_BASE_REF
 git check-ref-format --branch "$stack_root_base" >/dev/null
 # shellcheck disable=SC2016
 # GraphQL variables must reach gh unchanged.
-gh api graphql --paginate --slurp -f query='
+gh_api graphql --paginate --slurp -f query='
   query($owner:String!, $repo:String!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequests(first:100, states:OPEN, after:$endCursor) {
@@ -723,8 +703,22 @@ test -s "$body_file"
 # The caller supplies the actual intended base; do not silently substitute a
 # repository default. A workflow that explicitly targets the default may derive
 # it first, record that decision, then assign it here.
+github_host=github.com
 base_repo=BASE_OWNER/BASE_REPOSITORY
 base_ref=INTENDED_BASE_REF
+contract="./.github/scripts/pr-gate-contract.sh"
+test -x "$contract" || { echo "missing executable PR-gate contract helper" >&2; exit 1; }
+# Re-use the strict URL parser to validate the caller-supplied host/repository
+# before any API or Git network action. A temporary PR number is only syntax.
+IFS=$'\t' read -r parsed_host parsed_repo _ <<EOF
+$($contract parse-pr-url "https://$github_host/$base_repo/pull/1")
+EOF
+test "$parsed_host" = "$github_host" && test "$parsed_repo" = "$base_repo" || {
+  echo "invalid GitHub host or repository" >&2; exit 1;
+}
+hosted_repo="$github_host/$base_repo"
+gh_pr() { env GH_HOST="$github_host" gh pr "$@"; }
+gh_api() { env GH_HOST="$github_host" gh api --hostname "$github_host" "$@"; }
 git check-ref-format --branch "$base_ref" >/dev/null
 head_ref="$(git branch --show-current)"
 git check-ref-format --branch "$head_ref" >/dev/null
@@ -736,10 +730,10 @@ if git config --get-regexp '^url\..*\.(insteadOf|pushInsteadOf)$' >/dev/null; th
   echo "URL rewrite configuration is present; refusing draft creation" >&2
   exit 1
 fi
+expected_https_remote="https://$github_host/$base_repo.git"
 push_remote=""
 for candidate in $(git remote); do
-  fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
-    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || :)"
+  fetch_url="$(git remote get-url "$candidate")"
   push_urls="$(git remote get-url --push --all "$candidate")"
   push_count="$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')"
   if test "$push_count" != 1; then
@@ -747,10 +741,8 @@ for candidate in $(git remote); do
     continue
   fi
   push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
-  push_repo="$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner \
-    2>/dev/null || :)"
-  if test "$fetch_repo" != "$base_repo" || test "$push_repo" != "$base_repo"; then
-    printf 'rejecting remote %s: endpoint is not the target repository\n' "$candidate" >&2
+  if test "$fetch_url" != "$expected_https_remote" || test "$push_url" != "$expected_https_remote"; then
+    printf 'rejecting remote %s: endpoint is not the pinned HTTPS target repository\n' "$candidate" >&2
     continue
   fi
   test -z "$push_remote" || { echo "ambiguous verified remotes" >&2; exit 1; }
@@ -764,14 +756,30 @@ git fetch "$push_remote" \
   "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
 git rev-parse --verify "$push_remote/$base_ref^{commit}" >/dev/null
 test "$(git rev-parse "$push_remote/$head_ref")" = "$(git rev-parse HEAD)"
+source_oid="$(git rev-parse HEAD)"
+base_oid="$(git rev-parse "$push_remote/$base_ref")"
 
-pr_url="$(gh pr create --repo "$base_repo" --draft \
+pr_url="$(gh_pr create --repo "$hosted_repo" --draft \
   --head "$head_ref" --base "$base_ref" --title "feat: description" \
   --body-file "$body_file")"
 printf '%s\n' "$pr_url"
+IFS=$'\t' read -r created_host created_repo created_pr <<EOF
+$($contract parse-pr-url "$pr_url")
+EOF
+pr="$created_pr"
+test "$created_host" = "$github_host" && test "$created_repo" = "$base_repo" || {
+  echo "PR creation returned a different GitHub host or repository" >&2; exit 1;
+}
+gh_pr view "$pr" --repo "$hosted_repo" \
+  --json headRefName,headRefOid,headRepository,baseRefName,baseRefOid,baseRepository \
+  | jq -e --arg repo "$base_repo" --arg head "$head_ref" --arg headOid "$source_oid" \
+      --arg base "$base_ref" --arg baseOid "$base_oid" '
+      .headRepository.nameWithOwner == $repo and .headRefName == $head and .headRefOid == $headOid and
+      .baseRepository.nameWithOwner == $repo and .baseRefName == $base and .baseRefOid == $baseOid
+    ' >/dev/null || { echo "created PR source/base does not match verified refs" >&2; exit 1; }
 
 # Use the same file-only rule for an existing PR description.
-gh pr edit PR_NUMBER --repo "$base_repo" --body-file "$body_file"
+gh_pr edit "$pr" --repo "$hosted_repo" --body-file "$body_file"
 ```
 
 Read the stored raw body, inspect `bodyHTML`, and check the rendered web page
@@ -779,16 +787,16 @@ for headings, newlines, links, dependency heads, scope, limitations, and test
 evidence. Mark a draft ready only after the complete gate passes.
 
 ```bash
-gh pr view PR_NUMBER --repo "$base_repo" --json body --jq .body
+gh_pr view "$pr" --repo "$hosted_repo" --json body --jq .body
 # shellcheck disable=SC2016
 # GraphQL variables must reach gh unchanged.
-gh api graphql -f query='
+gh_api graphql -f query='
   query($owner:String!, $repo:String!, $pr:Int!) {
     repository(owner:$owner, name:$repo) { pullRequest(number:$pr) { bodyHTML } }
   }
-' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr=PR_NUMBER \
+' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr" \
   --jq .data.repository.pullRequest.bodyHTML
-gh pr view PR_NUMBER --repo "$base_repo" --web
+gh_pr view "$pr" --repo "$hosted_repo" --web
 ```
 
 The browser check is description-only. The separate fail-closed gate block is

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -213,8 +213,11 @@ Fetch GitHub's effective branch rules and branch-protection object into every
 snapshot. Inventory **every active rule type and its parameters**, not only
 status checks. The contract validates App-bound required checks directly and
 uses GitHub's exact-PR final `MERGEABLE`/`CLEAN` predicate in addition for
-active `pull_request`, `required_signatures`, `required_workflows`,
-`required_deployments`, and `required_code_scanning` rules. A merge queue,
+active `pull_request`, `required_signatures`, `workflows`,
+`required_deployments`, and `code_scanning` rules. The effective ruleset pages
+and classic branch-protection requirements form one inventory: a repository
+with no rulesets but an App-bound classic required check is supported, while a
+repository with neither fails closed. A merge queue,
 linear-history rule, or any unrecognised active type fails closed with the
 server-provided type/parameters in the error: extend the verifier for that
 type, or remove/replace the rule before using this ready/merge gate. It never
@@ -393,7 +396,10 @@ collect_policy_inventory() {
   gh_api --paginate --slurp \
     "repos/$base_repo/rules/branches/$base_ref" \
     >"$gate_dir/effective-rules.json"
-  jq -e 'type == "array" and length > 0 and all(.[]; type == "array")' \
+  # `--slurp` yields an array of arrays, one per pagination page. Empty
+  # ruleset pages are valid; the contract combines them with classic branch
+  # protection and rejects only when both sources are genuinely no-op.
+  jq -e 'type == "array" and all(.[]; type == "array")' \
     "$gate_dir/effective-rules.json" >/dev/null ||
     fail "missing or malformed effective branch rules"
 

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -25,11 +25,12 @@ Treat a PR as approved only when one complete, current evidence snapshot passes.
 
   The prompt uses [`.github/scripts/pr-gate-contract.sh`](../scripts/pr-gate-contract.sh)
   as the executable reference for URL parsing, conservative review freshness,
-  complete evidence manifests, draft binding, policy inventory, and exact
-  check-suite evidence. It tests API-shaped
+  submitted-review selection, complete evidence manifests, draft binding,
+  policy inventory, and exact check-suite evidence. It tests API-shaped
   fixtures, including a synthetic merge candidate that differs from the source
-  head and attacker-controlled suite/status cases; it does not test for text
-  in this document.
+  head and attacker-controlled suite/status cases, and executes the draft
+  lifecycle block with mocked GitHub/Git contracts. Unrelated prose is not
+  treated as an executable requirement.
 
 ## Formal review requirements
 
@@ -277,15 +278,9 @@ jq -e 'all(.[]; .data.repository.pullRequest != null and
   .[-1].data.repository.pullRequest.reviews.pageInfo.hasNextPage == false' \
   "$gate_dir/reviews.json" >/dev/null || fail "missing review pageInfo"
 
-jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" '
-  [ .[] | .data.repository.pullRequest.reviews.nodes[] |
-    select(.author.login == $login) ] |
-  if length == 0 then false else max_by(.submittedAt) |
-    if (.id != null and .state == "COMMENTED" and .submittedAt != null and
-        .commit.oid == $head) then . else false end
-  end
-' "$gate_dir/reviews.json" >"$gate_dir/copilot-review.json" ||
-  fail "missing current formal Copilot review"
+"$contract" select-copilot-review "$gate_dir/reviews.json" \
+  "$copilot_reviewer_login" "$head_oid" "$gate_dir/copilot-review.json" ||
+  fail "missing current, submitted formal Copilot review"
 
 review_submitted_at="$(jq -r .submittedAt "$gate_dir/copilot-review.json")"
 $contract verify-review-freshness "$gate_root/review-request.http" "$review_submitted_at" ||
@@ -497,6 +492,9 @@ capture_snapshot() {
 
 validate_snapshot() {
   snapshot="$1"
+  for evidence in "$snapshot"/*.json; do
+    "$contract" validate-json "$evidence"
+  done
   jq -e '.data.repository.pullRequest.reviewDecision == "APPROVED"' \
     "$snapshot/identity.json" >/dev/null || fail "missing current human approval"
   jq -e '[.[] | .data.repository.pullRequest.reviewThreads.nodes[] |
@@ -521,10 +519,12 @@ capture the **entire** evidence set again and compare the two manifests:
 ```bash
 manifest_snapshot() {
   snapshot="$1"
-  # JSON files are canonicalized. HTTP responses are parsed and validated,
+  # JSON files are canonicalized with duplicate object keys rejected. HTTP
+  # responses are parsed and validated,
   # then represented by final status, stable headers, and canonical body;
   # GitHub's volatile Date/request-ID/rate-limit transport metadata is
-  # deliberately excluded only after validation. Other artifacts use SHA-256.
+  # deliberately excluded only after validation. Repeated stable-header order
+  # is preserved. Other artifacts use SHA-256.
   # The helper omits only the manifest it is writing.
   "$contract" manifest-evidence "$snapshot" "$snapshot/gate.jsonl"
 }
@@ -733,6 +733,12 @@ set -euo pipefail
 body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
 vi "$body_file"                         # a known executable, not an EDITOR shell fragment
 test -s "$body_file"
+
+# The post-create verification writes into this run's private directory. Set it
+# up before the first PR mutation so a failed verification cannot be caused by
+# an unset path after the draft has already been created.
+gate_root="$(mktemp -d)"
+trap 'rm -rf "$gate_root"; rm -f "$body_file"' EXIT
 
 # The caller supplies the actual intended base; do not silently substitute a
 # repository default. A workflow that explicitly targets the default may derive

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -8,6 +8,10 @@ rebasing, squashing, writing descriptions, and interacting with CI.
 - GitHub CLI (`gh`) must be authenticated
 - EMU (Enterprise Managed User) accounts cannot use GitHub MCP API for
   write operations — always use `gh` CLI instead
+- Pass `--repo BASE_OWNER/BASE_REPOSITORY` to every `gh pr` and `gh run`
+  command. The installed `gh api` command has no `--repo` flag, so every REST
+  path and GraphQL `owner`/`repo` value below names the target repository
+  explicitly instead of relying on the current directory.
 
 ## Exact-Head Gate
 
@@ -32,13 +36,13 @@ all of the following apply to that exact object ID:
 # complete gate if the final snapshot differs.
 pr_snapshot() {
   gh pr view PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY \
-    --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository
+    --json baseRefName,baseRefOid,headRefName,headRefOid,headRepository,reviewDecision
 }
 before_snapshot="$(pr_snapshot)"
 printf '%s\n' "$before_snapshot"
 
 # CI output must be associated with the snapshot; see the CI rules below.
-gh pr checks PR_NUMBER --watch --required
+gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --watch --required
 
 # Read head and base again after CI, reviews, and threads have been examined.
 after_snapshot="$(pr_snapshot)"
@@ -53,6 +57,11 @@ runs, formal reviews (including each review's `commit.oid`), review threads,
 and minimized comments through GitHub GraphQL. Paginate every connection until
 `hasNextPage` is false. Repeat the complete snapshot after gathering the data;
 if either head or base changed, discard the result and restart the gate.
+
+Base movement invalidates the previous gate just as head movement does. When
+either OID changes, request a fresh formal Copilot review (unless an explicit,
+verified repository automation has already produced one for the new pair),
+repeat the human/code-owner approval check, and rerun CI/thread inspection.
 
 GitHub may run `pull_request` workflows on a synthetic test-merge SHA, and
 merge-queue workflows can run on a merge-queue candidate SHA. Therefore, do
@@ -72,6 +81,8 @@ gh api graphql -f query='
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
         headRefOid
+        baseRefOid
+        reviewDecision
         reviews(first:100, after:$cursor) {
           pageInfo { hasNextPage endCursor }
           nodes {
@@ -84,7 +95,7 @@ gh api graphql -f query='
       }
     }
   }
-' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
+' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F cursor=null
 ```
 
 Set `copilot_reviewer_login` to the known, repository-configured bot login; do
@@ -95,6 +106,12 @@ named account. The selected review must have that exact `author.login`,
 state is insufficient. Repeat with `cursor` set to `endCursor` until all review
 pages have been inspected.
 
+Copilot's `COMMENTED` review is distinct from human approval. Read
+`reviewDecision` and the actual branch ruleset/code-owner requirement for the
+captured head/base pair; require the current human and code-owner approvals
+that those rules demand. A current human approval cannot be replaced by a
+Copilot comment, and a Copilot comment cannot be replaced by a green check.
+
 ## Requesting a Formal Copilot Review
 
 Request Copilot as a PR reviewer; do **not** use an `@copilot review` comment.
@@ -102,7 +119,7 @@ That comment invokes the coding agent and is not a formal pull-request review
 request.
 
 ```bash
-gh pr edit PR_NUMBER --add-reviewer @copilot
+gh pr edit PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --add-reviewer @copilot
 ```
 
 The equivalent is GitHub's requested-reviewers REST endpoint with the Copilot
@@ -111,9 +128,9 @@ supports that bot reviewer.
 
 Copilot does not automatically re-review every pushed commit unless the
 repository has explicitly configured automatic re-reviews. After each pushed
-head, request another formal review when necessary and verify the resulting
-review commit OID against the new PR head. Never infer a new review from an
-older review, a comment, or the absence of new threads.
+head **or base OID change**, request another formal review when necessary and
+verify the resulting review commit OID against the new PR head. Never infer a
+new review from an older review, a comment, or the absence of new threads.
 
 ## Checking PR Review Threads
 
@@ -148,7 +165,7 @@ gh api graphql -f query='
       }
     }
   }
-' -f owner=telekom -f repo=REPO_NAME -F pr=PR_NUMBER -F cursor=null
+' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F cursor=null
 ```
 
 Repeat the thread query with `cursor` set to `endCursor` until the thread
@@ -208,22 +225,22 @@ gh api graphql -f query='
 '
 ```
 
-## Rebasing on Main
+## Rebasing on the PR Base
 
 Prefer a short, signed stack: put follow-up fixes in signed child commits and
 rebase only when a current base is actually required. Before rewriting a
 published branch, fetch it, capture the exact remote branch OID, and make sure
 the rewrite is authorized for that branch.
 
-This repository's policy is same-repository PRs only. Refuse to push a fork
-branch; never guess that `origin`, `main`, or the checked-out branch is the PR
-source. Derive the live PR head repository/ref and base repository/ref first,
-then select exactly one verified local remote for that head repository.
+This task's user-directed policy permits direct same-repository branches only.
+Refuse to push a fork branch; never guess that `origin`, `main`, or the
+checked-out branch is the PR source. Derive the live PR head repository/ref and
+base repository/ref first, then select exactly one verified local remote for
+that head repository.
 
 ```bash
 # Start from the actual target PR URL, not a branch name or local remote.
 pr_url="https://github.example/BASE_OWNER/BASE_REPOSITORY/pull/PR_NUMBER"
-pr_url="$(gh pr view "$pr_url" --json url --jq .url)"
 base_repo="$(printf '%s\n' "$pr_url" | awk -F/ '{print $(NF-3) "/" $(NF-2)}')"
 pr="$(printf '%s\n' "$pr_url" | awk -F/ '{print $NF}')"
 case "$base_repo" in */*) ;; *) echo "invalid PR URL" >&2; exit 1;; esac
@@ -235,19 +252,23 @@ head_ref="$(jq -r .headRefName <<<"$pr_data")"
 head_oid="$(jq -r .headRefOid <<<"$pr_data")"
 head_repo="$(jq -r .headRepository.nameWithOwner <<<"$pr_data")"
 
-# The current policy does not authorize pushes to forks.
+# The current user-directed policy does not authorize pushes to forks.
 test "$head_repo" = "$base_repo" || {
   echo "refusing to rewrite or push fork PR $head_repo" >&2
   exit 1
 }
 
-# Match a configured remote to the actual PR head repository, rather than
-# assuming that a remote named origin is safe. Refuse ambiguity.
+# Match a configured remote's fetch and push URLs to the actual PR head
+# repository, rather than assuming that a remote named origin is safe. Refuse
+# ambiguity or a distinct push target.
 push_remote=""
 for candidate in $(git remote); do
-  candidate_repo="$(gh repo view "$(git remote get-url "$candidate")" \
+  candidate_fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
     --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
-  test "$candidate_repo" = "$head_repo" || continue
+  candidate_push_repo="$(gh repo view "$(git remote get-url --push "$candidate")" \
+    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+  test "$candidate_fetch_repo" = "$head_repo" || continue
+  test "$candidate_push_repo" = "$head_repo" || continue
   test -z "$push_remote" || {
     echo "multiple remotes resolve to PR head repository" >&2
     exit 1
@@ -271,6 +292,10 @@ test "$remote_head" = "$head_oid" || {
   echo "PR head changed; refresh PR metadata before rebasing" >&2
   exit 1
 }
+test "$(git rev-parse HEAD)" = "$head_oid" || {
+  echo "local checkout is stale or is not the captured PR head" >&2
+  exit 1
+}
 local_branch="$(git branch --show-current)"
 test "$local_branch" = "$head_ref" || {
   echo "checked-out branch is not the PR head ref" >&2
@@ -280,16 +305,34 @@ test -z "$(git status --porcelain)" || {
   echo "refusing to rebase a dirty worktree" >&2
   exit 1
 }
-git rebase --gpg-sign "$push_remote/$base_ref"
-
-# If conflicts arise, resolve them and continue:
-git add -- path/to/resolved-conflict.go path/to/other-resolved-file.yaml
-git rebase --continue
+if ! git rebase --gpg-sign "$push_remote/$base_ref"; then
+  echo "rebase stopped; do not push" >&2
+  git status --short
+  echo "resolve only named conflict paths and continue, or run git rebase --abort" >&2
+  exit 1
+fi
 
 # --gpg-sign preserves signing for rewritten commits. Configure a suitable
 # signing key in advance; do not disable signing to bypass a local setup
 # problem. Check every rewritten commit before pushing.
-git log --show-signature --format=fuller "$push_remote/$base_ref..HEAD"
+git rebase --show-current-patch >/dev/null 2>&1 && {
+  echo "rebase state remains; do not push" >&2
+  exit 1
+}
+test -z "$(git status --porcelain)" || {
+  echo "worktree is not clean after rebase; do not push" >&2
+  exit 1
+}
+test "$(git merge-base HEAD "$push_remote/$base_ref")" = \
+  "$(git rev-parse "$push_remote/$base_ref")" || {
+  echo "rebased HEAD is not based on the captured PR base" >&2
+  exit 1
+}
+git log --show-signature --format='%H %G?' "$push_remote/$base_ref..HEAD"
+test -z "$(git log --format='%G?' "$push_remote/$base_ref..HEAD" | grep -v '^G$')" || {
+  echo "rewritten commits are not all validly signed" >&2
+  exit 1
+}
 
 # Only after the rebase is verified, update this personal branch without
 # overwriting a collaborator's intervening push. Re-read the live PR metadata
@@ -303,6 +346,23 @@ test "$current_pr_data" = "$pr_data" || {
 }
 git push --force-with-lease="refs/heads/$head_ref:$remote_head" \
   "$push_remote" "HEAD:refs/heads/$head_ref"
+```
+
+If the rebase stops, do not continue to the push block. Inspect its state,
+stage only the conflict paths that were actually resolved, and either continue
+or abandon the rebase. After a successful continuation, rerun every post-rebase
+guard above and re-read live PR metadata before considering a push.
+
+```bash
+# Resume only after resolving the named paths:
+git status --short
+git add -- path/to/resolved-conflict.go path/to/other-resolved-file.yaml
+git rebase --continue
+```
+
+```bash
+# Or, if the rebase should not proceed, discard only the rebase operation.
+git rebase --abort
 ```
 
 Do not use a broad `--force`. If the lease no longer matches, stop, fetch, and
@@ -328,28 +388,92 @@ explicit `--force-with-lease` after checking its recorded remote OID.
 
 ```bash
 # List all CI checks for a PR
-gh pr checks PR_NUMBER
+gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --required
 
 # Watch CI in real-time
-gh pr checks PR_NUMBER --watch
+gh pr checks PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --watch --required
 
 # Get detailed check run output
-gh run view RUN_ID --log-failed
+gh run view RUN_ID --repo BASE_OWNER/BASE_REPOSITORY --log-failed
 ```
 
-Before accepting the result, compare every required run/check's PR association
-to the captured `headRefOid` and `baseRefOid`. Its SHA can equal the source
-head only for head-based workflows; for pull-request test merges or merge
-queues, validate the selected synthetic candidate for that same source/base
-pair instead. Re-run the complete gate after any branch or base update,
-including an automatic rebase or a merge into the base branch.
+Get the expected check inventory and acceptable provider from the actual branch
+ruleset/required-workflow configuration for the captured base ref; do not infer
+them from whichever checks happened to appear in one run. For this task, every
+expected job must conclude `success`. `neutral` or `skipped` is acceptable only
+when the current rules explicitly name that exact job/provider as intentionally
+expected, and the gate records the rule source and reason; it is never silently
+treated as a pass.
+
+Use both check suites and check runs, and inspect the suite's associated PR
+objects. The REST commands deliberately carry the full repository path because
+`gh api` does not implement `--repo`:
+
+```bash
+# Record the PR source/base pair, test-merge candidate, merge-queue entry, and
+# GraphQL check-suite IDs. Paginate statusCheckRollup contexts when necessary.
+gh api graphql --paginate -f query='
+  query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        headRefOid
+        baseRefOid
+        potentialMergeCommit { oid }
+        mergeQueueEntry { id }
+        statusCheckRollup {
+          contexts(first:100, after:$endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              __typename
+              ... on CheckRun {
+                name
+                conclusion
+                detailsUrl
+                checkSuite { id }
+              }
+              ... on StatusContext { context state targetUrl }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER -F endCursor=null
+```
+
+```bash
+base_repo=BASE_OWNER/BASE_REPOSITORY
+head_oid=CAPTURED_PR_HEAD_OID
+base_oid=CAPTURED_PR_BASE_OID
+candidate_oid=CAPTURED_TEST_MERGE_OR_MERGE_QUEUE_OID
+
+# Inspect the source head and, when GitHub selected one, its test-merge or
+# merge-queue candidate. Paginate all response pages.
+for oid in "$head_oid" "$candidate_oid"; do
+  test -n "$oid" || continue
+  gh api --paginate "repos/$base_repo/commits/$oid/check-suites?per_page=100"
+  gh api --paginate "repos/$base_repo/commits/$oid/check-runs?per_page=100"
+  gh api --paginate "repos/$base_repo/commits/$oid/pulls?per_page=100"
+done
+```
+
+For every expected check, verify the check run, its check suite, and the
+suite's associated pull request all identify the captured `head_oid`,
+`base_oid`, repository, and refs. A head-based workflow may run directly on
+`head_oid`; a `pull_request` test merge or merge queue may use `candidate_oid`
+only when the suite's PR association proves that exact source/base pair. Record
+the selected candidate from the workflow/merge-queue event metadata (for a
+regular PR, `potentialMergeCommit.oid` can supply the current test-merge
+candidate). Re-run the complete gate after any branch or base update.
 
 ## Adding PR Comments
 
 ```bash
 # General comment
-gh pr comment PR_NUMBER --body "Comment text"
+gh pr comment PR_NUMBER --repo BASE_OWNER/BASE_REPOSITORY --body "Comment text"
 
+# gh api has no --repo flag. Use only IDs returned by the earlier GraphQL query
+# explicitly scoped to BASE_OWNER/BASE_REPOSITORY.
 # Reply to a review thread (use the thread's comment ID)
 gh api graphql -f query='
   mutation {
@@ -369,25 +493,30 @@ Markdown, backticks, variables, or escaped newlines through an inline
 `--body` argument or shell command substitution.
 
 ```bash
-# Edit a real temporary Markdown file using an editor or a repository template.
+# Select a known editor executable directly; do not evaluate a shell fragment
+# from EDITOR or interpolate Markdown through a shell command.
 body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
-"${EDITOR:?set EDITOR to populate the PR description}" "$body_file"
+vi "$body_file"
 test -s "$body_file" || {
   echo "refusing to create or edit a PR with an empty description" >&2
   exit 1
 }
 
-gh pr create \
+# Derive the target's actual default base; do not hardcode main.
+base_repo=BASE_OWNER/BASE_REPOSITORY
+base_ref="$(gh repo view "$base_repo" --json defaultBranchRef --jq .defaultBranchRef.name)"
+
+gh pr create --repo "$base_repo" \
   --title "feat: description" \
   --body-file "$body_file" \
-  --base main
+  --base "$base_ref"
 
 # The same rule applies to edits.
-gh pr edit PR_NUMBER --body-file "$body_file"
+gh pr edit PR_NUMBER --repo "$base_repo" --body-file "$body_file"
 
 # Read the stored body back and inspect the rendered PR to confirm headings,
 # newlines, links, dependency heads, scope, limitations, and test evidence.
-gh pr view PR_NUMBER --json body --jq .body
+gh pr view PR_NUMBER --repo "$base_repo" --json body --jq .body
 gh api graphql -f query='
   query($owner:String!, $repo:String!, $pr:Int!) {
     repository(owner:$owner, name:$repo) {
@@ -396,7 +525,7 @@ gh api graphql -f query='
   }
 ' -f owner=BASE_OWNER -f repo=BASE_REPOSITORY -F pr=PR_NUMBER --jq \
   .data.repository.pullRequest.bodyHTML
-gh pr view PR_NUMBER --web
+gh pr view PR_NUMBER --repo "$base_repo" --web
 ```
 
 Compare the raw body to the source file, inspect `bodyHTML`, and verify the

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -28,7 +28,8 @@ name or similarly named account. The selected review must be the newest review
 from that exact login with all of these properties:
 
 - `state` is `COMMENTED`, not dismissed;
-- `submittedAt` is non-null and later than the recorded review-request time;
+- `submittedAt` is non-null and provably later than the recorded
+  high-resolution review-request completion time;
 - `commit.oid` equals the captured PR `headRefOid`.
 
 Copilot does not re-review every push unless the repository explicitly
@@ -36,9 +37,9 @@ configures it. A head or base OID change restarts the gate and requires a fresh
 formal Copilot request/review. Its `COMMENTED` review is not a human approval:
 the captured `reviewDecision` and the actual branch ruleset/code-owner policy
 must independently show the current human and code-owner approvals required for
-that same head/base pair. A review commit OID does not bind the base: the review
-request timestamp is recorded after observing the pair, and final identity
-comparison provides the required base binding.
+that same head/base pair. A review commit OID does not bind the base: the
+request-completion timestamp is recorded after observing the pair, and final
+identity comparison provides the required base binding.
 
 ## Fail-closed exact-head/base gate
 
@@ -67,8 +68,18 @@ case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
 gate_root="$(mktemp -d)"
 trap 'rm -rf "$gate_root"' EXIT
 observed="$gate_root/observed.json"
+expected_inventory="${expected_inventory-}"
+ruleset_evidence="${ruleset_evidence-}"
+expected_inventory_validator="${expected_inventory_validator-}"
+copilot_reviewer_login="${copilot_reviewer_login-}"
+: "${copilot_reviewer_login:?set the repository-configured Copilot reviewer login}"
+case "$copilot_reviewer_login" in *[!A-Za-z0-9-]*)
+  fail "invalid Copilot reviewer login";;
+esac
 
 capture_identity() {
+  # shellcheck disable=SC2016
+  # GraphQL variables must reach gh unchanged.
   gh api graphql -f query='
     query($owner:String!, $repo:String!, $pr:Int!) {
       repository(owner:$owner, name:$repo) {
@@ -86,15 +97,24 @@ capture_identity() {
 
 # Observe the source/base before requesting a fresh review.
 capture_identity >"$observed"
-jq -e '.data.repository.pullRequest.headRefOid and
+jq -e '((.errors // []) | length) == 0 and .data != null and
+       .data.repository.pullRequest != null and
+       .data.repository.pullRequest.headRefOid and
        .data.repository.pullRequest.baseRefOid and
        .data.repository.pullRequest.headRepository.nameWithOwner' \
   "$observed" >/dev/null || fail "incomplete PR identity"
 
-request_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-jq -n --arg requestAt "$request_at" '{requestAt: $requestAt}' \
-  >"$gate_root/review-request.json"
 gh pr edit "$pr" --repo "$base_repo" --add-reviewer @copilot
+request_after_ns="$(date -u +%s%N 2>/dev/null || true)"
+case "$request_after_ns" in *N*|*[!0-9]*)
+  command -v ruby >/dev/null ||
+    fail "no high-resolution UTC clock; re-request/wait rather than guessing freshness"
+  request_after_ns="$(ruby -e \
+    'puts Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)')";;
+esac
+jq -n --arg requestAfterUnixNanoseconds "$request_after_ns" \
+  '{requestAfterUnixNanoseconds: $requestAfterUnixNanoseconds}' \
+  >"$gate_root/review-request.json"
 ```
 
 Do not infer a merge-queue commit SHA from `mergeQueueEntry.id`. This workflow
@@ -119,20 +139,6 @@ evidence capture in `$gate_root/verified`. Its `identity.json` must byte-match
 collection into `$gate_root/final` immediately before ready/merge. Both captures
 must use the same filenames and include a fresh `identity.json`.
 
-```bash
-gate_dir="$gate_root/verified"
-mkdir -p "$gate_dir"
-cp "$gate_root/review-request.json" "$gate_dir/review-request.json"
-capture_identity >"$gate_dir/identity.json"
-cmp -s "$observed" "$gate_dir/identity.json" || \
-  fail "PR head/base or candidate changed; restart the complete gate"
-head_oid="$(jq -r '.data.repository.pullRequest.headRefOid' "$gate_dir/identity.json")"
-base_oid="$(jq -r '.data.repository.pullRequest.baseRefOid' "$gate_dir/identity.json")"
-candidate_oid="$(jq -r \
-  '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
-  "$gate_dir/identity.json")"
-```
-
 ### Evidence that one gate snapshot must contain
 
 Capture every page of each connection. A complete snapshot contains:
@@ -140,10 +146,11 @@ Capture every page of each connection. A complete snapshot contains:
 | Evidence | Required fields and decision |
 | --- | --- |
 | PR identity | `headRefOid`, `baseRefOid`, head repository/ref, base ref, test-merge SHA, `reviewDecision` |
-| Formal reviews | reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review after `request_at` |
+| Formal reviews | review ID, configured reviewer `author.login`, state, `submittedAt`, `commit.oid`; select the newest configured Copilot review provably after `request_after_ns` |
 | Human approval | `reviewDecision` and current branch-ruleset/code-owner evidence for the pair; Copilot does not satisfy this row |
 | Threads and comments | every thread ID/resolution/outdated state and every comment ID, minimized state/reason, author, path, line, and timestamp |
 | Checks | complete expected inventory, result, `head_sha`, check-suite ID, and `CheckRun.app.owner.login`, `CheckRun.app.slug`, and `CheckRun.app.id` |
+| Legacy statuses | every context, state, target URL, and `creator.login`/`creator.id`; compare to the expected status provider inventory |
 | Check suites | suite ID, `head_sha`, app/provider identity, and each associated PR's repository, head SHA/ref, and base SHA/ref |
 
 Use repository rules/required-workflow configuration as the source of the full
@@ -158,34 +165,54 @@ Save each response under the gate directory and normalize it with sorted JSON
 before comparing snapshots.
 
 ```bash
-# Formal reviews; evaluate the exact-login/latest/COMMENTED/time/head predicate.
-gh api graphql --paginate --slurp -f query='
+require_graphql_pages() {
+  jq -e 'type == "array" and length > 0 and
+    all(.[]; ((.errors // []) | length) == 0 and .data != null)' "$1" >/dev/null ||
+    fail "GraphQL error, missing data, or incomplete page collection: $1"
+}
+
+collect_reviews_and_threads() {
+  gate_dir="$1"
+  # Formal reviews; evaluate the exact-login/latest/COMMENTED/time/head predicate.
+  # shellcheck disable=SC2016
+  # GraphQL variables must reach gh unchanged.
+  gh api graphql --paginate --slurp -f query='
   query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
         reviews(first:100, after:$endCursor) {
           pageInfo { hasNextPage endCursor }
-          nodes { author { login } state submittedAt commit { oid } }
+          nodes { id author { login } state submittedAt commit { oid } }
         }
       }
     }
   }
 ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr" \
   -F endCursor=null >"$gate_dir/reviews.json"
+require_graphql_pages "$gate_dir/reviews.json"
+jq -e 'all(.[]; .data.repository.pullRequest != null and
+  .data.repository.pullRequest.reviews.pageInfo != null) and
+  .[-1].data.repository.pullRequest.reviews.pageInfo.hasNextPage == false' \
+  "$gate_dir/reviews.json" >/dev/null || fail "missing review pageInfo"
 
-copilot_reviewer_login=REPOSITORY_CONFIGURED_COPILOT_LOGIN
-jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" \
-  --arg requested "$request_at" '
+jq -e --arg login "$copilot_reviewer_login" --arg head "$head_oid" '
   [ .[] | .data.repository.pullRequest.reviews.nodes[] |
     select(.author.login == $login) ] |
   if length == 0 then false else max_by(.submittedAt) |
-    (.state == "COMMENTED" and .submittedAt != null and
-     .submittedAt >= $requested and .commit.oid == $head)
+    (.id != null and .state == "COMMENTED" and .submittedAt != null and
+     .commit.oid == $head)
   end
 ' "$gate_dir/reviews.json" >/dev/null || fail "missing current formal Copilot review"
 
-# All review threads. Paginate every returned thread's comments separately.
-gh api graphql --paginate --slurp -f query='
+# GitHub review timestamps are normally second-resolution. The gate verifier
+# must parse submittedAt to UTC nanoseconds and prove it is strictly greater
+# than request_after_ns. Same-second, missing, rounded, or ambiguous data fails:
+# re-request and wait for an unambiguous fresh review.
+
+  # All review threads. Paginate every returned thread's comments separately.
+  # shellcheck disable=SC2016
+  # GraphQL variables must reach gh unchanged.
+  gh api graphql --paginate --slurp -f query='
   query($owner:String!, $repo:String!, $pr:Int!, $endCursor:String) {
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
@@ -204,11 +231,18 @@ gh api graphql --paginate --slurp -f query='
   }
 ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr="$pr" \
   -F endCursor=null >"$gate_dir/threads.json"
+require_graphql_pages "$gate_dir/threads.json"
+jq -e 'all(.[]; .data.repository.pullRequest != null and
+  .data.repository.pullRequest.reviewThreads.pageInfo != null) and
+  .[-1].data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false' \
+  "$gate_dir/threads.json" >/dev/null || fail "missing thread pageInfo"
 
 thread_number=0
-jq -r '.[].data.repository.pullRequest.reviewThreads.nodes[].id' \
+  jq -r '.[].data.repository.pullRequest.reviewThreads.nodes[].id' \
   "$gate_dir/threads.json" | while IFS= read -r thread_id; do
     thread_number=$((thread_number + 1))
+    # shellcheck disable=SC2016
+    # GraphQL variables must reach gh unchanged.
     gh api graphql --paginate --slurp -f query='
       query($thread:ID!, $endCursor:String) {
         node(id:$thread) {
@@ -222,29 +256,121 @@ jq -r '.[].data.repository.pullRequest.reviewThreads.nodes[].id' \
       }
     ' -F thread="$thread_id" -F endCursor=null \
       >"$gate_dir/thread-comments-$thread_number.json"
+    require_graphql_pages "$gate_dir/thread-comments-$thread_number.json"
+    jq -e 'all(.[]; .data.node != null and .data.node.comments.pageInfo != null) and
+      .[-1].data.node.comments.pageInfo.hasNextPage == false' \
+      "$gate_dir/thread-comments-$thread_number.json" >/dev/null ||
+      fail "missing comment pageInfo"
   done
+}
 ```
 
-Every unresolved thread blocks the gate, including an outdated thread, unless
-the current ruleset expressly permits that precise exception. Minimized is not
-resolved. Resolve a thread only after its fix is present in the current head.
+Every unresolved thread blocks this task's gate, including an outdated thread.
+Minimized is not resolved. A future ruleset exception must be machine-validated
+with its exact rule source; a “documented disposition” is never an exception.
+Resolve a thread only after its fix is present in the current head.
 
 ```bash
-# REST carries check runs and suites; its full path scopes gh api explicitly.
-for oid in "$head_oid" "$candidate_oid"; do
+collect_ci_and_statuses() {
+  gate_dir="$1"
+  # REST carries check runs, suites, and legacy statuses; its full path scopes gh api.
+  for oid in "$head_oid" "$candidate_oid"; do
   gh api --paginate --slurp \
     "repos/$base_repo/commits/$oid/check-runs?per_page=100" \
     >"$gate_dir/check-runs-$oid.json"
   gh api --paginate --slurp \
     "repos/$base_repo/commits/$oid/check-suites?per_page=100" \
     >"$gate_dir/check-suites-$oid.json"
-done
+    gh api --paginate --slurp \
+      "repos/$base_repo/commits/$oid/status?per_page=100" \
+      >"$gate_dir/status-contexts-$oid.json"
+
+    # A successful HTTP response is not enough: reject incomplete, malformed,
+    # or unexpectedly unpaginated payloads before the inventory validator sees
+    # them. Provider and result matching remains the validator's fail-closed job.
+    jq -e 'type == "array" and length > 0 and
+      all(.[]; (.check_runs | type) == "array")' \
+      "$gate_dir/check-runs-$oid.json" >/dev/null ||
+      fail "invalid check-run response for $oid"
+    jq -e 'type == "array" and length > 0 and
+      all(.[]; (.check_suites | type) == "array")' \
+      "$gate_dir/check-suites-$oid.json" >/dev/null ||
+      fail "invalid check-suite response for $oid"
+    jq -e 'type == "array" and length > 0 and
+      all(.[]; (.state | type) == "string" and (.statuses | type) == "array")' \
+      "$gate_dir/status-contexts-$oid.json" >/dev/null ||
+      fail "invalid legacy-status response for $oid"
+  done
+}
 ```
 
 Join each expected check run to its suite. The suite's associated PR must name
 the captured repository, `head_oid`/head ref, and `base_oid`/base ref. A run on
 `candidate_oid` is valid only with that exact association; an unrelated green
-run, a run for an earlier head, or one for a different base fails.
+run, a run for an earlier head, or one for a different base fails. Validate
+legacy status contexts with the same strict expected inventory: each context's
+creator login/ID and allowed state must match its configured provider; an
+unknown, missing, or non-success required context fails.
+
+The caller must provide a reviewed expected-inventory validator. It receives
+the complete raw snapshot, the actual branch-ruleset/required-workflow evidence,
+and the high-resolution review completion timestamp; it must enforce every row
+in the table rather than treating an unrecognized result as optional.
+
+```bash
+capture_snapshot() {
+  gate_dir="$1"
+  mkdir -p "$gate_dir"
+  cp "$gate_root/review-request.json" "$gate_dir/review-request.json"
+  cp "$expected_inventory" "$gate_dir/expected-inventory.json"
+  cp "$ruleset_evidence" "$gate_dir/ruleset-evidence.json"
+  capture_identity >"$gate_dir/identity.json"
+  jq -e '((.errors // []) | length) == 0 and
+    .data != null and .data.repository.pullRequest != null and
+    .data.repository.pullRequest.headRefOid != null and
+    .data.repository.pullRequest.baseRefOid != null and
+    .data.repository.pullRequest.headRepository.nameWithOwner != null and
+    .data.repository.pullRequest.mergeQueueEntry == null' \
+    "$gate_dir/identity.json" >/dev/null || fail "invalid final PR identity"
+  cmp -s "$observed" "$gate_dir/identity.json" ||
+    fail "PR head/base/candidate changed; restart and re-request Copilot"
+  head_oid="$(jq -r '.data.repository.pullRequest.headRefOid' "$gate_dir/identity.json")"
+  base_oid="$(jq -r '.data.repository.pullRequest.baseRefOid' "$gate_dir/identity.json")"
+  candidate_oid="$(jq -r \
+    '.data.repository.pullRequest.potentialMergeCommit.oid // .data.repository.pullRequest.headRefOid' \
+    "$gate_dir/identity.json")"
+  collect_reviews_and_threads "$gate_dir"
+  collect_ci_and_statuses "$gate_dir"
+}
+
+validate_snapshot() {
+  snapshot="$1"
+  jq -e '.data.repository.pullRequest.reviewDecision == "APPROVED"' \
+    "$snapshot/identity.json" >/dev/null || fail "missing current human approval"
+  jq -e '[.[] | .data.repository.pullRequest.reviewThreads.nodes[] |
+    select(.isResolved != true)] | length == 0' \
+    "$snapshot/threads.json" >/dev/null || fail "unresolved review thread"
+  test -x "$expected_inventory_validator" ||
+    fail "missing reviewed expected-inventory validator"
+  "$expected_inventory_validator" \
+    --snapshot "$snapshot" \
+    --expected "$snapshot/expected-inventory.json" \
+    --rules "$snapshot/ruleset-evidence.json" \
+    --review-after-ns "$request_after_ns"
+}
+
+: "${expected_inventory:?capture the current expected check/status provider inventory}"
+: "${ruleset_evidence:?capture current ruleset/code-owner evidence}"
+: "${expected_inventory_validator:?set the reviewed gate validator path}"
+test -s "$expected_inventory" && test -s "$ruleset_evidence" ||
+  fail "missing expected inventory or ruleset evidence"
+
+# First complete collection and validation, followed by the complete final rerun.
+capture_snapshot "$gate_root/verified"
+validate_snapshot "$gate_root/verified"
+capture_snapshot "$gate_root/final"
+validate_snapshot "$gate_root/final"
+```
 
 Before marking ready or merging, create a normalized, sorted manifest from all
 the files above plus the expected-check inventory and ruleset evidence. Validate
@@ -263,13 +389,16 @@ manifest_snapshot() {
     done >"$snapshot/gate.jsonl"
 }
 
-# After validating verified/, run every identity/review/thread/check collector
-# above again with gate_dir="$gate_root/final". Include expected inventory and
-# ruleset evidence JSON in both directories, then reject any change.
+# Both snapshots were collected and validated above. Reject any changed raw or
+# normalized evidence immediately before the ready mutation.
 manifest_snapshot "$gate_root/verified"
 manifest_snapshot "$gate_root/final"
 cmp -s "$gate_root/verified/gate.jsonl" "$gate_root/final/gate.jsonl" || \
   fail "gate evidence changed; restart from identity and request a new review"
+
+# This is the only mutation in this block. Do not launch a browser or inspect
+# additional mutable state between the final manifest comparison and ready.
+gh pr ready "$pr" --repo "$base_repo"
 ```
 
 The final capture must still have the observed head/base pair. A changed head or
@@ -293,6 +422,13 @@ head_oid="$(jq -r .headRefOid <<<"$pr_data")"
 head_repo="$(jq -r .headRepository.nameWithOwner <<<"$pr_data")"
 test "$head_repo" = "$base_repo" || { echo "refusing fork push" >&2; exit 1; }
 
+# A URL rewrite can make the configured spelling differ from the actual target.
+# Reject it rather than attempting to reason about insteadOf/pushInsteadOf.
+if git config --get-regexp '^url\..*\.(insteadOf|pushInsteadOf)$' >/dev/null; then
+  echo "URL rewrite configuration is present; refusing to select a push endpoint" >&2
+  exit 1
+fi
+
 # A selected remote must have exactly one push URL, and both its fetch and push
 # targets must resolve to the current PR head repository.
 push_remote=""
@@ -301,12 +437,17 @@ for candidate in $(git remote); do
     --json nameWithOwner --jq .nameWithOwner 2>/dev/null || :)"
   push_urls="$(git remote get-url --push --all "$candidate")"
   push_count="$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')"
-  test "$push_count" = 1 || continue
+  if test "$push_count" != 1; then
+    printf 'rejecting remote %s: expected exactly one push URL\n' "$candidate" >&2
+    continue
+  fi
   push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
   push_repo="$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner \
     2>/dev/null || :)"
-  test "$fetch_repo" = "$head_repo" || continue
-  test "$push_repo" = "$head_repo" || continue
+  if test "$fetch_repo" != "$head_repo" || test "$push_repo" != "$head_repo"; then
+    printf 'rejecting remote %s: endpoint is not the PR head repository\n' "$candidate" >&2
+    continue
+  fi
   test -z "$push_remote" || { echo "ambiguous verified remotes" >&2; exit 1; }
   push_remote="$candidate"
 done
@@ -351,6 +492,28 @@ continue; otherwise run `git rebase --abort`. After either path, rerun every
 post-rebase guard before a push. Never use broad `--force`, reset-based squash,
 unsigned amend, or `git add -A`.
 
+## Stacked child PRs
+
+Discover the open stack from actual base/head branch relationships; do not rely
+on PR number order or a manually remembered stack. Rebase in dependency order
+from parent to child, then run a fresh review and complete gate for **each** PR.
+
+```bash
+gh pr list --repo "$base_repo" --state open --limit 100 \
+  --json number,headRefName,baseRefName,url >"$gate_root/open-prs.json"
+
+# A child has baseRefName equal to its parent's headRefName. Build the directed
+# graph from this data, topologically order it parent -> child, and stop on a
+# cycle, missing parent, duplicate source branch, fork, or truncated listing.
+jq -r '.[] | [.number, .baseRefName, .headRefName, .url] | @tsv' \
+  "$gate_root/open-prs.json"
+```
+
+After a parent moves, re-fetch each child, verify its live head/base and one
+push endpoint using the rebase protocol above, rebase it onto the moved parent,
+and re-gate it. A parent review, approval, check, or manifest never approves a
+child; a child may not be pushed before its parent dependency is current.
+
 ## PR descriptions and draft lifecycle
 
 Prepare Markdown in a real file. Do not interpolate Markdown, backticks, or
@@ -363,21 +526,49 @@ body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
 vi "$body_file"                         # a known executable, not an EDITOR shell fragment
 test -s "$body_file"
 
-# Use the actual intended base, not a hardcoded main. Resolve the default only
-# when that is the intended target; otherwise set and validate the release base.
+# The caller supplies the actual intended base; do not silently substitute a
+# repository default. A workflow that explicitly targets the default may derive
+# it first, record that decision, then assign it here.
 base_repo=BASE_OWNER/BASE_REPOSITORY
-base_ref="$(gh repo view "$base_repo" --json defaultBranchRef --jq .defaultBranchRef.name)"
+base_ref=INTENDED_BASE_REF
+git check-ref-format --branch "$base_ref" >/dev/null
 head_ref="$(git branch --show-current)"
+git check-ref-format --branch "$head_ref" >/dev/null
 
-# The branch must already be pushed to one preverified same-repository target.
-push_remote=REMOTE_VERIFIED_FOR_THIS_BRANCH
-push_urls="$(git remote get-url --push --all "$push_remote")"
-test "$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')" = 1
-push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
-test "$(gh repo view "$(git remote get-url "$push_remote")" \
-  --json nameWithOwner --jq .nameWithOwner)" = "$base_repo"
-test "$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner)" = "$base_repo"
-git fetch "$push_remote" "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
+# Enumerate every remote and its push URLs immediately before draft creation.
+# There must be exactly one verified same-repository endpoint for this branch;
+# do not trust a remembered remote name or let Git choose a default.
+if git config --get-regexp '^url\..*\.(insteadOf|pushInsteadOf)$' >/dev/null; then
+  echo "URL rewrite configuration is present; refusing draft creation" >&2
+  exit 1
+fi
+push_remote=""
+for candidate in $(git remote); do
+  fetch_repo="$(gh repo view "$(git remote get-url "$candidate")" \
+    --json nameWithOwner --jq .nameWithOwner 2>/dev/null || :)"
+  push_urls="$(git remote get-url --push --all "$candidate")"
+  push_count="$(printf '%s\n' "$push_urls" | awk 'NF { count++ } END { print count + 0 }')"
+  if test "$push_count" != 1; then
+    printf 'rejecting remote %s: expected exactly one push URL\n' "$candidate" >&2
+    continue
+  fi
+  push_url="$(printf '%s\n' "$push_urls" | sed -n '1p')"
+  push_repo="$(gh repo view "$push_url" --json nameWithOwner --jq .nameWithOwner \
+    2>/dev/null || :)"
+  if test "$fetch_repo" != "$base_repo" || test "$push_repo" != "$base_repo"; then
+    printf 'rejecting remote %s: endpoint is not the target repository\n' "$candidate" >&2
+    continue
+  fi
+  test -z "$push_remote" || { echo "ambiguous verified remotes" >&2; exit 1; }
+  push_remote="$candidate"
+done
+test -n "$push_remote" || { echo "no single verified push target" >&2; exit 1; }
+
+# Re-fetch the actual source/base refs immediately before the draft mutation.
+git fetch "$push_remote" \
+  "refs/heads/$base_ref:refs/remotes/$push_remote/$base_ref" \
+  "refs/heads/$head_ref:refs/remotes/$push_remote/$head_ref"
+git rev-parse --verify "$push_remote/$base_ref^{commit}" >/dev/null
 test "$(git rev-parse "$push_remote/$head_ref")" = "$(git rev-parse HEAD)"
 
 pr_url="$(gh pr create --repo "$base_repo" --draft \
@@ -395,6 +586,8 @@ evidence. Mark a draft ready only after the complete gate passes.
 
 ```bash
 gh pr view PR_NUMBER --repo "$base_repo" --json body --jq .body
+# shellcheck disable=SC2016
+# GraphQL variables must reach gh unchanged.
 gh api graphql -f query='
   query($owner:String!, $repo:String!, $pr:Int!) {
     repository(owner:$owner, name:$repo) { pullRequest(number:$pr) { bodyHTML } }
@@ -402,9 +595,8 @@ gh api graphql -f query='
 ' -f owner="${base_repo%/*}" -f repo="${base_repo#*/}" -F pr=PR_NUMBER \
   --jq .data.repository.pullRequest.bodyHTML
 gh pr view PR_NUMBER --repo "$base_repo" --web
-gh pr ready PR_NUMBER --repo "$base_repo"
 ```
 
-Do not run the final `gh pr ready` command until the full gate snapshot has
-passed unchanged. No successful check, review, or absence of new comments from
-an earlier head/base pair is reusable evidence.
+The browser check is description-only. The separate fail-closed gate block is
+the only place that marks a PR ready. No successful check, review, or absence
+of new comments from an earlier head/base pair is reusable evidence.

--- a/.github/prompts/github-pr-management.md
+++ b/.github/prompts/github-pr-management.md
@@ -97,7 +97,7 @@ gh auth status --hostname "$github_host" >/dev/null ||
 case "$base_repo" in */*) ;; *) fail "invalid PR repository";; esac
 case "$pr" in ''|*[!0-9]*) fail "invalid PR number";; esac
 
-gate_root="$(mktemp -d)"
+gate_root="$(mktemp -d "${TMPDIR:-/tmp}/breakglass-pr-gate.XXXXXX")"
 trap 'rm -rf "$gate_root"' EXIT
 observed="$gate_root/observed.json"
 copilot_reviewer_login="${copilot_reviewer_login-}"
@@ -735,14 +735,14 @@ escaped newlines through `--body` or shell command substitution.
 ```bash
 set -euo pipefail
 
-body_file="$(mktemp -t breakglass-pr-description.XXXXXX.md)"
+body_file="$(mktemp "${TMPDIR:-/tmp}/breakglass-pr-description.XXXXXX.md")"
 vi "$body_file"                         # a known executable, not an EDITOR shell fragment
 test -s "$body_file"
 
 # The post-create verification writes into this run's private directory. Set it
 # up before the first PR mutation so a failed verification cannot be caused by
 # an unset path after the draft has already been created.
-gate_root="$(mktemp -d)"
+gate_root="$(mktemp -d "${TMPDIR:-/tmp}/breakglass-pr-gate.XXXXXX")"
 trap 'rm -rf "$gate_root"; rm -f "$body_file"' EXIT
 
 # The caller supplies the actual intended base; do not silently substitute a

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: CC0-1.0
+
+# A small, deliberately dependency-light verifier used by the PR-management
+# prompt.  It verifies *captured GitHub API evidence*; network collection and
+# mutations stay in the prompt so an operator can inspect the evidence before
+# changing a pull request.
+set -euo pipefail
+
+fail() {
+  printf 'pr-gate-contract: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  test -f "$1" || fail "missing file: $1"
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || fail "jq is required"
+}
+
+parse_pr_url() {
+  test "$#" = 1 || fail "usage: parse-pr-url HTTPS_PR_URL"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -r uri -e '
+    raw = ARGV.fetch(0)
+    uri = URI.parse(raw)
+    abort "PR URL must use HTTPS" unless uri.is_a?(URI::HTTPS)
+    abort "PR URL must not contain credentials, a port, query, or fragment" unless
+      uri.userinfo.nil? && uri.port == 443 && uri.query.nil? && uri.fragment.nil?
+    segments = uri.path.split("/").reject(&:empty?)
+    abort "PR URL must be /OWNER/REPOSITORY/pull/NUMBER" unless
+      segments.length == 4 && segments[2] == "pull" && segments[3].match?(/\A[1-9][0-9]*\z/)
+    owner, repo = segments.first(2)
+    valid = /\A[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?\z/
+    abort "invalid repository path" unless owner.match?(valid) && repo.match?(valid)
+    abort "invalid GitHub host" unless uri.host && uri.host.match?(/\A[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\z/i)
+    puts [uri.host.downcase, "#{owner}/#{repo}", segments[3]].join("\t")
+  ' "$1" || fail "invalid pull-request URL"
+}
+
+request_date() {
+  test "$#" = 1 || fail "usage: request-date HTTP_RESPONSE_FILE"
+  require_file "$1"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -e '
+    raw = File.binread(ARGV.fetch(0)).gsub("\r\n", "\n")
+    blocks = raw.split(/\n\n/).select { |block| block.start_with?("HTTP/") }
+    abort "missing HTTP response headers" if blocks.empty?
+    final = blocks.last.lines.map(&:strip)
+    status = final.shift
+    abort "non-successful review-request response" unless status.match?(/\AHTTP\/\S+ 2\d\d\b/)
+    dates = final.grep(/\Adate:\s*/i).map { |line| line.sub(/\Adate:\s*/i, "") }
+    abort "missing or ambiguous Date header" unless dates.length == 1
+    value = dates.fetch(0)
+    abort "invalid HTTP Date" unless value.match?(/\A(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), /)
+    puts value
+  ' "$1" || fail "ambiguous GitHub review-request Date"
+}
+
+request_date_to_ns() {
+  test "$#" = 1 || fail "usage: request-date-to-ns HTTP_RESPONSE_FILE"
+  local value
+  value="$(request_date "$1")"
+  ruby -r time -e '
+    parsed = Time.httpdate(ARGV.fetch(0)).utc
+    abort "non-UTC HTTP Date" unless parsed.utc?
+    puts (parsed.to_r * 1_000_000_000).to_i
+  ' "$value" || fail "ambiguous GitHub review-request Date"
+}
+
+review_timestamp_to_ns() {
+  test "$#" = 1 || fail "usage: review-timestamp-to-ns RFC3339_UTC_TIMESTAMP"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -r time -e '
+    value = ARGV.fetch(0)
+    abort "invalid RFC3339 timestamp" unless value.match?(/\A\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z\z/)
+    parsed = Time.iso8601(value).utc
+    abort "non-UTC review timestamp" unless parsed.utc?
+    puts (parsed.to_r * 1_000_000_000).to_i
+  ' "$1" || fail "invalid formal-review submittedAt"
+}
+
+verify_review_freshness() {
+  test "$#" = 2 || fail "usage: verify-review-freshness HTTP_RESPONSE_FILE RFC3339_UTC_TIMESTAMP"
+  local request_ns review_ns earliest_safe_ns
+  request_ns="$(request_date_to_ns "$1")"
+  review_ns="$(review_timestamp_to_ns "$2")"
+  earliest_safe_ns=$((request_ns + 1000000000))
+  # HTTP Date has one-second precision. A review stamped in that same second
+  # may have happened before the API response was generated, even when it has
+  # fractional seconds. The next whole second is the first provable boundary.
+  test "$review_ns" -ge "$earliest_safe_ns" ||
+    fail "formal review is not provably after GitHub review-request completion"
+}
+
+inventory_policy() {
+  test "$#" = 6 || fail "usage: inventory-policy HOST REPOSITORY BASE_REF EFFECTIVE_JSON PROTECTION_JSON OUTPUT_JSON"
+  local host="$1" repository="$2" base_ref="$3" effective="$4" protection="$5" output="$6"
+  require_jq
+  require_file "$effective"
+  require_file "$protection"
+
+  jq -n -e --arg host "$host" --arg repository "$repository" --arg baseRef "$base_ref" \
+    --slurpfile effective "$effective" --slurpfile protection "$protection" '
+    def rules:
+      if ($effective | length) == 1 and ($effective[0] | type) == "array" then $effective[0]
+      elif ($effective | length) == 1 and ($effective[0] | type) == "object" and
+           ($effective[0].rules | type) == "array" then $effective[0].rules
+      else error("malformed effective rules") end;
+    def protection: $protection[0];
+    def rule_checks:
+      [rules[] | select(.type == "required_status_checks") |
+       (.parameters.required_status_checks // [])[]? |
+       {context: (.context // ""), appId: (.integration_id // .app_id)}];
+    def protection_checks:
+      [((protection.required_status_checks.checks // [])[]?) |
+       {context: (.context // ""), appId: (.app_id // .integration_id)}];
+    def legacy_contexts: (protection.required_status_checks.contexts // []);
+    def supported_type:
+      . == "required_status_checks" or . == "pull_request" or
+      . == "required_signatures" or . == "required_workflows" or
+      . == "required_deployments" or . == "required_code_scanning";
+    rules as $rules |
+    (rule_checks + protection_checks) as $checks |
+    ([ $checks[] | .context ] | unique) as $names |
+    (legacy_contexts) as $legacy |
+    ([ $rules[] | select(.type | supported_type | not) |
+       {type, source, parameters} ]) as $unsupported |
+    if ($host | test("\\A[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\\z"; "i") | not) then
+      error("invalid GitHub host")
+    elif ($repository | test("\\A[^/ ]+/[^/ ]+\\z") | not) then
+      error("invalid repository")
+    elif ($rules | type) != "array" or ($rules | length) == 0 then
+      error("no effective server rules; refusing a no-op policy")
+    elif ($unsupported | length) != 0 then
+      error("unsupported active rule(s): " + ($unsupported | tojson) +
+            "; extend the verifier for these exact type/parameters or remove the rule before using this gate")
+    elif any($checks[]; (.context | type) != "string" or .context == "" or
+                       (.appId | type) != "number" or .appId <= 0) then
+      error("required check lacks an exact GitHub App integration ID")
+    elif ($names | length) != ($checks | length) then
+      error("duplicate required check context is ambiguous")
+    elif ($legacy | length) != 0 then
+      error("legacy required status context cannot be bound to a GitHub App; migrate it to a required check run")
+    else {
+      schema: 2,
+      githubHost: $host,
+      repository: $repository,
+      baseRef: $baseRef,
+      effectiveRules: $rules,
+      branchProtection: protection,
+      requiredCheckRuns: ($checks | sort_by(.context, .appId)),
+      mergeStateRequired: true,
+      directEvidence: {
+        required_status_checks: "exact App-bound check run and exact PR-associated suite",
+        pull_request: "GitHub reviewDecision plus zero unresolved review threads",
+        required_signatures: "exact PR final GitHub merge-state predicate",
+        required_workflows: "exact PR final GitHub merge-state predicate",
+        required_deployments: "exact PR final GitHub merge-state predicate",
+        required_code_scanning: "exact PR final GitHub merge-state predicate"
+      },
+      legacyStatusPolicy: "reject-required-contexts-without-provider-binding"
+    }
+    end
+  ' >"$output" || fail "could not build exact policy inventory"
+}
+
+verify_checks() {
+  test "$#" = 7 || fail "usage: verify-checks IDENTITY_JSON INVENTORY_JSON REPOSITORY_JSON RUNS_JSON SUITES_JSON STATUSES_JSON OUTPUT_JSON"
+  local identity="$1" inventory="$2" repository="$3" runs="$4" suites="$5" statuses="$6" output="$7"
+  require_jq
+  local item
+  for item in "$identity" "$inventory" "$repository" "$runs" "$suites" "$statuses"; do
+    require_file "$item"
+  done
+
+  jq -n -e --slurpfile identity "$identity" --slurpfile inventory "$inventory" \
+    --slurpfile repository "$repository" --slurpfile runs "$runs" \
+    --slurpfile suites "$suites" --slurpfile statuses "$statuses" '
+    $identity[0].data.repository.pullRequest as $pr |
+    $inventory[0] as $policy |
+    $repository[0] as $repo |
+    def nonempty_string: type == "string" and length > 0;
+    def exact_repo($candidate):
+      $candidate.id == $repo.id and
+      $candidate.full_name == $repo.full_name and
+      $candidate.html_url == $repo.html_url and
+      $candidate.url == $repo.url;
+    def exact_association($suite):
+      [ $suite.pull_requests[]? |
+        select(.head.sha == $pr.headRefOid and .head.ref == $pr.headRefName and
+               exact_repo(.head.repo) and
+               .base.sha == $pr.baseRefOid and .base.ref == $pr.baseRefName and
+               exact_repo(.base.repo))
+      ] | length == 1;
+    def suite_for($run):
+      [ $suites[0][] |
+        select(.id == $run.check_suite.id and .head_sha == $run.head_sha and
+               exact_repo(.repository) and .app.id == $run.app.id and
+               exact_association(.))
+      ] | length == 1;
+    def exact_success($need):
+      [ $runs[0][] |
+        select((.observedOid == .head_sha) and
+               (.head_sha == $pr.headRefOid or .head_sha == ($pr.potentialMergeCommit.oid // $pr.headRefOid)) and
+               .name == $need.context and .app.id == $need.appId and
+               (.app.owner.login | nonempty_string) and (.app.slug | nonempty_string) and
+               .status == "completed" and (.conclusion | ascii_upcase) == "SUCCESS" and suite_for(.))
+      ] | length > 0;
+    def required_status_names: ($policy.requiredCheckRuns | map(.context));
+    if ($policy.schema != 2 or $policy.mergeStateRequired != true) then
+      error("unsupported or incomplete policy inventory")
+    elif (($policy.repository != $repo.full_name) or (($policy.githubHost | nonempty_string) | not)) then
+      error("inventory and captured repository disagree")
+    elif (($repo.html_url != ("https://" + $policy.githubHost + "/" + $repo.full_name)) or
+          (($repo.url | nonempty_string) | not)) then
+      error("repository was not captured from the pinned HTTPS GitHub host")
+    elif ($pr.headRepository.nameWithOwner != $repo.full_name or
+          $pr.baseRepository.nameWithOwner != $repo.full_name) then
+      error("fork or mismatched source/base repository")
+    elif ($pr.isDraft != false or $pr.mergeable != "MERGEABLE" or $pr.mergeStateStatus != "CLEAN") then
+      error("GitHub does not currently attest that this exact PR is mergeable and policy-clean")
+    elif any($policy.requiredCheckRuns[]; exact_success(.) | not) then
+      error("a required App-bound check has no successful exact source-head or synthetic-candidate run")
+    elif any($statuses[0][]; (.context as $context | required_status_names | index($context)) != null) then
+      error("legacy status collides with a required check-run context and cannot be provider-bound safely")
+    else {
+      schema: 1,
+      verified: true,
+      acceptedHeads: [$pr.headRefOid, ($pr.potentialMergeCommit.oid // $pr.headRefOid)] | unique,
+      repository: $repo.full_name,
+      githubHost: $policy.githubHost
+    }
+    end
+  ' >"$output" || fail "required check/provider/suite evidence is invalid"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  pr-gate-contract.sh parse-pr-url HTTPS_PR_URL
+  pr-gate-contract.sh request-date HTTP_RESPONSE_FILE
+  pr-gate-contract.sh request-date-to-ns HTTP_RESPONSE_FILE
+  pr-gate-contract.sh verify-review-freshness HTTP_RESPONSE_FILE RFC3339_UTC_TIMESTAMP
+  pr-gate-contract.sh inventory-policy HOST REPOSITORY BASE_REF EFFECTIVE_JSON PROTECTION_JSON OUTPUT_JSON
+  pr-gate-contract.sh verify-checks IDENTITY_JSON INVENTORY_JSON REPOSITORY_JSON RUNS_JSON SUITES_JSON STATUSES_JSON OUTPUT_JSON
+EOF
+  exit 64
+}
+
+command="${1-}"
+case "$command" in
+  parse-pr-url) shift; parse_pr_url "$@" ;;
+  request-date) shift; request_date "$@" ;;
+  request-date-to-ns) shift; request_date_to_ns "$@" ;;
+  verify-review-freshness) shift; verify_review_freshness "$@" ;;
+  inventory-policy) shift; inventory_policy "$@" ;;
+  verify-checks) shift; verify_checks "$@" ;;
+  *) usage ;;
+esac

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -52,6 +52,13 @@ normalize_branch_protection_http() {
   require_file "$1"
   command -v ruby >/dev/null 2>&1 || fail "ruby is required"
   ruby -r json -r time -e '
+    class DuplicateJSONKeyError < StandardError; end
+    class UniqueHash < Hash
+      def []=(key, value)
+        raise DuplicateJSONKeyError, "duplicate JSON object key: #{key}" if key?(key)
+        super
+      end
+    end
     raw = File.binread(ARGV.fetch(0)).gsub("\r\n", "\n")
     blocks = raw.split(/\n\n/, -1)
     header_indexes = blocks.each_index.select { |index| blocks[index].start_with?("HTTP/") }
@@ -70,7 +77,7 @@ normalize_branch_protection_http() {
     body = blocks[(header_index + 1)..].join("\n\n")
     case code
     when "200"
-      parsed = JSON.parse(body)
+      parsed = JSON.parse(body, object_class: UniqueHash)
       abort "branch-protection response is not an object" unless parsed.is_a?(Hash)
       File.write(ARGV.fetch(1), JSON.generate(parsed) + "\n")
     when "404"
@@ -83,7 +90,7 @@ normalize_branch_protection_http() {
       content_types = headers.fetch("content-type", [])
       abort "404 missing/ambiguous JSON content type" unless content_types.length == 1 &&
         content_types.fetch(0).match?(/\Aapplication\/json(?:\s*;.*)?\z/i)
-      parsed = JSON.parse(body)
+      parsed = JSON.parse(body, object_class: UniqueHash)
       abort "404 error is not an object" unless parsed.is_a?(Hash)
       abort "unexpected 404 message" unless parsed["message"] == "Branch not protected"
       abort "missing 404 documentation URL" unless parsed["documentation_url"].is_a?(String) &&
@@ -103,6 +110,13 @@ manifest_evidence() {
   test -d "$1" || fail "missing snapshot directory: $1"
   command -v ruby >/dev/null 2>&1 || fail "ruby is required"
   ruby -r digest -r json -r time -e '
+    class DuplicateJSONKeyError < StandardError; end
+    class UniqueHash < Hash
+      def []=(key, value)
+        raise DuplicateJSONKeyError, "duplicate JSON object key: #{key}" if key?(key)
+        super
+      end
+    end
     root = File.realpath(ARGV.fetch(0))
     output = File.join(File.realpath(File.dirname(ARGV.fetch(1))), File.basename(ARGV.fetch(1)))
     abort "manifest output must be directly inside its snapshot" unless
@@ -152,8 +166,8 @@ manifest_evidence() {
         content_types.fetch(0).match?(%r{\Aapplication/(?:[A-Za-z0-9.+-]+\+)?json(?:\s*;.*)?\z}i)
       canonical_body = if json_body
         begin
-          {"json" => JSON.parse(body)}
-        rescue JSON::ParserError
+          {"json" => JSON.parse(body, object_class: UniqueHash)}
+        rescue JSON::ParserError, DuplicateJSONKeyError
           abort "invalid JSON HTTP body"
         end
       else
@@ -168,8 +182,10 @@ manifest_evidence() {
                           "x-ratelimit-remaining", "x-ratelimit-reset",
                           "x-ratelimit-resource", "x-ratelimit-used",
                           "server-timing", "via"]
+      # Preserve repeated-header order. RFC field ordering is not generally
+      # interchangeable, and security headers such as X-Frame-Options are not
+      # list-valued fields whose duplicate order can safely be discarded.
       stable_headers = headers.reject { |name, _| volatile_headers.include?(name) }
-        .transform_values { |values| values.sort }
       {"status" => code.to_i, "headers" => stable_headers, "body" => canonical_body}
     end
 
@@ -180,8 +196,8 @@ manifest_evidence() {
         relative = path.delete_prefix(root + File::SEPARATOR)
         evidence = if File.extname(path) == ".json"
           begin
-            canonical_json(JSON.parse(File.binread(path)))
-          rescue JSON::ParserError
+            canonical_json(JSON.parse(File.binread(path), object_class: UniqueHash))
+          rescue JSON::ParserError, DuplicateJSONKeyError
             abort "invalid JSON evidence: #{relative}"
           end
         elsif File.extname(path) == ".http"
@@ -227,6 +243,22 @@ request_date_to_ns() {
   ' "$value" || fail "ambiguous GitHub review-request Date"
 }
 
+validate_json() {
+  test "$#" = 1 || fail "usage: validate-json JSON_FILE"
+  require_file "$1"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -r json -e '
+    class DuplicateJSONKeyError < StandardError; end
+    class UniqueHash < Hash
+      def []=(key, value)
+        raise DuplicateJSONKeyError, "duplicate JSON object key: #{key}" if key?(key)
+        super
+      end
+    end
+    JSON.parse(File.binread(ARGV.fetch(0)), object_class: UniqueHash)
+  ' "$1" >/dev/null || fail "JSON evidence is malformed or contains duplicate object keys: $1"
+}
+
 review_timestamp_to_ns() {
   test "$#" = 1 || fail "usage: review-timestamp-to-ns RFC3339_UTC_TIMESTAMP"
   command -v ruby >/dev/null 2>&1 || fail "ruby is required"
@@ -252,11 +284,32 @@ verify_review_freshness() {
     fail "formal review is not provably after GitHub review-request completion"
 }
 
+select_copilot_review() {
+  test "$#" = 4 || fail "usage: select-copilot-review REVIEWS_JSON LOGIN HEAD_OID OUTPUT_JSON"
+  local reviews="$1" login="$2" head="$3" output="$4"
+  require_file "$reviews"
+  require_jq
+  validate_json "$reviews"
+  jq -e --arg login "$login" --arg head "$head" '
+    [ .[] | .data.repository.pullRequest.reviews.nodes[] |
+      select(.author.login == $login) ] as $reviews |
+    if (($reviews | length) == 0) or
+       any($reviews[]; .state == "PENDING" or .submittedAt == null) then
+      false
+    else
+      $reviews | max_by(.submittedAt) |
+      if (.id != null and .state == "COMMENTED" and .submittedAt != null and
+          .commit.oid == $head) then . else false end
+    end
+  ' "$reviews" >"$output" || fail "missing current, submitted formal Copilot review"
+}
+
 verify_created_draft() {
   test "$#" = 6 || fail "usage: verify-created-draft PR_JSON REPOSITORY HEAD_REF HEAD_OID BASE_REF BASE_OID"
   local pr_json="$1" repository="$2" head_ref="$3" head_oid="$4" base_ref="$5" base_oid="$6"
   require_jq
   require_file "$pr_json"
+  validate_json "$pr_json"
   jq -e --arg repository "$repository" --arg headRef "$head_ref" --arg headOid "$head_oid" \
     --arg baseRef "$base_ref" --arg baseOid "$base_oid" '
     type == "object" and .isDraft == true and
@@ -273,6 +326,8 @@ inventory_policy() {
   require_jq
   require_file "$effective"
   require_file "$protection"
+  validate_json "$effective"
+  validate_json "$protection"
 
   jq -n -e --arg host "$host" --arg repository "$repository" --arg baseRef "$base_ref" \
     --slurpfile effective "$effective" --slurpfile protection "$protection" '
@@ -544,6 +599,7 @@ verify_checks() {
   local item
   for item in "$identity" "$inventory" "$repository" "$runs" "$suites" "$statuses"; do
     require_file "$item"
+    validate_json "$item"
   done
 
   jq -n -e --slurpfile identity "$identity" --slurpfile inventory "$inventory" \
@@ -615,7 +671,9 @@ usage:
   pr-gate-contract.sh manifest-evidence SNAPSHOT_DIRECTORY OUTPUT_FILE
   pr-gate-contract.sh request-date HTTP_RESPONSE_FILE
   pr-gate-contract.sh request-date-to-ns HTTP_RESPONSE_FILE
+  pr-gate-contract.sh validate-json JSON_FILE
   pr-gate-contract.sh verify-review-freshness HTTP_RESPONSE_FILE RFC3339_UTC_TIMESTAMP
+  pr-gate-contract.sh select-copilot-review REVIEWS_JSON LOGIN HEAD_OID OUTPUT_JSON
   pr-gate-contract.sh verify-created-draft PR_JSON REPOSITORY HEAD_REF HEAD_OID BASE_REF BASE_OID
   pr-gate-contract.sh inventory-policy HOST REPOSITORY BASE_REF EFFECTIVE_JSON PROTECTION_JSON OUTPUT_JSON
   pr-gate-contract.sh verify-checks IDENTITY_JSON INVENTORY_JSON REPOSITORY_JSON RUNS_JSON SUITES_JSON STATUSES_JSON OUTPUT_JSON
@@ -630,7 +688,9 @@ case "$command" in
   manifest-evidence) shift; manifest_evidence "$@" ;;
   request-date) shift; request_date "$@" ;;
   request-date-to-ns) shift; request_date_to_ns "$@" ;;
+  validate-json) shift; validate_json "$@" ;;
   verify-review-freshness) shift; verify_review_freshness "$@" ;;
+  select-copilot-review) shift; select_copilot_review "$@" ;;
   verify-created-draft) shift; verify_created_draft "$@" ;;
   inventory-policy) shift; inventory_policy "$@" ;;
   verify-checks) shift; verify_checks "$@" ;;

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -28,6 +28,12 @@ parse_pr_url() {
     raw = ARGV.fetch(0)
     uri = URI.parse(raw)
     abort "PR URL must use HTTPS" unless uri.is_a?(URI::HTTPS)
+    authority = raw[/\Ahttps:\/\/([^\/]+)/i, 1]
+    # URI#port normalizes an explicit :443 to the HTTPS default. The gate
+    # promises a host-only HTTPS endpoint, so inspect the original authority
+    # as well and reject every explicit port, including :443.
+    abort "PR URL must not contain an explicit port" unless authority &&
+      authority.casecmp?(uri.host.to_s)
     abort "PR URL must not contain credentials, a port, query, or fragment" unless
       uri.userinfo.nil? && uri.port == 443 && uri.query.nil? && uri.fragment.nil?
     segments = uri.path.split("/").reject(&:empty?)
@@ -39,6 +45,36 @@ parse_pr_url() {
     abort "invalid GitHub host" unless uri.host && uri.host.match?(/\A[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\z/i)
     puts [uri.host.downcase, "#{owner}/#{repo}", segments[3]].join("\t")
   ' "$1" || fail "invalid pull-request URL"
+}
+
+normalize_branch_protection_http() {
+  test "$#" = 2 || fail "usage: normalize-branch-protection-http HTTP_RESPONSE_FILE OUTPUT_JSON"
+  require_file "$1"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -r json -e '
+    raw = File.binread(ARGV.fetch(0)).gsub("\r\n", "\n")
+    blocks = raw.split(/\n\n/, -1)
+    header_indexes = blocks.each_index.select { |index| blocks[index].start_with?("HTTP/") }
+    abort "missing HTTP response headers" if header_indexes.empty?
+    header_index = header_indexes.last
+    status = blocks.fetch(header_index).lines.first.to_s.strip
+    code = status[/\AHTTP\/\S+\s+(\d{3})\b/, 1]
+    abort "malformed HTTP status" unless code
+    body = blocks[(header_index + 1)..].join("\n\n")
+    case code
+    when "200"
+      parsed = JSON.parse(body)
+      abort "branch-protection response is not an object" unless parsed.is_a?(Hash)
+      File.write(ARGV.fetch(1), JSON.generate(parsed) + "\n")
+    when "404"
+      # The authenticated endpoint conclusively says classic branch protection
+      # is absent. Preserve a normalized empty object rather than treating an
+      # arbitrary transport/API failure as absence.
+      File.write(ARGV.fetch(1), "{}\n")
+    else
+      abort "branch-protection request returned HTTP #{code}"
+    end
+  ' "$1" "$2" || fail "could not normalize authenticated branch-protection response"
 }
 
 request_date() {
@@ -114,6 +150,72 @@ inventory_policy() {
         [ $effective[0][] | .[] ]
       else error("malformed paginated effective-rules response") end;
     def protection: $protection[0];
+    def nonempty_string: type == "string" and length > 0;
+    def enabled_object: type == "object" and .enabled == true;
+    def nonempty_restrictions:
+      [(.users // [])[], (.teams // [])[], (.apps // [])[]] | length > 0;
+    def valid_required_check:
+      type == "object" and (.context | nonempty_string) and
+      ((.integration_id // .app_id) | type) == "number" and
+      (.integration_id // .app_id) > 0;
+    def valid_workflow:
+      type == "object" and (.repository_id | type) == "number" and .repository_id > 0 and
+      (.path | nonempty_string) and (.ref | nonempty_string) and
+      (.sha | type) == "string" and (.sha | test("^[0-9a-fA-F]{40}$"));
+    def valid_code_scanning_tool:
+      type == "object" and (.tool | nonempty_string) and
+      (.alerts_threshold | nonempty_string) and
+      (.security_alerts_threshold | nonempty_string);
+    def valid_known_ruleset_rule:
+      type == "object" and (.type | nonempty_string) and (.parameters | type) == "object" and
+      (if .type == "required_status_checks" then
+         (.parameters.required_status_checks | type) == "array" and
+         all(.parameters.required_status_checks[]; valid_required_check)
+       elif .type == "workflows" then
+         (.parameters.workflows | type) == "array" and
+         (.parameters.workflows | length) > 0 and
+         all(.parameters.workflows[]; valid_workflow)
+       elif .type == "code_scanning" then
+         (.parameters.code_scanning_tools | type) == "array" and
+         (.parameters.code_scanning_tools | length) > 0 and
+         all(.parameters.code_scanning_tools[]; valid_code_scanning_tool)
+       elif .type == "required_deployments" then
+         (.parameters.required_deployment_environments | type) == "array" and
+         (.parameters.required_deployment_environments | length) > 0 and
+         all(.parameters.required_deployment_environments[]; nonempty_string)
+       else true end);
+    def valid_classic_enabled_field($field):
+      (protection[$field] == null) or
+      ((protection[$field] | type) == "object" and
+       (protection[$field].enabled | type) == "boolean");
+    def valid_classic_protection:
+      (protection | type) == "object" and
+      ((protection.required_status_checks == null) or
+       ((protection.required_status_checks | type) == "object" and
+        ((protection.required_status_checks.checks // []) | type) == "array" and
+        all(protection.required_status_checks.checks[]?; valid_required_check) and
+        ((protection.required_status_checks.contexts // []) | type) == "array" and
+        all(protection.required_status_checks.contexts[]?; nonempty_string))) and
+      ((protection.required_pull_request_reviews == null) or
+       ((protection.required_pull_request_reviews | type) == "object" and
+        ((protection.required_pull_request_reviews.required_approving_review_count // 0) | type) == "number" and
+        (protection.required_pull_request_reviews.required_approving_review_count // 0) >= 0)) and
+      ((protection.required_conversation_resolution == null) or
+       valid_classic_enabled_field("required_conversation_resolution")) and
+      valid_classic_enabled_field("required_signatures") and
+      valid_classic_enabled_field("required_commit_signatures") and
+      valid_classic_enabled_field("required_linear_history") and
+      valid_classic_enabled_field("enforce_admins") and
+      valid_classic_enabled_field("allow_force_pushes") and
+      valid_classic_enabled_field("allow_deletions") and
+      valid_classic_enabled_field("lock_branch") and
+      valid_classic_enabled_field("allow_fork_syncing") and
+      valid_classic_enabled_field("block_creations") and
+      ((protection.restrictions == null) or
+       ((protection.restrictions | type) == "object" and
+        ((protection.restrictions.users // []) | type) == "array" and
+        ((protection.restrictions.teams // []) | type) == "array" and
+        ((protection.restrictions.apps // []) | type) == "array"));
     def has_classic_status_checks:
       (protection.required_status_checks | type) == "object" and
       (((protection.required_status_checks.checks // []) | length) > 0 or
@@ -136,7 +238,51 @@ inventory_policy() {
            protection.required_commit_signatures.enabled == true then
           {type: "required_signatures", source: "classic_branch_protection",
            parameters: (protection.required_signatures // protection.required_commit_signatures)}
-        else empty end
+        else empty end,
+        if protection.required_linear_history.enabled == true then
+          {type: "required_linear_history", source: "classic_branch_protection",
+           parameters: protection.required_linear_history}
+        else empty end,
+        if protection.enforce_admins.enabled == true then
+          {type: "enforce_admins", source: "classic_branch_protection",
+           parameters: protection.enforce_admins}
+        else empty end,
+        if protection.allow_force_pushes.enabled == true then
+          {type: "allow_force_pushes", source: "classic_branch_protection",
+           parameters: protection.allow_force_pushes}
+        else empty end,
+        if protection.allow_deletions.enabled == true then
+          {type: "allow_deletions", source: "classic_branch_protection",
+           parameters: protection.allow_deletions}
+        else empty end,
+        if protection.lock_branch.enabled == true then
+          {type: "lock_branch", source: "classic_branch_protection",
+           parameters: protection.lock_branch}
+        else empty end,
+        if protection.allow_fork_syncing.enabled == true then
+          {type: "allow_fork_syncing", source: "classic_branch_protection",
+           parameters: protection.allow_fork_syncing}
+        else empty end,
+        if protection.block_creations.enabled == true then
+          {type: "block_creations", source: "classic_branch_protection",
+           parameters: protection.block_creations}
+        else empty end,
+        if (protection.restrictions | type) == "object" and
+           (protection.restrictions | nonempty_restrictions) then
+          {type: "restrictions", source: "classic_branch_protection",
+           parameters: protection.restrictions}
+        else empty end,
+        [protection | to_entries[] |
+         select(.key as $key |
+           ["url", "enabled", "required_status_checks", "required_pull_request_reviews",
+            "required_conversation_resolution", "required_signatures", "required_commit_signatures",
+            "required_linear_history", "enforce_admins", "allow_force_pushes", "allow_deletions",
+            "lock_branch", "allow_fork_syncing", "block_creations", "restrictions"] | index($key) | not) |
+         select((.value | type) == "boolean" and .value == true or
+                (.value | enabled_object) or
+                ((.value | type) == "array" and (.value | length) > 0)) |
+         {type: ("classic_" + .key), source: "classic_branch_protection", parameters: .value}
+        ][]
       ];
     def rule_checks($all_rules):
       [$all_rules[] | select(.type == "required_status_checks") |
@@ -164,6 +310,10 @@ inventory_policy() {
       error("invalid repository")
     elif ($all_rules | type) != "array" or ($all_rules | length) == 0 then
       error("no active ruleset or classic branch-protection requirement; refusing a no-op policy")
+    elif valid_classic_protection | not then
+      error("malformed classic branch-protection schema")
+    elif any($rules[]; valid_known_ruleset_rule | not) then
+      error("malformed known ruleset schema or parameters")
     elif ($unsupported | length) != 0 then
       error("unsupported active rule(s): " + ($unsupported | tojson) +
             "; extend the verifier for these exact type/parameters or remove the rule before using this gate")
@@ -272,6 +422,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   pr-gate-contract.sh parse-pr-url HTTPS_PR_URL
+  pr-gate-contract.sh normalize-branch-protection-http HTTP_RESPONSE_FILE OUTPUT_JSON
   pr-gate-contract.sh request-date HTTP_RESPONSE_FILE
   pr-gate-contract.sh request-date-to-ns HTTP_RESPONSE_FILE
   pr-gate-contract.sh verify-review-freshness HTTP_RESPONSE_FILE RFC3339_UTC_TIMESTAMP
@@ -284,6 +435,7 @@ EOF
 command="${1-}"
 case "$command" in
   parse-pr-url) shift; parse_pr_url "$@" ;;
+  normalize-branch-protection-http) shift; normalize_branch_protection_http "$@" ;;
   request-date) shift; request_date "$@" ;;
   request-date-to-ns) shift; request_date_to_ns "$@" ;;
   verify-review-freshness) shift; verify_review_freshness "$@" ;;

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -51,15 +51,22 @@ normalize_branch_protection_http() {
   test "$#" = 2 || fail "usage: normalize-branch-protection-http HTTP_RESPONSE_FILE OUTPUT_JSON"
   require_file "$1"
   command -v ruby >/dev/null 2>&1 || fail "ruby is required"
-  ruby -r json -e '
+  ruby -r json -r time -e '
     raw = File.binread(ARGV.fetch(0)).gsub("\r\n", "\n")
     blocks = raw.split(/\n\n/, -1)
     header_indexes = blocks.each_index.select { |index| blocks[index].start_with?("HTTP/") }
     abort "missing HTTP response headers" if header_indexes.empty?
     header_index = header_indexes.last
-    status = blocks.fetch(header_index).lines.first.to_s.strip
+    header_lines = blocks.fetch(header_index).lines.map(&:strip)
+    status = header_lines.shift.to_s
     code = status[/\AHTTP\/\S+\s+(\d{3})\b/, 1]
     abort "malformed HTTP status" unless code
+    headers = Hash.new { |hash, key| hash[key] = [] }
+    header_lines.each do |line|
+      name, value = line.split(":", 2)
+      abort "malformed HTTP header" unless name && value
+      headers[name.downcase] << value.strip
+    end
     body = blocks[(header_index + 1)..].join("\n\n")
     case code
     when "200"
@@ -67,14 +74,73 @@ normalize_branch_protection_http() {
       abort "branch-protection response is not an object" unless parsed.is_a?(Hash)
       File.write(ARGV.fetch(1), JSON.generate(parsed) + "\n")
     when "404"
-      # The authenticated endpoint conclusively says classic branch protection
-      # is absent. Preserve a normalized empty object rather than treating an
-      # arbitrary transport/API failure as absence.
+      dates = headers.fetch("date", [])
+      abort "404 missing/ambiguous Date header" unless dates.length == 1
+      Time.httpdate(dates.fetch(0))
+      request_ids = headers.fetch("x-github-request-id", [])
+      abort "404 missing/ambiguous GitHub request ID" unless request_ids.length == 1 &&
+        request_ids.fetch(0).match?(/\A[A-Za-z0-9:_-]+\z/)
+      content_types = headers.fetch("content-type", [])
+      abort "404 missing/ambiguous JSON content type" unless content_types.length == 1 &&
+        content_types.fetch(0).match?(/\Aapplication\/json(?:\s*;.*)?\z/i)
+      parsed = JSON.parse(body)
+      abort "404 error is not an object" unless parsed.is_a?(Hash)
+      abort "unexpected 404 message" unless parsed["message"] == "Branch not protected"
+      abort "missing 404 documentation URL" unless parsed["documentation_url"].is_a?(String) &&
+        parsed["documentation_url"].match?(%r{\Ahttps://docs\.github\.com/})
+      abort "unexpected 404 status" unless parsed["status"] == "404" || parsed["status"] == 404
+      # The authenticated, GitHub-shaped 404 conclusively says classic branch
+      # protection is absent. No other error is normalized as an empty policy.
       File.write(ARGV.fetch(1), "{}\n")
     else
       abort "branch-protection request returned HTTP #{code}"
     end
   ' "$1" "$2" || fail "could not normalize authenticated branch-protection response"
+}
+
+manifest_evidence() {
+  test "$#" = 2 || fail "usage: manifest-evidence SNAPSHOT_DIRECTORY OUTPUT_FILE"
+  test -d "$1" || fail "missing snapshot directory: $1"
+  command -v ruby >/dev/null 2>&1 || fail "ruby is required"
+  ruby -r digest -r json -e '
+    root = File.realpath(ARGV.fetch(0))
+    output = File.expand_path(ARGV.fetch(1))
+    abort "manifest output must be directly inside its snapshot" unless
+      File.realpath(File.dirname(output)) == root
+
+    def canonical_json(value)
+      case value
+      when Hash
+        "{" + value.keys.sort.map { |key|
+          JSON.generate(key) + ":" + canonical_json(value.fetch(key))
+        }.join(",") + "}"
+      when Array
+        "[" + value.map { |item| canonical_json(item) }.join(",") + "]"
+      else
+        JSON.generate(value)
+      end
+    end
+
+    entries = Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
+      .select { |path| File.file?(path) }
+      .reject { |path| File.expand_path(path) == output }
+      .map do |path|
+        relative = path.delete_prefix(root + File::SEPARATOR)
+        evidence = if File.extname(path) == ".json"
+          begin
+            canonical_json(JSON.parse(File.binread(path)))
+          rescue JSON::ParserError
+            abort "invalid JSON evidence: #{relative}"
+          end
+        else
+          "sha256:" + Digest::SHA256.file(path).hexdigest
+        end
+        [relative, evidence]
+      end
+    File.binwrite(output, entries.sort_by(&:first).map { |relative, evidence|
+      "#{relative}\t#{evidence}\n"
+    }.join)
+  ' "$1" "$2" || fail "could not create complete evidence manifest"
 }
 
 request_date() {
@@ -132,6 +198,21 @@ verify_review_freshness() {
     fail "formal review is not provably after GitHub review-request completion"
 }
 
+verify_created_draft() {
+  test "$#" = 6 || fail "usage: verify-created-draft PR_JSON REPOSITORY HEAD_REF HEAD_OID BASE_REF BASE_OID"
+  local pr_json="$1" repository="$2" head_ref="$3" head_oid="$4" base_ref="$5" base_oid="$6"
+  require_jq
+  require_file "$pr_json"
+  jq -e --arg repository "$repository" --arg headRef "$head_ref" --arg headOid "$head_oid" \
+    --arg baseRef "$base_ref" --arg baseOid "$base_oid" '
+    type == "object" and .isDraft == true and
+    (.headRepository | type) == "object" and .headRepository.nameWithOwner == $repository and
+    .headRefName == $headRef and .headRefOid == $headOid and
+    (.baseRepository | type) == "object" and .baseRepository.nameWithOwner == $repository and
+    .baseRefName == $baseRef and .baseRefOid == $baseOid
+  ' "$pr_json" >/dev/null || fail "created draft does not match the verified source/base repository, ref, and OID"
+}
+
 inventory_policy() {
   test "$#" = 6 || fail "usage: inventory-policy HOST REPOSITORY BASE_REF EFFECTIVE_JSON PROTECTION_JSON OUTPUT_JSON"
   local host="$1" repository="$2" base_ref="$3" effective="$4" protection="$5" output="$6"
@@ -151,26 +232,85 @@ inventory_policy() {
       else error("malformed paginated effective-rules response") end;
     def protection: $protection[0];
     def nonempty_string: type == "string" and length > 0;
-    def enabled_object: type == "object" and .enabled == true;
+    def json_integer: type == "number" and floor == .;
     def nonempty_restrictions:
-      [(.users // [])[], (.teams // [])[], (.apps // [])[]] | length > 0;
-    def valid_required_check:
+      [.users[], .teams[], .apps[]] | length > 0;
+    # Rulesets call this provider identifier `integration_id`; classic branch
+    # protection calls it `app_id`. Neither `null` nor -1 binds a check to an
+    # exact GitHub App, so this gate deliberately does not accept either.
+    def valid_ruleset_required_check:
       type == "object" and (.context | nonempty_string) and
-      ((.integration_id // .app_id) | type) == "number" and
-      (.integration_id // .app_id) > 0;
+      (.integration_id | json_integer) and .integration_id > 0;
+    def valid_classic_required_check:
+      type == "object" and (.context | nonempty_string) and
+      (.app_id | json_integer) and .app_id > 0;
     def valid_workflow:
-      type == "object" and (.repository_id | type) == "number" and .repository_id > 0 and
-      (.path | nonempty_string) and (.ref | nonempty_string) and
+      type == "object" and (.repository_id | json_integer) and .repository_id > 0 and
+      (.path | nonempty_string) and
+      ((has("ref") | not) or (.ref | nonempty_string)) and
       (.sha | type) == "string" and (.sha | test("^[0-9a-fA-F]{40}$"));
     def valid_code_scanning_tool:
       type == "object" and (.tool | nonempty_string) and
-      (.alerts_threshold | nonempty_string) and
-      (.security_alerts_threshold | nonempty_string);
+      (.alerts_threshold | IN("none", "errors", "errors_and_warnings", "all")) and
+      (.security_alerts_threshold |
+       IN("none", "critical", "high_or_higher", "medium_or_higher", "all"));
+    def valid_actor_lists:
+      type == "object" and (.users | type) == "array" and
+      (.teams | type) == "array" and (.apps | type) == "array";
+    def valid_pull_request_rule:
+      (.parameters | type) == "object" and
+      (.parameters.dismiss_stale_reviews_on_push | type) == "boolean" and
+      (.parameters.require_code_owner_review | type) == "boolean" and
+      (.parameters.require_last_push_approval | type) == "boolean" and
+      (.parameters.required_approving_review_count | json_integer) and
+      .parameters.required_approving_review_count >= 0 and
+      (.parameters.required_review_thread_resolution | type) == "boolean" and
+      ((.parameters.dismissal_restriction == null) or
+       ((.parameters.dismissal_restriction | type) == "object" and
+        (.parameters.dismissal_restriction.enabled | type) == "boolean" and
+        (.parameters.dismissal_restriction.allowed_actors | type) == "array" and
+        all(.parameters.dismissal_restriction.allowed_actors[];
+          (.id | json_integer) and .id > 0 and
+          (.type | IN("User", "Team", "IntegrationInstallation", "RepositoryRole"))))) and
+      ((.parameters.allowed_merge_methods == null) or
+       ((.parameters.allowed_merge_methods | type) == "array" and
+        (.parameters.allowed_merge_methods | length) > 0 and
+        all(.parameters.allowed_merge_methods[]; IN("merge", "squash", "rebase")))) and
+      ((.parameters.required_reviewers == null) or
+       ((.parameters.required_reviewers | type) == "array" and
+        all(.parameters.required_reviewers[];
+          type == "object" and (.file_patterns | type) == "array" and
+          all(.file_patterns[]; nonempty_string) and
+          (.minimum_approvals | json_integer) and .minimum_approvals >= 0 and
+          (.reviewer | type) == "object" and (.reviewer.id | json_integer) and
+          .reviewer.id > 0 and .reviewer.type == "Team")));
+    def valid_classic_pull_request_reviews:
+      type == "object" and
+      (.dismissal_restrictions | valid_actor_lists) and
+      (.dismiss_stale_reviews | type) == "boolean" and
+      (.require_code_owner_reviews | type) == "boolean" and
+      (.required_approving_review_count | json_integer) and
+      .required_approving_review_count >= 0 and
+      (.require_last_push_approval | type) == "boolean" and
+      ((.bypass_pull_request_allowances == null) or
+       (.bypass_pull_request_allowances | valid_actor_lists));
+    def valid_classic_status_checks:
+      type == "object" and (.strict | type) == "boolean" and
+      (.contexts | type) == "array" and all(.contexts[]; nonempty_string) and
+      (.checks | type) == "array" and all(.checks[]; valid_classic_required_check) and
+      ((.contexts | length) + (.checks | length)) > 0;
     def valid_known_ruleset_rule:
-      type == "object" and (.type | nonempty_string) and (.parameters | type) == "object" and
+      type == "object" and (.type | nonempty_string) and
       (if .type == "required_status_checks" then
+         (.parameters | type) == "object" and
+         (.parameters.strict_required_status_checks_policy | type) == "boolean" and
+         ((.parameters.do_not_enforce_on_create == null) or
+          (.parameters.do_not_enforce_on_create | type) == "boolean") and
          (.parameters.required_status_checks | type) == "array" and
-         all(.parameters.required_status_checks[]; valid_required_check)
+         (.parameters.required_status_checks | length) > 0 and
+         all(.parameters.required_status_checks[]; valid_ruleset_required_check)
+       elif .type == "pull_request" then
+         valid_pull_request_rule
        elif .type == "workflows" then
          (.parameters.workflows | type) == "array" and
          (.parameters.workflows | length) > 0 and
@@ -180,26 +320,29 @@ inventory_policy() {
          (.parameters.code_scanning_tools | length) > 0 and
          all(.parameters.code_scanning_tools[]; valid_code_scanning_tool)
        elif .type == "required_deployments" then
+         (.parameters | type) == "object" and
          (.parameters.required_deployment_environments | type) == "array" and
          (.parameters.required_deployment_environments | length) > 0 and
          all(.parameters.required_deployment_environments[]; nonempty_string)
-       else true end);
+       elif .type == "required_signatures" then
+         ((has("parameters") | not) or .parameters == null or
+          ((.parameters | type) == "object" and (.parameters | length) == 0))
+       else false end);
     def valid_classic_enabled_field($field):
       (protection[$field] == null) or
       ((protection[$field] | type) == "object" and
        (protection[$field].enabled | type) == "boolean");
+    def known_classic_fields:
+      ["url", "enabled", "required_status_checks", "required_pull_request_reviews",
+       "required_conversation_resolution", "required_signatures", "required_commit_signatures",
+       "required_linear_history", "enforce_admins", "allow_force_pushes", "allow_deletions",
+       "lock_branch", "allow_fork_syncing", "block_creations", "restrictions"];
     def valid_classic_protection:
       (protection | type) == "object" and
       ((protection.required_status_checks == null) or
-       ((protection.required_status_checks | type) == "object" and
-        ((protection.required_status_checks.checks // []) | type) == "array" and
-        all(protection.required_status_checks.checks[]?; valid_required_check) and
-        ((protection.required_status_checks.contexts // []) | type) == "array" and
-        all(protection.required_status_checks.contexts[]?; nonempty_string))) and
+       (protection.required_status_checks | valid_classic_status_checks)) and
       ((protection.required_pull_request_reviews == null) or
-       ((protection.required_pull_request_reviews | type) == "object" and
-        ((protection.required_pull_request_reviews.required_approving_review_count // 0) | type) == "number" and
-        (protection.required_pull_request_reviews.required_approving_review_count // 0) >= 0)) and
+       (protection.required_pull_request_reviews | valid_classic_pull_request_reviews)) and
       ((protection.required_conversation_resolution == null) or
        valid_classic_enabled_field("required_conversation_resolution")) and
       valid_classic_enabled_field("required_signatures") and
@@ -212,14 +355,14 @@ inventory_policy() {
       valid_classic_enabled_field("allow_fork_syncing") and
       valid_classic_enabled_field("block_creations") and
       ((protection.restrictions == null) or
-       ((protection.restrictions | type) == "object" and
-        ((protection.restrictions.users // []) | type) == "array" and
-        ((protection.restrictions.teams // []) | type) == "array" and
-        ((protection.restrictions.apps // []) | type) == "array"));
+       (protection.restrictions | valid_actor_lists)) and
+      ([protection | to_entries[] |
+        select(.key as $key | known_classic_fields | index($key) | not) |
+        select(.value != null)] | length) == 0;
     def has_classic_status_checks:
       (protection.required_status_checks | type) == "object" and
-      (((protection.required_status_checks.checks // []) | length) > 0 or
-       ((protection.required_status_checks.contexts // []) | length) > 0);
+      ((protection.required_status_checks.checks | length) > 0 or
+       (protection.required_status_checks.contexts | length) > 0);
     def classic_rules:
       [
         if has_classic_status_checks then
@@ -271,18 +414,7 @@ inventory_policy() {
            (protection.restrictions | nonempty_restrictions) then
           {type: "restrictions", source: "classic_branch_protection",
            parameters: protection.restrictions}
-        else empty end,
-        [protection | to_entries[] |
-         select(.key as $key |
-           ["url", "enabled", "required_status_checks", "required_pull_request_reviews",
-            "required_conversation_resolution", "required_signatures", "required_commit_signatures",
-            "required_linear_history", "enforce_admins", "allow_force_pushes", "allow_deletions",
-            "lock_branch", "allow_fork_syncing", "block_creations", "restrictions"] | index($key) | not) |
-         select((.value | type) == "boolean" and .value == true or
-                (.value | enabled_object) or
-                ((.value | type) == "array" and (.value | length) > 0)) |
-         {type: ("classic_" + .key), source: "classic_branch_protection", parameters: .value}
-        ][]
+        else empty end
       ];
     def rule_checks($all_rules):
       [$all_rules[] | select(.type == "required_status_checks") |
@@ -290,8 +422,11 @@ inventory_policy() {
        {context: (.context // ""), appId: (.integration_id // .app_id)}];
     def protection_checks:
       [((protection.required_status_checks.checks // [])[]?) |
-       {context: (.context // ""), appId: (.app_id // .integration_id)}];
-    def legacy_contexts: (protection.required_status_checks.contexts // []);
+       {context: .context, appId: .app_id}];
+    def legacy_contexts:
+      (protection.required_status_checks.contexts // []) as $contexts |
+      ([protection_checks[] | .context]) as $provider_bound |
+      [$contexts[] | select($provider_bound | index(.) | not)];
     def supported_type:
       . == "required_status_checks" or . == "pull_request" or
       . == "required_signatures" or . == "workflows" or
@@ -423,9 +558,11 @@ usage() {
 usage:
   pr-gate-contract.sh parse-pr-url HTTPS_PR_URL
   pr-gate-contract.sh normalize-branch-protection-http HTTP_RESPONSE_FILE OUTPUT_JSON
+  pr-gate-contract.sh manifest-evidence SNAPSHOT_DIRECTORY OUTPUT_FILE
   pr-gate-contract.sh request-date HTTP_RESPONSE_FILE
   pr-gate-contract.sh request-date-to-ns HTTP_RESPONSE_FILE
   pr-gate-contract.sh verify-review-freshness HTTP_RESPONSE_FILE RFC3339_UTC_TIMESTAMP
+  pr-gate-contract.sh verify-created-draft PR_JSON REPOSITORY HEAD_REF HEAD_OID BASE_REF BASE_OID
   pr-gate-contract.sh inventory-policy HOST REPOSITORY BASE_REF EFFECTIVE_JSON PROTECTION_JSON OUTPUT_JSON
   pr-gate-contract.sh verify-checks IDENTITY_JSON INVENTORY_JSON REPOSITORY_JSON RUNS_JSON SUITES_JSON STATUSES_JSON OUTPUT_JSON
 EOF
@@ -436,9 +573,11 @@ command="${1-}"
 case "$command" in
   parse-pr-url) shift; parse_pr_url "$@" ;;
   normalize-branch-protection-http) shift; normalize_branch_protection_http "$@" ;;
+  manifest-evidence) shift; manifest_evidence "$@" ;;
   request-date) shift; request_date "$@" ;;
   request-date-to-ns) shift; request_date_to_ns "$@" ;;
   verify-review-freshness) shift; verify_review_freshness "$@" ;;
+  verify-created-draft) shift; verify_created_draft "$@" ;;
   inventory-policy) shift; inventory_policy "$@" ;;
   verify-checks) shift; verify_checks "$@" ;;
   *) usage ;;

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -77,7 +77,10 @@ normalize_branch_protection_http() {
     body = blocks[(header_index + 1)..].join("\n\n")
     case code
     when "200"
-      parsed = JSON.parse(body, object_class: UniqueHash)
+      # Recent json gem versions optimize duplicate-key insertion and bypass a
+      # Hash subclass []= hook. Keep the hook for older runtimes, while the
+      # parser option makes the rejection portable across supported Rubies.
+      parsed = JSON.parse(body, object_class: UniqueHash, allow_duplicate_key: false)
       abort "branch-protection response is not an object" unless parsed.is_a?(Hash)
       File.write(ARGV.fetch(1), JSON.generate(parsed) + "\n")
     when "404"
@@ -90,7 +93,7 @@ normalize_branch_protection_http() {
       content_types = headers.fetch("content-type", [])
       abort "404 missing/ambiguous JSON content type" unless content_types.length == 1 &&
         content_types.fetch(0).match?(/\Aapplication\/json(?:\s*;.*)?\z/i)
-      parsed = JSON.parse(body, object_class: UniqueHash)
+      parsed = JSON.parse(body, object_class: UniqueHash, allow_duplicate_key: false)
       abort "404 error is not an object" unless parsed.is_a?(Hash)
       abort "unexpected 404 message" unless parsed["message"] == "Branch not protected"
       abort "missing 404 documentation URL" unless parsed["documentation_url"].is_a?(String) &&
@@ -166,7 +169,7 @@ manifest_evidence() {
         content_types.fetch(0).match?(%r{\Aapplication/(?:[A-Za-z0-9.+-]+\+)?json(?:\s*;.*)?\z}i)
       canonical_body = if json_body
         begin
-          {"json" => JSON.parse(body, object_class: UniqueHash)}
+          {"json" => JSON.parse(body, object_class: UniqueHash, allow_duplicate_key: false)}
         rescue JSON::ParserError, DuplicateJSONKeyError
           abort "invalid JSON HTTP body"
         end
@@ -196,7 +199,7 @@ manifest_evidence() {
         relative = path.delete_prefix(root + File::SEPARATOR)
         evidence = if File.extname(path) == ".json"
           begin
-            canonical_json(JSON.parse(File.binread(path), object_class: UniqueHash))
+            canonical_json(JSON.parse(File.binread(path), object_class: UniqueHash, allow_duplicate_key: false))
           rescue JSON::ParserError, DuplicateJSONKeyError
             abort "invalid JSON evidence: #{relative}"
           end
@@ -255,7 +258,7 @@ validate_json() {
         super
       end
     end
-    JSON.parse(File.binread(ARGV.fetch(0)), object_class: UniqueHash)
+    JSON.parse(File.binread(ARGV.fetch(0)), object_class: UniqueHash, allow_duplicate_key: false)
   ' "$1" >/dev/null || fail "JSON evidence is malformed or contains duplicate object keys: $1"
 }
 

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -28,6 +28,8 @@ parse_pr_url() {
     raw = ARGV.fetch(0)
     uri = URI.parse(raw)
     abort "PR URL must use HTTPS" unless uri.is_a?(URI::HTTPS)
+    abort "PR URL must not contain credentials, a port, query, or fragment" unless
+      uri.userinfo.nil?
     authority = raw[/\Ahttps:\/\/([^\/]+)/i, 1]
     # URI#port normalizes an explicit :443 to the HTTPS default. The gate
     # promises a host-only HTTPS endpoint, so inspect the original authority
@@ -35,7 +37,7 @@ parse_pr_url() {
     abort "PR URL must not contain an explicit port" unless authority &&
       authority.casecmp?(uri.host.to_s)
     abort "PR URL must not contain credentials, a port, query, or fragment" unless
-      uri.userinfo.nil? && uri.port == 443 && uri.query.nil? && uri.fragment.nil?
+      uri.port == 443 && uri.query.nil? && uri.fragment.nil?
     segments = uri.path.split("/").reject(&:empty?)
     abort "PR URL must be /OWNER/REPOSITORY/pull/NUMBER" unless
       segments.length == 4 && segments[2] == "pull" && segments[3].match?(/\A[1-9][0-9]*\z/)

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -102,9 +102,9 @@ manifest_evidence() {
   test "$#" = 2 || fail "usage: manifest-evidence SNAPSHOT_DIRECTORY OUTPUT_FILE"
   test -d "$1" || fail "missing snapshot directory: $1"
   command -v ruby >/dev/null 2>&1 || fail "ruby is required"
-  ruby -r digest -r json -e '
+  ruby -r digest -r json -r time -e '
     root = File.realpath(ARGV.fetch(0))
-    output = File.expand_path(ARGV.fetch(1))
+    output = File.join(File.realpath(File.dirname(ARGV.fetch(1))), File.basename(ARGV.fetch(1)))
     abort "manifest output must be directly inside its snapshot" unless
       File.realpath(File.dirname(output)) == root
 
@@ -121,6 +121,58 @@ manifest_evidence() {
       end
     end
 
+    def canonical_http(path)
+      raw = File.binread(path).gsub("\r\n", "\n")
+      blocks = raw.split(/\n\n/, -1)
+      header_indexes = blocks.each_index.select { |index| blocks[index].start_with?("HTTP/") }
+      abort "missing HTTP response headers" if header_indexes.empty?
+      header_index = header_indexes.last
+      lines = blocks.fetch(header_index).lines.map(&:chomp)
+      status = lines.shift.to_s
+      code = status[/\AHTTP\/\d(?:\.\d)?\s+(\d{3})(?:\s|\z)/, 1]
+      abort "malformed HTTP status" unless code
+
+      headers = Hash.new { |hash, key| hash[key] = [] }
+      lines.each do |line|
+        name, value = line.split(":", 2)
+        abort "malformed HTTP header" unless name && value &&
+          name.match?(%r{\A[!#$%&*+\-.^_`|~0-9A-Za-z]+\z})
+        headers[name.downcase] << value.strip
+      end
+      dates = headers.fetch("date", [])
+      abort "missing/ambiguous HTTP Date" unless dates.length == 1
+      Time.httpdate(dates.fetch(0))
+      request_ids = headers.fetch("x-github-request-id", [])
+      abort "missing/ambiguous GitHub request ID" unless request_ids.length == 1 &&
+        request_ids.fetch(0).match?(/\A[A-Za-z0-9:_-]+\z/)
+
+      body = blocks[(header_index + 1)..].join("\n\n")
+      content_types = headers.fetch("content-type", [])
+      json_body = content_types.length == 1 &&
+        content_types.fetch(0).match?(%r{\Aapplication/(?:[A-Za-z0-9.+-]+\+)?json(?:\s*;.*)?\z}i)
+      canonical_body = if json_body
+        begin
+          {"json" => JSON.parse(body)}
+        rescue JSON::ParserError
+          abort "invalid JSON HTTP body"
+        end
+      else
+        {"sha256" => Digest::SHA256.hexdigest(body)}
+      end
+
+      # GitHub Date and request ID prove the response is a fresh, traceable
+      # transport event, but necessarily differ between equivalent snapshots.
+      # Every other header remains bound into the evidence projection so a
+      # changed content type, redirect, auth, or security policy is visible.
+      volatile_headers = ["date", "x-github-request-id", "x-ratelimit-limit",
+                          "x-ratelimit-remaining", "x-ratelimit-reset",
+                          "x-ratelimit-resource", "x-ratelimit-used",
+                          "server-timing", "via"]
+      stable_headers = headers.reject { |name, _| volatile_headers.include?(name) }
+        .transform_values { |values| values.sort }
+      {"status" => code.to_i, "headers" => stable_headers, "body" => canonical_body}
+    end
+
     entries = Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
       .select { |path| File.file?(path) }
       .reject { |path| File.expand_path(path) == output }
@@ -132,6 +184,8 @@ manifest_evidence() {
           rescue JSON::ParserError
             abort "invalid JSON evidence: #{relative}"
           end
+        elsif File.extname(path) == ".http"
+          canonical_json(canonical_http(path))
         else
           "sha256:" + Digest::SHA256.file(path).hexdigest
         end

--- a/.github/scripts/pr-gate-contract.sh
+++ b/.github/scripts/pr-gate-contract.sh
@@ -106,13 +106,40 @@ inventory_policy() {
   jq -n -e --arg host "$host" --arg repository "$repository" --arg baseRef "$base_ref" \
     --slurpfile effective "$effective" --slurpfile protection "$protection" '
     def rules:
-      if ($effective | length) == 1 and ($effective[0] | type) == "array" then $effective[0]
-      elif ($effective | length) == 1 and ($effective[0] | type) == "object" and
-           ($effective[0].rules | type) == "array" then $effective[0].rules
-      else error("malformed effective rules") end;
+      # `gh api --paginate --slurp` writes one array per API page, wrapped in
+      # a single JSON array. Keep every page: a required rule may be on a
+      # later page rather than the first one.
+      if ($effective | length) == 1 and ($effective[0] | type) == "array" and
+           all($effective[0][]; type == "array") then
+        [ $effective[0][] | .[] ]
+      else error("malformed paginated effective-rules response") end;
     def protection: $protection[0];
-    def rule_checks:
-      [rules[] | select(.type == "required_status_checks") |
+    def has_classic_status_checks:
+      (protection.required_status_checks | type) == "object" and
+      (((protection.required_status_checks.checks // []) | length) > 0 or
+       ((protection.required_status_checks.contexts // []) | length) > 0);
+    def classic_rules:
+      [
+        if has_classic_status_checks then
+          {type: "required_status_checks", source: "classic_branch_protection",
+           parameters: protection.required_status_checks}
+        else empty end,
+        if (protection.required_pull_request_reviews | type) == "object" then
+          {type: "pull_request", source: "classic_branch_protection",
+           parameters: protection.required_pull_request_reviews}
+        else empty end,
+        if protection.required_conversation_resolution.enabled == true then
+          {type: "pull_request", source: "classic_branch_protection",
+           parameters: protection.required_conversation_resolution}
+        else empty end,
+        if protection.required_signatures.enabled == true or
+           protection.required_commit_signatures.enabled == true then
+          {type: "required_signatures", source: "classic_branch_protection",
+           parameters: (protection.required_signatures // protection.required_commit_signatures)}
+        else empty end
+      ];
+    def rule_checks($all_rules):
+      [$all_rules[] | select(.type == "required_status_checks") |
        (.parameters.required_status_checks // [])[]? |
        {context: (.context // ""), appId: (.integration_id // .app_id)}];
     def protection_checks:
@@ -121,20 +148,22 @@ inventory_policy() {
     def legacy_contexts: (protection.required_status_checks.contexts // []);
     def supported_type:
       . == "required_status_checks" or . == "pull_request" or
-      . == "required_signatures" or . == "required_workflows" or
-      . == "required_deployments" or . == "required_code_scanning";
+      . == "required_signatures" or . == "workflows" or
+      . == "required_deployments" or . == "code_scanning";
     rules as $rules |
-    (rule_checks + protection_checks) as $checks |
+    classic_rules as $classic_rules |
+    ($rules + $classic_rules) as $all_rules |
+    (rule_checks($all_rules) + protection_checks) as $checks |
     ([ $checks[] | .context ] | unique) as $names |
     (legacy_contexts) as $legacy |
-    ([ $rules[] | select(.type | supported_type | not) |
+    ([ $all_rules[] | select(.type | supported_type | not) |
        {type, source, parameters} ]) as $unsupported |
     if ($host | test("\\A[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\\z"; "i") | not) then
       error("invalid GitHub host")
     elif ($repository | test("\\A[^/ ]+/[^/ ]+\\z") | not) then
       error("invalid repository")
-    elif ($rules | type) != "array" or ($rules | length) == 0 then
-      error("no effective server rules; refusing a no-op policy")
+    elif ($all_rules | type) != "array" or ($all_rules | length) == 0 then
+      error("no active ruleset or classic branch-protection requirement; refusing a no-op policy")
     elif ($unsupported | length) != 0 then
       error("unsupported active rule(s): " + ($unsupported | tojson) +
             "; extend the verifier for these exact type/parameters or remove the rule before using this gate")
@@ -151,6 +180,7 @@ inventory_policy() {
       repository: $repository,
       baseRef: $baseRef,
       effectiveRules: $rules,
+      classicBranchProtectionRules: $classic_rules,
       branchProtection: protection,
       requiredCheckRuns: ($checks | sort_by(.context, .appId)),
       mergeStateRequired: true,
@@ -158,9 +188,9 @@ inventory_policy() {
         required_status_checks: "exact App-bound check run and exact PR-associated suite",
         pull_request: "GitHub reviewDecision plus zero unresolved review threads",
         required_signatures: "exact PR final GitHub merge-state predicate",
-        required_workflows: "exact PR final GitHub merge-state predicate",
+        workflows: "exact PR final GitHub merge-state predicate",
         required_deployments: "exact PR final GitHub merge-state predicate",
-        required_code_scanning: "exact PR final GitHub merge-state predicate"
+        code_scanning: "exact PR final GitHub merge-state predicate"
       },
       legacyStatusPolicy: "reject-required-contexts-without-provider-binding"
     }

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -45,6 +45,8 @@ write_fixture "$fixture_root/protection-200.http" $'HTTP/2 200 OK\r\nDate: Fri, 
 "$contract" normalize-branch-protection-http "$fixture_root/protection-200.http" "$fixture_root/protection-200.json"
 jq -e '.required_status_checks.checks == []' "$fixture_root/protection-200.json" >/dev/null ||
   fail "authenticated branch-protection 200 response was not normalized"
+write_fixture "$fixture_root/protection-200-duplicate.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"required_status_checks":{},"required_status_checks":{}}'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-200-duplicate.http" "$fixture_root/ignored.json"
 write_fixture "$fixture_root/protection-404.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json; charset=utf-8\r\nX-GitHub-Request-Id: AB12:CD34:EF56\r\n\r\n{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-branch-protection","status":"404"}'
 "$contract" normalize-branch-protection-http "$fixture_root/protection-404.http" "$fixture_root/protection-404.json"
 jq -e '. == {}' "$fixture_root/protection-404.json" >/dev/null ||
@@ -73,6 +75,59 @@ jq '.headRefOid = "attacker-head"' "$fixture_root/created-draft.json" >"$fixture
 expect_failure "$contract" verify-created-draft "$fixture_root/wrong-draft-head.json" telekom/k8s-breakglass \
   codex/network-debug source-head main base-head
 
+# The newest exact-login review must be submitted. A newer pending review must
+# not be hidden by max_by(.submittedAt) selecting an older submitted review.
+write_fixture "$fixture_root/reviews.json" '[
+  {"data":{"repository":{"pullRequest":{"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+    {"id":"submitted","author":{"login":"copilot[bot]"},"state":"COMMENTED","submittedAt":"2026-08-28T08:00:00Z","commit":{"oid":"source-head"}}
+  ]}}}}}
+]'
+"$contract" select-copilot-review "$fixture_root/reviews.json" 'copilot[bot]' source-head \
+  "$fixture_root/selected-review.json"
+jq -e '.id == "submitted"' "$fixture_root/selected-review.json" >/dev/null ||
+  fail "submitted Copilot review was not selected"
+write_fixture "$fixture_root/reviews-with-pending.json" '[
+  {"data":{"repository":{"pullRequest":{"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+    {"id":"submitted","author":{"login":"copilot[bot]"},"state":"COMMENTED","submittedAt":"2026-08-28T08:00:00Z","commit":{"oid":"source-head"}},
+    {"id":"pending","author":{"login":"copilot[bot]"},"state":"PENDING","submittedAt":null,"commit":null}
+  ]}}}}}
+]'
+expect_failure "$contract" select-copilot-review "$fixture_root/reviews-with-pending.json" 'copilot[bot]' \
+  source-head "$fixture_root/ignored.json"
+
+# Execute the actual draft-lifecycle fenced prompt block with mocked network
+# and Git commands. This catches standalone-snippet failures that helper-only
+# tests and docs grep cannot see, including an unset gate_root after create.
+mock_bin="$fixture_root/mock-bin"
+mkdir -p "$mock_bin"
+write_fixture "$mock_bin/vi" $'#!/usr/bin/env bash\nprintf "%s\\n" "test body" >"$1"\n'
+# The generated mock intentionally contains literal shell variables.
+# shellcheck disable=SC2016
+write_fixture "$mock_bin/gh" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-} ${2-}" in\n  "auth status") exit 0 ;;\n  "pr create")\n    printf "%s\\n" create >>"$DRAFT_LOG"\n    printf "%s\\n" "https://github.com/telekom/k8s-breakglass/pull/999"\n    exit 0\n    ;;\n  "pr view")\n    printf "%s\\n" "{\\"isDraft\\":true,\\"headRefName\\":\\"codex/network-debug\\",\\"headRefOid\\":\\"source-head\\",\\"headRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"},\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"base-head\\",\\"baseRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"}}"\n    exit 0\n    ;;\n  "pr edit")\n    printf "%s\\n" edit >>"$DRAFT_LOG"\n    exit 0\n    ;;\nesac\nexit 2\n'
+write_fixture "$mock_bin/git" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-}" in\n  check-ref-format) exit 0 ;;\n  branch) printf "%s\\n" codex/network-debug ; exit 0 ;;\n  config) exit 1 ;;\n  remote)\n    if [ "$#" = 1 ]; then printf "%s\\n" origin; exit 0; fi\n    if [ "${2-}" = get-url ]; then\n      printf "%s\\n" https://github.com/telekom/k8s-breakglass.git\n      exit 0\n    fi\n    ;;\n  fetch) exit 0 ;;\n  rev-parse)\n    for arg in "$@"; do\n      case "$arg" in\n        *origin/main*) printf "%s\\n" base-head; exit 0 ;;\n        *origin/codex/network-debug*|HEAD) printf "%s\\n" source-head; exit 0 ;;\n      esac\n    done\n    ;;\nesac\nexit 2\n'
+chmod +x "$mock_bin/vi" "$mock_bin/gh" "$mock_bin/git"
+draft_snippet="$fixture_root/draft-snippet.sh"
+awk '
+  /^```bash$/ { in_block = 1; block = ""; next }
+  in_block && /^```$/ {
+    if (block ~ /gh_pr create/) printf "%s", block
+    in_block = 0
+    next
+  }
+  in_block { block = block $0 ORS }
+' .github/prompts/github-pr-management.md >"$draft_snippet"
+sed -e 's|^base_repo=.*$|base_repo=telekom/k8s-breakglass|' \
+  -e 's|^base_ref=.*$|base_ref=main|' \
+  -e "s|^contract=.*$|contract=\"$contract\"|" \
+  "$draft_snippet" >"$draft_snippet.rendered"
+mv "$draft_snippet.rendered" "$draft_snippet"
+draft_log="$fixture_root/draft-lifecycle.log"
+DRAFT_LOG="$draft_log" PATH="$mock_bin:$PATH" /bin/bash "$draft_snippet" ||
+  fail "actual draft lifecycle prompt block failed under its mocked API contract"
+test "$(sed -n '1p' "$draft_log")" = create || fail "draft lifecycle did not create the draft"
+test "$(sed -n '2p' "$draft_log")" = edit ||
+  fail "draft lifecycle did not verify before editing the body"
+
 # The evidence manifest validates raw HTTP responses but projects away only
 # response-specific transport metadata. Equivalent GitHub responses must
 # compare equal despite a fresh Date/request ID and JSON key order; status,
@@ -98,12 +153,23 @@ write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 
 "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
   fail "changed security-relevant HTTP header did not change the manifest"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: NINTH:REQUEST\r\nContent-Type: application/json\r\nX-Frame-Options: DENY\r\nX-Frame-Options: SAMEORIGIN\r\n\r\n{"first":1,"second":2}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cp "$fixture_root/manifest-snapshot/gate.jsonl" "$fixture_root/repeated-header-manifest.jsonl"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:20 GMT\r\nX-GitHub-Request-Id: TENTH:REQUEST\r\nContent-Type: application/json\r\nX-Frame-Options: SAMEORIGIN\r\nX-Frame-Options: DENY\r\n\r\n{"first":1,"second":2}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cmp -s "$fixture_root/repeated-header-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
+  fail "reordered repeated security headers did not change the manifest"
 write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: SIXTH:REQUEST\r\nMalformed Header\r\n\r\n{}'
 expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: not-a-date\r\nX-GitHub-Request-Id: SEVENTH:REQUEST\r\nContent-Type: application/json\r\n\r\n{}'
 expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: EIGHTH:REQUEST\r\nContent-Type: application/json\r\n\r\nnot-json'
 expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: ELEVENTH:REQUEST\r\nContent-Type: application/json\r\n\r\n{"outer":{"a":1,"a":2}}'
+expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+write_fixture "$fixture_root/duplicate.json" '{"outer":{"a":1,"a":2}}'
+expect_failure "$contract" validate-json "$fixture_root/duplicate.json"
 
 write_fixture "$fixture_root/effective-rules.json" '[[
   {"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":false,"required_approving_review_count":1,"required_review_thread_resolution":true}},

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -105,7 +105,8 @@ write_fixture "$mock_bin/vi" $'#!/usr/bin/env bash\nprintf "%s\\n" "test body" >
 # shellcheck disable=SC2016
 write_fixture "$mock_bin/gh" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-} ${2-}" in\n  "auth status") exit 0 ;;\n  "pr create")\n    printf "%s\\n" create >>"$DRAFT_LOG"\n    printf "%s\\n" "https://github.com/telekom/k8s-breakglass/pull/999"\n    exit 0\n    ;;\n  "pr view")\n    printf "%s\\n" "{\\"isDraft\\":true,\\"headRefName\\":\\"codex/network-debug\\",\\"headRefOid\\":\\"source-head\\",\\"headRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"},\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"base-head\\",\\"baseRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"}}"\n    exit 0\n    ;;\n  "pr edit")\n    printf "%s\\n" edit >>"$DRAFT_LOG"\n    exit 0\n    ;;\nesac\nexit 2\n'
 write_fixture "$mock_bin/git" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-}" in\n  check-ref-format) exit 0 ;;\n  branch) printf "%s\\n" codex/network-debug ; exit 0 ;;\n  config) exit 1 ;;\n  remote)\n    if [ "$#" = 1 ]; then printf "%s\\n" origin; exit 0; fi\n    if [ "${2-}" = get-url ]; then\n      printf "%s\\n" https://github.com/telekom/k8s-breakglass.git\n      exit 0\n    fi\n    ;;\n  fetch) exit 0 ;;\n  rev-parse)\n    for arg in "$@"; do\n      case "$arg" in\n        *origin/main*) printf "%s\\n" base-head; exit 0 ;;\n        *origin/codex/network-debug*|HEAD) printf "%s\\n" source-head; exit 0 ;;\n      esac\n    done\n    ;;\nesac\nexit 2\n'
-chmod +x "$mock_bin/vi" "$mock_bin/gh" "$mock_bin/git"
+write_fixture "$mock_bin/mktemp" $'#!/usr/bin/env bash\nset -euo pipefail\nresult="$(/usr/bin/mktemp "$@")"\nprintf "%s\\n" "$result"\nif [ -n "${MKTEMP_LOG-}" ]; then\n  printf "%s\\n" "$result" >>"$MKTEMP_LOG"\nfi\n'
+chmod +x "$mock_bin/vi" "$mock_bin/gh" "$mock_bin/git" "$mock_bin/mktemp"
 draft_snippet="$fixture_root/draft-snippet.sh"
 awk '
   /^```bash$/ { in_block = 1; block = ""; next }
@@ -122,11 +123,40 @@ sed -e 's|^base_repo=.*$|base_repo=telekom/k8s-breakglass|' \
   "$draft_snippet" >"$draft_snippet.rendered"
 mv "$draft_snippet.rendered" "$draft_snippet"
 draft_log="$fixture_root/draft-lifecycle.log"
-DRAFT_LOG="$draft_log" PATH="$mock_bin:$PATH" /bin/bash "$draft_snippet" ||
+success_mktemp_log="$fixture_root/success-mktemp.log"
+DRAFT_LOG="$draft_log" MKTEMP_LOG="$success_mktemp_log" PATH="$mock_bin:$PATH" /bin/bash "$draft_snippet" ||
   fail "actual draft lifecycle prompt block failed under its mocked API contract"
 test "$(sed -n '1p' "$draft_log")" = create || fail "draft lifecycle did not create the draft"
 test "$(sed -n '2p' "$draft_log")" = edit ||
   fail "draft lifecycle did not verify before editing the body"
+success_body_file="$(sed -n '1p' "$success_mktemp_log")"
+success_gate_root="$(sed -n '2p' "$success_mktemp_log")"
+test ! -e "$success_body_file" || fail "successful draft lifecycle did not clean up its body file"
+test ! -e "$success_gate_root" || fail "successful draft lifecycle did not clean up its gate directory"
+
+# A create response must not authorize editing when the subsequent view is
+# bound to a different head/base. This runs the same extracted prompt block,
+# and verifies both fail-closed behavior and EXIT-trap cleanup.
+wrong_bin="$fixture_root/wrong-bin"
+mkdir -p "$wrong_bin"
+# The generated mock intentionally contains literal shell variables.
+# shellcheck disable=SC2016
+write_fixture "$wrong_bin/gh" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-} ${2-}" in\n  "auth status") exit 0 ;;\n  "pr create")\n    printf "%s\\n" create >>"$DRAFT_LOG"\n    printf "%s\\n" "https://github.com/telekom/k8s-breakglass/pull/999"\n    exit 0\n    ;;\n  "pr view")\n    printf "%s\\n" "{\\"isDraft\\":true,\\"headRefName\\":\\"codex/network-debug\\",\\"headRefOid\\":\\"attacker-head\\",\\"headRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"},\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"attacker-base\\",\\"baseRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"}}"\n    exit 0\n    ;;\n  "pr edit")\n    printf "%s\\n" edit >>"$DRAFT_LOG"\n    exit 0\n    ;;\nesac\nexit 2\n'
+chmod +x "$wrong_bin/gh"
+wrong_draft_log="$fixture_root/wrong-draft-lifecycle.log"
+wrong_mktemp_log="$fixture_root/wrong-mktemp.log"
+if DRAFT_LOG="$wrong_draft_log" MKTEMP_LOG="$wrong_mktemp_log" \
+  PATH="$wrong_bin:$mock_bin:$PATH" /bin/bash "$draft_snippet"; then
+  fail "actual draft lifecycle accepted a mismatched created PR"
+fi
+test "$(sed -n '1p' "$wrong_draft_log")" = create ||
+  fail "mismatched draft lifecycle did not create the draft before checking it"
+test "$(wc -l <"$wrong_draft_log" | tr -d ' ')" = 1 ||
+  fail "mismatched draft lifecycle attempted an edit after failed verification"
+wrong_body_file="$(sed -n '1p' "$wrong_mktemp_log")"
+wrong_gate_root="$(sed -n '2p' "$wrong_mktemp_log")"
+test ! -e "$wrong_body_file" || fail "failed draft lifecycle did not clean up its body file"
+test ! -e "$wrong_gate_root" || fail "failed draft lifecycle did not clean up its gate directory"
 
 # The evidence manifest validates raw HTTP responses but projects away only
 # response-specific transport metadata. Equivalent GitHub responses must

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -33,6 +33,7 @@ parsed="$($contract parse-pr-url "$valid_pr_url")"
 test "$parsed" = $'github.com\ttelekom/k8s-breakglass\t1268' || fail "valid HTTPS PR URL was not parsed"
 expect_failure "$contract" parse-pr-url 'http://github.com/telekom/k8s-breakglass/pull/1268'
 expect_failure "$contract" parse-pr-url 'https://token@github.com/telekom/k8s-breakglass/pull/1268'
+expect_failure "$contract" parse-pr-url 'https://github.com:443/telekom/k8s-breakglass/pull/1268'
 
 write_fixture "$fixture_root/review-request.http" $'HTTP/2 201 Created\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\n\r\n{}'
 expect_failure "$contract" verify-review-freshness "$fixture_root/review-request.http" '2026-08-28T07:14:18.999Z'
@@ -40,14 +41,24 @@ expect_failure "$contract" verify-review-freshness "$fixture_root/review-request
 write_fixture "$fixture_root/redirected-review-request.http" $'HTTP/2 302 Found\r\nDate: Fri, 28 Aug 2026 07:14:17 GMT\r\n\r\nHTTP/2 201 Created\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{}'
 test "$("$contract" request-date "$fixture_root/redirected-review-request.http")" = 'Fri, 28 Aug 2026 07:14:18 GMT' ||
   fail "final HTTP response Date was not selected"
+write_fixture "$fixture_root/protection-200.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"required_status_checks":{"checks":[],"contexts":[]}}'
+"$contract" normalize-branch-protection-http "$fixture_root/protection-200.http" "$fixture_root/protection-200.json"
+jq -e '.required_status_checks.checks == []' "$fixture_root/protection-200.json" >/dev/null ||
+  fail "authenticated branch-protection 200 response was not normalized"
+write_fixture "$fixture_root/protection-404.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"message":"Branch not protected"}'
+"$contract" normalize-branch-protection-http "$fixture_root/protection-404.http" "$fixture_root/protection-404.json"
+jq -e '. == {}' "$fixture_root/protection-404.json" >/dev/null ||
+  fail "authenticated branch-protection 404 did not become an empty policy"
+write_fixture "$fixture_root/protection-403.http" $'HTTP/2 403 Forbidden\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"message":"forbidden"}'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-403.http" "$fixture_root/ignored.json"
 
 write_fixture "$fixture_root/effective-rules.json" '[[
   {"type":"pull_request","parameters":{"required_approving_review_count":1,"require_code_owner_review":true}},
-  {"type":"workflows","parameters":{"workflows":[{"path":".github/workflows/test.yml","ref":"main"}]}}
+  {"type":"workflows","parameters":{"workflows":[{"repository_id":42,"path":".github/workflows/test.yml","ref":"main","sha":"0123456789abcdef0123456789abcdef01234567"}]}}
 ], [
   {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},
   {"type":"required_deployments","parameters":{"required_deployment_environments":["staging"]}},
-  {"type":"code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}},
+  {"type":"code_scanning","parameters":{"code_scanning_tools":[{"tool":"CodeQL","alerts_threshold":"errors","security_alerts_threshold":"high_or_higher"}]}},
   {"type":"required_signatures","parameters":{}}
 ]]'
 write_fixture "$fixture_root/protection.json" '{"required_status_checks":{"checks":[],"contexts":[]}}'
@@ -63,6 +74,20 @@ expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass ma
 write_fixture "$fixture_root/legacy-protection.json" '{"required_status_checks":{"checks":[],"contexts":["test"]}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/effective-rules.json" "$fixture_root/legacy-protection.json" "$fixture_root/ignored.json"
+
+# Known ruleset types must not be accepted with guessed/defaulted structures.
+write_fixture "$fixture_root/malformed-status-rules.json" '[[{"type":"required_status_checks","parameters":{"required_status_checks":{"context":"test","integration_id":15368}}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-status-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-status-entry-rules.json" '[[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":42,"integration_id":"15368"}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-status-entry-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-workflow-rules.json" '[[{"type":"workflows","parameters":{"workflows":[{"path":".github/workflows/test.yml","ref":"main"}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-workflow-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-code-scanning-rules.json" '[[{"type":"code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-code-scanning-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
 
 # Empty ruleset pages are valid API output. A real classic branch-protection
 # requirement must still produce a complete, usable inventory.
@@ -81,6 +106,16 @@ jq -e '.effectiveRules == [] and (.classicBranchProtectionRules | length) == 3 a
 write_fixture "$fixture_root/empty-protection.json" '{}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/empty-effective-rules.json" "$fixture_root/empty-protection.json" "$fixture_root/ignored.json"
+
+write_fixture "$fixture_root/linear-history-protection.json" '{"required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},"required_linear_history":{"enabled":true}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/linear-history-protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/unsupported-classic-protection.json" '{"required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},"block_creations":{"enabled":true}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/unsupported-classic-protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-classic-protection.json" '{"required_status_checks":{"checks":"test","contexts":[]}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/malformed-classic-protection.json" "$fixture_root/ignored.json"
 
 write_fixture "$fixture_root/repository.json" '{
   "id": 42,

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -45,23 +45,57 @@ write_fixture "$fixture_root/protection-200.http" $'HTTP/2 200 OK\r\nDate: Fri, 
 "$contract" normalize-branch-protection-http "$fixture_root/protection-200.http" "$fixture_root/protection-200.json"
 jq -e '.required_status_checks.checks == []' "$fixture_root/protection-200.json" >/dev/null ||
   fail "authenticated branch-protection 200 response was not normalized"
-write_fixture "$fixture_root/protection-404.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"message":"Branch not protected"}'
+write_fixture "$fixture_root/protection-404.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json; charset=utf-8\r\nX-GitHub-Request-Id: AB12:CD34:EF56\r\n\r\n{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-branch-protection","status":"404"}'
 "$contract" normalize-branch-protection-http "$fixture_root/protection-404.http" "$fixture_root/protection-404.json"
 jq -e '. == {}' "$fixture_root/protection-404.json" >/dev/null ||
   fail "authenticated branch-protection 404 did not become an empty policy"
+write_fixture "$fixture_root/protection-404-empty.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\nX-GitHub-Request-Id: AB12:CD34\r\n\r\n'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-404-empty.http" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/protection-404-not-json.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\nX-GitHub-Request-Id: AB12:CD34\r\n\r\nnot-json'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-404-not-json.http" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/protection-404-malformed.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: text/plain\r\nX-GitHub-Request-Id: AB12:CD34\r\n\r\n{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-branch-protection","status":404}'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-404-malformed.http" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/protection-404-missing-request-id.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\n\r\n{"message":"Branch not protected","documentation_url":"https://docs.github.com/rest/branches/branch-protection#get-branch-protection","status":404}'
+expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-404-missing-request-id.http" "$fixture_root/ignored.json"
 write_fixture "$fixture_root/protection-403.http" $'HTTP/2 403 Forbidden\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{"message":"forbidden"}'
 expect_failure "$contract" normalize-branch-protection-http "$fixture_root/protection-403.http" "$fixture_root/ignored.json"
 
+# A draft returned by gh must be the exact same direct-repository ref/OID pair
+# that was verified before creation. A successful create response alone is not
+# authorization to edit or ready an arbitrary PR.
+write_fixture "$fixture_root/created-draft.json" '{"isDraft":true,"headRefName":"codex/network-debug","headRefOid":"source-head","headRepository":{"nameWithOwner":"telekom/k8s-breakglass"},"baseRefName":"main","baseRefOid":"base-head","baseRepository":{"nameWithOwner":"telekom/k8s-breakglass"}}'
+"$contract" verify-created-draft "$fixture_root/created-draft.json" telekom/k8s-breakglass \
+  codex/network-debug source-head main base-head
+jq '.isDraft = false' "$fixture_root/created-draft.json" >"$fixture_root/not-a-draft.json"
+expect_failure "$contract" verify-created-draft "$fixture_root/not-a-draft.json" telekom/k8s-breakglass \
+  codex/network-debug source-head main base-head
+jq '.headRefOid = "attacker-head"' "$fixture_root/created-draft.json" >"$fixture_root/wrong-draft-head.json"
+expect_failure "$contract" verify-created-draft "$fixture_root/wrong-draft-head.json" telekom/k8s-breakglass \
+  codex/network-debug source-head main base-head
+
+# The evidence manifest covers every artifact, rather than just JSON. This
+# catches a changed HTTP response (such as a different final status/header)
+# between the verified and final snapshots.
+mkdir -p "$fixture_root/manifest-snapshot"
+write_fixture "$fixture_root/manifest-snapshot/identity.json" '{"b":2,"a":1}'
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cp "$fixture_root/manifest-snapshot/gate.jsonl" "$fixture_root/first-manifest.jsonl"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\n\r\n{}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
+  fail "changed HTTP evidence did not change the manifest"
+
 write_fixture "$fixture_root/effective-rules.json" '[[
-  {"type":"pull_request","parameters":{"required_approving_review_count":1,"require_code_owner_review":true}},
+  {"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":false,"required_approving_review_count":1,"required_review_thread_resolution":true}},
   {"type":"workflows","parameters":{"workflows":[{"repository_id":42,"path":".github/workflows/test.yml","ref":"main","sha":"0123456789abcdef0123456789abcdef01234567"}]}}
 ], [
-  {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},
+  {"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true,"required_status_checks":[{"context":"test","integration_id":15368}]}},
   {"type":"required_deployments","parameters":{"required_deployment_environments":["staging"]}},
   {"type":"code_scanning","parameters":{"code_scanning_tools":[{"tool":"CodeQL","alerts_threshold":"errors","security_alerts_threshold":"high_or_higher"}]}},
-  {"type":"required_signatures","parameters":{}}
+  {"type":"required_signatures"}
 ]]'
-write_fixture "$fixture_root/protection.json" '{"required_status_checks":{"checks":[],"contexts":[]}}'
+write_fixture "$fixture_root/protection.json" '{}'
 "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/effective-rules.json" "$fixture_root/protection.json" "$fixture_root/inventory.json"
 jq -e '.schema == 2 and (.requiredCheckRuns == [{"context":"test","appId":15368}]) and .mergeStateRequired' \
@@ -71,7 +105,7 @@ write_fixture "$fixture_root/unknown-rule.json" '[[{"type":"required_status_chec
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/unknown-rule.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
 
-write_fixture "$fixture_root/legacy-protection.json" '{"required_status_checks":{"checks":[],"contexts":["test"]}}'
+write_fixture "$fixture_root/legacy-protection.json" '{"required_status_checks":{"strict":true,"checks":[],"contexts":["test"]}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/effective-rules.json" "$fixture_root/legacy-protection.json" "$fixture_root/ignored.json"
 
@@ -88,13 +122,28 @@ expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass ma
 write_fixture "$fixture_root/malformed-code-scanning-rules.json" '[[{"type":"code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}}]]'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/malformed-code-scanning-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/no-op-status-rules.json" '[[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true,"required_status_checks":[]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/no-op-status-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-pull-rules.json" '[[{"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":"true","require_code_owner_review":true,"require_last_push_approval":false,"required_approving_review_count":1,"required_review_thread_resolution":true}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-pull-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-status-flag-rules.json" '[[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":"true","required_status_checks":[{"context":"test","integration_id":15368}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-status-flag-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/fractional-workflow-id-rules.json" '[[{"type":"workflows","parameters":{"workflows":[{"repository_id":42.5,"path":".github/workflows/test.yml","sha":"0123456789abcdef0123456789abcdef01234567"}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/fractional-workflow-id-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-code-threshold-rules.json" '[[{"type":"code_scanning","parameters":{"code_scanning_tools":[{"tool":"CodeQL","alerts_threshold":"warning","security_alerts_threshold":"high"}]}}]]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/malformed-code-threshold-rules.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
 
 # Empty ruleset pages are valid API output. A real classic branch-protection
 # requirement must still produce a complete, usable inventory.
 write_fixture "$fixture_root/empty-effective-rules.json" '[[], []]'
 write_fixture "$fixture_root/classic-protection.json" '{
-  "required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},
-  "required_pull_request_reviews":{"required_approving_review_count":1,"require_code_owner_reviews":true},
+  "required_status_checks":{"strict":true,"checks":[{"context":"test","app_id":15368}],"contexts":["test"]},
+  "required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":[],"apps":[]},"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1,"require_last_push_approval":false,"bypass_pull_request_allowances":{"users":[],"teams":[],"apps":[]}},
   "required_conversation_resolution":{"enabled":true}
 }'
 "$contract" inventory-policy github.com telekom/k8s-breakglass main \
@@ -107,15 +156,24 @@ write_fixture "$fixture_root/empty-protection.json" '{}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/empty-effective-rules.json" "$fixture_root/empty-protection.json" "$fixture_root/ignored.json"
 
-write_fixture "$fixture_root/linear-history-protection.json" '{"required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},"required_linear_history":{"enabled":true}}'
+write_fixture "$fixture_root/linear-history-protection.json" '{"required_status_checks":{"strict":true,"checks":[{"context":"test","app_id":15368}],"contexts":["test"]},"required_linear_history":{"enabled":true}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/empty-effective-rules.json" "$fixture_root/linear-history-protection.json" "$fixture_root/ignored.json"
-write_fixture "$fixture_root/unsupported-classic-protection.json" '{"required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},"block_creations":{"enabled":true}}'
+write_fixture "$fixture_root/unsupported-classic-protection.json" '{"required_status_checks":{"strict":true,"checks":[{"context":"test","app_id":15368}],"contexts":["test"]},"block_creations":{"enabled":true}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/empty-effective-rules.json" "$fixture_root/unsupported-classic-protection.json" "$fixture_root/ignored.json"
 write_fixture "$fixture_root/malformed-classic-protection.json" '{"required_status_checks":{"checks":"test","contexts":[]}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/empty-effective-rules.json" "$fixture_root/malformed-classic-protection.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-classic-status-policy.json" '{"required_status_checks":{"strict":"true","checks":[{"context":"test","app_id":15368}],"contexts":["test"]}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/malformed-classic-status-policy.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/malformed-classic-review.json" '{"required_status_checks":{"strict":true,"checks":[{"context":"test","app_id":15368}],"contexts":["test"]},"required_pull_request_reviews":{"dismissal_restrictions":{"users":[],"teams":[],"apps":[]},"dismiss_stale_reviews":true,"require_code_owner_reviews":"true","required_approving_review_count":1,"require_last_push_approval":false}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/malformed-classic-review.json" "$fixture_root/ignored.json"
+write_fixture "$fixture_root/no-op-classic-status-policy.json" '{"required_status_checks":{"strict":true,"checks":[],"contexts":[]}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/no-op-classic-status-policy.json" "$fixture_root/ignored.json"
 
 write_fixture "$fixture_root/repository.json" '{
   "id": 42,

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -116,7 +116,7 @@ awk '
     next
   }
   in_block { block = block $0 ORS }
-' .github/prompts/github-pr-management.md >"$draft_snippet"
+' "$script_dir/../prompts/github-pr-management.md" >"$draft_snippet"
 sed -e 's|^base_repo=.*$|base_repo=telekom/k8s-breakglass|' \
   -e 's|^base_ref=.*$|base_ref=main|' \
   -e "s|^contract=.*$|contract=\"$contract\"|" \

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -41,27 +41,46 @@ write_fixture "$fixture_root/redirected-review-request.http" $'HTTP/2 302 Found\
 test "$("$contract" request-date "$fixture_root/redirected-review-request.http")" = 'Fri, 28 Aug 2026 07:14:18 GMT' ||
   fail "final HTTP response Date was not selected"
 
-write_fixture "$fixture_root/effective-rules.json" '[
-  {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},
+write_fixture "$fixture_root/effective-rules.json" '[[
   {"type":"pull_request","parameters":{"required_approving_review_count":1,"require_code_owner_review":true}},
-  {"type":"required_workflows","parameters":{"workflows":[{"path":".github/workflows/test.yml","ref":"main"}]}},
+  {"type":"workflows","parameters":{"workflows":[{"path":".github/workflows/test.yml","ref":"main"}]}}
+], [
+  {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},
   {"type":"required_deployments","parameters":{"required_deployment_environments":["staging"]}},
-  {"type":"required_code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}},
+  {"type":"code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}},
   {"type":"required_signatures","parameters":{}}
-]'
+]]'
 write_fixture "$fixture_root/protection.json" '{"required_status_checks":{"checks":[],"contexts":[]}}'
 "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/effective-rules.json" "$fixture_root/protection.json" "$fixture_root/inventory.json"
 jq -e '.schema == 2 and (.requiredCheckRuns == [{"context":"test","appId":15368}]) and .mergeStateRequired' \
   "$fixture_root/inventory.json" >/dev/null || fail "supported rules were not inventoried"
 
-write_fixture "$fixture_root/unknown-rule.json" '[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},{"type":"commit_message_pattern","parameters":{"operator":"regex","pattern":".*"}}]'
+write_fixture "$fixture_root/unknown-rule.json" '[[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}}],[{"type":"commit_message_pattern","parameters":{"operator":"regex","pattern":".*"}}]]'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/unknown-rule.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
 
 write_fixture "$fixture_root/legacy-protection.json" '{"required_status_checks":{"checks":[],"contexts":["test"]}}'
 expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
   "$fixture_root/effective-rules.json" "$fixture_root/legacy-protection.json" "$fixture_root/ignored.json"
+
+# Empty ruleset pages are valid API output. A real classic branch-protection
+# requirement must still produce a complete, usable inventory.
+write_fixture "$fixture_root/empty-effective-rules.json" '[[], []]'
+write_fixture "$fixture_root/classic-protection.json" '{
+  "required_status_checks":{"checks":[{"context":"test","app_id":15368}],"contexts":[]},
+  "required_pull_request_reviews":{"required_approving_review_count":1,"require_code_owner_reviews":true},
+  "required_conversation_resolution":{"enabled":true}
+}'
+"$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/classic-protection.json" "$fixture_root/classic-inventory.json"
+jq -e '.effectiveRules == [] and (.classicBranchProtectionRules | length) == 3 and
+  .requiredCheckRuns == [{"context":"test","appId":15368}]' \
+  "$fixture_root/classic-inventory.json" >/dev/null || fail "classic branch protection was not inventoried"
+
+write_fixture "$fixture_root/empty-protection.json" '{}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/empty-effective-rules.json" "$fixture_root/empty-protection.json" "$fixture_root/ignored.json"
 
 write_fixture "$fixture_root/repository.json" '{
   "id": 42,
@@ -112,6 +131,12 @@ write_fixture "$fixture_root/statuses.json" '[]'
   "$fixture_root/statuses.json" "$fixture_root/verified.json"
 jq -e '.verified == true and (.acceptedHeads | index("source-head")) != null and (.acceptedHeads | index("synthetic-candidate")) != null' \
   "$fixture_root/verified.json" >/dev/null || fail "exact source-head evidence was not accepted"
+
+"$contract" verify-checks "$fixture_root/identity.json" "$fixture_root/classic-inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/runs.json" "$fixture_root/suites.json" \
+  "$fixture_root/statuses.json" "$fixture_root/classic-verified.json"
+jq -e '.verified == true' "$fixture_root/classic-verified.json" >/dev/null ||
+  fail "classic branch-protection evidence was not accepted"
 
 # The active workflow/deployment/code-scanning/signature rules are accepted
 # only while GitHub's own exact-PR aggregate predicate remains policy-clean.

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+# SPDX-License-Identifier: CC0-1.0
+
+# Behavioral conformance tests for pr-gate-contract.sh. The tests use captured
+# API-shaped fixtures and never inspect prompt text.
+set -euo pipefail
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+contract="$script_dir/pr-gate-contract.sh"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+fail() {
+  printf 'test-pr-gate-contract: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  if "$@" >/dev/null 2>&1; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+write_fixture() {
+  local path="$1"
+  shift
+  printf '%s\n' "$1" >"$path"
+}
+
+valid_pr_url="https://github.com/telekom/k8s-breakglass/pull/1268"
+parsed="$($contract parse-pr-url "$valid_pr_url")"
+test "$parsed" = $'github.com\ttelekom/k8s-breakglass\t1268' || fail "valid HTTPS PR URL was not parsed"
+expect_failure "$contract" parse-pr-url 'http://github.com/telekom/k8s-breakglass/pull/1268'
+expect_failure "$contract" parse-pr-url 'https://token@github.com/telekom/k8s-breakglass/pull/1268'
+
+write_fixture "$fixture_root/review-request.http" $'HTTP/2 201 Created\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\n\r\n{}'
+expect_failure "$contract" verify-review-freshness "$fixture_root/review-request.http" '2026-08-28T07:14:18.999Z'
+"$contract" verify-review-freshness "$fixture_root/review-request.http" '2026-08-28T07:14:19.000Z'
+write_fixture "$fixture_root/redirected-review-request.http" $'HTTP/2 302 Found\r\nDate: Fri, 28 Aug 2026 07:14:17 GMT\r\n\r\nHTTP/2 201 Created\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{}'
+test "$("$contract" request-date "$fixture_root/redirected-review-request.http")" = 'Fri, 28 Aug 2026 07:14:18 GMT' ||
+  fail "final HTTP response Date was not selected"
+
+write_fixture "$fixture_root/effective-rules.json" '[
+  {"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},
+  {"type":"pull_request","parameters":{"required_approving_review_count":1,"require_code_owner_review":true}},
+  {"type":"required_workflows","parameters":{"workflows":[{"path":".github/workflows/test.yml","ref":"main"}]}},
+  {"type":"required_deployments","parameters":{"required_deployment_environments":["staging"]}},
+  {"type":"required_code_scanning","parameters":{"required_code_scanning_tools":[{"tool":"CodeQL"}]}},
+  {"type":"required_signatures","parameters":{}}
+]'
+write_fixture "$fixture_root/protection.json" '{"required_status_checks":{"checks":[],"contexts":[]}}'
+"$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/effective-rules.json" "$fixture_root/protection.json" "$fixture_root/inventory.json"
+jq -e '.schema == 2 and (.requiredCheckRuns == [{"context":"test","appId":15368}]) and .mergeStateRequired' \
+  "$fixture_root/inventory.json" >/dev/null || fail "supported rules were not inventoried"
+
+write_fixture "$fixture_root/unknown-rule.json" '[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"test","integration_id":15368}]}},{"type":"commit_message_pattern","parameters":{"operator":"regex","pattern":".*"}}]'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/unknown-rule.json" "$fixture_root/protection.json" "$fixture_root/ignored.json"
+
+write_fixture "$fixture_root/legacy-protection.json" '{"required_status_checks":{"checks":[],"contexts":["test"]}}'
+expect_failure "$contract" inventory-policy github.com telekom/k8s-breakglass main \
+  "$fixture_root/effective-rules.json" "$fixture_root/legacy-protection.json" "$fixture_root/ignored.json"
+
+write_fixture "$fixture_root/repository.json" '{
+  "id": 42,
+  "full_name": "telekom/k8s-breakglass",
+  "html_url": "https://github.com/telekom/k8s-breakglass",
+  "url": "https://api.github.com/repos/telekom/k8s-breakglass"
+}'
+write_fixture "$fixture_root/identity.json" '{
+  "data": {"repository": {"pullRequest": {
+    "headRefName": "codex/network-debug",
+    "headRefOid": "source-head",
+    "baseRefName": "main",
+    "baseRefOid": "base-head",
+    "headRepository": {"nameWithOwner": "telekom/k8s-breakglass"},
+    "baseRepository": {"nameWithOwner": "telekom/k8s-breakglass"},
+    "potentialMergeCommit": {"oid": "synthetic-candidate"},
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN"
+  }}}
+}'
+write_fixture "$fixture_root/runs.json" '[{
+  "id": 111,
+  "observedOid": "source-head",
+  "head_sha": "source-head",
+  "name": "test",
+  "status": "completed",
+  "conclusion": "success",
+  "app": {"id": 15368, "owner": {"login": "github"}, "slug": "github-actions"},
+  "check_suite": {"id": 222}
+}]'
+write_fixture "$fixture_root/suites.json" '[{
+  "id": 222,
+  "head_sha": "source-head",
+  "app": {"id": 15368},
+  "repository": {"id": 42, "full_name": "telekom/k8s-breakglass", "html_url": "https://github.com/telekom/k8s-breakglass", "url": "https://api.github.com/repos/telekom/k8s-breakglass"},
+  "pull_requests": [{
+    "head": {"sha": "source-head", "ref": "codex/network-debug", "repo": {"id": 42, "full_name": "telekom/k8s-breakglass", "html_url": "https://github.com/telekom/k8s-breakglass", "url": "https://api.github.com/repos/telekom/k8s-breakglass"}},
+    "base": {"sha": "base-head", "ref": "main", "repo": {"id": 42, "full_name": "telekom/k8s-breakglass", "html_url": "https://github.com/telekom/k8s-breakglass", "url": "https://api.github.com/repos/telekom/k8s-breakglass"}}
+  }]
+}]'
+write_fixture "$fixture_root/statuses.json" '[]'
+
+# A passing check run on the exact source head is valid even though GitHub has
+# also produced a distinct synthetic candidate for the same source/base pair.
+"$contract" verify-checks "$fixture_root/identity.json" "$fixture_root/inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/runs.json" "$fixture_root/suites.json" \
+  "$fixture_root/statuses.json" "$fixture_root/verified.json"
+jq -e '.verified == true and (.acceptedHeads | index("source-head")) != null and (.acceptedHeads | index("synthetic-candidate")) != null' \
+  "$fixture_root/verified.json" >/dev/null || fail "exact source-head evidence was not accepted"
+
+# The converse supported GitHub shape also passes: a check suite may be built
+# for the synthetic candidate while its PR association still names the exact
+# source/base pair.
+jq '.[0].observedOid = "synthetic-candidate" | .[0].head_sha = "synthetic-candidate"' \
+  "$fixture_root/runs.json" >"$fixture_root/candidate-runs.json"
+jq '.[0].head_sha = "synthetic-candidate"' "$fixture_root/suites.json" >"$fixture_root/candidate-suites.json"
+"$contract" verify-checks "$fixture_root/identity.json" "$fixture_root/inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/candidate-runs.json" "$fixture_root/candidate-suites.json" \
+  "$fixture_root/statuses.json" "$fixture_root/candidate-verified.json"
+jq -e '.verified == true' "$fixture_root/candidate-verified.json" >/dev/null || fail "exact synthetic-candidate evidence was not accepted"
+
+# The same context/App is not enough: a suite associated with a different
+# source ref must not authorize the check.
+jq '.[0].pull_requests[0].head.ref = "attacker-ref"' "$fixture_root/suites.json" >"$fixture_root/foreign-suite.json"
+expect_failure "$contract" verify-checks "$fixture_root/identity.json" "$fixture_root/inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/runs.json" "$fixture_root/foreign-suite.json" \
+  "$fixture_root/statuses.json" "$fixture_root/ignored.json"
+
+# A creator field on a legacy status cannot prove its GitHub App integration;
+# any context collision therefore fails closed.
+write_fixture "$fixture_root/colliding-statuses.json" '[{"context":"test","state":"success","creator":{"login":"github-actions[bot]","id":41898282}}]'
+expect_failure "$contract" verify-checks "$fixture_root/identity.json" "$fixture_root/inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/runs.json" "$fixture_root/suites.json" \
+  "$fixture_root/colliding-statuses.json" "$fixture_root/ignored.json"
+
+printf 'pr-gate-contract behavioral tests passed\n'

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 contract="$script_dir/pr-gate-contract.sh"
-fixture_root="$(mktemp -d)"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/breakglass-pr-contract.XXXXXX")"
 trap 'rm -rf "$fixture_root"' EXIT
 
 fail() {
@@ -122,7 +122,7 @@ write_fixture "$mock_bin/vi" $'#!/usr/bin/env bash\nprintf "%s\\n" "test body" >
 # shellcheck disable=SC2016
 write_fixture "$mock_bin/gh" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-} ${2-}" in\n  "auth status") exit 0 ;;\n  "pr create")\n    printf "%s\\n" create >>"$DRAFT_LOG"\n    printf "%s\\n" "https://github.com/telekom/k8s-breakglass/pull/999"\n    exit 0\n    ;;\n  "pr view")\n    printf "%s\\n" "{\\"isDraft\\":true,\\"headRefName\\":\\"codex/network-debug\\",\\"headRefOid\\":\\"source-head\\",\\"headRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"},\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"base-head\\",\\"baseRepository\\":{\\"nameWithOwner\\":\\"telekom/k8s-breakglass\\"}}"\n    exit 0\n    ;;\n  "pr edit")\n    printf "%s\\n" edit >>"$DRAFT_LOG"\n    exit 0\n    ;;\nesac\nexit 2\n'
 write_fixture "$mock_bin/git" $'#!/usr/bin/env bash\nset -euo pipefail\ncase "${1-}" in\n  check-ref-format) exit 0 ;;\n  branch) printf "%s\\n" codex/network-debug ; exit 0 ;;\n  config) exit 1 ;;\n  remote)\n    if [ "$#" = 1 ]; then printf "%s\\n" origin; exit 0; fi\n    if [ "${2-}" = get-url ]; then\n      printf "%s\\n" https://github.com/telekom/k8s-breakglass.git\n      exit 0\n    fi\n    ;;\n  fetch) exit 0 ;;\n  rev-parse)\n    for arg in "$@"; do\n      case "$arg" in\n        *origin/main*) printf "%s\\n" base-head; exit 0 ;;\n        *origin/codex/network-debug*|HEAD) printf "%s\\n" source-head; exit 0 ;;\n      esac\n    done\n    ;;\nesac\nexit 2\n'
-write_fixture "$mock_bin/mktemp" $'#!/usr/bin/env bash\nset -euo pipefail\nresult="$(/usr/bin/mktemp "$@")"\nprintf "%s\\n" "$result"\nif [ -n "${MKTEMP_LOG-}" ]; then\n  printf "%s\\n" "$result" >>"$MKTEMP_LOG"\nfi\n'
+write_fixture "$mock_bin/mktemp" $'#!/usr/bin/env bash\nset -euo pipefail\nif [ "$#" = 1 ] && [ "$1" = "-d" ]; then\n  printf "%s\\n" "mktemp requires a template" >&2\n  exit 64\nfi\nresult="$(/usr/bin/mktemp "$@")"\nprintf "%s\\n" "$result"\nif [ -n "${MKTEMP_LOG-}" ]; then\n  printf "%s\\n" "$result" >>"$MKTEMP_LOG"\nfi\n'
 chmod +x "$mock_bin/vi" "$mock_bin/gh" "$mock_bin/git" "$mock_bin/mktemp"
 draft_snippet="$fixture_root/draft-snippet.sh"
 awk '

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -22,6 +22,19 @@ expect_failure() {
   fi
 }
 
+expect_failure_message() {
+  local expected="$1"
+  shift
+  local output
+  if output="$({ "$@" >/dev/null; } 2>&1)"; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+  case "$output" in
+    *"$expected"*) ;;
+    *) fail "failure for $* did not contain '$expected': $output" ;;
+  esac
+}
+
 write_fixture() {
   local path="$1"
   shift
@@ -32,8 +45,12 @@ valid_pr_url="https://github.com/telekom/k8s-breakglass/pull/1268"
 parsed="$($contract parse-pr-url "$valid_pr_url")"
 test "$parsed" = $'github.com\ttelekom/k8s-breakglass\t1268' || fail "valid HTTPS PR URL was not parsed"
 expect_failure "$contract" parse-pr-url 'http://github.com/telekom/k8s-breakglass/pull/1268'
-expect_failure "$contract" parse-pr-url 'https://token@github.com/telekom/k8s-breakglass/pull/1268'
+expect_failure_message credentials "$contract" parse-pr-url 'https://token@github.com/telekom/k8s-breakglass/pull/1268'
 expect_failure "$contract" parse-pr-url 'https://github.com:443/telekom/k8s-breakglass/pull/1268'
+
+encoded_ref="$(jq -nr --arg ref 'feature/review refs+checks' '$ref | @uri')"
+test "$encoded_ref" = 'feature%2Freview%20refs%2Bchecks' ||
+  fail "branch refs were not URL encoded as one path segment"
 
 write_fixture "$fixture_root/review-request.http" $'HTTP/2 201 Created\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nContent-Type: application/json\r\n\r\n{}'
 expect_failure "$contract" verify-review-freshness "$fixture_root/review-request.http" '2026-08-28T07:14:18.999Z'

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -113,6 +113,13 @@ write_fixture "$fixture_root/statuses.json" '[]'
 jq -e '.verified == true and (.acceptedHeads | index("source-head")) != null and (.acceptedHeads | index("synthetic-candidate")) != null' \
   "$fixture_root/verified.json" >/dev/null || fail "exact source-head evidence was not accepted"
 
+# The active workflow/deployment/code-scanning/signature rules are accepted
+# only while GitHub's own exact-PR aggregate predicate remains policy-clean.
+jq '.data.repository.pullRequest.mergeStateStatus = "BLOCKED"' "$fixture_root/identity.json" >"$fixture_root/blocked-identity.json"
+expect_failure "$contract" verify-checks "$fixture_root/blocked-identity.json" "$fixture_root/inventory.json" \
+  "$fixture_root/repository.json" "$fixture_root/runs.json" "$fixture_root/suites.json" \
+  "$fixture_root/statuses.json" "$fixture_root/ignored.json"
+
 # The converse supported GitHub shape also passes: a check suite may be built
 # for the synthetic candidate while its PR association still names the exact
 # source/base pair.

--- a/.github/scripts/test-pr-gate-contract.sh
+++ b/.github/scripts/test-pr-gate-contract.sh
@@ -73,18 +73,37 @@ jq '.headRefOid = "attacker-head"' "$fixture_root/created-draft.json" >"$fixture
 expect_failure "$contract" verify-created-draft "$fixture_root/wrong-draft-head.json" telekom/k8s-breakglass \
   codex/network-debug source-head main base-head
 
-# The evidence manifest covers every artifact, rather than just JSON. This
-# catches a changed HTTP response (such as a different final status/header)
-# between the verified and final snapshots.
+# The evidence manifest validates raw HTTP responses but projects away only
+# response-specific transport metadata. Equivalent GitHub responses must
+# compare equal despite a fresh Date/request ID and JSON key order; status,
+# body, or security-header changes must not.
 mkdir -p "$fixture_root/manifest-snapshot"
 write_fixture "$fixture_root/manifest-snapshot/identity.json" '{"b":2,"a":1}'
-write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\n\r\n{}'
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:18 GMT\r\nX-GitHub-Request-Id: FIRST:REQUEST\r\nContent-Type: application/json\r\nX-GitHub-Api-Version: 2026-03-10\r\nX-Frame-Options: DENY\r\n\r\n{"second":2,"first":1}'
 "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 cp "$fixture_root/manifest-snapshot/gate.jsonl" "$fixture_root/first-manifest.jsonl"
-write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\n\r\n{}'
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nX-Frame-Options: DENY\r\nContent-Type: application/json\r\nX-GitHub-Request-Id: SECOND:REQUEST\r\nX-GitHub-Api-Version: 2026-03-10\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\n\r\n{"first":1,"second":2}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" ||
+  fail "volatile HTTP headers changed an equivalent evidence manifest"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 404 Not Found\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: THIRD:REQUEST\r\nContent-Type: application/json\r\nX-GitHub-Api-Version: 2026-03-10\r\nX-Frame-Options: DENY\r\n\r\n{"first":1,"second":2}'
 "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
-  fail "changed HTTP evidence did not change the manifest"
+  fail "changed HTTP status did not change the evidence manifest"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: FOURTH:REQUEST\r\nContent-Type: application/json\r\nX-GitHub-Api-Version: 2026-03-10\r\nX-Frame-Options: DENY\r\n\r\n{"first":1,"second":3}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
+  fail "changed HTTP body did not change the evidence manifest"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: FIFTH:REQUEST\r\nContent-Type: application/json\r\nX-GitHub-Api-Version: 2026-03-10\r\nX-Frame-Options: SAMEORIGIN\r\n\r\n{"first":1,"second":2}'
+"$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+cmp -s "$fixture_root/first-manifest.jsonl" "$fixture_root/manifest-snapshot/gate.jsonl" &&
+  fail "changed security-relevant HTTP header did not change the manifest"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: SIXTH:REQUEST\r\nMalformed Header\r\n\r\n{}'
+expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: not-a-date\r\nX-GitHub-Request-Id: SEVENTH:REQUEST\r\nContent-Type: application/json\r\n\r\n{}'
+expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
+write_fixture "$fixture_root/manifest-snapshot/branch-protection.http" $'HTTP/2 200 OK\r\nDate: Fri, 28 Aug 2026 07:14:19 GMT\r\nX-GitHub-Request-Id: EIGHTH:REQUEST\r\nContent-Type: application/json\r\n\r\nnot-json'
+expect_failure "$contract" manifest-evidence "$fixture_root/manifest-snapshot" "$fixture_root/manifest-snapshot/gate.jsonl"
 
 write_fixture "$fixture_root/effective-rules.json" '[[
   {"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":true,"require_code_owner_review":true,"require_last_push_approval":false,"required_approving_review_count":1,"required_review_thread_resolution":true}},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         run: make verify-release-provenance
       - name: Verify documentation snippets
         run: make verify-docs-snippets
+      - name: Verify PR gate contract behavior
+        run: |
+          shellcheck .github/scripts/pr-gate-contract.sh .github/scripts/test-pr-gate-contract.sh
+          .github/scripts/test-pr-gate-contract.sh
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
## Intent

Make the repository's GitHub PR-management guidance fail closed and directly
testable. Read this as an operational contract for agents and maintainers who
create, rebase, review, and ready pull requests; it is not a Breakglass runtime
change.

## What changed

- `.github/scripts/pr-gate-contract.sh` validates HTTPS PR URLs, rejects
  credentials before authority/port diagnostics, validates captured GitHub
  evidence, and binds readiness to the exact repository, refs, OIDs, review,
  policy, and check inventory.
- `.github/prompts/github-pr-management.md` documents the evidence workflow,
  same-repository branch policy, atomic draft verification, exact-head/base
  checks, and URL-encodes branch refs before REST requests.
- `.github/scripts/test-pr-gate-contract.sh` exercises allow and deny behavior
  with API-shaped fixtures and mocked `gh`/`git` commands.
- `.github/workflows/ci.yml` runs the behavioral suite and ShellCheck in lint.

## How to use

Run `./.github/scripts/test-pr-gate-contract.sh` before relying on a changed
copy of the workflow. During PR work, collect fresh evidence from the exact PR
URL and host, verify the source and base repository/ref/OID pair, request a
formal Copilot review, inventory effective branch rules and required checks,
verify all review threads are resolved, and only then mark the PR ready.
Use `gh pr`/`gh run` with `--repo` and `gh api` with `--hostname`; retain raw
evidence in a private temporary directory until the gate completes.

## Behavioral verification

At base `e975129ceb8362a800e3e3513a3911b2a164ae6f`, this branch head is
`ebcfe99ce6e2a3e97cea8fca2cde5cea0d82d802`. Local checks passed:

- `bash -n .github/scripts/pr-gate-contract.sh .github/scripts/test-pr-gate-contract.sh`
- `shellcheck .github/scripts/pr-gate-contract.sh .github/scripts/test-pr-gate-contract.sh`
- `.github/scripts/test-pr-gate-contract.sh`
- `make verify-docs-snippets`
- `git diff --check`

The behavioral suite proves exact source/base and rerun-attempt binding,
missing/pending/stale/wrong-login Copilot review rejection, incomplete review
thread pagination rejection, canonicalization of volatile HTTP metadata while
detecting status/body/security-header changes, duplicate JSON-key rejection at
arbitrary nesting, atomic draft create/view/edit behavior, credential-specific
URL diagnostics, and URI encoding of branch refs.

## Scope and limitations

This changes contributor guidance and CI validation only. It does not alter
Breakglass APIs, CRDs, Helm values, controllers, images, or release artifacts.
The policy intentionally permits only direct same-repository branches for this
workflow; fork pushes remain out of scope. GitHub's legacy status contexts
cannot be bound to an integration and therefore cannot satisfy this
fail-closed inventory. A head/base or policy change invalidates prior evidence
and requires a fresh gate and formal review.

## Security and cleanup

The URL parser rejects credentials, ports, queries, fragments, malformed hosts,
and malformed PR paths before network use. Captured API responses remain in a
private temporary directory, and draft body/evidence files are removed by the
workflow's exit trap. No credentials or captured evidence are committed.

## Dependencies and base assumptions

This is a documentation and CI-validation change: it adds no runtime package,
image, CRD, Helm value, or external service dependency. The executable contract
uses the repository's existing Bash, Ruby, and `jq` tooling; CI additionally
runs ShellCheck. The direct same-repository branch
`codex/pr-management-review-guidance` was restacked after priority PR #1266's
exact squash merge and currently targets base
`e975129ceb8362a800e3e3513a3911b2a164ae6f`. There are no downstream stacked PRs
in this handoff. Any base/head or policy change invalidates this evidence and
requires a fresh rebase, review, and check run.

## Rollout and rollback

There is no runtime rollout or data migration. Once merged, the guidance and
CI lint behavior apply to subsequent PR-management work and CI runs. If a
regression is found, revert the resulting squash commit; this restores the
prior guidance and CI behavior without changing Breakglass runtime state. Before
merging, re-run the exact-head gate if the base or branch changes.

## Merge order and handoff

Merge priority PR #1266 first (completed as squash
`e975129ceb8362a800e3e3513a3911b2a164ae6f`), then merge this PR normally as a
squash only after the final exact base/head, Copilot, thread, CI, security, and
E2E checks are green. Do not use an admin or bypass merge. Afterward, monitor
all post-merge workflows on the new `main` commit.
