### PR TITLE
fix(webhook): refresh stale session cache reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Authorization webhook session selection**: Register shared BreakglassSession
+  field indexes even when reconcilers are disabled, so approved sessions remain
+  discoverable by the SubjectAccessReview path (PR #1297).
+- **`bgctl session drop` empty requests**: Omit the JSON `Content-Type` header
+  for empty drop requests, matching the API's empty-body contract (PR #1298).
 - **Authorization webhook cache consistency**: Refresh session selection from
-  the live API reader when an indexed cache lookup is empty, avoiding transient
-  denials immediately after approval (PR #1300).
+  the live API reader when an indexed cache lookup has no currently eligible
+  session, avoiding transient denials after approval or cache lag (PR #1300).
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Authorization webhook session selection**: Register shared BreakglassSession
-  field indexes even when reconcilers are disabled, so approved sessions remain
-  discoverable by the SubjectAccessReview path (PR #1297).
-- **`bgctl session drop` empty requests**: Omit the JSON `Content-Type` header
-  for empty drop requests, matching the API's empty-body contract (PR #1298).
+- **Authorization webhook cache consistency**: Refresh session selection from
+  the live API reader when an indexed cache lookup is empty, avoiding transient
+  denials immediately after approval (PR #1300).
 - **Diagnostic collector traversal bound**: Crashdump enumeration now uses
   bounded NUL spools and fixed directory/regular-file filters while retaining
   the 30-second process-group deadline, exact entry/candidate diagnostics, and

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -178,12 +178,6 @@ Notes on matching behavior
 
 - The `{cluster-name}` path segment is used by the webhook to determine which managed cluster the request targets. The webhook will match this value against the following, in order of relevance:
   - `ClusterConfig.metadata.name` (recommended canonical identifier)
-
-### Cache consistency after approval
-
-Authorization selection normally uses the indexed shared cache. If that cache
-has not observed a newly approved session yet, the selection path refreshes
-from the live API reader before deciding that no session exists.
   - `BreakglassSession.spec.cluster` values present on active sessions
   - Entries listed in `BreakglassEscalation.spec.allowed.clusters` for escalation-based checks
 
@@ -191,12 +185,11 @@ from the live API reader before deciding that no session exists.
 
 - If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook immediately denies the request with a human-friendly message (`Cluster "foo" is not registered with Breakglass`) and emits a `cluster-missing` reason in metrics. This reduces confusion for platform users and surfaces onboarding gaps early. Create the missing ClusterConfig or update the webhook URL path to match an existing name.
 
-### Split deployments
+### Cache consistency after approval
 
-The API and authorization webhook use the reconciler manager's shared cache to
-select `BreakglassSession` resources. The session field indexes remain enabled
-when controller reconcilers are disabled, so split deployments continue to
-discover approved sessions by cluster and user.
+Authorization selection normally uses the indexed shared cache. If that cache
+has not observed a newly approved session yet, the selection path refreshes
+from the live API reader before deciding that no session exists.
 
 ### Authentication Methods
 

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -178,6 +178,12 @@ Notes on matching behavior
 
 - The `{cluster-name}` path segment is used by the webhook to determine which managed cluster the request targets. The webhook will match this value against the following, in order of relevance:
   - `ClusterConfig.metadata.name` (recommended canonical identifier)
+
+### Cache consistency after approval
+
+Authorization selection normally uses the indexed shared cache. If that cache
+has not observed a newly approved session yet, the selection path refreshes
+from the live API reader before deciding that no session exists.
   - `BreakglassSession.spec.cluster` values present on active sessions
   - Entries listed in `BreakglassEscalation.spec.allowed.clusters` for escalation-based checks
 

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -185,6 +185,13 @@ Notes on matching behavior
 
 - If a ClusterConfig is not present for the provided `{cluster-name}`, the webhook immediately denies the request with a human-friendly message (`Cluster "foo" is not registered with Breakglass`) and emits a `cluster-missing` reason in metrics. This reduces confusion for platform users and surfaces onboarding gaps early. Create the missing ClusterConfig or update the webhook URL path to match an existing name.
 
+### Split deployments
+
+The API and authorization webhook use the reconciler manager's shared cache to
+select `BreakglassSession` resources. The session field indexes remain enabled
+when controller reconcilers are disabled, so split deployments continue to
+discover approved sessions by cluster and user.
+
 ### Cache consistency after approval
 
 Authorization selection normally uses the indexed shared cache. If that cache

--- a/pkg/breakglass/session_controller_approval_utils.go
+++ b/pkg/breakglass/session_controller_approval_utils.go
@@ -481,6 +481,18 @@ func IsSessionRetained(session breakglassv1alpha1.BreakglassSession) bool {
 	return time.Now().After(session.Status.RetainedUntil.Time)
 }
 
+// IsSessionAuthorizationEligible reports whether a session can currently grant access.
+func IsSessionAuthorizationEligible(session breakglassv1alpha1.BreakglassSession, now time.Time) bool {
+	if IsSessionRetained(session) ||
+		session.Status.State != breakglassv1alpha1.SessionStateApproved ||
+		!session.Status.RejectedAt.IsZero() ||
+		session.Status.ExpiresAt.IsZero() ||
+		!session.Status.ExpiresAt.After(now) {
+		return false
+	}
+	return true
+}
+
 func collectAuthIdentifiers(email, username, userID string) []string {
 	identifiers := make([]string, 0, 3)
 	if email != "" {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/metrics"
@@ -24,9 +25,13 @@ type SessionManager struct {
 	client.Client
 	reader          client.Reader
 	liveReader      client.Reader
+	liveFallbackMu  sync.Mutex
+	liveFallbackAt  map[string]time.Time
 	log             *zap.SugaredLogger
 	logFallbackOnce sync.Once
 }
+
+const liveReaderNegativeCacheTTL = time.Second
 
 // getLogger returns the injected logger or falls back to the global logger.
 // Callers should prefer passing a logger via WithSessionLogger to avoid
@@ -394,8 +399,21 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 		return filtered, nil
 	}
 	if len(bsl.Items) == 0 && c.liveReader != nil {
+		fallbackKey := cluster + "\x00" + user
+		if !c.allowLiveReaderFallback(fallbackKey, time.Now()) {
+			return bsl.Items, nil
+		}
 		var liveList breakglassv1alpha1.BreakglassSessionList
-		if err := c.liveReader.List(ctx, &liveList); err != nil {
+		err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
+			"spec.cluster": cluster,
+			"spec.user":    user,
+		})
+		if err != nil {
+			if IsFieldIndexError(err) {
+				err = c.liveReader.List(ctx, &liveList)
+			}
+		}
+		if err != nil {
 			log.Warnw("Failed to refresh BreakglassSessions from live reader after empty cache lookup",
 				"cluster", cluster, "user", user, "error", err)
 			return bsl.Items, nil
@@ -407,6 +425,7 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 			}
 		}
 		if len(filtered) > 0 {
+			c.clearLiveReaderFallback(fallbackKey)
 			log.Infow("Fetched BreakglassSessions from live reader after empty cache lookup",
 				"count", len(filtered), "cluster", cluster, "user", user)
 		}
@@ -414,6 +433,26 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 	}
 	log.Infow("Fetched BreakglassSessions (indexed)", "count", len(bsl.Items), "cluster", cluster, "user", user)
 	return bsl.Items, nil
+}
+
+func (c *SessionManager) allowLiveReaderFallback(key string, now time.Time) bool {
+	c.liveFallbackMu.Lock()
+	defer c.liveFallbackMu.Unlock()
+
+	if last, ok := c.liveFallbackAt[key]; ok && now.Sub(last) < liveReaderNegativeCacheTTL {
+		return false
+	}
+	if c.liveFallbackAt == nil {
+		c.liveFallbackAt = make(map[string]time.Time)
+	}
+	c.liveFallbackAt[key] = now
+	return true
+}
+
+func (c *SessionManager) clearLiveReaderFallback(key string) {
+	c.liveFallbackMu.Lock()
+	defer c.liveFallbackMu.Unlock()
+	delete(c.liveFallbackAt, key)
 }
 
 // GetBreakglassSessions with custom field selector string.

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -579,12 +579,6 @@ func (c *SessionManager) recordLiveReaderFallback(key string, now time.Time) {
 	c.liveFallbackAt[key] = now
 }
 
-func (c *SessionManager) clearLiveReaderFallback(key string) {
-	c.liveFallbackMu.Lock()
-	defer c.liveFallbackMu.Unlock()
-	delete(c.liveFallbackAt, key)
-}
-
 // GetBreakglassSessions with custom field selector string.
 func (c *SessionManager) GetBreakglassSessionsWithSelectorString(ctx context.Context,
 	selectorString string,

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -3,7 +3,6 @@ package breakglass
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -454,9 +453,6 @@ func (c *SessionManager) refreshClusterUserBreakglassSessions(ctx context.Contex
 	if !refreshed {
 		return cached, refreshed, nil
 	}
-	if sessionResultsEqual(cached, live) {
-		c.recordLiveReaderFallback(fallbackKey, time.Now())
-	}
 	return live, true, nil
 }
 
@@ -541,25 +537,6 @@ func mergeSessionResults(cached, live []breakglassv1alpha1.BreakglassSession) []
 		result = append(result, session)
 	}
 	return result
-}
-
-func sessionResultsEqual(left, right []breakglassv1alpha1.BreakglassSession) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	rightByKey := make(map[string]breakglassv1alpha1.BreakglassSession, len(right))
-	for _, session := range right {
-		rightByKey[session.Namespace+"/"+session.Name] = session
-	}
-	for _, session := range left {
-		other, ok := rightByKey[session.Namespace+"/"+session.Name]
-		if !ok ||
-			!reflect.DeepEqual(session.Spec, other.Spec) ||
-			!reflect.DeepEqual(session.Status, other.Status) {
-			return false
-		}
-	}
-	return true
 }
 
 func (c *SessionManager) liveReaderFallbackSuppressed(key string, now time.Time) bool {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -36,6 +36,7 @@ type SessionManager struct {
 }
 
 const liveReaderNegativeCacheTTL = time.Second
+const liveReaderRefreshTimeout = 10 * time.Second
 
 // getLogger returns the injected logger or falls back to the global logger.
 // Callers should prefer passing a logger via WithSessionLogger to avoid
@@ -468,14 +469,16 @@ func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Cont
 	if c.liveReaderFallbackSuppressed(fallbackKey, time.Now()) {
 		return nil, false
 	}
-	value, _, _ := c.liveFallbackFlight.Do(fallbackKey, func() (interface{}, error) {
+	resultCh := c.liveFallbackFlight.DoChan(fallbackKey, func() (interface{}, error) {
+		opCtx, cancel := context.WithTimeout(context.Background(), liveReaderRefreshTimeout)
+		defer cancel()
 		var liveList breakglassv1alpha1.BreakglassSessionList
-		err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
+		err := c.liveReader.List(opCtx, &liveList, client.MatchingFields{
 			"spec.cluster": cluster,
 			"spec.user":    user,
 		})
 		if err != nil && IsFieldIndexError(err) {
-			err = c.liveReader.List(ctx, &liveList)
+			err = c.liveReader.List(opCtx, &liveList)
 		}
 		if err != nil {
 			log.Warnw("Failed to refresh BreakglassSessions from live reader after cache lookup found no eligible session",
@@ -494,6 +497,13 @@ func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Cont
 		c.recordLiveReaderFallback(fallbackKey, time.Now())
 		return liveFallbackResult{sessions: filtered, success: true}, nil
 	})
+	var value interface{}
+	select {
+	case result := <-resultCh:
+		value = result.Val
+	case <-ctx.Done():
+		return nil, false
+	}
 	fallback, ok := value.(liveFallbackResult)
 	if !ok || !fallback.success {
 		return nil, false

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -429,13 +429,13 @@ func (c *SessionManager) RefreshClusterUserBreakglassSessions(ctx context.Contex
 	}
 	fallbackKey := cluster + "\x00" + user
 	live, refreshed := c.fetchLiveClusterUserBreakglassSessions(ctx, cluster, user, fallbackKey, c.getLogger())
-	if !refreshed || len(live) == 0 {
+	if !refreshed {
 		return cached, refreshed, nil
 	}
 	if sessionResultsEqual(cached, live) {
 		c.recordLiveReaderFallback(fallbackKey, time.Now())
 	}
-	return mergeSessionResults(cached, live), true, nil
+	return live, true, nil
 }
 
 func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Context,

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -23,6 +23,7 @@ import (
 type SessionManager struct {
 	client.Client
 	reader          client.Reader
+	liveReader      client.Reader
 	log             *zap.SugaredLogger
 	logFallbackOnce sync.Once
 }
@@ -82,17 +83,19 @@ func NewSessionManager(contextName string) (*SessionManager, error) {
 // configured with the Breakglass scheme.
 // Configuration is applied via functional options (WithSessionLogger).
 func NewSessionManagerWithClient(c client.Client, opts ...SessionManagerOption) *SessionManager {
-	return NewSessionManagerWithClientAndReader(c, c, opts...)
+	return NewSessionManagerWithClientAndReader(c, nil, opts...)
 }
 
 // NewSessionManagerWithClientAndReader allows using a cached client for writes and an optional reader
 // (e.g., APIReader) for consistent reads when required.
 // Configuration is applied via functional options (WithSessionLogger).
 func NewSessionManagerWithClientAndReader(c client.Client, reader client.Reader, opts ...SessionManagerOption) *SessionManager {
-	if reader == nil {
-		reader = c
-	}
 	sm := &SessionManager{Client: c, reader: reader}
+	if reader == nil {
+		sm.reader = c
+	} else {
+		sm.liveReader = reader
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(sm)
@@ -387,6 +390,25 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 			if s.Spec.Cluster == cluster && s.Spec.User == user {
 				filtered = append(filtered, s)
 			}
+		}
+		return filtered, nil
+	}
+	if len(bsl.Items) == 0 && c.liveReader != nil {
+		var liveList breakglassv1alpha1.BreakglassSessionList
+		if err := c.liveReader.List(ctx, &liveList); err != nil {
+			log.Warnw("Failed to refresh BreakglassSessions from live reader after empty cache lookup",
+				"cluster", cluster, "user", user, "error", err)
+			return bsl.Items, nil
+		}
+		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
+		for _, s := range liveList.Items {
+			if s.Spec.Cluster == cluster && s.Spec.User == user {
+				filtered = append(filtered, s)
+			}
+		}
+		if len(filtered) > 0 {
+			log.Infow("Fetched BreakglassSessions from live reader after empty cache lookup",
+				"count", len(filtered), "cluster", cluster, "user", user)
 		}
 		return filtered, nil
 	}

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -434,8 +434,6 @@ func (c *SessionManager) RefreshClusterUserBreakglassSessions(ctx context.Contex
 	}
 	if sessionResultsEqual(cached, live) {
 		c.recordLiveReaderFallback(fallbackKey, time.Now())
-	} else {
-		c.clearLiveReaderFallback(fallbackKey)
 	}
 	return mergeSessionResults(cached, live), true, nil
 }
@@ -470,10 +468,9 @@ func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Cont
 			}
 		}
 		if hasAuthorizationEligibleSession(filtered, time.Now()) {
-			c.clearLiveReaderFallback(fallbackKey)
-		} else {
-			c.recordLiveReaderFallback(fallbackKey, time.Now())
+			return liveFallbackResult{sessions: filtered, success: true}, nil
 		}
+		c.recordLiveReaderFallback(fallbackKey, time.Now())
 		return liveFallbackResult{sessions: filtered, success: true}, nil
 	})
 	fallback, ok := value.(liveFallbackResult)

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -427,6 +427,27 @@ func (c *SessionManager) RefreshClusterUserBreakglassSessions(ctx context.Contex
 	if err != nil || c.liveReader == nil {
 		return cached, false, err
 	}
+	return c.refreshClusterUserBreakglassSessions(ctx, cluster, user, cached)
+}
+
+// RefreshClusterUserBreakglassSessionsWithCached refreshes a previously loaded
+// cluster/user result without issuing a second cached lookup.
+func (c *SessionManager) RefreshClusterUserBreakglassSessionsWithCached(ctx context.Context,
+	cluster string,
+	user string,
+	cached []breakglassv1alpha1.BreakglassSession,
+) ([]breakglassv1alpha1.BreakglassSession, bool, error) {
+	if c.liveReader == nil {
+		return cached, false, nil
+	}
+	return c.refreshClusterUserBreakglassSessions(ctx, cluster, user, cached)
+}
+
+func (c *SessionManager) refreshClusterUserBreakglassSessions(ctx context.Context,
+	cluster string,
+	user string,
+	cached []breakglassv1alpha1.BreakglassSession,
+) ([]breakglassv1alpha1.BreakglassSession, bool, error) {
 	fallbackKey := cluster + "\x00" + user
 	live, refreshed := c.fetchLiveClusterUserBreakglassSessions(ctx, cluster, user, fallbackKey, c.getLogger())
 	if !refreshed {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -398,7 +398,7 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 		}
 		return filtered, nil
 	}
-	if len(bsl.Items) == 0 && c.liveReader != nil {
+	if c.liveReader != nil && !hasApprovedSession(bsl.Items) {
 		fallbackKey := cluster + "\x00" + user
 		if !c.allowLiveReaderFallback(fallbackKey, time.Now()) {
 			return bsl.Items, nil
@@ -426,19 +426,48 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 		}
 		if len(filtered) > 0 {
 			c.clearLiveReaderFallback(fallbackKey)
-			log.Infow("Fetched BreakglassSessions from live reader after empty cache lookup",
-				"count", len(filtered), "cluster", cluster, "user", user)
+			result := append([]breakglassv1alpha1.BreakglassSession(nil), bsl.Items...)
+			positions := make(map[string]int, len(result))
+			for _, s := range bsl.Items {
+				positions[s.Namespace+"/"+s.Name] = len(positions)
+			}
+			for _, s := range filtered {
+				key := s.Namespace + "/" + s.Name
+				if position, exists := positions[key]; exists {
+					result[position] = s
+					continue
+				}
+				positions[key] = len(result)
+				result = append(result, s)
+			}
+			log.Infow("Fetched BreakglassSessions from live reader after cache lookup found no approved session",
+				"count", len(result), "cluster", cluster, "user", user)
+			return result, nil
 		}
-		return filtered, nil
+		return bsl.Items, nil
 	}
 	log.Infow("Fetched BreakglassSessions (indexed)", "count", len(bsl.Items), "cluster", cluster, "user", user)
 	return bsl.Items, nil
+}
+
+func hasApprovedSession(sessions []breakglassv1alpha1.BreakglassSession) bool {
+	for _, session := range sessions {
+		if session.Status.State == breakglassv1alpha1.SessionStateApproved {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *SessionManager) allowLiveReaderFallback(key string, now time.Time) bool {
 	c.liveFallbackMu.Lock()
 	defer c.liveFallbackMu.Unlock()
 
+	for cachedKey, last := range c.liveFallbackAt {
+		if now.Sub(last) >= liveReaderNegativeCacheTTL {
+			delete(c.liveFallbackAt, cachedKey)
+		}
+	}
 	if last, ok := c.liveFallbackAt[key]; ok && now.Sub(last) < liveReaderNegativeCacheTTL {
 		return false
 	}

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -24,13 +24,14 @@ import (
 // SessionManager is kubernetes client based object for managing CRUD operation on BreakglassSession custom resource.
 type SessionManager struct {
 	client.Client
-	reader             client.Reader
-	liveReader         client.Reader
-	liveFallbackMu     sync.Mutex
-	liveFallbackAt     map[string]time.Time
-	liveFallbackFlight singleflight.Group
-	log                *zap.SugaredLogger
-	logFallbackOnce    sync.Once
+	reader              client.Reader
+	liveReader          client.Reader
+	liveFallbackMu      sync.Mutex
+	liveFallbackAt      map[string]time.Time
+	liveFallbackSweepAt time.Time
+	liveFallbackFlight  singleflight.Group
+	log                 *zap.SugaredLogger
+	logFallbackOnce     sync.Once
 }
 
 const liveReaderNegativeCacheTTL = time.Second
@@ -402,47 +403,78 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 	}
 	if c.liveReader != nil && !hasAuthorizationEligibleSession(bsl.Items, time.Now()) {
 		fallbackKey := cluster + "\x00" + user
-		if c.liveReaderFallbackSuppressed(fallbackKey, time.Now()) {
+		fallback, refreshed := c.fetchLiveClusterUserBreakglassSessions(ctx, cluster, user, fallbackKey, log)
+		if !refreshed || len(fallback) == 0 {
 			return bsl.Items, nil
 		}
-		value, _, _ := c.liveFallbackFlight.Do(fallbackKey, func() (interface{}, error) {
-			var liveList breakglassv1alpha1.BreakglassSessionList
-			err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
-				"spec.cluster": cluster,
-				"spec.user":    user,
-			})
-			if err != nil && IsFieldIndexError(err) {
-				err = c.liveReader.List(ctx, &liveList)
-			}
-			if err != nil {
-				log.Warnw("Failed to refresh BreakglassSessions from live reader after cache lookup found no eligible session",
-					"cluster", cluster, "user", user, "error", err)
-				return liveFallbackResult{}, nil
-			}
-			filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
-			for _, s := range liveList.Items {
-				if s.Spec.Cluster == cluster && s.Spec.User == user {
-					filtered = append(filtered, s)
-				}
-			}
-			if len(filtered) == 0 {
-				c.recordLiveReaderFallback(fallbackKey, time.Now())
-			} else {
-				c.clearLiveReaderFallback(fallbackKey)
-			}
-			return liveFallbackResult{sessions: filtered, success: true}, nil
-		})
-		fallback, ok := value.(liveFallbackResult)
-		if !ok || !fallback.success || len(fallback.sessions) == 0 {
-			return bsl.Items, nil
-		}
-		result := mergeSessionResults(bsl.Items, fallback.sessions)
+		result := mergeSessionResults(bsl.Items, fallback)
 		log.Infow("Fetched BreakglassSessions from live reader after cache lookup found no eligible session",
 			"count", len(result), "cluster", cluster, "user", user)
 		return result, nil
 	}
 	log.Infow("Fetched BreakglassSessions (indexed)", "count", len(bsl.Items), "cluster", cluster, "user", user)
 	return bsl.Items, nil
+}
+
+// RefreshClusterUserBreakglassSessions refreshes a cached cluster/user lookup
+// after the cached sessions failed to authorize a specific request.
+func (c *SessionManager) RefreshClusterUserBreakglassSessions(ctx context.Context,
+	cluster string,
+	user string,
+) ([]breakglassv1alpha1.BreakglassSession, bool, error) {
+	cached, err := c.GetClusterUserBreakglassSessions(ctx, cluster, user)
+	if err != nil || c.liveReader == nil {
+		return cached, false, err
+	}
+	fallbackKey := cluster + "\x00" + user
+	live, refreshed := c.fetchLiveClusterUserBreakglassSessions(ctx, cluster, user, fallbackKey, c.getLogger())
+	if !refreshed || len(live) == 0 {
+		return cached, refreshed, nil
+	}
+	return mergeSessionResults(cached, live), true, nil
+}
+
+func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Context,
+	cluster string,
+	user string,
+	fallbackKey string,
+	log *zap.SugaredLogger,
+) ([]breakglassv1alpha1.BreakglassSession, bool) {
+	if c.liveReaderFallbackSuppressed(fallbackKey, time.Now()) {
+		return nil, false
+	}
+	value, _, _ := c.liveFallbackFlight.Do(fallbackKey, func() (interface{}, error) {
+		var liveList breakglassv1alpha1.BreakglassSessionList
+		err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
+			"spec.cluster": cluster,
+			"spec.user":    user,
+		})
+		if err != nil && IsFieldIndexError(err) {
+			err = c.liveReader.List(ctx, &liveList)
+		}
+		if err != nil {
+			log.Warnw("Failed to refresh BreakglassSessions from live reader after cache lookup found no eligible session",
+				"cluster", cluster, "user", user, "error", err)
+			return liveFallbackResult{}, nil
+		}
+		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
+		for _, s := range liveList.Items {
+			if s.Spec.Cluster == cluster && s.Spec.User == user {
+				filtered = append(filtered, s)
+			}
+		}
+		if hasAuthorizationEligibleSession(filtered, time.Now()) {
+			c.clearLiveReaderFallback(fallbackKey)
+		} else {
+			c.recordLiveReaderFallback(fallbackKey, time.Now())
+		}
+		return liveFallbackResult{sessions: filtered, success: true}, nil
+	})
+	fallback, ok := value.(liveFallbackResult)
+	if !ok || !fallback.success {
+		return nil, false
+	}
+	return fallback.sessions, true
 }
 
 type liveFallbackResult struct {
@@ -481,10 +513,13 @@ func (c *SessionManager) liveReaderFallbackSuppressed(key string, now time.Time)
 	c.liveFallbackMu.Lock()
 	defer c.liveFallbackMu.Unlock()
 
-	for cachedKey, last := range c.liveFallbackAt {
-		if now.Sub(last) >= liveReaderNegativeCacheTTL {
-			delete(c.liveFallbackAt, cachedKey)
+	if c.liveFallbackSweepAt.IsZero() || now.Sub(c.liveFallbackSweepAt) >= liveReaderNegativeCacheTTL {
+		for cachedKey, last := range c.liveFallbackAt {
+			if now.Sub(last) >= liveReaderNegativeCacheTTL {
+				delete(c.liveFallbackAt, cachedKey)
+			}
 		}
+		c.liveFallbackSweepAt = now
 	}
 	if last, ok := c.liveFallbackAt[key]; ok && now.Sub(last) < liveReaderNegativeCacheTTL {
 		return true

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -3,6 +3,7 @@ package breakglass
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -431,6 +432,11 @@ func (c *SessionManager) RefreshClusterUserBreakglassSessions(ctx context.Contex
 	if !refreshed || len(live) == 0 {
 		return cached, refreshed, nil
 	}
+	if sessionResultsEqual(cached, live) {
+		c.recordLiveReaderFallback(fallbackKey, time.Now())
+	} else {
+		c.clearLiveReaderFallback(fallbackKey)
+	}
 	return mergeSessionResults(cached, live), true, nil
 }
 
@@ -507,6 +513,25 @@ func mergeSessionResults(cached, live []breakglassv1alpha1.BreakglassSession) []
 		result = append(result, session)
 	}
 	return result
+}
+
+func sessionResultsEqual(left, right []breakglassv1alpha1.BreakglassSession) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	rightByKey := make(map[string]breakglassv1alpha1.BreakglassSession, len(right))
+	for _, session := range right {
+		rightByKey[session.Namespace+"/"+session.Name] = session
+	}
+	for _, session := range left {
+		other, ok := rightByKey[session.Namespace+"/"+session.Name]
+		if !ok ||
+			!reflect.DeepEqual(session.Spec, other.Spec) ||
+			!reflect.DeepEqual(session.Status, other.Status) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *SessionManager) liveReaderFallbackSuppressed(key string, now time.Time) bool {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/system"
 	"github.com/telekom/k8s-breakglass/pkg/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -23,12 +24,13 @@ import (
 // SessionManager is kubernetes client based object for managing CRUD operation on BreakglassSession custom resource.
 type SessionManager struct {
 	client.Client
-	reader          client.Reader
-	liveReader      client.Reader
-	liveFallbackMu  sync.Mutex
-	liveFallbackAt  map[string]time.Time
-	log             *zap.SugaredLogger
-	logFallbackOnce sync.Once
+	reader             client.Reader
+	liveReader         client.Reader
+	liveFallbackMu     sync.Mutex
+	liveFallbackAt     map[string]time.Time
+	liveFallbackFlight singleflight.Group
+	log                *zap.SugaredLogger
+	logFallbackOnce    sync.Once
 }
 
 const liveReaderNegativeCacheTTL = time.Second
@@ -398,68 +400,84 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 		}
 		return filtered, nil
 	}
-	if c.liveReader != nil && !hasApprovedSession(bsl.Items) {
+	if c.liveReader != nil && !hasAuthorizationEligibleSession(bsl.Items, time.Now()) {
 		fallbackKey := cluster + "\x00" + user
-		if !c.allowLiveReaderFallback(fallbackKey, time.Now()) {
+		if c.liveReaderFallbackSuppressed(fallbackKey, time.Now()) {
 			return bsl.Items, nil
 		}
-		var liveList breakglassv1alpha1.BreakglassSessionList
-		err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
-			"spec.cluster": cluster,
-			"spec.user":    user,
-		})
-		if err != nil {
-			if IsFieldIndexError(err) {
+		value, _, _ := c.liveFallbackFlight.Do(fallbackKey, func() (interface{}, error) {
+			var liveList breakglassv1alpha1.BreakglassSessionList
+			err := c.liveReader.List(ctx, &liveList, client.MatchingFields{
+				"spec.cluster": cluster,
+				"spec.user":    user,
+			})
+			if err != nil && IsFieldIndexError(err) {
 				err = c.liveReader.List(ctx, &liveList)
 			}
-		}
-		if err != nil {
-			log.Warnw("Failed to refresh BreakglassSessions from live reader after empty cache lookup",
-				"cluster", cluster, "user", user, "error", err)
+			if err != nil {
+				log.Warnw("Failed to refresh BreakglassSessions from live reader after cache lookup found no eligible session",
+					"cluster", cluster, "user", user, "error", err)
+				return liveFallbackResult{}, nil
+			}
+			filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
+			for _, s := range liveList.Items {
+				if s.Spec.Cluster == cluster && s.Spec.User == user {
+					filtered = append(filtered, s)
+				}
+			}
+			if len(filtered) == 0 {
+				c.recordLiveReaderFallback(fallbackKey, time.Now())
+			} else {
+				c.clearLiveReaderFallback(fallbackKey)
+			}
+			return liveFallbackResult{sessions: filtered, success: true}, nil
+		})
+		fallback, ok := value.(liveFallbackResult)
+		if !ok || !fallback.success || len(fallback.sessions) == 0 {
 			return bsl.Items, nil
 		}
-		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
-		for _, s := range liveList.Items {
-			if s.Spec.Cluster == cluster && s.Spec.User == user {
-				filtered = append(filtered, s)
-			}
-		}
-		if len(filtered) > 0 {
-			c.clearLiveReaderFallback(fallbackKey)
-			result := append([]breakglassv1alpha1.BreakglassSession(nil), bsl.Items...)
-			positions := make(map[string]int, len(result))
-			for _, s := range bsl.Items {
-				positions[s.Namespace+"/"+s.Name] = len(positions)
-			}
-			for _, s := range filtered {
-				key := s.Namespace + "/" + s.Name
-				if position, exists := positions[key]; exists {
-					result[position] = s
-					continue
-				}
-				positions[key] = len(result)
-				result = append(result, s)
-			}
-			log.Infow("Fetched BreakglassSessions from live reader after cache lookup found no approved session",
-				"count", len(result), "cluster", cluster, "user", user)
-			return result, nil
-		}
-		return bsl.Items, nil
+		result := mergeSessionResults(bsl.Items, fallback.sessions)
+		log.Infow("Fetched BreakglassSessions from live reader after cache lookup found no eligible session",
+			"count", len(result), "cluster", cluster, "user", user)
+		return result, nil
 	}
 	log.Infow("Fetched BreakglassSessions (indexed)", "count", len(bsl.Items), "cluster", cluster, "user", user)
 	return bsl.Items, nil
 }
 
-func hasApprovedSession(sessions []breakglassv1alpha1.BreakglassSession) bool {
+type liveFallbackResult struct {
+	sessions []breakglassv1alpha1.BreakglassSession
+	success  bool
+}
+
+func hasAuthorizationEligibleSession(sessions []breakglassv1alpha1.BreakglassSession, now time.Time) bool {
 	for _, session := range sessions {
-		if session.Status.State == breakglassv1alpha1.SessionStateApproved {
+		if IsSessionAuthorizationEligible(session, now) {
 			return true
 		}
 	}
 	return false
 }
 
-func (c *SessionManager) allowLiveReaderFallback(key string, now time.Time) bool {
+func mergeSessionResults(cached, live []breakglassv1alpha1.BreakglassSession) []breakglassv1alpha1.BreakglassSession {
+	result := append([]breakglassv1alpha1.BreakglassSession(nil), cached...)
+	positions := make(map[string]int, len(result))
+	for _, session := range result {
+		positions[session.Namespace+"/"+session.Name] = len(positions)
+	}
+	for _, session := range live {
+		key := session.Namespace + "/" + session.Name
+		if position, exists := positions[key]; exists {
+			result[position] = session
+			continue
+		}
+		positions[key] = len(result)
+		result = append(result, session)
+	}
+	return result
+}
+
+func (c *SessionManager) liveReaderFallbackSuppressed(key string, now time.Time) bool {
 	c.liveFallbackMu.Lock()
 	defer c.liveFallbackMu.Unlock()
 
@@ -469,13 +487,18 @@ func (c *SessionManager) allowLiveReaderFallback(key string, now time.Time) bool
 		}
 	}
 	if last, ok := c.liveFallbackAt[key]; ok && now.Sub(last) < liveReaderNegativeCacheTTL {
-		return false
+		return true
 	}
+	return false
+}
+
+func (c *SessionManager) recordLiveReaderFallback(key string, now time.Time) {
+	c.liveFallbackMu.Lock()
+	defer c.liveFallbackMu.Unlock()
 	if c.liveFallbackAt == nil {
 		c.liveFallbackAt = make(map[string]time.Time)
 	}
 	c.liveFallbackAt[key] = now
-	return true
 }
 
 func (c *SessionManager) clearLiveReaderFallback(key string) {

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -319,7 +319,8 @@ func TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale(t *
 			Cluster: "tind-workload-01.tst.local-dev",
 		},
 		Status: breakglassv1alpha1.BreakglassSessionStatus{
-			State: breakglassv1alpha1.SessionStateApproved,
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
 		},
 	}
 	cachedClient := fake.NewClientBuilder().
@@ -364,7 +365,8 @@ func TestSessionManager_AuthorizationSelectionRefreshesStalePendingCache(t *test
 			Cluster: "tind-workload-01.tst.local-dev",
 		},
 		Status: breakglassv1alpha1.BreakglassSessionStatus{
-			State: breakglassv1alpha1.SessionStatePending,
+			State:     breakglassv1alpha1.SessionStatePending,
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
 		},
 	}
 	liveSession := cachedSession.DeepCopy()

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -401,7 +401,7 @@ func TestSessionManager_AuthorizationSelectionRefreshesStalePendingCache(t *test
 	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, sessions[0].Status.State)
 }
 
-func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.T) {
+func TestSessionManager_AuthorizationSelectionNegativeCachesLiveResponseWithoutEligibleSession(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
 
@@ -414,6 +414,17 @@ func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.
 			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
 		}).
 		Build()
+	retainedSession := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "retained-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster: "tind-workload-01.tst.local-dev",
+			User:    "platform-requester@example.com",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:         breakglassv1alpha1.SessionStateExpired,
+			RetainedUntil: metav1.NewTime(time.Now().Add(time.Hour)),
+		},
+	}
 	liveReads := 0
 	liveReader := stubReader{
 		listFn: func(list client.ObjectList) error {
@@ -421,21 +432,78 @@ func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.
 			if _, ok := list.(*breakglassv1alpha1.BreakglassSessionList); !ok {
 				return fmt.Errorf("unexpected list type %T", list)
 			}
+			list.(*breakglassv1alpha1.BreakglassSessionList).Items = []breakglassv1alpha1.BreakglassSession{retainedSession}
 			return nil
 		},
 	}
 	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
 
-	for range 2 {
+	for i := range 2 {
 		sessions, err := manager.GetClusterUserBreakglassSessions(
 			context.Background(),
 			"tind-workload-01.tst.local-dev",
 			"platform-requester@example.com",
 		)
 		require.NoError(t, err)
-		require.Empty(t, sessions)
+		if i == 0 {
+			require.Len(t, sessions, 1)
+			assert.Equal(t, breakglassv1alpha1.SessionStateExpired, sessions[0].Status.State)
+		} else {
+			require.Empty(t, sessions)
+		}
 	}
 	assert.Equal(t, 1, liveReads)
+}
+
+func TestSessionManager_RefreshReturnsNewGrantWhenCachedGrantCannotAuthorize(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+	now := time.Now()
+	cached := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "cached-viewer"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:      "cluster",
+			User:         "user@example.com",
+			GrantedGroup: "viewers",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(now.Add(time.Hour)),
+		},
+	}
+	newGrant := cached
+	newGrant.Name = "new-admin"
+	newGrant.Spec.GrantedGroup = "admins"
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&cached).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			list.(*breakglassv1alpha1.BreakglassSessionList).Items = []breakglassv1alpha1.BreakglassSession{cached, newGrant}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	initial, err := manager.GetClusterUserBreakglassSessions(context.Background(), "cluster", "user@example.com")
+	require.NoError(t, err)
+	require.Len(t, initial, 1)
+	assert.Equal(t, "viewers", initial[0].Spec.GrantedGroup)
+
+	refreshed, didRefresh, err := manager.RefreshClusterUserBreakglassSessions(
+		context.Background(), "cluster", "user@example.com",
+	)
+	require.NoError(t, err)
+	assert.True(t, didRefresh)
+	require.Len(t, refreshed, 2)
+	assert.Equal(t, "admins", refreshed[1].Spec.GrantedGroup)
 }
 
 func TestSessionManager_AuthorizationSelectionDeduplicatesLiveFallback(t *testing.T) {
@@ -562,6 +630,7 @@ func TestSessionManager_LiveFallbackEvictsExpiredEntries(t *testing.T) {
 
 	manager.recordLiveReaderFallback("expired", now.Add(-2*liveReaderNegativeCacheTTL))
 	manager.recordLiveReaderFallback("fresh", now)
+	manager.liveReaderFallbackSuppressed("other", now)
 
 	manager.liveFallbackMu.Lock()
 	defer manager.liveFallbackMu.Unlock()

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -306,6 +306,51 @@ func TestSessionManager_FieldSelectorMethods(t *testing.T) {
 	})
 }
 
+func TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	session := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:    "platform-requester@example.com",
+			Cluster: "tind-workload-01.tst.local-dev",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStateApproved,
+		},
+	}
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			sessionList, ok := list.(*breakglassv1alpha1.BreakglassSessionList)
+			if !ok {
+				return fmt.Errorf("unexpected list type %T", list)
+			}
+			sessionList.Items = []breakglassv1alpha1.BreakglassSession{session}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	sessions, err := manager.GetClusterUserBreakglassSessions(
+		context.Background(),
+		"tind-workload-01.tst.local-dev",
+		"platform-requester@example.com",
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "approved-session", sessions[0].Name)
+}
+
 func TestSessionManager_LoggerInjection(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(Scheme).Build()
 

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -351,6 +352,54 @@ func TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale(t *
 	assert.Equal(t, "approved-session", sessions[0].Name)
 }
 
+func TestSessionManager_AuthorizationSelectionRefreshesStalePendingCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	cachedSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:    "platform-requester@example.com",
+			Cluster: "tind-workload-01.tst.local-dev",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State: breakglassv1alpha1.SessionStatePending,
+		},
+	}
+	liveSession := cachedSession.DeepCopy()
+	liveSession.Status.State = breakglassv1alpha1.SessionStateApproved
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cachedSession).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			sessionList, ok := list.(*breakglassv1alpha1.BreakglassSessionList)
+			if !ok {
+				return fmt.Errorf("unexpected list type %T", list)
+			}
+			sessionList.Items = []breakglassv1alpha1.BreakglassSession{*liveSession}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	sessions, err := manager.GetClusterUserBreakglassSessions(
+		context.Background(),
+		"tind-workload-01.tst.local-dev",
+		"platform-requester@example.com",
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, breakglassv1alpha1.SessionStateApproved, sessions[0].Status.State)
+}
+
 func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
@@ -386,6 +435,19 @@ func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.
 		require.Empty(t, sessions)
 	}
 	assert.Equal(t, 1, liveReads)
+}
+
+func TestSessionManager_LiveFallbackEvictsExpiredEntries(t *testing.T) {
+	manager := &SessionManager{}
+	now := time.Now()
+
+	manager.allowLiveReaderFallback("expired", now.Add(-2*liveReaderNegativeCacheTTL))
+	manager.allowLiveReaderFallback("fresh", now)
+
+	manager.liveFallbackMu.Lock()
+	defer manager.liveFallbackMu.Unlock()
+	_, expiredPresent := manager.liveFallbackAt["expired"]
+	assert.False(t, expiredPresent)
 }
 
 func TestSessionManager_LoggerInjection(t *testing.T) {

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -351,6 +351,43 @@ func TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale(t *
 	assert.Equal(t, "approved-session", sessions[0].Name)
 }
 
+func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveReads := 0
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			liveReads++
+			if _, ok := list.(*breakglassv1alpha1.BreakglassSessionList); !ok {
+				return fmt.Errorf("unexpected list type %T", list)
+			}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	for range 2 {
+		sessions, err := manager.GetClusterUserBreakglassSessions(
+			context.Background(),
+			"tind-workload-01.tst.local-dev",
+			"platform-requester@example.com",
+		)
+		require.NoError(t, err)
+		require.Empty(t, sessions)
+	}
+	assert.Equal(t, 1, liveReads)
+}
+
 func TestSessionManager_LoggerInjection(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(Scheme).Build()
 

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -3,6 +3,7 @@ package breakglass
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -437,12 +438,130 @@ func TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss(t *testing.
 	assert.Equal(t, 1, liveReads)
 }
 
+func TestSessionManager_AuthorizationSelectionDeduplicatesLiveFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveSession := breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:    "platform-requester@example.com",
+			Cluster: "tind-workload-01.tst.local-dev",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
+		},
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	liveReads := 0
+	var readsMu sync.Mutex
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			readsMu.Lock()
+			liveReads++
+			readsMu.Unlock()
+			startedOnce.Do(func() { close(started) })
+			<-release
+			list.(*breakglassv1alpha1.BreakglassSessionList).Items = []breakglassv1alpha1.BreakglassSession{liveSession}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	var wg sync.WaitGroup
+	results := make(chan []breakglassv1alpha1.BreakglassSession, 2)
+	call := func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sessions, err := manager.GetClusterUserBreakglassSessions(
+				context.Background(),
+				"tind-workload-01.tst.local-dev",
+				"platform-requester@example.com",
+			)
+			require.NoError(t, err)
+			results <- sessions
+		}()
+	}
+	call()
+	<-started
+	call()
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(results)
+
+	assert.Equal(t, 1, liveReads)
+	for sessions := range results {
+		require.Len(t, sessions, 1)
+		assert.Equal(t, "approved-session", sessions[0].Name)
+	}
+}
+
+func TestSessionManager_AuthorizationSelectionRefreshesExpiredApprovedCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, breakglassv1alpha1.AddToScheme(scheme))
+
+	now := time.Now()
+	cachedSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approved-session"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User:    "platform-requester@example.com",
+			Cluster: "tind-workload-01.tst.local-dev",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(now.Add(-time.Minute)),
+		},
+	}
+	liveSession := cachedSession.DeepCopy()
+	liveSession.Status.ExpiresAt = metav1.NewTime(now.Add(time.Hour))
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cachedSession).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		}).
+		Build()
+	liveReader := stubReader{
+		listFn: func(list client.ObjectList) error {
+			list.(*breakglassv1alpha1.BreakglassSessionList).Items = []breakglassv1alpha1.BreakglassSession{*liveSession}
+			return nil
+		},
+	}
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	sessions, err := manager.GetClusterUserBreakglassSessions(
+		context.Background(),
+		"tind-workload-01.tst.local-dev",
+		"platform-requester@example.com",
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.True(t, sessions[0].Status.ExpiresAt.After(now))
+}
+
 func TestSessionManager_LiveFallbackEvictsExpiredEntries(t *testing.T) {
 	manager := &SessionManager{}
 	now := time.Now()
 
-	manager.allowLiveReaderFallback("expired", now.Add(-2*liveReaderNegativeCacheTTL))
-	manager.allowLiveReaderFallback("fresh", now)
+	manager.recordLiveReaderFallback("expired", now.Add(-2*liveReaderNegativeCacheTTL))
+	manager.recordLiveReaderFallback("fresh", now)
 
 	manager.liveFallbackMu.Lock()
 	defer manager.liveFallbackMu.Unlock()

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -606,10 +606,14 @@ func TestSessionManager_AuthorizationSelectionDeduplicatesLiveFallback(t *testin
 
 	var wg sync.WaitGroup
 	results := make(chan []breakglassv1alpha1.BreakglassSession, 2)
-	call := func() {
+	secondStarted := make(chan struct{})
+	call := func(started chan struct{}) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			if started != nil {
+				close(started)
+			}
 			sessions, err := manager.GetClusterUserBreakglassSessions(
 				context.Background(),
 				"tind-workload-01.tst.local-dev",
@@ -619,10 +623,10 @@ func TestSessionManager_AuthorizationSelectionDeduplicatesLiveFallback(t *testin
 			results <- sessions
 		}()
 	}
-	call()
+	call(nil)
 	<-started
-	call()
-	time.Sleep(20 * time.Millisecond)
+	call(secondStarted)
+	<-secondStarted
 	close(release)
 	wg.Wait()
 	close(results)

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -20,18 +20,72 @@ import (
 )
 
 type stubReader struct {
-	listFn func(list client.ObjectList) error
+	listFn         func(list client.ObjectList) error
+	listFnWithOpts func(list client.ObjectList, opts []client.ListOption) error
 }
 
 func (s stubReader) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
 	return nil
 }
 
-func (s stubReader) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+func (s stubReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if s.listFnWithOpts != nil {
+		return s.listFnWithOpts(list, opts)
+	}
 	if s.listFn != nil {
 		return s.listFn(list)
 	}
 	return nil
+}
+
+func TestSessionManager_LiveFallbackSelectorsAndErrors(t *testing.T) {
+	t.Run("passes cluster and user selectors", func(t *testing.T) {
+		var got client.ListOptions
+		reader := stubReader{listFnWithOpts: func(list client.ObjectList, opts []client.ListOption) error {
+			for _, opt := range opts {
+				opt.ApplyToList(&got)
+			}
+			return nil
+		}}
+		manager := &SessionManager{liveReader: reader}
+		_, refreshed := manager.fetchLiveClusterUserBreakglassSessions(
+			context.Background(), "cluster", "user", "cluster\x00user", zap.NewNop().Sugar(),
+		)
+		require.True(t, refreshed)
+		assert.Contains(t, got.FieldSelector.String(), "spec.cluster=cluster")
+		assert.Contains(t, got.FieldSelector.String(), "spec.user=user")
+	})
+
+	t.Run("falls back only for unsupported selectors", func(t *testing.T) {
+		calls := 0
+		reader := stubReader{listFn: func(list client.ObjectList) error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("no index with name spec.cluster")
+			}
+			return nil
+		}}
+		manager := &SessionManager{liveReader: reader}
+		_, refreshed := manager.fetchLiveClusterUserBreakglassSessions(
+			context.Background(), "cluster", "user", "cluster\x00user", zap.NewNop().Sugar(),
+		)
+		require.True(t, refreshed)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("does not retry non-selector errors", func(t *testing.T) {
+		calls := 0
+		reader := stubReader{listFn: func(list client.ObjectList) error {
+			calls++
+			return fmt.Errorf("forbidden")
+		}}
+		manager := &SessionManager{liveReader: reader}
+		_, refreshed := manager.fetchLiveClusterUserBreakglassSessions(
+			context.Background(), "cluster", "user", "cluster\x00user", zap.NewNop().Sugar(),
+		)
+		assert.False(t, refreshed)
+		assert.Equal(t, 1, calls)
+	})
 }
 
 func TestSessionManager_Simple(t *testing.T) {

--- a/pkg/breakglass/session_state_helpers_test.go
+++ b/pkg/breakglass/session_state_helpers_test.go
@@ -277,6 +277,58 @@ func TestIsSessionRetained_TimeVariants(t *testing.T) {
 	}
 }
 
+func TestIsSessionAuthorizationEligible(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		session breakglassv1alpha1.BreakglassSession
+		want    bool
+	}{
+		{
+			name: "approved and unexpired",
+			session: breakglassv1alpha1.BreakglassSession{Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: metav1.NewTime(now.Add(time.Minute)),
+			}},
+			want: true,
+		},
+		{
+			name: "expired approved",
+			session: breakglassv1alpha1.BreakglassSession{Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: metav1.NewTime(now.Add(-time.Minute)),
+			}},
+		},
+		{
+			name: "pending",
+			session: breakglassv1alpha1.BreakglassSession{Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStatePending,
+				ExpiresAt: metav1.NewTime(now.Add(time.Minute)),
+			}},
+		},
+		{
+			name: "rejected approval",
+			session: breakglassv1alpha1.BreakglassSession{Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:      breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt:  metav1.NewTime(now.Add(time.Minute)),
+				RejectedAt: metav1.NewTime(now.Add(-time.Minute)),
+			}},
+		},
+		{
+			name: "missing expiry",
+			session: breakglassv1alpha1.BreakglassSession{Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State: breakglassv1alpha1.SessionStateApproved,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSessionAuthorizationEligible(tt.session, now))
+		})
+	}
+}
+
 // TestIsSessionValid tests the IsSessionValid function
 func TestIsSessionValid(t *testing.T) {
 	t.Run("empty state is invalid", func(t *testing.T) {

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -328,13 +328,17 @@ func (wc *WebhookController) checkEarlyDebugSession(c *gin.Context, s *authorize
 // evaluateDenyPolicies runs global and per-session deny-policy evaluation.
 // Returns handled=true if a deny response was written.
 func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeState) bool {
-	return wc.evaluateDenyPoliciesInternal(c, s, true)
+	return wc.evaluateDenyPoliciesInternal(c, s, true, true)
 }
 
-func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *authorizeState, refreshOnSessionDeny bool) bool {
-	s.phases.StartPhase() // Start deny_policy phase
+func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *authorizeState, refreshOnSessionDeny, trackPhase bool) bool {
+	if trackPhase {
+		s.phases.StartPhase() // Start deny_policy phase
+	}
 	if s.sar.Spec.ResourceAttributes == nil {
-		s.phases.EndPhase(PhaseDenyPolicy)
+		if trackPhase {
+			s.phases.EndPhase(PhaseDenyPolicy)
+		}
 		return false
 	}
 
@@ -370,10 +374,10 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 			}
 			needsLabels, checkErr := wc.denyEval.RequiresNamespaceLabels(s.ctx, actions...)
 			if checkErr != nil {
-				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-label-check", checkErr)
+				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-label-check", checkErr, trackPhase)
 			}
 			if needsLabels {
-				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-labels", err)
+				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-labels", err, trackPhase)
 			}
 			// NamespaceLabels will be nil; pattern-only namespace rules remain evaluable.
 		} else {
@@ -398,7 +402,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 	// Global deny-policy evaluation
 	if denied, pol, podSecResult, derr := wc.denyEval.MatchWithDetails(s.ctx, act); derr != nil {
 		s.reqLog.With("error", derr.Error(), "action", act).Error("deny evaluation error")
-		return wc.denyPolicyEvaluationFailure(c, s, act, "global", derr)
+		return wc.denyPolicyEvaluationFailure(c, s, act, "global", derr, trackPhase)
 	} else {
 		// Emit pod security audit event if we have a result
 		if podSecResult != nil {
@@ -431,7 +435,9 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 			wc.emitPolicyDenialAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, "global")
 
 			reason := wc.buildDenyPolicyReason(s, pol)
-			s.phases.EndPhase(PhaseDenyPolicy)
+			if trackPhase {
+				s.phases.EndPhase(PhaseDenyPolicy)
+			}
 			s.phases.LogSummary()
 			c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 				ApiVersion: s.sar.APIVersion,
@@ -448,7 +454,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		if denied, pol, podSecResult, derr := wc.denyEval.MatchWithDetails(s.ctx, act); derr != nil {
 			s.reqLog.With("error", derr.Error(), "session", sess.Name, "action", act).
 				Error("deny evaluation error for session")
-			return wc.denyPolicyEvaluationFailure(c, s, act, "session", derr)
+			return wc.denyPolicyEvaluationFailure(c, s, act, "session", derr, trackPhase)
 		} else {
 			// Emit pod security audit event if we have a result
 			if podSecResult != nil {
@@ -464,7 +470,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 							s.sessions = refreshedSessions
 							s.idpMismatches = refreshedMismatches
 							s.groups = grantedGroupsFromSessions(s.sessions)
-							return wc.evaluateDenyPoliciesInternal(c, s, false)
+							return wc.evaluateDenyPoliciesInternal(c, s, false, false)
 						}
 					}
 				}
@@ -494,8 +500,10 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 				wc.emitPolicyDenialAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, "session:"+sess.Name)
 
 				reason := wc.buildDenyPolicyReason(s, pol)
-				s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase (early exit)
-				s.phases.LogSummary()              // Log timing summary
+				if trackPhase {
+					s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase (early exit)
+					s.phases.LogSummary()              // Log timing summary
+				}
 				c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 					ApiVersion: s.sar.APIVersion,
 					Kind:       s.sar.Kind,
@@ -506,7 +514,9 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		}
 	}
 
-	s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase
+	if trackPhase {
+		s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase
+	}
 	return false
 }
 
@@ -516,6 +526,7 @@ func (wc *WebhookController) denyPolicyEvaluationFailure(
 	act policy.Action,
 	scope string,
 	err error,
+	trackPhase bool,
 ) bool {
 	s.reqLog.With("error", err.Error(), "scope", scope, "action", act).
 		Error("deny policy evaluation failed closed")
@@ -526,8 +537,10 @@ func (wc *WebhookController) denyPolicyEvaluationFailure(
 		Observe(time.Since(s.startTime).Seconds())
 
 	reason := wc.finalizeReason("DenyPolicy evaluation failed; request denied fail-closed", false, s.clusterName)
-	s.phases.EndPhase(PhaseDenyPolicy)
-	s.phases.LogSummary()
+	if trackPhase {
+		s.phases.EndPhase(PhaseDenyPolicy)
+		s.phases.LogSummary()
+	}
 	c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 		ApiVersion: s.sar.APIVersion,
 		Kind:       s.sar.Kind,
@@ -670,7 +683,7 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 				s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
 				s.groups = grantedGroupsFromSessions(s.sessions)
 				sessionPhaseStart := s.phases.phaseStart
-				deniedByPolicy := wc.evaluateDenyPolicies(c, s)
+				deniedByPolicy := wc.evaluateDenyPoliciesInternal(c, s, false, false)
 				s.phases.phaseStart = sessionPhaseStart
 				if deniedByPolicy {
 					return false

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -651,6 +651,9 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 				s.reqLog.With("error", refreshErr.Error()).Warn("Unable to refresh session candidates after authorization denial")
 			} else if ok {
 				s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
+				if wc.evaluateDenyPolicies(c, s) {
+					return false
+				}
 				if allowedSession, grp, sesName, impersonated := wc.authorizeViaSessions(
 					s.ctx, rc, s.sessions, s.sar, s.clusterName, s.reqLog); allowedSession {
 					s.reqLog.With("sessionGroup", system.RedactGroupName(grp), "session", sesName, "impersonationGroup", system.RedactGroupName(impersonated)).

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -642,7 +642,7 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 
 			// Record session activity for idle timeout detection and usage analytics (#314)
 			wc.recordSessionActivity(s.sessions, sesName, s.clusterName, grp)
-		} else if len(s.sessions) > 0 {
+		} else if len(s.sessions) > 0 || len(s.idpMismatches) > 0 {
 			// A different eligible cached session can hide a newly approved grant.
 			// Refresh only after the cached candidates fail this request's SAR.
 			if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -337,17 +337,9 @@ func (wc *WebhookController) checkEarlyDebugSession(c *gin.Context, s *authorize
 // evaluateDenyPolicies runs global and per-session deny-policy evaluation.
 // Returns handled=true if a deny response was written.
 func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeState) bool {
-	return wc.evaluateDenyPoliciesInternal(c, s, true, true)
-}
-
-func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *authorizeState, refreshOnSessionDeny, trackPhase bool) bool {
-	if trackPhase {
-		s.phases.StartPhase() // Start deny_policy phase
-	}
+	s.phases.StartPhase() // Start deny_policy phase
 	if s.sar.Spec.ResourceAttributes == nil {
-		if trackPhase {
-			s.phases.EndPhase(PhaseDenyPolicy)
-		}
+		s.phases.EndPhase(PhaseDenyPolicy)
 		return false
 	}
 	ra := s.sar.Spec.ResourceAttributes
@@ -382,10 +374,10 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 			}
 			needsLabels, checkErr := wc.denyEval.RequiresNamespaceLabels(s.ctx, actions...)
 			if checkErr != nil {
-				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-label-check", checkErr, trackPhase)
+				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-label-check", checkErr)
 			}
 			if needsLabels {
-				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-labels", err, trackPhase)
+				return wc.denyPolicyEvaluationFailure(c, s, act, "namespace-labels", err)
 			}
 			// NamespaceLabels will be nil; pattern-only namespace rules remain evaluable.
 		} else {
@@ -410,7 +402,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 	// Global deny-policy evaluation
 	if denied, pol, podSecResult, derr := wc.denyEval.MatchWithDetails(s.ctx, act); derr != nil {
 		s.reqLog.With("error", derr.Error(), "action", act).Error("deny evaluation error")
-		return wc.denyPolicyEvaluationFailure(c, s, act, "global", derr, trackPhase)
+		return wc.denyPolicyEvaluationFailure(c, s, act, "global", derr)
 	} else {
 		// Emit pod security audit event if we have a result
 		if podSecResult != nil {
@@ -443,9 +435,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 			wc.emitPolicyDenialAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, "global")
 
 			reason := wc.buildDenyPolicyReason(s, pol)
-			if trackPhase {
-				s.phases.EndPhase(PhaseDenyPolicy)
-			}
+			s.phases.EndPhase(PhaseDenyPolicy)
 			s.phases.LogSummary()
 			c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 				ApiVersion: s.sar.APIVersion,
@@ -462,7 +452,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		if denied, pol, podSecResult, derr := wc.denyEval.MatchWithDetails(s.ctx, act); derr != nil {
 			s.reqLog.With("error", derr.Error(), "session", sess.Name, "action", act).
 				Error("deny evaluation error for session")
-			return wc.denyPolicyEvaluationFailure(c, s, act, "session", derr, trackPhase)
+			return wc.denyPolicyEvaluationFailure(c, s, act, "session", derr)
 		} else {
 			// Emit pod security audit event if we have a result
 			if podSecResult != nil {
@@ -495,10 +485,8 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 				wc.emitPolicyDenialAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, "session:"+sess.Name)
 
 				reason := wc.buildDenyPolicyReason(s, pol)
-				if trackPhase {
-					s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase (early exit)
-					s.phases.LogSummary()              // Log timing summary
-				}
+				s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase (early exit)
+				s.phases.LogSummary()              // Log timing summary
 				c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 					ApiVersion: s.sar.APIVersion,
 					Kind:       s.sar.Kind,
@@ -509,9 +497,7 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		}
 	}
 
-	if trackPhase {
-		s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase
-	}
+	s.phases.EndPhase(PhaseDenyPolicy) // End deny_policy phase
 	return false
 }
 
@@ -521,7 +507,6 @@ func (wc *WebhookController) denyPolicyEvaluationFailure(
 	act policy.Action,
 	scope string,
 	err error,
-	trackPhase bool,
 ) bool {
 	s.reqLog.With("error", err.Error(), "scope", scope, "action", act).
 		Error("deny policy evaluation failed closed")
@@ -532,10 +517,8 @@ func (wc *WebhookController) denyPolicyEvaluationFailure(
 		Observe(time.Since(s.startTime).Seconds())
 
 	reason := wc.finalizeReason("DenyPolicy evaluation failed; request denied fail-closed", false, s.clusterName)
-	if trackPhase {
-		s.phases.EndPhase(PhaseDenyPolicy)
-		s.phases.LogSummary()
-	}
+	s.phases.EndPhase(PhaseDenyPolicy)
+	s.phases.LogSummary()
 	c.JSON(http.StatusOK, &SubjectAccessReviewResponse{
 		ApiVersion: s.sar.APIVersion,
 		Kind:       s.sar.Kind,

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -283,6 +283,15 @@ func (wc *WebhookController) loadSessionsAndGroups(c *gin.Context, s *authorizeS
 		c.Status(http.StatusInternalServerError)
 		return false
 	}
+	if len(s.sessions) > 0 || len(s.idpMismatches) > 0 {
+		candidates := append(append([]breakglassv1alpha1.BreakglassSession{}, s.sessions...), s.idpMismatches...)
+		if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessionsWithCached(
+			s.ctx, s.clusterName, s.sar.Spec.User, candidates,
+		); refreshErr == nil && ok {
+			s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
+			s.groups = grantedGroupsFromSessions(s.sessions)
+		}
+	}
 	s.phases.EndPhase(PhaseSessions) // End sessions phase
 	s.reqLog.With("groupCount", len(s.groups), "sessions", len(s.sessions),
 		"tenant", s.tenant, "idpMismatches", len(s.idpMismatches)).
@@ -341,15 +350,6 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		}
 		return false
 	}
-	if len(s.sessions) > 0 || len(s.idpMismatches) > 0 {
-		if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
-			s.ctx, s.clusterName, s.sar.Spec.User,
-		); refreshErr == nil && ok {
-			s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
-			s.groups = grantedGroupsFromSessions(s.sessions)
-		}
-	}
-
 	ra := s.sar.Spec.ResourceAttributes
 
 	// Get PodSecurityOverrides from user's active session escalation (if any)

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -642,6 +642,25 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 
 			// Record session activity for idle timeout detection and usage analytics (#314)
 			wc.recordSessionActivity(s.sessions, sesName, s.clusterName, grp)
+		} else if len(s.sessions) > 0 {
+			// A different eligible cached session can hide a newly approved grant.
+			// Refresh only after the cached candidates fail this request's SAR.
+			if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
+				s.ctx, s.clusterName, username,
+			); refreshErr != nil {
+				s.reqLog.With("error", refreshErr.Error()).Warn("Unable to refresh session candidates after authorization denial")
+			} else if ok {
+				s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
+				if allowedSession, grp, sesName, impersonated := wc.authorizeViaSessions(
+					s.ctx, rc, s.sessions, s.sar, s.clusterName, s.reqLog); allowedSession {
+					s.reqLog.With("sessionGroup", system.RedactGroupName(grp), "session", sesName, "impersonationGroup", system.RedactGroupName(impersonated)).
+						Debug("Authorized via refreshed breakglass session group")
+					s.allowed = true
+					s.allowSource = "session"
+					s.allowDetail = fmt.Sprintf("session=%s sessionGroup=%s impersonationGroup=%s", sesName, system.RedactGroupName(grp), system.RedactGroupName(impersonated))
+					wc.recordSessionActivity(s.sessions, sesName, s.clusterName, grp)
+				}
+			}
 		}
 	}
 	s.phases.EndPhase(PhaseSessionSARs) // End session_sars phase

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -341,6 +341,14 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 		}
 		return false
 	}
+	if len(s.sessions) > 0 || len(s.idpMismatches) > 0 {
+		if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
+			s.ctx, s.clusterName, s.sar.Spec.User,
+		); refreshErr == nil && ok {
+			s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
+			s.groups = grantedGroupsFromSessions(s.sessions)
+		}
+	}
 
 	ra := s.sar.Spec.ResourceAttributes
 
@@ -461,19 +469,6 @@ func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *aut
 				wc.emitPodSecurityAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, podSecResult)
 			}
 			if denied {
-				if refreshOnSessionDeny {
-					if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
-						s.ctx, s.clusterName, s.sar.Spec.User,
-					); refreshErr == nil && ok {
-						refreshedSessions, refreshedMismatches := filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
-						if sessionCandidatesChanged(s.sessions, refreshedSessions) {
-							s.sessions = refreshedSessions
-							s.idpMismatches = refreshedMismatches
-							s.groups = grantedGroupsFromSessions(s.sessions)
-							return wc.evaluateDenyPoliciesInternal(c, s, false, false)
-						}
-					}
-				}
 				// Log detailed rejection info at INFO level for observability
 				s.reqLog.Infow("Request denied by session-scoped DenyPolicy",
 					"policy", pol,
@@ -672,32 +667,6 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 
 			// Record session activity for idle timeout detection and usage analytics (#314)
 			wc.recordSessionActivity(s.sessions, sesName, s.clusterName, grp)
-		} else if len(s.sessions) > 0 || len(s.idpMismatches) > 0 {
-			// A different eligible cached session can hide a newly approved grant.
-			// Refresh only after the cached candidates fail this request's SAR.
-			if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
-				s.ctx, s.clusterName, username,
-			); refreshErr != nil {
-				s.reqLog.With("error", refreshErr.Error()).Warn("Unable to refresh session candidates after authorization denial")
-			} else if ok {
-				s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
-				s.groups = grantedGroupsFromSessions(s.sessions)
-				sessionPhaseStart := s.phases.phaseStart
-				deniedByPolicy := wc.evaluateDenyPoliciesInternal(c, s, false, false)
-				s.phases.phaseStart = sessionPhaseStart
-				if deniedByPolicy {
-					return false
-				}
-				if allowedSession, grp, sesName, impersonated := wc.authorizeViaSessions(
-					s.ctx, rc, s.sessions, s.sar, s.clusterName, s.reqLog); allowedSession {
-					s.reqLog.With("sessionGroup", system.RedactGroupName(grp), "session", sesName, "impersonationGroup", system.RedactGroupName(impersonated)).
-						Debug("Authorized via refreshed breakglass session group")
-					s.allowed = true
-					s.allowSource = "session"
-					s.allowDetail = fmt.Sprintf("session=%s sessionGroup=%s impersonationGroup=%s", sesName, system.RedactGroupName(grp), system.RedactGroupName(impersonated))
-					wc.recordSessionActivity(s.sessions, sesName, s.clusterName, grp)
-				}
-			}
 		}
 	}
 	s.phases.EndPhase(PhaseSessionSARs) // End session_sars phase

--- a/pkg/webhook/authorize_helpers.go
+++ b/pkg/webhook/authorize_helpers.go
@@ -328,6 +328,10 @@ func (wc *WebhookController) checkEarlyDebugSession(c *gin.Context, s *authorize
 // evaluateDenyPolicies runs global and per-session deny-policy evaluation.
 // Returns handled=true if a deny response was written.
 func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeState) bool {
+	return wc.evaluateDenyPoliciesInternal(c, s, true)
+}
+
+func (wc *WebhookController) evaluateDenyPoliciesInternal(c *gin.Context, s *authorizeState, refreshOnSessionDeny bool) bool {
 	s.phases.StartPhase() // Start deny_policy phase
 	if s.sar.Spec.ResourceAttributes == nil {
 		s.phases.EndPhase(PhaseDenyPolicy)
@@ -451,6 +455,19 @@ func (wc *WebhookController) evaluateDenyPolicies(c *gin.Context, s *authorizeSt
 				wc.emitPodSecurityAudit(s.ctx, s.sar.Spec.User, s.groups, s.clusterName, &s.sar, pol, podSecResult)
 			}
 			if denied {
+				if refreshOnSessionDeny {
+					if refreshed, ok, refreshErr := wc.sesManager.RefreshClusterUserBreakglassSessions(
+						s.ctx, s.clusterName, s.sar.Spec.User,
+					); refreshErr == nil && ok {
+						refreshedSessions, refreshedMismatches := filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
+						if sessionCandidatesChanged(s.sessions, refreshedSessions) {
+							s.sessions = refreshedSessions
+							s.idpMismatches = refreshedMismatches
+							s.groups = grantedGroupsFromSessions(s.sessions)
+							return wc.evaluateDenyPoliciesInternal(c, s, false)
+						}
+					}
+				}
 				// Log detailed rejection info at INFO level for observability
 				s.reqLog.Infow("Request denied by session-scoped DenyPolicy",
 					"policy", pol,
@@ -651,7 +668,11 @@ func (wc *WebhookController) resolveSessionAuthorization(c *gin.Context, s *auth
 				s.reqLog.With("error", refreshErr.Error()).Warn("Unable to refresh session candidates after authorization denial")
 			} else if ok {
 				s.sessions, s.idpMismatches = filterSessionsForAuthorization(refreshed, s.issuer, time.Now())
-				if wc.evaluateDenyPolicies(c, s) {
+				s.groups = grantedGroupsFromSessions(s.sessions)
+				sessionPhaseStart := s.phases.phaseStart
+				deniedByPolicy := wc.evaluateDenyPolicies(c, s)
+				s.phases.phaseStart = sessionPhaseStart
+				if deniedByPolicy {
 					return false
 				}
 				if allowedSession, grp, sesName, impersonated := wc.authorizeViaSessions(

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -785,6 +786,31 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	}
 	out, idpMismatches := filterSessionsForAuthorization(all, issuer, time.Now())
 	return out, idpMismatches, nil
+}
+
+func grantedGroupsFromSessions(sessions []breakglassv1alpha1.BreakglassSession) []string {
+	groups := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		groups = append(groups, session.Spec.GrantedGroup)
+	}
+	return groups
+}
+
+func sessionCandidatesChanged(left, right []breakglassv1alpha1.BreakglassSession) bool {
+	if len(left) != len(right) {
+		return true
+	}
+	rightByKey := make(map[string]breakglassv1alpha1.BreakglassSessionSpec, len(right))
+	for _, session := range right {
+		rightByKey[session.Namespace+"/"+session.Name] = session.Spec
+	}
+	for _, session := range left {
+		spec, ok := rightByKey[session.Namespace+"/"+session.Name]
+		if !ok || !reflect.DeepEqual(session.Spec, spec) {
+			return true
+		}
+	}
+	return false
 }
 
 func filterSessionsForAuthorization(sessions []breakglassv1alpha1.BreakglassSession,

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -787,16 +787,7 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	idpMismatches := make([]breakglassv1alpha1.BreakglassSession, 0)
 	now := time.Now()
 	for _, s := range all {
-		if breakglass.IsSessionRetained(s) {
-			continue
-		}
-		// Only include sessions that are in Approved state with a valid time window.
-		// Terminal states (IdleExpired, Expired, Rejected, Withdrawn, etc.) must be excluded
-		// even if their ExpiresAt is still in the future.
-		if s.Status.State != breakglassv1alpha1.SessionStateApproved {
-			continue
-		}
-		if s.Status.RejectedAt.IsZero() && !s.Status.ExpiresAt.IsZero() && s.Status.ExpiresAt.After(now) {
+		if breakglass.IsSessionAuthorizationEligible(s, now) {
 			// If issuer is provided and session does NOT allow IDP mismatch,
 			// only include sessions that match the issuer (multi-IDP mode)
 			if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -783,22 +783,27 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	out := make([]breakglassv1alpha1.BreakglassSession, 0, len(all))
-	idpMismatches := make([]breakglassv1alpha1.BreakglassSession, 0)
-	now := time.Now()
-	for _, s := range all {
-		if breakglass.IsSessionAuthorizationEligible(s, now) {
-			// If issuer is provided and session does NOT allow IDP mismatch,
-			// only include sessions that match the issuer (multi-IDP mode)
-			if issuer != "" && !s.Spec.AllowIDPMismatch && s.Spec.IdentityProviderIssuer != issuer {
-				// Track sessions filtered out due to IDP mismatch
-				idpMismatches = append(idpMismatches, s)
-				continue
-			}
-			out = append(out, s)
-		}
-	}
+	out, idpMismatches := filterSessionsForAuthorization(all, issuer, time.Now())
 	return out, idpMismatches, nil
+}
+
+func filterSessionsForAuthorization(sessions []breakglassv1alpha1.BreakglassSession,
+	issuer string,
+	now time.Time,
+) ([]breakglassv1alpha1.BreakglassSession, []breakglassv1alpha1.BreakglassSession) {
+	out := make([]breakglassv1alpha1.BreakglassSession, 0, len(sessions))
+	idpMismatches := make([]breakglassv1alpha1.BreakglassSession, 0)
+	for _, session := range sessions {
+		if !breakglass.IsSessionAuthorizationEligible(session, now) {
+			continue
+		}
+		if issuer != "" && !session.Spec.AllowIDPMismatch && session.Spec.IdentityProviderIssuer != issuer {
+			idpMismatches = append(idpMismatches, session)
+			continue
+		}
+		out = append(out, session)
+	}
+	return out, idpMismatches
 }
 
 // dedupeStrings removes duplicates from a slice of strings while preserving order.

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"reflect"
 	"strings"
 	"time"
 
@@ -794,23 +793,6 @@ func grantedGroupsFromSessions(sessions []breakglassv1alpha1.BreakglassSession) 
 		groups = append(groups, session.Spec.GrantedGroup)
 	}
 	return groups
-}
-
-func sessionCandidatesChanged(left, right []breakglassv1alpha1.BreakglassSession) bool {
-	if len(left) != len(right) {
-		return true
-	}
-	rightByKey := make(map[string]breakglassv1alpha1.BreakglassSessionSpec, len(right))
-	for _, session := range right {
-		rightByKey[session.Namespace+"/"+session.Name] = session.Spec
-	}
-	for _, session := range left {
-		spec, ok := rightByKey[session.Namespace+"/"+session.Name]
-		if !ok || !reflect.DeepEqual(session.Spec, spec) {
-			return true
-		}
-	}
-	return false
 }
 
 func filterSessionsForAuthorization(sessions []breakglassv1alpha1.BreakglassSession,


### PR DESCRIPTION
## Summary
The authorization webhook can deny a newly approved BreakglassSession when the shared informer cache has not observed the session or its approval yet, even though the live Kubernetes API already contains it.

## Root cause
- `pkg/webhook/controller.go:781-782` obtains candidates through `GetClusterUserBreakglassSessions`.
- `pkg/breakglass/session_manager.go:365-374` performs an indexed list through the cached client.
- `cmd/main.go:463-465` constructs this manager with both the shared cached client and an uncached API reader.
- With controllers enabled, indexes are present, but newly created/approved sessions can still be absent from the cache. An indexed cache lookup returns an empty list, and the previous code treated that as authoritative.
- The cache can also contain the session with stale `Pending` status after the live object is already `Approved`; authorization then filtered the cached candidate out.

## Controllers-enabled reproduction
The default is enabled by `pkg/cli/cli.go:159` (`getEnvBool("ENABLE_CONTROLLERS", true)`). The inspected T-CaaS deployment has no `--enable-controllers` argument and no `ENABLE_CONTROLLERS` environment variable, so it runs with controllers enabled.

The equivalent indexed selection reproduction with controllers enabled passed, confirming PR #1297 only covers explicit controller-disabled deployments:

```text
=== RUN   TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled
--- PASS: TestAuthorizationSelectionUsesSharedIndexesWhenControllersEnabled
PASS
```

## Red-green review evidence
The first commit (`1344e46e`) adds the stale-cache reproduction before the original production fix (`39629ce4`):

```text
=== RUN   TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale
Error: "[]" should have 1 item(s), but has 0
--- FAIL: TestSessionManager_AuthorizationSelectionUsesLiveReaderWhenCacheIsStale
FAIL
```

Copilot identified that an empty-cache fallback could call the API server on every miss. The follow-up test commit (`3cd0c8ae`) failed against the uncapped fallback:

```text
=== RUN   TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss
Error: Not equal: expected: 1 actual: 2
--- FAIL: TestSessionManager_AuthorizationSelectionNegativeCachesLiveMiss
FAIL
```

The second fix (`f66c75bb`) added server-side field selectors and a per cluster/user one-second negative cache.

Copilot then identified stale cached `Pending` status and expired negative-cache entries. The follow-up tests (`e2a31710`) failed before the final fix:

```text
=== RUN   TestSessionManager_AuthorizationSelectionRefreshesStalePendingCache
Error: Not equal: expected: "Approved" actual: "Pending"
--- FAIL: TestSessionManager_AuthorizationSelectionRefreshesStalePendingCache

=== RUN   TestSessionManager_LiveFallbackEvictsExpiredEntries
Error: Should be false
--- FAIL: TestSessionManager_LiveFallbackEvictsExpiredEntries
```

The final fix (`7138d658`) makes the live refresh run when cached candidates contain no Approved session, merges live results while replacing stale objects, and actively evicts expired negative-cache entries. All four stale-cache regression tests now pass.

## Fix
The session manager retains an explicitly supplied live reader and refreshes when the indexed cache has no currently Approved candidate. The live lookup uses `spec.cluster`/`spec.user` selectors and falls back to a filtered full list only when selectors are unsupported. Empty live misses are negatively cached for one second, with expired entries evicted during subsequent insertions. Positive matches clear the negative entry. Reader failures remain fail-closed for the current lookup and are logged with cluster/user context.

## Documentation
Updated the webhook setup guide and `CHANGELOG.md`.

## Verification
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test ./pkg/webhook/... ./pkg/bgctl/... ./api/... ./pkg/reconciler/... ./pkg/breakglass/...` — all packages passed
- `make lint` with `GOTOOLCHAIN=go1.26.6` — `0 issues`
- `make test` with `GOTOOLCHAIN=go1.26.6` — all unit-test packages passed under race detection on rerun. One earlier run hit the repository's unrelated timing assertion in `pkg/audit/TestIsolatedMultiSink_Independence` (`10.157333ms` was not less than `10ms`); the rerun passed.
