### PR TITLE
test: cover T-CaaS deployment wiring

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ Every utility is published as an immutable,
 - **[Technical Debt](./TECHNICAL_DEBT.md)** - Known TODOs, future enhancements, and maintenance tracking
 - **[Package Structure](./package-structure.md)** - Sub-package layout of `pkg/breakglass/`
 - **[Release Process](./release-process.md)** - Release signing, provenance, and checklist
+- **[T-CaaS deployment-model E2E coverage audit](./e2e-tcaas-coverage-audit.md)** - Deployment-shape coverage, evidence, and remaining gaps
 
 ## Contributing
 

--- a/docs/e2e-tcaas-coverage-audit.md
+++ b/docs/e2e-tcaas-coverage-audit.md
@@ -1,0 +1,94 @@
+<!--
+SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# T-CaaS deployment-model E2E coverage audit
+
+This audit compares the Breakglass test suites with the management-cluster /
+tenant-cluster deployment used by T-CaaS. The repository's multi-cluster job
+already provides the closest executable model; it is opt-in locally and runs
+in CI as the `Multi-Cluster E2E Tests` job.
+
+## Phase 1 inventory
+
+| Suite | Shape exercised | Evidence |
+| --- | --- | --- |
+| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; CRDs, Keycloak, MailHog, controller deployment, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-475` |
+| `e2e/api/*` without `multicluster` | Single cluster API/UI-facing flows; most sessions are created through API helpers. | `e2e/api/approval_workflow_test.go:56-67`, `e2e/helpers/api.go` |
+| `e2e/api/*` with `multicluster` | One hub plus two real Kind spokes. Spokes use structured authentication and authorization, OIDC tokens, and the hub's authorization route. | `e2e/kind-setup-multi.sh:137-218`, `e2e/api/spoke_hub_authorization_test.go:145-220` |
+| `e2e/cli` | CLI flows against the configured test cluster; shell coverage is opt-in. | `Makefile:183-184`, `.github/workflows/ci.yml:1098-1107` |
+| `pkg/*_test.go` | Unit tests, including fake clients, controller logic, webhook logic, limits, OIDC parsing and email behavior. | `Makefile:121-123` |
+| `pkg/api/api_end_to_end_test.go` | In-process API-to-session/controller integration, not a deployed management/tenant topology. | `pkg/api/api_end_to_end_test.go:1-70` |
+| GitHub Actions | Bootstrap smoke, single-cluster, OIDC comprehensive, UI and multi-cluster jobs. Multi-cluster runs `go test -tags=multicluster ./e2e/api/...`. | `.github/workflows/e2e-smoke.yml:35-70`, `.github/workflows/ci.yml:719-1120`, `1293-1550`, `2291-2735` |
+
+`MAINTAINING.md` and `internal/test/envtest/` are not present in this checkout;
+the envtest-like coverage is colocated with package tests and the Makefile
+uses controller-runtime's standard test dependencies rather than a repository
+`internal/test/envtest` harness.
+
+## Gap matrix
+
+Legend: **covered** means the suite exercises the behavior; **partial** means
+only a unit/static or single-cluster approximation exists; **gap** means the
+T-CaaS shape is not exercised.
+
+| Deployment aspect | Single E2E | Multi-cluster E2E | Package tests | Gap |
+| --- | --- | --- | --- | --- |
+| Frontend/API/cleanup/webhooks/validating-webhooks flags | partial: dev overlay defaults | partial: same overlay | covered as parser/setup-plan cases | No deployed matrix for every toggle |
+| `--enable-controllers` on and off | partial: default-on only | partial: default-on only | covered for parser and setup plan | No deployed controller-off session-selection test on the default branch |
+| Deployed flag combination | partial: `config/deployment/app.yaml:31-50` | partial: overlay-derived | gap | Added deployment-contract assertions in this change |
+| ConfigMap-mounted `--config-path` | covered by `TestBootstrapW003_DeploymentModel` (live Deployment and ConfigMap) | covered: hub setup uses the mounted overlay ConfigMap | covered by config loader tests | — |
+| Different tenant cluster authorizes through management webhook | gap | covered by `spoke_hub_authorization_test.go:145-220` | gap | Existing path is HTTP in the Kind harness, not the T-CaaS external TLS path |
+| Create → approve → real webhook session selection | partial | covered by `spoke_hub_authorization_test.go:174-220` | misleading cases below | Existing test is the primary regression guard |
+| OIDC prefixes and group claims | partial | partial: plain `groups` claims and two realms | covered for prefix stripping | TDI/TDG prefix/delimiter combinations are not deployed |
+| Four-eyes approval and self-approval rejection | covered through API approval suites | partial | covered | No cross-cluster authorization assertion after four-eyes approval |
+| Revocation and expiry remove access | partial | covered: revocation at `spoke_hub_authorization_test.go:237-289`, expiry at `:421+` | covered | — |
+| Per-user, total and group-overridden session limits | gap in deployed E2E | gap in deployed E2E | covered extensively | Expensive setup needed for API lifecycle assertions |
+| Leader election namespace/id | partial: `TestBootstrapW003_DeploymentModel` verifies the live Lease | partial: no multi-replica failover test | partial parser/resource-lock tests | No multi-replica failover test |
+| Email enabled and `--disable-email` | enabled MailHog smoke | disabled path is not deployed | covered with fakes | No deployed toggle matrix |
+| Webhook TLS/cert path | validating webhook resources are installed | CA is generated, but SAR route uses hub HTTP API NodePort | partial | The cross-cluster harness does not currently exercise `:9443` TLS |
+| Metrics and health ports (`8081`, `8082`, `8083`) | metrics/health partial | `8081` partial | covered in server tests | No deployed assertion for all three endpoints |
+| `authorizedTTL`/`unauthorizedTTL` authorization caching | gap | gap: cache explicitly disabled in `kind-setup-multi.sh:185-190` | gap | Needs a Kubernetes apiserver configuration test |
+
+## Tests that bypass production wiring
+
+* `pkg/webhook/authorize_helpers_test.go:96-103` and `:131-141` assign
+  `authorizeState.sessions` directly. They test reason formatting, but cannot
+  detect a broken session list, cache, or field-index registration.
+* `pkg/webhook/controller_test.go:80-95` and the repeated builders in that file
+  hand-register indexes on fake clients. This proves the selector logic only
+  when the test has already supplied the wiring that production startup may
+  omit.
+* `pkg/webhook/error_scenarios_test.go:28-44` and
+  `ratelimit_test.go:246-258` use the same hand-built indexed fake-client
+  pattern; they do not prove `reconciler.Setup` registered those indexes.
+* `e2e/api/hub_spoke_test.go:286-310` and `:326-348` create
+  `BreakglassSession` objects directly with the hub client. These tests verify
+  resource visibility, not the authenticated API request and approval path.
+* `pkg/api/api_end_to_end_test.go:31-50` supplies fake clients and indexes in
+  process. It is useful integration coverage but is not a deployed manager/cache
+  or tenant-apiserver test.
+* `e2e/api/controller_resilience_test.go:260-278` records leader-election
+  claims as log messages only; it does not inspect a Lease or run a second
+  replica.
+
+These tests are not removed: their narrow unit/integration assertions remain
+valuable. They are explicitly not counted as evidence for the T-CaaS
+create/approve/authorize path.
+
+## Existing PRs checked
+
+* [PR #1297](https://github.com/telekom/k8s-breakglass/pull/1297), draft,
+  `fix/webhook-session-index-registration`, base
+  `36c7ce67ddad7ac6b05d6e541f946a4972195eff`, head
+  `50f26e4d81bbb674c8e345fe510e0186df0b4246`. CI was still running when
+  audited; lint, unit, CodeQL, security and manifest checks were green.
+* [PR #1298](https://github.com/telekom/k8s-breakglass/pull/1298), draft,
+  `fix/bgctl-session-drop-request`, base
+  `36c7ce67ddad7ac6b05d6e541f946a4972195eff`, head
+  `2471e9bf11fa76cc5af3bf10a4c746471f99054d`. CI was still running when
+  audited; lint, unit, CodeQL, security and manifest checks were green.
+
+Neither PR is modified by this work.

--- a/docs/e2e-tcaas-coverage-audit.md
+++ b/docs/e2e-tcaas-coverage-audit.md
@@ -15,9 +15,9 @@ in CI as the `Multi-Cluster E2E Tests` job.
 
 | Suite | Shape exercised | Evidence |
 | --- | --- | --- |
-| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; CRDs, Keycloak, MailHog, controller deployment, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-475` |
+| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; controller deployment wiring, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-475`, `:462-622` |
 | `e2e/api/*` without `multicluster` | Single cluster API/UI-facing flows; most sessions are created through API helpers. | `e2e/api/approval_workflow_test.go:56-67`, `e2e/helpers/api.go` |
-| `e2e/api/*` with `multicluster` | One hub plus two real Kind spokes. Spokes use structured authentication and authorization, OIDC tokens, and the hub's authorization route. | `e2e/kind-setup-multi.sh:137-218`, `e2e/api/spoke_hub_authorization_test.go:145-220` |
+| `e2e/api/*` with `multicluster` | One hub plus two real Kind spokes. Spokes use structured authentication and authorization, OIDC tokens, and the hub's authorization route. | `e2e/kind-setup-multi.sh:137-218`, `e2e/api/spoke_hub_authorization_test.go:145-236` |
 | `e2e/cli` | CLI flows against the configured test cluster; shell coverage is opt-in. | `Makefile:183-184`, `.github/workflows/ci.yml:1098-1107` |
 | `pkg/*_test.go` | Unit tests, including fake clients, controller logic, webhook logic, limits, OIDC parsing and email behavior. | `Makefile:121-123` |
 | `pkg/api/api_end_to_end_test.go` | In-process API-to-session/controller integration, not a deployed management/tenant topology. | `pkg/api/api_end_to_end_test.go:1-70` |
@@ -40,16 +40,16 @@ T-CaaS shape is not exercised.
 | `--enable-controllers` on and off | partial: default-on only | partial: default-on only | covered for parser and setup plan | No deployed controller-off session-selection test on the default branch |
 | Deployed flag combination | partial: `config/deployment/app.yaml:31-50` | partial: overlay-derived | gap | Added deployment-contract assertions in this change |
 | ConfigMap-mounted `--config-path` | covered by `TestBootstrapW003_DeploymentModel` (live Deployment and ConfigMap) | covered: hub setup uses the mounted overlay ConfigMap | covered by config loader tests | — |
-| Different tenant cluster authorizes through management webhook | gap | covered by `spoke_hub_authorization_test.go:145-220` | gap | Existing path is HTTP in the Kind harness, not the T-CaaS external TLS path |
-| Create → approve → real webhook session selection | partial | covered by `spoke_hub_authorization_test.go:174-220` | misleading cases below | Existing test is the primary regression guard |
+| Different tenant cluster authorizes through management webhook | gap | covered by `spoke_hub_authorization_test.go:145-236` | gap | Existing path is HTTP in the Kind harness, not the T-CaaS external TLS path |
+| Create → approve → real webhook session selection | partial | covered by `spoke_hub_authorization_test.go:174-236` | misleading cases below | Existing test is the primary regression guard |
 | OIDC prefixes and group claims | partial | partial: plain `groups` claims and two realms | covered for prefix stripping | TDI/TDG prefix/delimiter combinations are not deployed |
 | Four-eyes approval and self-approval rejection | covered through API approval suites | partial | covered | No cross-cluster authorization assertion after four-eyes approval |
-| Revocation and expiry remove access | partial | covered: revocation at `spoke_hub_authorization_test.go:237-289`, expiry at `:421+` | covered | — |
+| Revocation and expiry remove access | partial | covered: revocation at `spoke_hub_authorization_test.go:238-289`, expiry at `:421+` | covered | — |
 | Per-user, total and group-overridden session limits | gap in deployed E2E | gap in deployed E2E | covered extensively | Expensive setup needed for API lifecycle assertions |
 | Leader election namespace/id | partial: `TestBootstrapW003_DeploymentModel` verifies the live Lease | partial: no multi-replica failover test | partial parser/resource-lock tests | No multi-replica failover test |
 | Email enabled and `--disable-email` | enabled MailHog smoke | disabled path is not deployed | covered with fakes | No deployed toggle matrix |
 | Webhook TLS/cert path | validating webhook resources are installed | CA is generated, but SAR route uses hub HTTP API NodePort | partial | The cross-cluster harness does not currently exercise `:9443` TLS |
-| Metrics and health ports (`8081`, `8082`, `8083`) | metrics/health partial | `8081` partial | covered in server tests | No deployed assertion for all three endpoints |
+| Metrics, health and webhook ports (`8081`, `8082`, `8083`, `9443`) | metrics/health partial | `8081` partial | covered in server tests | No deployed assertion for all endpoints |
 | `authorizedTTL`/`unauthorizedTTL` authorization caching | gap | gap: cache explicitly disabled in `kind-setup-multi.sh:185-190` | gap | Needs a Kubernetes apiserver configuration test |
 
 ## Tests that bypass production wiring

--- a/docs/e2e-tcaas-coverage-audit.md
+++ b/docs/e2e-tcaas-coverage-audit.md
@@ -15,7 +15,7 @@ in CI as the `Multi-Cluster E2E Tests` job.
 
 | Suite | Shape exercised | Evidence |
 | --- | --- | --- |
-| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; controller deployment wiring, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-475`, `:462-622` |
+| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; controller deployment wiring, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-625`, `:646-821` |
 | `e2e/api/*` without `multicluster` | Single cluster API/UI-facing flows; most sessions are created through API helpers. | `e2e/api/approval_workflow_test.go:56-67`, `e2e/helpers/api.go` |
 | `e2e/api/*` with `multicluster` | One hub plus two real Kind spokes. Spokes use structured authentication and authorization, OIDC tokens, and the hub's authorization route. | `e2e/kind-setup-multi.sh:137-218`, `e2e/api/spoke_hub_authorization_test.go:145-236` |
 | `e2e/cli` | CLI flows against the configured test cluster; shell coverage is opt-in. | `Makefile:183-184`, `.github/workflows/ci.yml:1098-1107` |

--- a/docs/e2e-tcaas-coverage-audit.md
+++ b/docs/e2e-tcaas-coverage-audit.md
@@ -78,17 +78,13 @@ These tests are not removed: their narrow unit/integration assertions remain
 valuable. They are explicitly not counted as evidence for the T-CaaS
 create/approve/authorize path.
 
-## Existing PRs checked
+## Related upstream PRs
 
-* [PR #1297](https://github.com/telekom/k8s-breakglass/pull/1297), draft,
-  `fix/webhook-session-index-registration`, base
-  `36c7ce67ddad7ac6b05d6e541f946a4972195eff`, head
-  `50f26e4d81bbb674c8e345fe510e0186df0b4246`. CI was still running when
-  audited; lint, unit, CodeQL, security and manifest checks were green.
-* [PR #1298](https://github.com/telekom/k8s-breakglass/pull/1298), draft,
-  `fix/bgctl-session-drop-request`, base
-  `36c7ce67ddad7ac6b05d6e541f946a4972195eff`, head
-  `2471e9bf11fa76cc5af3bf10a4c746471f99054d`. CI was still running when
-  audited; lint, unit, CodeQL, security and manifest checks were green.
-
-Neither PR is modified by this work.
+* [PR #1297](https://github.com/telekom/k8s-breakglass/pull/1297) registers
+  the shared session indexes used by the controller-enabled deployment path.
+* [PR #1298](https://github.com/telekom/k8s-breakglass/pull/1298) fixes the
+  empty JSON request body sent by `bgctl session drop`.
+* [PR #1299](https://github.com/telekom/k8s-breakglass/pull/1299) adds the
+  deployment-contract assertions in this audit.
+* [PR #1300](https://github.com/telekom/k8s-breakglass/pull/1300) covers
+  stale session-cache reads in the live webhook authorization path.

--- a/docs/e2e-tcaas-coverage-audit.md
+++ b/docs/e2e-tcaas-coverage-audit.md
@@ -15,7 +15,7 @@ in CI as the `Multi-Cluster E2E Tests` job.
 
 | Suite | Shape exercised | Evidence |
 | --- | --- | --- |
-| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; controller deployment wiring, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:422-625`, `:646-821` |
+| `e2e/bootstrap_e2e_test.go` | One Kind management cluster; controller deployment wiring, generated webhook kubeconfig and ClusterConfig bootstrap. | `e2e/bootstrap_e2e_test.go:421-643`, `:663-837` |
 | `e2e/api/*` without `multicluster` | Single cluster API/UI-facing flows; most sessions are created through API helpers. | `e2e/api/approval_workflow_test.go:56-67`, `e2e/helpers/api.go` |
 | `e2e/api/*` with `multicluster` | One hub plus two real Kind spokes. Spokes use structured authentication and authorization, OIDC tokens, and the hub's authorization route. | `e2e/kind-setup-multi.sh:137-218`, `e2e/api/spoke_hub_authorization_test.go:145-236` |
 | `e2e/cli` | CLI flows against the configured test cluster; shell coverage is opt-in. | `Makefile:183-184`, `.github/workflows/ci.yml:1098-1107` |
@@ -50,7 +50,7 @@ T-CaaS shape is not exercised.
 | Email enabled and `--disable-email` | enabled MailHog smoke | disabled path is not deployed | covered with fakes | No deployed toggle matrix |
 | Webhook TLS/cert path | validating webhook resources are installed | CA is generated, but SAR route uses hub HTTP API NodePort | partial | The cross-cluster harness does not currently exercise `:9443` TLS |
 | Metrics, health and webhook ports (`8081`, `8082`, `8083`, `9443`) | metrics/health partial | `8081` partial | covered in server tests | No deployed assertion for all endpoints |
-| `authorizedTTL`/`unauthorizedTTL` authorization caching | gap | gap: cache explicitly disabled in `kind-setup-multi.sh:185-190` | gap | Needs a Kubernetes apiserver configuration test |
+| `authorizedTTL`/`unauthorizedTTL` authorization caching | gap | gap: cache explicitly disabled in `kind-setup-multi.sh:199-202` | gap | Needs a Kubernetes apiserver configuration test |
 
 ## Tests that bypass production wiring
 

--- a/e2e/api/spoke_hub_authorization_test.go
+++ b/e2e/api/spoke_hub_authorization_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -232,6 +233,59 @@ func (s *SpokeHubAuthorizationSuite) TestUserWithApprovedSessionAllowed() {
 	t.Logf("✓ kubectl get pods succeeded:\n%s", strings.TrimSpace(output))
 
 	t.Log("=== Complete User Journey Test Passed! ===")
+}
+
+// TestRevokedSessionRemovesSpokeAccess verifies that an approved session is
+// removed from the hub webhook's selection path when an approver cancels it.
+// This is a new cross-cluster lifecycle assertion rather than a defect-fix
+// test: it exercises the real API, cache, webhook and tenant apiserver wiring.
+func (s *SpokeHubAuthorizationSuite) TestRevokedSessionRemovesSpokeAccess() {
+	t := s.T()
+	spokeCluster := s.mcCtx.Config.SpokeAClusterName
+	testUser := helpers.MultiClusterTestUsers.Employee
+
+	t.Log("=== Test: Revoking an approved session removes spoke access ===")
+	userToken := s.mcCtx.GetEmployeeToken(t, s.ctx)
+	userAPI := helpers.NewAPIClientWithAuth(userToken)
+	userAPI.BaseURL = s.mcCtx.Config.HubAPIURL
+	userAPI = userAPI.WithCleanupClient(s.hubClient, s.namespace)
+
+	session, err := userAPI.CreateSessionAndWaitForPending(s.ctx, t, helpers.SessionRequest{
+		Cluster: spokeCluster,
+		User:    testUser.Email,
+		Group:   "breakglass-read-only",
+		Reason:  "E2E Test - approved session revocation removes spoke access",
+	}, helpers.WaitForStateTimeout)
+	s.Require().NoError(err, "session should be created through the management API")
+	s.cleanup.Add(session)
+
+	s.Require().NoError(
+		s.approverAPI.ApproveSessionViaAPI(s.ctx, t, session.Name, session.Namespace),
+		"approver should approve the session through the management API",
+	)
+	helpers.WaitForSessionState(t, s.ctx, s.hubClient, session.Name, session.Namespace,
+		breakglassv1alpha1.SessionStateApproved, helpers.WaitForStateTimeout)
+
+	kubeconfig := s.getOIDCKubeconfig(spokeCluster)
+	output, err := s.runKubectlWithToken(kubeconfig, userToken, "get", "pods", "-n", "default")
+	s.Require().NoError(err, "approved session should allow spoke access: %s", output)
+
+	s.Require().NoError(
+		s.approverAPI.CancelSessionViaAPI(s.ctx, t, session.Name, session.Namespace),
+		"approver should cancel the approved session through the management API",
+	)
+	helpers.WaitForSessionState(t, s.ctx, s.hubClient, session.Name, session.Namespace,
+		breakglassv1alpha1.SessionStateExpired, helpers.WaitForStateTimeout)
+
+	var deniedOutput string
+	require.Eventually(t, func() bool {
+		var requestErr error
+		deniedOutput, requestErr = s.runKubectlWithToken(kubeconfig, userToken, "get", "pods", "-n", "default")
+		return requestErr != nil &&
+			(strings.Contains(deniedOutput, "forbidden") || strings.Contains(deniedOutput, "Forbidden"))
+	}, 30*time.Second, helpers.PollInterval, "cancelled session must no longer allow spoke access")
+	t.Logf("Revoked-session authorization response: %s", strings.TrimSpace(deniedOutput))
+	t.Log("=== Session revocation removed spoke access as expected ===")
 }
 
 // TestSessionClusterScopeEnforced verifies that a session on one cluster does not

--- a/e2e/bootstrap_e2e_test.go
+++ b/e2e/bootstrap_e2e_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -456,6 +457,186 @@ func TestBootstrapW001_ControllerDeploymentReady(t *testing.T) {
 	}
 	assert.True(t, imageFound,
 		"at least one container in deployment %s should use image containing %q", deployName, expectedImage)
+}
+
+// TestBootstrapW003_DeploymentModel verifies that the deployed controller
+// exposes the ports and startup arguments used by the management cluster
+// deployment model, including the ConfigMap-backed configuration path.
+func TestBootstrapW003_DeploymentModel(t *testing.T) {
+	skipUnlessE2E(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cli := setupClient(t)
+	deployName, err := findDeploymentByLabel(ctx, cli, bootstrapSystem, "app=breakglass")
+	require.NoError(t, err, "breakglass controller deployment should exist")
+
+	var deploy appsv1.Deployment
+	require.NoError(t,
+		cli.Get(ctx, client.ObjectKey{Namespace: bootstrapSystem, Name: deployName}, &deploy),
+		"failed to get controller deployment",
+	)
+
+	var container *corev1.Container
+	for i := range deploy.Spec.Template.Spec.Containers {
+		if deploy.Spec.Template.Spec.Containers[i].Name == "breakglass" {
+			container = &deploy.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, container, "deployment must contain the breakglass container")
+
+	args := make(map[string]struct{}, len(container.Args))
+	for _, arg := range container.Args {
+		args[arg] = struct{}{}
+	}
+	for _, arg := range []string{
+		"--config-path=/config/config.yaml",
+		"--pod-namespace=$(POD_NAMESPACE)",
+		"--metrics-bind-address=:8081",
+		"--health-probe-bind-address=:8082",
+		"--leader-elect-namespace=$(POD_NAMESPACE)",
+		"--leader-elect-id=breakglass.telekom.io",
+		"--escalation-status-update-interval=10m",
+		"--enable-frontend=true",
+		"--enable-api=true",
+		"--enable-cleanup=true",
+		"--enable-webhooks=true",
+		"--enable-validating-webhooks=true",
+		"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
+		"--webhook-bind-address=0.0.0.0:9443",
+		"--webhooks-metrics-bind-address=:8083",
+		"--webhooks-metrics-secure=false",
+	} {
+		assert.Contains(t, args, arg, "deployment argument must preserve the T-CaaS startup contract")
+	}
+	assert.True(t,
+		hasAnyArg(args, "--cluster-config-check-interval=10m", "--cluster-config-check-interval=10s"),
+		"deployment must configure the cluster check interval (T-CaaS uses 10m; the Kind overlay shortens it to 10s)",
+	)
+
+	// T-CaaS omits --enable-controllers and therefore relies on its CLI default
+	// (true). If the rendered deployment supplies an argument or environment
+	// override, verify that effective setting is still enabled.
+	controllersEnabled := true
+	for arg := range args {
+		if strings.HasPrefix(arg, "--enable-controllers=") {
+			controllersEnabled = isTruthy(arg[len("--enable-controllers="):])
+			break
+		}
+	}
+	for _, env := range container.Env {
+		if env.Name != "ENABLE_CONTROLLERS" {
+			continue
+		}
+		require.Nil(t, env.ValueFrom, "ENABLE_CONTROLLERS must not use an unresolved value source")
+		if env.Value != "" {
+			controllersEnabled = isTruthy(env.Value)
+		}
+	}
+	require.True(t, controllersEnabled,
+		"the T-CaaS deployment model must not disable controllers")
+
+	var configMount, tmpMount, certMount *corev1.VolumeMount
+	for i := range container.VolumeMounts {
+		switch container.VolumeMounts[i].MountPath {
+		case "/config/":
+			configMount = &container.VolumeMounts[i]
+		case "/tmp":
+			tmpMount = &container.VolumeMounts[i]
+		case "/tmp/k8s-webhook-server/serving-certs":
+			certMount = &container.VolumeMounts[i]
+		}
+	}
+	require.NotNil(t, configMount, "deployment must mount /config/")
+	require.True(t, configMount.ReadOnly, "the ConfigMap-backed /config/ mount must be read-only")
+	require.NotNil(t, tmpMount, "deployment must mount writable /tmp for webhook certificates")
+	require.False(t, tmpMount.ReadOnly, "the webhook certificate mount must be writable")
+	require.NotNil(t, certMount, "deployment must mount the configured webhook certificate path")
+	require.True(t, certMount.ReadOnly, "webhook certificates must be mounted read-only")
+
+	var configVolume *corev1.Volume
+	for i := range deploy.Spec.Template.Spec.Volumes {
+		if deploy.Spec.Template.Spec.Volumes[i].Name == configMount.Name {
+			configVolume = &deploy.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, configVolume, "the /config/ volume must be declared")
+	require.NotNil(t, configVolume.ConfigMap, "the /config/ volume must come from a ConfigMap")
+	require.NotEmpty(t, configVolume.ConfigMap.Name, "the /config/ ConfigMap name must be set")
+
+	var certVolume *corev1.Volume
+	for i := range deploy.Spec.Template.Spec.Volumes {
+		if deploy.Spec.Template.Spec.Volumes[i].Name == certMount.Name {
+			certVolume = &deploy.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, certVolume, "the webhook certificate volume must be declared")
+	require.NotNil(t, certVolume.Secret, "the webhook certificate volume must come from a Secret")
+	require.NotEmpty(t, certVolume.Secret.SecretName, "the webhook certificate Secret name must be set")
+
+	var configMap corev1.ConfigMap
+	require.NoError(t,
+		cli.Get(ctx, client.ObjectKey{
+			Namespace: bootstrapSystem,
+			Name:      configVolume.ConfigMap.Name,
+		}, &configMap),
+		"the mounted configuration ConfigMap must exist",
+	)
+	require.Contains(t, configMap.Data, "config.yaml",
+		"the mounted ConfigMap must provide config.yaml")
+
+	var podNamespaceEnv *corev1.EnvVar
+	for i := range container.Env {
+		if container.Env[i].Name == "POD_NAMESPACE" {
+			podNamespaceEnv = &container.Env[i]
+			break
+		}
+	}
+	require.NotNil(t, podNamespaceEnv, "POD_NAMESPACE must be injected into the container")
+	require.NotNil(t, podNamespaceEnv.ValueFrom, "POD_NAMESPACE must use a downward API fieldRef")
+	require.NotNil(t, podNamespaceEnv.ValueFrom.FieldRef, "POD_NAMESPACE must use a fieldRef")
+	assert.Equal(t, "metadata.namespace", podNamespaceEnv.ValueFrom.FieldRef.FieldPath)
+
+	expectedPorts := map[int32]bool{8080: false, 8081: false, 8082: false, 8083: false}
+	for _, port := range container.Ports {
+		if _, ok := expectedPorts[port.ContainerPort]; ok {
+			expectedPorts[port.ContainerPort] = true
+		}
+	}
+	for port, found := range expectedPorts {
+		assert.True(t, found, "breakglass container must expose port %d", port)
+	}
+
+	var lease coordinationv1.Lease
+	require.NoError(t,
+		cli.Get(ctx, client.ObjectKey{
+			Namespace: bootstrapSystem,
+			Name:      "breakglass.telekom.io",
+		}, &lease),
+		"leader election must create the configured Lease",
+	)
+}
+
+func hasAnyArg(args map[string]struct{}, expected ...string) bool {
+	for _, arg := range expected {
+		if _, ok := args[arg]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(value) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 // --- W-002: Webhook kubeconfig ---

--- a/e2e/bootstrap_e2e_test.go
+++ b/e2e/bootstrap_e2e_test.go
@@ -623,6 +623,20 @@ func TestBootstrapW003_DeploymentModel(t *testing.T) {
 		}, &lease),
 		"leader election must create the configured Lease",
 	)
+
+	var idp breakglassv1alpha1.IdentityProvider
+	require.NoError(t,
+		cli.Get(ctx, client.ObjectKey{Name: "breakglass-e2e-idp"}, &idp),
+		"the bootstrap IdentityProvider must exist",
+	)
+	for _, condition := range idp.Status.Conditions {
+		if breakglassv1alpha1.IdentityProviderConditionType(condition.Type) == breakglassv1alpha1.IdentityProviderConditionReady {
+			assert.Equal(t, metav1.ConditionTrue, condition.Status,
+				"the bootstrap IdentityProvider must be reconciled Ready when controllers are enabled")
+			return
+		}
+	}
+	require.Fail(t, "the bootstrap IdentityProvider must have a Ready condition when controllers are enabled")
 }
 
 func hasAnyArg(args map[string]struct{}, expected ...string) bool {

--- a/e2e/bootstrap_e2e_test.go
+++ b/e2e/bootstrap_e2e_test.go
@@ -516,31 +516,33 @@ func TestBootstrapW003_DeploymentModel(t *testing.T) {
 		"deployment must configure the cluster check interval (T-CaaS uses 10m; the Kind overlay shortens it to 10s)",
 	)
 
-	// T-CaaS omits --enable-controllers and therefore relies on its CLI default
-	// (true). If the rendered deployment supplies an argument or environment
-	// override, verify that effective setting is still enabled.
-	controllersEnabled := true
-	controllerFlagSupplied := false
+	// T-CaaS omits --enable-controllers and therefore relies on the running
+	// controller effect below to verify the default. Explicit overrides must
+	// still leave controllers enabled.
+	var controllerOverride *bool
 	for arg := range args {
 		if strings.HasPrefix(arg, "--enable-controllers=") {
-			controllerFlagSupplied = true
-			controllersEnabled = isTruthy(arg[len("--enable-controllers="):])
+			enabled := isTruthy(arg[len("--enable-controllers="):])
+			controllerOverride = &enabled
 			break
 		}
 	}
-	if !controllerFlagSupplied {
+	if controllerOverride == nil {
 		for _, env := range container.Env {
 			if env.Name != "ENABLE_CONTROLLERS" {
 				continue
 			}
 			require.Nil(t, env.ValueFrom, "ENABLE_CONTROLLERS must not use an unresolved value source")
 			if env.Value != "" {
-				controllersEnabled = isTruthy(env.Value)
+				enabled := isTruthy(env.Value)
+				controllerOverride = &enabled
 			}
 		}
 	}
-	require.True(t, controllersEnabled,
-		"the T-CaaS deployment model must not disable controllers")
+	if controllerOverride != nil {
+		require.True(t, *controllerOverride,
+			"the T-CaaS deployment model must not disable controllers")
+	}
 
 	var configMount, tmpMount, certMount *corev1.VolumeMount
 	for i := range container.VolumeMounts {
@@ -629,14 +631,15 @@ func TestBootstrapW003_DeploymentModel(t *testing.T) {
 		cli.Get(ctx, client.ObjectKey{Name: "breakglass-e2e-idp"}, &idp),
 		"the bootstrap IdentityProvider must exist",
 	)
+	ready := false
 	for _, condition := range idp.Status.Conditions {
 		if breakglassv1alpha1.IdentityProviderConditionType(condition.Type) == breakglassv1alpha1.IdentityProviderConditionReady {
-			assert.Equal(t, metav1.ConditionTrue, condition.Status,
-				"the bootstrap IdentityProvider must be reconciled Ready when controllers are enabled")
-			return
+			ready = condition.Status == metav1.ConditionTrue
+			break
 		}
 	}
-	require.Fail(t, "the bootstrap IdentityProvider must have a Ready condition when controllers are enabled")
+	require.True(t, ready,
+		"the bootstrap IdentityProvider must be reconciled Ready, proving the effective controller default is enabled")
 }
 
 func hasAnyArg(args map[string]struct{}, expected ...string) bool {

--- a/e2e/bootstrap_e2e_test.go
+++ b/e2e/bootstrap_e2e_test.go
@@ -520,19 +520,23 @@ func TestBootstrapW003_DeploymentModel(t *testing.T) {
 	// (true). If the rendered deployment supplies an argument or environment
 	// override, verify that effective setting is still enabled.
 	controllersEnabled := true
+	controllerFlagSupplied := false
 	for arg := range args {
 		if strings.HasPrefix(arg, "--enable-controllers=") {
+			controllerFlagSupplied = true
 			controllersEnabled = isTruthy(arg[len("--enable-controllers="):])
 			break
 		}
 	}
-	for _, env := range container.Env {
-		if env.Name != "ENABLE_CONTROLLERS" {
-			continue
-		}
-		require.Nil(t, env.ValueFrom, "ENABLE_CONTROLLERS must not use an unresolved value source")
-		if env.Value != "" {
-			controllersEnabled = isTruthy(env.Value)
+	if !controllerFlagSupplied {
+		for _, env := range container.Env {
+			if env.Name != "ENABLE_CONTROLLERS" {
+				continue
+			}
+			require.Nil(t, env.ValueFrom, "ENABLE_CONTROLLERS must not use an unresolved value source")
+			if env.Value != "" {
+				controllersEnabled = isTruthy(env.Value)
+			}
 		}
 	}
 	require.True(t, controllersEnabled,
@@ -601,7 +605,7 @@ func TestBootstrapW003_DeploymentModel(t *testing.T) {
 	require.NotNil(t, podNamespaceEnv.ValueFrom.FieldRef, "POD_NAMESPACE must use a fieldRef")
 	assert.Equal(t, "metadata.namespace", podNamespaceEnv.ValueFrom.FieldRef.FieldPath)
 
-	expectedPorts := map[int32]bool{8080: false, 8081: false, 8082: false, 8083: false}
+	expectedPorts := map[int32]bool{8080: false, 8081: false, 8082: false, 8083: false, 9443: false}
 	for _, port := range container.Ports {
 		if _, ok := expectedPorts[port.ContainerPort]; ok {
 			expectedPorts[port.ContainerPort] = true


### PR DESCRIPTION
## Summary

- Add the Phase 1 T-CaaS deployment-model coverage audit and gap matrix.
- Add bootstrap E2E coverage that inspects the live Breakglass Deployment, verifies the T-CaaS startup contract, ConfigMap-backed `/config/config.yaml`, webhook certificate volume, exposed ports, downward-API namespace, and configured leader-election Lease.
- Explicitly document tests that bypass production wiring and the existing multi-cluster create → approve → authorize regression guard.

## Scope

The existing `multicluster` suite already exercises the highest-blast-radius path: a real OIDC-authenticated tenant apiserver sends authorization requests to the management Breakglass webhook after a session is created and approved through the API. This PR adds the missing deployed wiring assertions without modifying PRs #1297 or #1298.

The new test is new coverage of working behavior, not a defect-fix test, so a red-then-green defect run is not applicable. The existing defect-driven multi-cluster test remains behavior-based and meaningful after #1297 lands.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./e2e/helpers/... ./pkg/webhook ./pkg/reconciler -count=1` ✅
- `go test -tags=e2e_bootstrap ./e2e/... -run '^TestBootstrapW003_DeploymentModel$' -count=1` ✅ (compile/skip without a cluster)
- `make test` ✅
- `make lint` ✅ (`0 issues`)

Full live Kind E2E was not run locally because Docker/Kind is not available in this worktree; CI's bootstrap and multi-cluster jobs run the live tests.
