### PR TITLE
fix(webhook): keep shared session indexes enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Authorization webhook session selection**: Register shared BreakglassSession
+  field indexes even when reconcilers are disabled, so approved sessions remain
+  discoverable by the SubjectAccessReview path (PR #1297).
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -684,8 +684,8 @@ func startBackgroundRoutines(ctx context.Context, wg *sync.WaitGroup, errCh chan
 	}
 
 	// Reconciler manager stays running for shared manager services such as
-	// health checks, metrics, and clients. Controller-specific indexes and
-	// reconcilers are gated by --enable-controllers.
+	// health checks, metrics, clients, and field indexes. Reconcilers are gated
+	// by --enable-controllers.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/docs/cli-flags-reference.md
+++ b/docs/cli-flags-reference.md
@@ -601,6 +601,27 @@ When **disabled**:
 
 ---
 
+#### `--enable-controllers`
+
+Enable Kubernetes reconcilers and controller-specific background handlers.
+Shared cache field indexes remain enabled when this flag is `false` because the
+API and authorization webhook continue to use the shared cache.
+
+| Property | Value |
+|----------|-------|
+| **Type** | `bool` |
+| **Default** | `true` |
+| **Environment** | `ENABLE_CONTROLLERS` |
+| **Example** | `--enable-controllers=false` |
+
+When **disabled**:
+- Kubernetes reconcilers do not run
+- Cache invalidation handlers, the ClusterConfig checker, and escalation status updater do not run
+- Shared session-selection field indexes remain registered
+- Useful for API/webhook-only split deployments
+
+---
+
 ### Interval Configuration
 
 #### `--cluster-config-check-interval`

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -178,6 +178,13 @@ Notes on matching behavior
 
 - The `{cluster-name}` path segment is used by the webhook to determine which managed cluster the request targets. The webhook will match this value against the following, in order of relevance:
   - `ClusterConfig.metadata.name` (recommended canonical identifier)
+
+### Split deployments
+
+The API and authorization webhook use the reconciler manager's shared cache to
+select `BreakglassSession` resources. The session field indexes remain enabled
+when controller reconcilers are disabled, so split deployments continue to
+discover approved sessions by cluster and user.
   - `BreakglassSession.spec.cluster` values present on active sessions
   - Entries listed in `BreakglassEscalation.spec.allowed.clusters` for escalation-based checks
 

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -178,6 +178,12 @@ Notes on matching behavior
 
 - The `{cluster-name}` path segment is used by the webhook to determine which managed cluster the request targets. The webhook will match this value against the following, in order of relevance:
   - `ClusterConfig.metadata.name` (recommended canonical identifier)
+  - `BreakglassSession.spec.cluster` values present on active sessions
+  - Entries listed in `BreakglassEscalation.spec.allowed.clusters` for escalation-based checks
+
+- Make sure the value you expose in the webhook URL is identical (including case) to the `ClusterConfig` name or the cluster identifier used in session/escalation objects. URL-encode any characters that are not valid in a URL path.
+
+- If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook immediately denies the request with a human-friendly message (`Cluster "foo" is not registered with Breakglass`) and emits a `cluster-missing` reason in metrics. This reduces confusion for platform users and surfaces onboarding gaps early. Create the missing ClusterConfig or update the webhook URL path to match an existing name.
 
 ### Split deployments
 
@@ -185,12 +191,6 @@ The API and authorization webhook use the reconciler manager's shared cache to
 select `BreakglassSession` resources. The session field indexes remain enabled
 when controller reconcilers are disabled, so split deployments continue to
 discover approved sessions by cluster and user.
-  - `BreakglassSession.spec.cluster` values present on active sessions
-  - Entries listed in `BreakglassEscalation.spec.allowed.clusters` for escalation-based checks
-
-- Make sure the value you expose in the webhook URL is identical (including case) to the `ClusterConfig` name or the cluster identifier used in session/escalation objects. URL-encode any characters that are not valid in a URL path.
-
-- If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook immediately denies the request with a human-friendly message (`Cluster "foo" is not registered with Breakglass`) and emits a `cluster-missing` reason in metrics. This reduces confusion for platform users and surfaces onboarding gaps early. Create the missing ClusterConfig or update the webhook URL path to match an existing name.
 
 ### Authentication Methods
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -157,7 +157,7 @@ func Parse() *Config {
 	flag.BoolVar(&config.EnableCleanup, "enable-cleanup", getEnvBool("ENABLE_CLEANUP", true),
 		"Enable the background cleanup routine for expired sessions. Use false when deploying a webhook-only instance")
 	flag.BoolVar(&config.EnableControllers, "enable-controllers", getEnvBool("ENABLE_CONTROLLERS", true),
-		"Enable Kubernetes reconcilers, controller field indexes, cache invalidation handlers, ClusterConfig checker, and escalation status updater")
+		"Enable Kubernetes reconcilers, cache invalidation handlers, ClusterConfig checker, and escalation status updater. Shared cache field indexes remain enabled")
 	flag.BoolVar(&config.EnableValidatingWebhooks, "enable-validating-webhooks", getEnvBool("ENABLE_VALIDATING_WEBHOOKS", true),
 		"Enable validating webhooks for breakglass CRDs. Disable when running a frontend/API-only instance")
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -112,6 +112,8 @@ func InformerSyncCheck(cache CacheSyncer) func(req *http.Request) error {
 }
 
 type controllerSetupPlan struct {
+	// Cached clients are shared by API and webhook paths, so these indexes are
+	// required even when reconcilers are disabled.
 	registerControllerIndexes bool
 	registerReconcilers       bool
 	attachCachedReconcilers   bool
@@ -119,7 +121,7 @@ type controllerSetupPlan struct {
 
 func newControllerSetupPlan(enableControllers bool) controllerSetupPlan {
 	return controllerSetupPlan{
-		registerControllerIndexes: enableControllers,
+		registerControllerIndexes: true,
 		registerReconcilers:       enableControllers,
 		attachCachedReconcilers:   enableControllers,
 	}
@@ -170,8 +172,6 @@ func Setup(
 		if err := indexer.AssertIndexesRegistered(log); err != nil {
 			return fmt.Errorf("index registration assertion failed: %w", err)
 		}
-	} else {
-		log.Infow("Controller field indexes disabled via --enable-controllers=false")
 	}
 
 	if plan.registerReconcilers {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -172,7 +172,7 @@ func TestControllerSetupPlan(t *testing.T) {
 			name:              "controllers disabled",
 			enableControllers: false,
 			want: controllerSetupPlan{
-				registerControllerIndexes: false,
+				registerControllerIndexes: true,
 				registerReconcilers:       false,
 				attachCachedReconcilers:   false,
 			},

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
+	"github.com/telekom/k8s-breakglass/pkg/breakglass"
 )
 
 // fakeCacheSyncer implements CacheSyncer for testing.
@@ -180,6 +184,70 @@ func TestControllerSetupPlan(t *testing.T) {
 			assert.Equal(t, tt.want, newControllerSetupPlan(tt.enableControllers))
 		})
 	}
+}
+
+type emptyUnindexedListClient struct {
+	client.Client
+	indexed bool
+}
+
+// emptyUnindexedListClient models the cache behavior observed in the
+// authorization deployment: an unregistered field selector produces an empty
+// list instead of a list error.
+func (c *emptyUnindexedListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if !c.indexed {
+		var listOptions client.ListOptions
+		for _, opt := range opts {
+			opt.ApplyToList(&listOptions)
+		}
+		if listOptions.FieldSelector != nil && listOptions.FieldSelector.String() != "" {
+			return nil
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:    "platform-requester@example.com",
+			Cluster: "tind-workload-01.tst.local-dev",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+	plan := newControllerSetupPlan(false)
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session)
+	if plan.registerControllerIndexes {
+		builder = builder.
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+				return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+			}).
+			WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+				return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+			})
+	}
+	cachedClient := builder.Build()
+
+	manager := breakglass.NewSessionManagerWithClient(&emptyUnindexedListClient{
+		Client:  cachedClient,
+		indexed: plan.registerControllerIndexes,
+	})
+	sessions, err := manager.GetClusterUserBreakglassSessions(
+		context.Background(),
+		"tind-workload-01.tst.local-dev",
+		"platform-requester@example.com",
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "approved-session", sessions[0].Name)
 }
 
 func TestNewManager_MetricsServerOptions(t *testing.T) {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -207,7 +207,7 @@ func (c *emptyUnindexedListClient) List(ctx context.Context, list client.ObjectL
 	return c.Client.List(ctx, list, opts...)
 }
 
-func TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled(t *testing.T) {
+func assertAuthorizationSelectionUsesSharedIndexes(t *testing.T, enableControllers bool) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
 
@@ -221,7 +221,7 @@ func TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled(t *testi
 			State: breakglassv1alpha1.SessionStateApproved,
 		},
 	}
-	plan := newControllerSetupPlan(false)
+	plan := newControllerSetupPlan(enableControllers)
 	builder := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(session)
@@ -248,6 +248,14 @@ func TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled(t *testi
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 	assert.Equal(t, "approved-session", sessions[0].Name)
+}
+
+func TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled(t *testing.T) {
+	assertAuthorizationSelectionUsesSharedIndexes(t, false)
+}
+
+func TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled(t *testing.T) {
+	assertAuthorizationSelectionUsesSharedIndexes(t, true)
 }
 
 func TestNewManager_MetricsServerOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
An approved BreakglassSession can be denied by the authorization webhook when controller reconcilers are explicitly disabled because the cache used by the API/webhook session manager has no BreakglassSession field indexes.

## Root cause
- `pkg/webhook/controller.go:781-782` selects sessions through `GetClusterUserBreakglassSessions`.
- `pkg/breakglass/session_manager.go:365-374` performs that lookup with the cached client and `spec.cluster` plus `spec.user` field selectors.
- The shared session manager is built from the reconciler manager's cached client (`cmd/main.go:463-465`).
- The reconciler setup previously registered indexes only when `--enable-controllers` was true.
- `pkg/webhook/manager.go:65-82` registers indexes on a separate webhook manager, which does not configure the reconciler manager cache used by SAR authorization.

## Scope verification
This PR affects configurations that explicitly set `--enable-controllers=false` or `ENABLE_CONTROLLERS=false`.

The default is enabled: `pkg/cli/cli.go:159` uses `getEnvBool("ENABLE_CONTROLLERS", true)`. The T-CaaS deployment manifest checked for this investigation includes `--enable-frontend`, `--enable-api`, `--enable-cleanup`, `--enable-webhooks`, and `--enable-validating-webhooks`, but no `--enable-controllers` argument or `ENABLE_CONTROLLERS` environment variable. A repository search of the function's rendered deployment/configuration returned `No matches found` for both names. Therefore that deployment runs with controllers enabled and this PR is not the explanation for the reported default TIND lab failure.

## Red-green evidence
The first commit (`96ad8db6`) adds the real selection-path reproduction. It seeds an Approved session for `platform-requester@example.com` and `tind-workload-01.tst.local-dev`, applies the production `spec.cluster`/`spec.user` index contract only when the setup plan enables indexes, and models the observed unindexed-cache behavior.

With controllers disabled, before the production fix:

```text
=== RUN   TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled
Error: "[]" should have 1 item(s), but has 0
--- FAIL: TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled
FAIL
```

After the fix:

```text
=== RUN   TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled
--- PASS: TestAuthorizationSelectionUsesSharedIndexesWhenControllersDisabled
PASS
```

The permanent `TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled` comparison runs the same selection path with `newControllerSetupPlan(true)` and registered indexes. It passes against the unmodified code:

```text
=== RUN   TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled
--- PASS: TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled
PASS
```

This confirms the default TIND lab blocker is not caused by the controller-disabled index gate; the cache-coherence failure is addressed separately in PR #1300.

## Fix
The second commit (`50f26e4d`) always registers and asserts common field indexes on the shared reconciler manager. Reconcilers and cached reconciler wiring remain gated by `--enable-controllers`.

## Documentation
Updated the webhook setup guide and `CHANGELOG.md`.

## Verification
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./pkg/webhook/... ./pkg/bgctl/... ./api/... ./pkg/reconciler/... ./pkg/breakglass/...` — all packages passed
- `make test` — all unit-test packages passed under race detection
- `make lint` — `0 issues`

Follow-up: the controllers-enabled cache-coherence failure found during validation is addressed separately in PR #1300.
