### PR TITLE
release: prepare v0.3.0-rc.2

### DIFF
--- a/charts/escalation-config/Chart.yaml
+++ b/charts/escalation-config/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Helm chart to create BreakglassEscalation, ClusterConfig, DebugSessionClusterBinding, and DenyPolicy CRs.
   Supports single and multi-IDP configurations for flexible authentication.
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/telekom/k8s-breakglass/main/frontend/public/favicon.svg
 keywords:


### PR DESCRIPTION
## Summary
- bump the escalation-config Helm chart from 0.3.5 to 0.3.6
- unblock publication for v0.3.0-rc.2 after v0.3.0-rc.1 detected an existing GHCR chart version

Release-preparation change only; no runtime behavior changes.

Assisted-by: Copilot:github-copilot/gpt-5.6-luna