### PR TITLE
ci: grant scorecard workflow metadata access

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -33,6 +33,8 @@ jobs:
     name: OpenSSF Scorecard
     runs-on: ubuntu-24.04
     permissions:
+      # Needed by actions/checkout to read repository contents
+      contents: read
       # Needed for Code scanning upload
       security-events: write
       # Needed for GitHub OIDC token if publish_results is true

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -4,7 +4,7 @@
 
 # This workflow generates an OpenSSF scorecard report, and uploads the report
 # (i) as an artifact to the actions tab, and (ii) to GitHub's code scanning dashboard
-# Note: This workflow file is slightly adpated version of
+# Note: This workflow file is slightly adapted version of
 # https://github.com/ossf/scorecard/blob/99b664e5d18f6774ef63dd1e7acb9f255c6285de/.github/workflows/scorecard-analysis.yml
 #
 # SPDX-FileCopyrightText: 2020 OpenSSF Scorecard Authors, 2024 Deutsche Telekom AG

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     branches:
       - main
-      
+
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'
@@ -37,7 +37,9 @@ jobs:
       security-events: write
       # Needed for GitHub OIDC token if publish_results is true
       id-token: write
-      
+      # Needed to read workflow metadata for SARIF upload
+      actions: read
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Implementation plan

- Grant the OpenSSF Scorecard analysis job `actions: read` for explicit,
  read-only access to workflow metadata consumed by the pinned CodeQL SARIF
  uploader.
- Grant the analysis job `contents: read` for the repository checkout while
  keeping all other job permissions unchanged.
- Normalize `.github/workflows/openssf-scorecard.yml` to LF line endings and
  correct its existing header spelling typo without changing workflow logic.
- Keep this PR Draft until fresh exact-head CI and Copilot/Codex review gates
  are complete.

## Scope

This Draft PR changes only `.github/workflows/openssf-scorecard.yml`. No
application code, generated files, dependency pins, or documentation are
included.

## Current state

- Rebased content-preservingly onto live `main` at
  `3543755547d0f12ede958054cffea6cc83c45831`, which includes merged
  Dependabot PR #1286.
- Current exact PR head:
  `fa06b15ff90dc2b189194c292c2e478b475c19bd`.
- The three signed commits retain DCO and
  `Assisted-by: OpenCode GPT-5.6 Sol <noreply@opencode.ai>` trailers.
- PR remains Draft. Fresh CI and exact-head Copilot review are required after
  this force-with-lease restack.

## Evidence

- The analysis job has job-level `contents: read`, `actions: read`,
  `security-events: write`, and `id-token: write`; unspecified permissions
  remain denied because job-level permissions replace the workflow default.
- The pinned `github/codeql-action/upload-sarif` implementation reads Actions
  run/workflow metadata, so `actions: read` is explicit and least-privilege.
- `contents: read` is required by the pinned `actions/checkout` step.
- The workflow uses immutable action SHAs and no functional step, trigger, or
  dependency changes.
- YAML parsing succeeds with Ruby Psych; the byte-level check reports zero
  CRLF and zero bare CR line endings.

## Limitations

- `actionlint` is not installed in the validation environment; CI must run the
  repository's workflow validation.
- The repository's existing `.yamllint.yml` reports an unrelated `colons`
  error for the pre-existing double space in `cron:  '30 1 * * 6'`; it is
  intentionally preserved because this PR is limited to the stated changes.
- This permission/hygiene change has no application-runtime test surface.

## Rollout / rollback

After independent review, fresh exact-head Copilot/Codex review, all required
checks green, and maintainer approval, mark the PR Ready and merge normally.
To roll back, revert this PR; that removes only the explicit read permissions
and harmless comment/line-ending normalization.
