### PR TITLE
fix(bgctl): omit content type for empty actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`bgctl session drop` request body**: Send owner session drop actions without
-  a JSON content type, matching the API's empty-body contract (PR #1298).
+- **`bgctl session drop` empty requests**: Omit the JSON `Content-Type` header
+  for empty drop requests, matching the API's empty-body contract (PR #1298).
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bgctl session drop` request body**: Send owner session drop actions without
+  a JSON content type, matching the API's empty-body contract (PR #1298).
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -534,8 +534,7 @@ POST /api/breakglassSessions/{session-name}/withdraw
 Authorization: Bearer <token>
 ```
 
-This action does not accept a request body or `Content-Type` header. Non-empty
-bodies return `400 Bad Request`.
+This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
 
 **Status Code:** `200 OK`
 
@@ -588,7 +587,8 @@ POST /api/breakglassSessions/{session-name}/drop
 Authorization: Bearer <token>
 ```
 
-This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
+This action does not accept a request body. Clients should omit `Content-Type`
+when sending an empty request. Non-empty bodies return `400 Bad Request`.
 
 **Status Codes:**
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -534,7 +534,8 @@ POST /api/breakglassSessions/{session-name}/withdraw
 Authorization: Bearer <token>
 ```
 
-This action does not accept a request body. Non-empty bodies return `400 Bad Request`.
+This action does not accept a request body or `Content-Type` header. Non-empty
+bodies return `400 Bad Request`.
 
 **Status Code:** `200 OK`
 

--- a/pkg/bgctl/client/client.go
+++ b/pkg/bgctl/client/client.go
@@ -168,7 +168,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any, out 
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.Header.Set(CorrelationIDHeader, correlationID)
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)

--- a/pkg/bgctl/client/sessions_test.go
+++ b/pkg/bgctl/client/sessions_test.go
@@ -165,6 +165,7 @@ func TestSessionsRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/breakglassSessions", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		var req SessionRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/bgctl/client/sessions_test.go
+++ b/pkg/bgctl/client/sessions_test.go
@@ -285,6 +285,8 @@ func TestSessionsDrop(t *testing.T) {
 		require.Equal(t, "/api/breakglassSessions/session-123/drop", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Empty(t, r.Header.Get("Content-Type"))
+		_, contentTypePresent := r.Header["Content-Type"]
+		require.False(t, contentTypePresent)
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Empty(t, body)

--- a/pkg/bgctl/client/sessions_test.go
+++ b/pkg/bgctl/client/sessions_test.go
@@ -284,6 +284,7 @@ func TestSessionsDrop(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/breakglassSessions/session-123/drop", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
+		require.Empty(t, r.Header.Get("Content-Type"))
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Empty(t, body)


### PR DESCRIPTION
## Summary
`bgctl session drop` sends an empty action request with `Content-Type: application/json`, while the server contract requires an empty body. The misleading content type causes the API to reject the lifecycle revocation request in affected deployments.

## Root cause
- `pkg/breakglass/session_controller_actions.go:155-160` validates that the drop action has no body via `RequireEmptyBody`.
- `pkg/bgctl/client/sessions.go:135-149` correctly passes a nil payload for `Drop`.
- `pkg/bgctl/client/client.go` nevertheless set `Content-Type: application/json` unconditionally for every request, including nil-payload actions.

## Red-green evidence
The first commit (`88b0e0eb`) adds the request-shape assertion to `TestSessionsDrop`. It verifies POST `/api/breakglassSessions/session-123/drop`, an empty body, and no content type.

Before the production fix, the test failed with the actual defect:

```text
=== RUN   TestSessionsDrop
Error: Should be empty, but was application/json
--- FAIL: TestSessionsDrop
FAIL
```

After the fix, the same test passed:

```text
=== RUN   TestSessionsDrop
--- PASS: TestSessionsDrop
PASS
```

## Fix
The second commit (`2471e9bf`) sets `Content-Type` only when the client actually marshals a request body. Empty actions now send no body and no misleading content type; body-bearing requests remain JSON.

## Documentation
Updated the API reference and `CHANGELOG.md`.

## Verification
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./pkg/webhook/... ./pkg/bgctl/... ./api/... ./pkg/reconciler/... ./pkg/breakglass/...` — all packages passed
- `make test` — all unit-test packages passed under race detection
- `make lint` — `0 issues`
