### PR TITLE
fix(frontend): align Node.js engine with dependency floor

### DIFF
--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -9,175 +9,86 @@
  */
 
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, "../..");
 const frontendDirectory = path.join(repositoryRoot, "frontend");
+const requireFromFrontend = createRequire(path.join(frontendDirectory, "package.json"));
+const semver = requireFromFrontend("semver");
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
 function parseVersion(value, label) {
-  const match = String(value).match(/^v?(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) {
+  const text = String(value);
+  if (!/^v?\d+\.\d+\.\d+$/.test(text)) {
     throw new Error(`${label} must be an exact major.minor.patch version, got ${value}`);
   }
-  return match.slice(1).map(Number);
-}
-
-function parseRangeVersion(value, label) {
-  const match = String(value).match(/^v?(\d+)(?:\.(\d+|x|X|\*))?(?:\.(\d+|x|X|\*))?$/);
-  if (!match) {
-    throw new Error(`${label} is not a supported semver version, got ${value}`);
+  const parsed = semver.parse(text);
+  if (!parsed || parsed.prerelease.length || parsed.build.length) {
+    throw new Error(`${label} must be an exact stable semver version, got ${value}`);
   }
-  const parts = match.slice(1);
-  const wildcardComponent =
-    parts[1] !== undefined && /^[xX*]$/.test(parts[1]) ? 0 : parts[2] !== undefined && /^[xX*]$/.test(parts[2]) ? 1 : null;
-  const precision = parts[1] === undefined ? 1 : parts[2] === undefined ? 2 : 3;
-  return {
-    version: parts.map((part) => (part === undefined || /^[xX*]$/.test(part) ? 0 : Number(part))),
-    precision,
-    wildcard: parts.slice(1).some((part) => part !== undefined && /^[xX*]$/.test(part)),
-    wildcardComponent,
-  };
-}
-
-function compareVersions(left, right) {
-  for (let index = 0; index < left.length; index += 1) {
-    if (left[index] !== right[index]) {
-      return left[index] - right[index];
-    }
-  }
-  return 0;
+  return [parsed.major, parsed.minor, parsed.patch];
 }
 
 function versionText(version) {
   return version.join(".");
 }
 
-function incrementVersion(version, component) {
-  const next = [...version];
-  next[component] += 1;
-  for (let index = component + 1; index < next.length; index += 1) {
-    next[index] = 0;
-  }
-  return next;
-}
-
-function incrementPatch(version) {
-  return incrementVersion(version, 2);
-}
-
-function updateLower(current, version, inclusive) {
-  if (!current) {
-    return { version, inclusive };
-  }
-  const comparison = compareVersions(version, current.version);
-  return comparison > 0 || (comparison === 0 && !inclusive && current.inclusive)
-    ? { version, inclusive }
-    : current;
-}
-
-function updateUpper(current, version, inclusive) {
-  if (!current) {
-    return { version, inclusive };
-  }
-  const comparison = compareVersions(version, current.version);
-  return comparison < 0 || (comparison === 0 && !inclusive && current.inclusive)
-    ? { version, inclusive }
-    : current;
-}
-
 function parseRange(engine) {
-  const normalized = String(engine)
-    .replace(/([<>]=?|[~^=])\s+/g, "$1")
-    .trim();
-  if (!normalized) {
+  const text = String(engine).trim();
+  if (!text) {
     return [];
   }
-
-  return normalized.split(/\s*\|\|\s*/).map((alternative) => {
-    const tokens = alternative.trim().split(/\s+/).filter(Boolean);
-    let lower;
-    let upper;
-    for (const token of tokens) {
-      const match = token.match(/^(\^|~|>=|<=|>|<|=)?(v?\d+(?:\.(?:\d+|x|X|\*))?(?:\.(?:\d+|x|X|\*))?)$/);
-      if (!match) {
-        throw new Error(`unsupported Node.js engine range token ${token} in ${engine}`);
-      }
-      const operator = match[1] ?? "";
-      const parsed = parseRangeVersion(match[2], `dependency engine ${engine}`);
-      const version = parsed.version;
-      if (operator === "^") {
-        lower = updateLower(lower, version, true);
-        const upperComponent = version[0] > 0 ? 0 : version[1] > 0 ? 1 : 2;
-        upper = updateUpper(upper, incrementVersion(version, upperComponent), false);
-      } else if (operator === "~") {
-        lower = updateLower(lower, version, true);
-        upper = updateUpper(upper, incrementVersion(version, parsed.precision === 1 ? 0 : 1), false);
-      } else if (operator === ">=") {
-        lower = updateLower(lower, version, true);
-      } else if (operator === ">") {
-        lower = updateLower(lower, version, false);
-      } else if (operator === "<=") {
-        upper = updateUpper(upper, version, true);
-      } else if (operator === "<") {
-        upper = updateUpper(upper, version, false);
-      } else if (operator === "=") {
-        lower = updateLower(lower, version, true);
-        upper = updateUpper(upper, version, true);
-      } else if (parsed.precision === 1 || parsed.wildcard) {
-        lower = updateLower(lower, version, true);
-        upper = updateUpper(
-          upper,
-          incrementVersion(version, parsed.wildcardComponent === null ? 0 : parsed.wildcardComponent),
-          false,
-        );
-      } else {
-        lower = updateLower(lower, version, true);
-        upper = updateUpper(upper, version, true);
-      }
-    }
-    return { lower, upper };
-  });
+  try {
+    return new semver.Range(text).set;
+  } catch (error) {
+    throw new Error(`unsupported Node.js engine range ${engine}: ${error.message}`);
+  }
 }
 
-function includesVersionFromBounds(version, { lower, upper }) {
-  const comparisonToLower = lower ? compareVersions(version, lower.version) : 1;
-  const comparisonToUpper = upper ? compareVersions(version, upper.version) : -1;
-  return (
-    (!lower || comparisonToLower > 0 || (comparisonToLower === 0 && lower.inclusive)) &&
-    (!upper || comparisonToUpper < 0 || (comparisonToUpper === 0 && upper.inclusive))
-  );
+function compareVersions(left, right) {
+  return semver.compare(versionText(left), versionText(right));
+}
+
+function includesVersionInComparatorSet(version, comparatorSet) {
+  const parsed = new semver.SemVer(versionText(version));
+  return comparatorSet.every((comparator) => comparator.test(parsed));
 }
 
 function includesVersion(engine, version) {
-  return parseRange(engine).some((bounds) => includesVersionFromBounds(version, bounds));
+  return parseRange(engine).some((comparatorSet) => includesVersionInComparatorSet(version, comparatorSet));
 }
 
 function minimumVersionInMajor(engine, major) {
   const candidateFloor = [major, 0, 0];
   const candidates = [];
-  for (const bounds of parseRange(engine)) {
-    let candidate = candidateFloor;
-    if (bounds.lower) {
-      if (bounds.lower.version[0] > major) {
-        continue;
-      }
-      if (bounds.lower.version[0] === major) {
-        candidate = bounds.lower.inclusive ? bounds.lower.version : incrementPatch(bounds.lower.version);
-      }
+  for (const comparatorSet of parseRange(engine)) {
+    const minimum = semver.minVersion(comparatorSet.map((comparator) => comparator.value).join(" "));
+    if (!minimum || minimum.major > major) {
+      continue;
     }
-    if (candidate[0] === major && includesVersionFromBounds(candidate, bounds)) {
+    const candidate = minimum.major === major ? [minimum.major, minimum.minor, minimum.patch] : candidateFloor;
+    if (includesVersionInComparatorSet(candidate, comparatorSet)) {
       candidates.push(candidate);
     }
   }
   return candidates.reduce(
     (minimum, candidate) => (!minimum || compareVersions(candidate, minimum) < 0 ? candidate : minimum),
     null,
+  );
+}
+
+function hasUnboundedBranchAtMajor(engine, major) {
+  const version = [major, 0, 0];
+  return parseRange(engine).some(
+    (comparatorSet) =>
+      !comparatorSet.some((comparator) => comparator.operator === "<" || comparator.operator === "<=") &&
+      includesVersionInComparatorSet(version, comparatorSet),
   );
 }
 
@@ -206,7 +117,7 @@ function main() {
   const lockfileEngine = lockfile.packages?.[""]?.engines?.node;
   const packageFloor = minimumVersionInMajor(packageEngine ?? "", 24);
   const packageNode25Floor = minimumVersionInMajor(packageEngine ?? "", 25);
-  if (!packageFloor || packageNode25Floor || !includesVersion(packageEngine, [26, 0, 0])) {
+  if (!packageFloor || packageNode25Floor || !hasUnboundedBranchAtMajor(packageEngine ?? "", 26)) {
     throw new Error(
       `frontend/package.json must support Node 24 from its dependency floor, exclude Node 25, and support Node 26+, got ${packageEngine}`,
     );
@@ -216,6 +127,7 @@ function main() {
       `frontend/package-lock.json root engine ${lockfileEngine} does not match package.json ${packageEngine}`,
     );
   }
+  const projectNodeVersions = [packageFloor, [24, 99, 99], [26, 0, 0], [27, 0, 0], [100, 0, 0]];
 
   const dependencyRanges = [];
   const node24DependencyRanges = [];
@@ -245,7 +157,7 @@ function main() {
   }
   for (const { packageName, engine } of dependencyRanges) {
     assert(
-      includesVersion(engine, packageFloor) && includesVersion(engine, [24, 99, 99]) && includesVersion(engine, [26, 0, 0]),
+      projectNodeVersions.every((version) => includesVersion(engine, version)) && hasUnboundedBranchAtMajor(engine, 26),
       `${packageName} engine ${engine} does not support the project Node range ${packageEngine}`,
     );
   }
@@ -278,7 +190,14 @@ function main() {
   );
 }
 
-export { compareVersions, includesVersion, minimumVersionInMajor, parseRange, parseVersion };
+export {
+  compareVersions,
+  hasUnboundedBranchAtMajor,
+  includesVersion,
+  minimumVersionInMajor,
+  parseRange,
+  parseVersion,
+};
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -34,11 +34,14 @@ function parseRangeVersion(value, label) {
     throw new Error(`${label} is not a supported semver version, got ${value}`);
   }
   const parts = match.slice(1);
+  const wildcardComponent =
+    parts[1] !== undefined && /^[xX*]$/.test(parts[1]) ? 0 : parts[2] !== undefined && /^[xX*]$/.test(parts[2]) ? 1 : null;
   const precision = parts[1] === undefined ? 1 : parts[2] === undefined ? 2 : 3;
   return {
     version: parts.map((part) => (part === undefined || /^[xX*]$/.test(part) ? 0 : Number(part))),
     precision,
     wildcard: parts.slice(1).some((part) => part !== undefined && /^[xX*]$/.test(part)),
+    wildcardComponent,
   };
 }
 
@@ -128,7 +131,11 @@ function parseRange(engine) {
         upper = updateUpper(upper, version, true);
       } else if (parsed.precision === 1 || parsed.wildcard) {
         lower = updateLower(lower, version, true);
-        upper = updateUpper(upper, incrementVersion(version, parsed.precision === 1 ? 0 : 1), false);
+        upper = updateUpper(
+          upper,
+          incrementVersion(version, parsed.wildcardComponent === null ? 0 : parsed.wildcardComponent),
+          false,
+        );
       } else {
         lower = updateLower(lower, version, true);
         upper = updateUpper(upper, version, true);
@@ -211,19 +218,25 @@ function main() {
   }
 
   const dependencyRanges = [];
+  const node24DependencyRanges = [];
   for (const [packageName, packageMetadata] of Object.entries(lockfile.packages ?? {})) {
     if (packageName === "" || !packageMetadata.engines?.node) {
       continue;
     }
     const engine = packageMetadata.engines.node;
-    dependencyRanges.push({ packageName, engine, floor: minimumVersionInMajor(engine, 24) });
+    const floor = minimumVersionInMajor(engine, 24);
+    const entry = { packageName, engine, floor };
+    dependencyRanges.push(entry);
+    if (floor) {
+      node24DependencyRanges.push(entry);
+    }
   }
-  if (dependencyRanges.length === 0) {
+  if (node24DependencyRanges.length === 0) {
     throw new Error("could not find a Node 24 dependency engine range in frontend/package-lock.json");
   }
-  const dependencyFloor = dependencyRanges.reduce(
-    (highest, entry) => (entry.floor && compareVersions(entry.floor, highest) > 0 ? entry.floor : highest),
-    [0, 0, 0],
+  const dependencyFloor = node24DependencyRanges.reduce(
+    (highest, entry) => (!highest || compareVersions(entry.floor, highest) > 0 ? entry.floor : highest),
+    null,
   );
   if (compareVersions(packageFloor, dependencyFloor) !== 0) {
     throw new Error(

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+// SPDX-License-Identifier: CC0-1.0
+
+/**
+ * Keep the frontend Node.js baseline at or above the Node 24 engine floor
+ * declared by the dependency lockfile, and keep every setup-node workflow pin
+ * at that same baseline.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../..");
+const frontendDirectory = path.join(repositoryRoot, "frontend");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function parseVersion(value, label) {
+  const match = String(value).match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`${label} must be an exact major.minor.patch version, got ${value}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+function versionText(version) {
+  return version.join(".");
+}
+
+function assertAtLeast(version, minimum, label) {
+  if (compareVersions(version, minimum) < 0) {
+    throw new Error(`${label} ${versionText(version)} is below ${versionText(minimum)}`);
+  }
+}
+
+function node24Versions(engine) {
+  return [...String(engine).matchAll(/(?:^|[^\d])(?:\^|>=|>|~|=)?(24\.\d+\.\d+)/g)].map((match) =>
+    parseVersion(match[1], `dependency engine ${engine}`),
+  );
+}
+
+function workflowFiles(directory) {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return workflowFiles(entryPath);
+      }
+      return /\.(?:yml|yaml)$/.test(entry.name) ? [entryPath] : [];
+    });
+}
+
+function main() {
+  const packageJson = readJson(path.join(frontendDirectory, "package.json"));
+  const lockfile = readJson(path.join(frontendDirectory, "package-lock.json"));
+  const packageEngine = packageJson.engines?.node;
+  const lockfileEngine = lockfile.packages?.[""]?.engines?.node;
+  const packageMatch = String(packageEngine ?? "").match(/^>=\s*(\d+\.\d+\.\d+)$/);
+  if (!packageMatch) {
+    throw new Error(`frontend/package.json must declare an exact >= engine floor, got ${packageEngine}`);
+  }
+  if (lockfileEngine !== packageEngine) {
+    throw new Error(
+      `frontend/package-lock.json root engine ${lockfileEngine} does not match package.json ${packageEngine}`,
+    );
+  }
+
+  const dependencyFloors = [];
+  for (const [packageName, packageMetadata] of Object.entries(lockfile.packages ?? {})) {
+    if (packageName === "") {
+      continue;
+    }
+    for (const version of node24Versions(packageMetadata.engines?.node ?? "")) {
+      dependencyFloors.push({ packageName, version });
+    }
+  }
+  if (dependencyFloors.length === 0) {
+    throw new Error("could not find a Node 24 dependency engine floor in frontend/package-lock.json");
+  }
+  const dependencyFloor = dependencyFloors.reduce(
+    (highest, entry) => (compareVersions(entry.version, highest) > 0 ? entry.version : highest),
+    [0, 0, 0],
+  );
+  const packageVersion = parseVersion(packageMatch[1], "frontend/package.json engine");
+  assertAtLeast(packageVersion, dependencyFloor, "frontend/package.json engine");
+
+  const pins = [];
+  for (const workflowPath of workflowFiles(path.join(repositoryRoot, ".github", "workflows"))) {
+    const contents = fs.readFileSync(workflowPath, "utf8");
+    for (const match of contents.matchAll(/^\s*node-version:\s*['"]?([^'"\s#]+)['"]?/gm)) {
+      const version = parseVersion(match[1], `${path.relative(repositoryRoot, workflowPath)} node-version`);
+      assertAtLeast(version, dependencyFloor, `${path.relative(repositoryRoot, workflowPath)} node-version`);
+      pins.push({ workflowPath, version });
+    }
+  }
+  if (pins.length === 0) {
+    throw new Error("could not find any setup-node workflow version pins");
+  }
+
+  console.log(
+    `Node version contract OK: baseline ${versionText(packageVersion)}, dependency floor ${versionText(
+      dependencyFloor,
+    )} (${dependencyFloors.length} lockfile engine declarations), ${pins.length} workflow pins checked`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Node version contract failed: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -105,6 +105,13 @@ function main() {
     for (const match of contents.matchAll(/^\s*node-version:\s*['"]?([^'"\s#]+)['"]?/gm)) {
       const version = parseVersion(match[1], `${path.relative(repositoryRoot, workflowPath)} node-version`);
       assertAtLeast(version, dependencyFloor, `${path.relative(repositoryRoot, workflowPath)} node-version`);
+      if (compareVersions(version, packageVersion) !== 0) {
+        throw new Error(
+          `${path.relative(repositoryRoot, workflowPath)} node-version ${versionText(
+            version,
+          )} does not match frontend/package.json baseline ${versionText(packageVersion)}`,
+        );
+      }
       pins.push({ workflowPath, version });
     }
   }

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -44,6 +44,9 @@ function parseRange(engine) {
   if (!text) {
     return [];
   }
+  if (/-\s*$/.test(text) || /\b(?:v?\d+)\.(?:x|X|\*)\.\d+\b/.test(text)) {
+    throw new Error(`unsupported Node.js engine range ${engine}: malformed range syntax`);
+  }
   try {
     return new semver.Range(text).set;
   } catch (error) {

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -198,7 +198,8 @@ function main() {
   const packageEngine = packageJson.engines?.node;
   const lockfileEngine = lockfile.packages?.[""]?.engines?.node;
   const packageFloor = minimumVersionInMajor(packageEngine ?? "", 24);
-  if (!packageFloor || !includesVersion(packageEngine, [26, 0, 0]) || includesVersion(packageEngine, [25, 0, 0])) {
+  const packageNode25Floor = minimumVersionInMajor(packageEngine ?? "", 25);
+  if (!packageFloor || packageNode25Floor || !includesVersion(packageEngine, [26, 0, 0])) {
     throw new Error(
       `frontend/package.json must support Node 24 from its dependency floor, exclude Node 25, and support Node 26+, got ${packageEngine}`,
     );

--- a/.github/scripts/test-node-version-contract.mjs
+++ b/.github/scripts/test-node-version-contract.mjs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: CC0-1.0
 
 /**
- * Keep the frontend Node.js baseline at or above the Node 24 engine floor
+ * Keep the frontend Node.js baseline aligned with the Node.js engine ranges
  * declared by the dependency lockfile, and keep every setup-node workflow pin
- * at that same baseline.
+ * at that baseline.
  */
 
 import fs from "node:fs";
@@ -21,11 +21,25 @@ function readJson(filePath) {
 }
 
 function parseVersion(value, label) {
-  const match = String(value).match(/^(\d+)\.(\d+)\.(\d+)$/);
+  const match = String(value).match(/^v?(\d+)\.(\d+)\.(\d+)$/);
   if (!match) {
     throw new Error(`${label} must be an exact major.minor.patch version, got ${value}`);
   }
   return match.slice(1).map(Number);
+}
+
+function parseRangeVersion(value, label) {
+  const match = String(value).match(/^v?(\d+)(?:\.(\d+|x|X|\*))?(?:\.(\d+|x|X|\*))?$/);
+  if (!match) {
+    throw new Error(`${label} is not a supported semver version, got ${value}`);
+  }
+  const parts = match.slice(1);
+  const precision = parts[1] === undefined ? 1 : parts[2] === undefined ? 2 : 3;
+  return {
+    version: parts.map((part) => (part === undefined || /^[xX*]$/.test(part) ? 0 : Number(part))),
+    precision,
+    wildcard: parts.slice(1).some((part) => part !== undefined && /^[xX*]$/.test(part)),
+  };
 }
 
 function compareVersions(left, right) {
@@ -41,16 +55,129 @@ function versionText(version) {
   return version.join(".");
 }
 
-function assertAtLeast(version, minimum, label) {
-  if (compareVersions(version, minimum) < 0) {
-    throw new Error(`${label} ${versionText(version)} is below ${versionText(minimum)}`);
+function incrementVersion(version, component) {
+  const next = [...version];
+  next[component] += 1;
+  for (let index = component + 1; index < next.length; index += 1) {
+    next[index] = 0;
   }
+  return next;
 }
 
-function node24Versions(engine) {
-  return [...String(engine).matchAll(/(?:^|[^\d])(?:\^|>=|>|~|=)?(24\.\d+\.\d+)/g)].map((match) =>
-    parseVersion(match[1], `dependency engine ${engine}`),
+function incrementPatch(version) {
+  return incrementVersion(version, 2);
+}
+
+function updateLower(current, version, inclusive) {
+  if (!current) {
+    return { version, inclusive };
+  }
+  const comparison = compareVersions(version, current.version);
+  return comparison > 0 || (comparison === 0 && !inclusive && current.inclusive)
+    ? { version, inclusive }
+    : current;
+}
+
+function updateUpper(current, version, inclusive) {
+  if (!current) {
+    return { version, inclusive };
+  }
+  const comparison = compareVersions(version, current.version);
+  return comparison < 0 || (comparison === 0 && !inclusive && current.inclusive)
+    ? { version, inclusive }
+    : current;
+}
+
+function parseRange(engine) {
+  const normalized = String(engine)
+    .replace(/([<>]=?|[~^=])\s+/g, "$1")
+    .trim();
+  if (!normalized) {
+    return [];
+  }
+
+  return normalized.split(/\s*\|\|\s*/).map((alternative) => {
+    const tokens = alternative.trim().split(/\s+/).filter(Boolean);
+    let lower;
+    let upper;
+    for (const token of tokens) {
+      const match = token.match(/^(\^|~|>=|<=|>|<|=)?(v?\d+(?:\.(?:\d+|x|X|\*))?(?:\.(?:\d+|x|X|\*))?)$/);
+      if (!match) {
+        throw new Error(`unsupported Node.js engine range token ${token} in ${engine}`);
+      }
+      const operator = match[1] ?? "";
+      const parsed = parseRangeVersion(match[2], `dependency engine ${engine}`);
+      const version = parsed.version;
+      if (operator === "^") {
+        lower = updateLower(lower, version, true);
+        const upperComponent = version[0] > 0 ? 0 : version[1] > 0 ? 1 : 2;
+        upper = updateUpper(upper, incrementVersion(version, upperComponent), false);
+      } else if (operator === "~") {
+        lower = updateLower(lower, version, true);
+        upper = updateUpper(upper, incrementVersion(version, parsed.precision === 1 ? 0 : 1), false);
+      } else if (operator === ">=") {
+        lower = updateLower(lower, version, true);
+      } else if (operator === ">") {
+        lower = updateLower(lower, version, false);
+      } else if (operator === "<=") {
+        upper = updateUpper(upper, version, true);
+      } else if (operator === "<") {
+        upper = updateUpper(upper, version, false);
+      } else if (operator === "=") {
+        lower = updateLower(lower, version, true);
+        upper = updateUpper(upper, version, true);
+      } else if (parsed.precision === 1 || parsed.wildcard) {
+        lower = updateLower(lower, version, true);
+        upper = updateUpper(upper, incrementVersion(version, parsed.precision === 1 ? 0 : 1), false);
+      } else {
+        lower = updateLower(lower, version, true);
+        upper = updateUpper(upper, version, true);
+      }
+    }
+    return { lower, upper };
+  });
+}
+
+function includesVersionFromBounds(version, { lower, upper }) {
+  const comparisonToLower = lower ? compareVersions(version, lower.version) : 1;
+  const comparisonToUpper = upper ? compareVersions(version, upper.version) : -1;
+  return (
+    (!lower || comparisonToLower > 0 || (comparisonToLower === 0 && lower.inclusive)) &&
+    (!upper || comparisonToUpper < 0 || (comparisonToUpper === 0 && upper.inclusive))
   );
+}
+
+function includesVersion(engine, version) {
+  return parseRange(engine).some((bounds) => includesVersionFromBounds(version, bounds));
+}
+
+function minimumVersionInMajor(engine, major) {
+  const candidateFloor = [major, 0, 0];
+  const candidates = [];
+  for (const bounds of parseRange(engine)) {
+    let candidate = candidateFloor;
+    if (bounds.lower) {
+      if (bounds.lower.version[0] > major) {
+        continue;
+      }
+      if (bounds.lower.version[0] === major) {
+        candidate = bounds.lower.inclusive ? bounds.lower.version : incrementPatch(bounds.lower.version);
+      }
+    }
+    if (candidate[0] === major && includesVersionFromBounds(candidate, bounds)) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates.reduce(
+    (minimum, candidate) => (!minimum || compareVersions(candidate, minimum) < 0 ? candidate : minimum),
+    null,
+  );
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
 }
 
 function workflowFiles(directory) {
@@ -70,9 +197,11 @@ function main() {
   const lockfile = readJson(path.join(frontendDirectory, "package-lock.json"));
   const packageEngine = packageJson.engines?.node;
   const lockfileEngine = lockfile.packages?.[""]?.engines?.node;
-  const packageMatch = String(packageEngine ?? "").match(/^>=\s*(\d+\.\d+\.\d+)$/);
-  if (!packageMatch) {
-    throw new Error(`frontend/package.json must declare an exact >= engine floor, got ${packageEngine}`);
+  const packageFloor = minimumVersionInMajor(packageEngine ?? "", 24);
+  if (!packageFloor || !includesVersion(packageEngine, [26, 0, 0]) || includesVersion(packageEngine, [25, 0, 0])) {
+    throw new Error(
+      `frontend/package.json must support Node 24 from its dependency floor, exclude Node 25, and support Node 26+, got ${packageEngine}`,
+    );
   }
   if (lockfileEngine !== packageEngine) {
     throw new Error(
@@ -80,36 +209,45 @@ function main() {
     );
   }
 
-  const dependencyFloors = [];
+  const dependencyRanges = [];
   for (const [packageName, packageMetadata] of Object.entries(lockfile.packages ?? {})) {
-    if (packageName === "") {
+    if (packageName === "" || !packageMetadata.engines?.node) {
       continue;
     }
-    for (const version of node24Versions(packageMetadata.engines?.node ?? "")) {
-      dependencyFloors.push({ packageName, version });
-    }
+    const engine = packageMetadata.engines.node;
+    dependencyRanges.push({ packageName, engine, floor: minimumVersionInMajor(engine, 24) });
   }
-  if (dependencyFloors.length === 0) {
-    throw new Error("could not find a Node 24 dependency engine floor in frontend/package-lock.json");
+  if (dependencyRanges.length === 0) {
+    throw new Error("could not find a Node 24 dependency engine range in frontend/package-lock.json");
   }
-  const dependencyFloor = dependencyFloors.reduce(
-    (highest, entry) => (compareVersions(entry.version, highest) > 0 ? entry.version : highest),
+  const dependencyFloor = dependencyRanges.reduce(
+    (highest, entry) => (entry.floor && compareVersions(entry.floor, highest) > 0 ? entry.floor : highest),
     [0, 0, 0],
   );
-  const packageVersion = parseVersion(packageMatch[1], "frontend/package.json engine");
-  assertAtLeast(packageVersion, dependencyFloor, "frontend/package.json engine");
+  if (compareVersions(packageFloor, dependencyFloor) !== 0) {
+    throw new Error(
+      `frontend/package.json Node 24 floor ${versionText(packageFloor)} does not match dependency floor ${versionText(dependencyFloor)}`,
+    );
+  }
+  for (const { packageName, engine } of dependencyRanges) {
+    assert(
+      includesVersion(engine, packageFloor) && includesVersion(engine, [24, 99, 99]) && includesVersion(engine, [26, 0, 0]),
+      `${packageName} engine ${engine} does not support the project Node range ${packageEngine}`,
+    );
+  }
 
   const pins = [];
   for (const workflowPath of workflowFiles(path.join(repositoryRoot, ".github", "workflows"))) {
     const contents = fs.readFileSync(workflowPath, "utf8");
     for (const match of contents.matchAll(/^\s*node-version:\s*['"]?([^'"\s#]+)['"]?/gm)) {
       const version = parseVersion(match[1], `${path.relative(repositoryRoot, workflowPath)} node-version`);
-      assertAtLeast(version, dependencyFloor, `${path.relative(repositoryRoot, workflowPath)} node-version`);
-      if (compareVersions(version, packageVersion) !== 0) {
+      assert(
+        includesVersion(packageEngine, version),
+        `${path.relative(repositoryRoot, workflowPath)} node-version ${versionText(version)} is outside ${packageEngine}`,
+      );
+      if (compareVersions(version, packageFloor) !== 0) {
         throw new Error(
-          `${path.relative(repositoryRoot, workflowPath)} node-version ${versionText(
-            version,
-          )} does not match frontend/package.json baseline ${versionText(packageVersion)}`,
+          `${path.relative(repositoryRoot, workflowPath)} node-version ${versionText(version)} does not match Node 24 baseline ${versionText(packageFloor)}`,
         );
       }
       pins.push({ workflowPath, version });
@@ -120,15 +258,19 @@ function main() {
   }
 
   console.log(
-    `Node version contract OK: baseline ${versionText(packageVersion)}, dependency floor ${versionText(
+    `Node version contract OK: range ${packageEngine}, Node 24 floor ${versionText(packageFloor)}, dependency floor ${versionText(
       dependencyFloor,
-    )} (${dependencyFloors.length} lockfile engine declarations), ${pins.length} workflow pins checked`,
+    )} (${dependencyRanges.length} lockfile engine ranges), ${pins.length} workflow pins checked`,
   );
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`Node version contract failed: ${error.message}`);
-  process.exitCode = 1;
+export { compareVersions, includesVersion, minimumVersionInMajor, parseRange, parseVersion };
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Node version contract failed: ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/.github/scripts/test-node-version-contract.test.mjs
+++ b/.github/scripts/test-node-version-contract.test.mjs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+// SPDX-License-Identifier: CC0-1.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { includesVersion, minimumVersionInMajor, parseRange } from "./test-node-version-contract.mjs";
+
+test("minimum Node 24 version uses the earliest union branch", () => {
+  assert.deepEqual(minimumVersionInMajor("^24.15 || ^24.16", 24), [24, 15, 0]);
+});
+
+test("an upper bound below Node 24.15 does not become a false floor", () => {
+  assert.deepEqual(minimumVersionInMajor("<24.15", 24), [24, 0, 0]);
+  assert.equal(includesVersion("<24.15", [24, 15, 0]), false);
+});
+
+test("Node range semantics exclude Node 25 while retaining Node 26", () => {
+  const engine = "^24.15.0 || >=26.0.0";
+  assert.equal(includesVersion(engine, [24, 15, 0]), true);
+  assert.equal(includesVersion(engine, [24, 99, 99]), true);
+  assert.equal(includesVersion(engine, [25, 0, 0]), false);
+  assert.equal(includesVersion(engine, [26, 0, 0]), true);
+});
+
+test("comparator ranges and spaced operators are evaluated semantically", () => {
+  assert.equal(includesVersion(">= 24.15.0 < 25", [24, 20, 0]), true);
+  assert.equal(includesVersion(">= 24.15.0 < 25", [25, 0, 0]), false);
+  assert.deepEqual(minimumVersionInMajor(">24.15.0 <25", 24), [24, 15, 1]);
+  assert.equal(includesVersion("~24.15", [24, 15, 99]), true);
+  assert.equal(includesVersion("~24.15", [24, 16, 0]), false);
+  assert.equal(parseRange("^24.15 || ^24.16").length, 2);
+});

--- a/.github/scripts/test-node-version-contract.test.mjs
+++ b/.github/scripts/test-node-version-contract.test.mjs
@@ -4,7 +4,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { includesVersion, minimumVersionInMajor, parseRange } from "./test-node-version-contract.mjs";
+import {
+  hasUnboundedBranchAtMajor,
+  includesVersion,
+  minimumVersionInMajor,
+  parseRange,
+} from "./test-node-version-contract.mjs";
 
 test("minimum Node 24 version uses the earliest union branch", () => {
   assert.deepEqual(minimumVersionInMajor("^24.15 || ^24.16", 24), [24, 15, 0]);
@@ -29,12 +34,47 @@ test("comparator ranges and spaced operators are evaluated semantically", () => 
   assert.equal(includesVersion(">= 24.15.0 < 25", [24, 20, 0]), true);
   assert.equal(includesVersion(">= 24.15.0 < 25", [25, 0, 0]), false);
   assert.deepEqual(minimumVersionInMajor(">24.15.0 <25", 24), [24, 15, 1]);
+  assert.deepEqual(minimumVersionInMajor(">24.15 <25", 24), [24, 16, 0]);
+  assert.equal(includesVersion(">24.15", [24, 15, 1]), false);
+  assert.equal(includesVersion(">24.15", [24, 16, 0]), true);
+  assert.equal(includesVersion("<=24.15", [24, 15, 99]), true);
+  assert.equal(includesVersion("<=24.15", [24, 16, 0]), false);
+  assert.equal(includesVersion("=24.15", [24, 15, 99]), true);
+  assert.equal(includesVersion("24.15", [24, 15, 99]), true);
   assert.equal(includesVersion("~24.15", [24, 15, 99]), true);
   assert.equal(includesVersion("~24.15", [24, 16, 0]), false);
   assert.equal(parseRange("^24.15 || ^24.16").length, 2);
 });
 
 test("wildcard ranges include full matching major and exclude next major", () => {
+  assert.equal(includesVersion("*", [100, 0, 0]), true);
   assert.equal(includesVersion("24.*", [24, 99, 99]), true);
   assert.equal(includesVersion("24.*", [25, 0, 0]), false);
+  assert.equal(includesVersion("24.15.x", [24, 15, 99]), true);
+  assert.equal(includesVersion("24.15.x", [24, 16, 0]), false);
+  assert.equal(includesVersion("6.* || 8.* || >= 10.*", [6, 99, 99]), true);
+  assert.equal(includesVersion("6.* || 8.* || >= 10.*", [9, 0, 0]), false);
+});
+
+test("hyphen ranges use inclusive endpoints and partial upper bounds", () => {
+  assert.equal(includesVersion("24.15.0 - 24.99.99", [24, 15, 0]), true);
+  assert.equal(includesVersion("24.15.0 - 24.99.99", [24, 99, 99]), true);
+  assert.equal(includesVersion("24.15.0 - 24.99.99", [25, 0, 0]), false);
+  assert.equal(includesVersion("24.15 - 26", [24, 15, 0]), true);
+  assert.equal(includesVersion("24.15 - 26", [26, 99, 99]), true);
+  assert.equal(includesVersion("24.15 - 26", [27, 0, 0]), false);
+});
+
+test("Node 26 support requires an unbounded branch", () => {
+  const project = "^24.15.0 || >=26.0.0";
+  assert.equal(hasUnboundedBranchAtMajor(project, 26), true);
+  assert.equal(hasUnboundedBranchAtMajor("^24.15.0 || ^26.0.0", 26), false);
+  assert.equal(hasUnboundedBranchAtMajor(">=24.15.0 <27.0.0", 26), false);
+  assert.equal(includesVersion(project, [27, 0, 0]), true);
+  assert.equal(includesVersion(project, [100, 0, 0]), true);
+});
+
+test("malformed or unsupported range syntax fails closed", () => {
+  assert.throws(() => parseRange("24.x.15"), /unsupported Node.js engine range/);
+  assert.throws(() => parseRange("24.15.0 -"), /unsupported Node.js engine range/);
 });

--- a/.github/scripts/test-node-version-contract.test.mjs
+++ b/.github/scripts/test-node-version-contract.test.mjs
@@ -21,6 +21,8 @@ test("Node range semantics exclude Node 25 while retaining Node 26", () => {
   assert.equal(includesVersion(engine, [24, 99, 99]), true);
   assert.equal(includesVersion(engine, [25, 0, 0]), false);
   assert.equal(includesVersion(engine, [26, 0, 0]), true);
+  assert.equal(minimumVersionInMajor(engine, 25), null);
+  assert.deepEqual(minimumVersionInMajor(">=24.15.0", 25), [25, 0, 0]);
 });
 
 test("comparator ranges and spaced operators are evaluated semantically", () => {

--- a/.github/scripts/test-node-version-contract.test.mjs
+++ b/.github/scripts/test-node-version-contract.test.mjs
@@ -33,3 +33,8 @@ test("comparator ranges and spaced operators are evaluated semantically", () => 
   assert.equal(includesVersion("~24.15", [24, 16, 0]), false);
   assert.equal(parseRange("^24.15 || ^24.16").length, 2);
 });
+
+test("wildcard ranges include full matching major and exclude next major", () => {
+  assert.equal(includesVersion("24.*", [24, 99, 99]), true);
+  assert.equal(includesVersion("24.*", [25, 0, 0]), false);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,10 +337,10 @@ jobs:
           node-version: '24.15.0'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
-      - name: Check Node.js version contract
-        run: npm run test:node-version-contract
       - name: Install dependencies
         run: npm ci
+      - name: Check Node.js version contract
+        run: npm run test:node-version-contract
       - name: Type check
         run: npm run typecheck
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.11.0'
+          node-version: '24.15.0'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: Frontend security audit (npm)
@@ -334,9 +334,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.11.0'
+          node-version: '24.15.0'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
+      - name: Check Node.js version contract
+        run: npm run test:node-version-contract
       - name: Install dependencies
         run: npm ci
       - name: Type check
@@ -1641,7 +1643,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.11.0'
+          node-version: '24.15.0'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.11.0'
+          node-version: '24.15.0'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Frontend Node.js engine baseline**: Raised the frontend package, lockfile,
   documentation, and all `setup-node` CI pins to Node.js 24.15.0, the minimum
-  Node 24 release line accepted by the updated transitive `abbrev` and `nopt`
-  dependencies. Added a contract test to keep dependency engines and CI pins
-  aligned.
+  Node 24 release line required by the existing dependency graph (including
+  the `abbrev` and `nopt` versions brought in by Dependabot #1288). The
+  supported engine range is `^24.15.0 || >=26.0.0`, and a contract test keeps
+  dependency engines and CI pins aligned without admitting Node 25.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bridge-fdb-replace` for one exact FDB tuple, and read-only `node-recovery`
   evidence when mutation is not required.
 
-### Fixed
+### Changed
 
 - **Frontend Node.js engine baseline**: Raised the frontend package, lockfile,
   documentation, and all `setup-node` CI pins to Node.js 24.15.0, the minimum
   Node 24 release line accepted by the updated transitive `abbrev` and `nopt`
   dependencies. Added a contract test to keep dependency engines and CI pins
   aligned.
+
+### Fixed
 
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Frontend Node.js engine baseline**: Raised the frontend package, lockfile,
+  documentation, and all `setup-node` CI pins to Node.js 24.15.0, the minimum
+  Node 24 release line accepted by the updated transitive `abbrev` and `nopt`
+  dependencies. Added a contract test to keep dependency engines and CI pins
+  aligned.
+
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,13 +6,13 @@ state management.
 
 ## Prerequisites
 
-- **Node.js** 24.15.0 or newer
+- **Node.js** 24.15.0 or newer within the Node 24 release line, or 26.0.0 or newer
 - **npm** ≥ 9
 
-Node.js 24.15.0 is the supported project baseline for the current frontend
-toolchain and CI. Some transitive packages advertise lower engine ranges, but
-the dependency lockfile requires Node.js 24.15.0 or newer for its supported
-Node 24 release line.
+Node.js `^24.15.0 || >=26.0.0` is the supported range for the current
+frontend toolchain and CI. Node 25 is intentionally not included. The existing
+dependency lockfile requires Node.js 24.15.0 for its supported Node 24 release
+line, while its dependency engine ranges also support Node 26 and newer.
 
 ## IDE Setup
 
@@ -117,7 +117,7 @@ Edit `frontend/mock-api/data.mjs` if you want to pin additional permutations. Th
 Express server automatically after each save.
 
 > **Node version**: The built-in `node --watch` flag only requires Node.js **18.11.0 or newer**, but this project requires
-> Node.js **24.15.0 or newer**. Use the project baseline when running `npm run mock-api` or `npm run dev:mock`.
+> Node.js **24.15.0 through Node 24**, or **26.0.0 or newer**. Use the project baseline when running `npm run mock-api` or `npm run dev:mock`.
 
 ### Type-Check, Compile and Minify for Production
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,12 +6,13 @@ state management.
 
 ## Prerequisites
 
-- **Node.js** 24.11.0 or newer
+- **Node.js** 24.15.0 or newer
 - **npm** ≥ 9
 
-Node.js 24.11.0 is the supported project baseline for the current frontend
+Node.js 24.15.0 is the supported project baseline for the current frontend
 toolchain and CI. Some transitive packages advertise lower engine ranges, but
-the Playwright/Vite test stack is validated on Node.js 24.11.0 or newer.
+the dependency lockfile requires Node.js 24.15.0 or newer for its supported
+Node 24 release line.
 
 ## IDE Setup
 
@@ -116,7 +117,7 @@ Edit `frontend/mock-api/data.mjs` if you want to pin additional permutations. Th
 Express server automatically after each save.
 
 > **Node version**: The built-in `node --watch` flag only requires Node.js **18.11.0 or newer**, but this project requires
-> Node.js **24.11.0 or newer**. Use the project baseline when running `npm run mock-api` or `npm run dev:mock`.
+> Node.js **24.15.0 or newer**. Use the project baseline when running `npm run mock-api` or `npm run dev:mock`.
 
 ### Type-Check, Compile and Minify for Production
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "jsdom": "^30.0.1",
         "playwright": "^1.58.2",
         "prettier": "^3.9.6",
+        "semver": "^6.3.1",
         "terser": "^5.51.2",
         "typescript": "npm:@typescript/typescript6@~6.0.2",
         "vite": "^8.2.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
         "vue-tsc": "^3.3.11"
       },
       "engines": {
-        "node": ">=24.11.0"
+        "node": ">=24.15.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
         "vue-tsc": "^3.3.11"
       },
       "engines": {
-        "node": ">=24.15.0"
+        "node": "^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=24.15.0"
+    "node": "^24.15.0 || >=26.0.0"
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
@@ -23,7 +23,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts",
     "lint:fix": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "test": "vitest run",
-    "test:node-version-contract": "node ../.github/scripts/test-node-version-contract.mjs",
+    "test:node-version-contract": "node ../.github/scripts/test-node-version-contract.mjs && node --test ../.github/scripts/test-node-version-contract.test.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=24.11.0"
+    "node": ">=24.15.0"
   },
   "overrides": {
     "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
@@ -23,6 +23,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts",
     "lint:fix": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "test": "vitest run",
+    "test:node-version-contract": "node ../.github/scripts/test-node-version-contract.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "jsdom": "^30.0.1",
     "playwright": "^1.58.2",
     "prettier": "^3.9.6",
+    "semver": "^6.3.1",
     "terser": "^5.51.2",
     "typescript": "npm:@typescript/typescript6@~6.0.2",
     "vite": "^8.2.2",


### PR DESCRIPTION
## Summary

Raise the frontend Node.js baseline from 24.11.0 to the minimum Node 24
release required by the existing dependency graph, while preserving the
dependency engine union `^24.15.0 || >=26.0.0` and excluding Node 25.

## Implementation

- Keep `frontend/package.json`, lockfile root metadata, frontend documentation,
  and every `actions/setup-node` pin aligned with Node 24.15.0 and the
  supported engine union.
- Use the pinned frontend `semver` package for standards-compliant range
  parsing, including unions, partial comparators, bare/exact partials,
  wildcards, hyphen ranges, and future major versions.
- Reject malformed ranges that semver permissively normalizes (invalid
  wildcard placement and dangling hyphens), so the contract fails closed.
- Run the Node version contract after `npm ci`, then require every lockfile
  engine range to support Node 24.15 through Node 24 and the complete
  unbounded Node 26+ branch.
- Keep this PR Draft until exact-head CI and fresh Copilot review are complete.

## Scope

- Frontend package engine and semver dev dependency metadata.
- Four `setup-node` pins in `ci.yml` and `ui-screenshots.yml`.
- Frontend prerequisite and mock-API documentation.
- `.github/scripts/test-node-version-contract.mjs` and focused semver tests.
- Unreleased changelog entry.

No frontend production source, rendered manifests, or runtime behavior is
changed. The existing Node 26 Docker builder image is unchanged.

## Evidence

- Rebased onto live `main` at `e231a3071f0100d69dfd0ee4fdf785de9d1a70db`.
- Current head: `4ba182a5a730e902f9e91ea069bb42ee086ede20`.
- `npm ci --ignore-scripts` completed with 584 packages and 0 vulnerabilities.
- `npm run test:node-version-contract` passed: Node 24 floor `24.15.0`,
  dependency floor `24.15.0` across 435 lockfile engine ranges, 4 workflow
  pins, and 8 focused semver tests.
- `npm ci --dry-run --ignore-scripts --offline`, frontend lint, and
  `git diff --check` completed without diagnostics.
- The prior run `33382547174` failed only in Frontend Tests job `99458022480`,
  at `Check Node.js version contract`, because semver accepted malformed
  `24.15.0 -` input; the parser and fail-closed tests now reject that input
  and invalid `24.x.15` wildcard placement.
- The prior run’s other CI jobs passed; E2E and publish jobs were skipped.

## Limitations

- Fresh CI for head `4ba182a5a730e902f9e91ea069bb42ee086ede20` is required;
  this PR remains Draft and is not ready for merge.
- No Docker runtime or browser/E2E suite was run locally.

## Rollout and rollback

The change takes effect for frontend local development and CI on merge. Roll
back by reverting this PR only while the lockfile dependency graph remains
compatible with the restored engine contract; otherwise first restore
compatible dependency versions, then revert the baseline.
