### PR TITLE
fix: authorize DebugSession creation from active Breakglass grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Filter Breakglass grants used for DebugSession creation by the request issuer unless the grant explicitly allows IDP mismatch (PR #1326).
 
+- Keep DebugSession creation grant matching exact to authenticated username/email claims; email local-part aliases remain limited to the issuer-scoped webhook compatibility path (PR #1326).
+
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Restrict webhook local-part compatibility to single-at-sign email identities and skip alias lookups for email-form requesters (PR #1326).
+
 - Filter Breakglass grants used for DebugSession creation by the request issuer unless the grant explicitly allows IDP mismatch (PR #1326).
-
 - Keep DebugSession creation grant matching exact to authenticated username/email claims; email local-part aliases remain limited to the issuer-scoped webhook compatibility path (PR #1326).
-
 - Allow the webhook's issuer-scoped email alias fallback when exact sessions are expired or issuer-ineligible, while preserving eligible exact-match precedence and issuer ambiguity rejection (PR #1326).
-
 - Use indexed BreakglassSession lookups for DebugSession grant checks while retaining a fresh-reader fallback when the cache has no eligible exact grant (PR #1326).
-
 - Revalidate positive cached DebugSession grants through the fresh reader, rejecting revoked or deleted sessions and stale object identities (PR #1326).
-
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep DebugSession creation grant matching exact to authenticated username/email claims; email local-part aliases remain limited to the issuer-scoped webhook compatibility path (PR #1326).
 
+- Allow the webhook's issuer-scoped email alias fallback when exact sessions are expired or issuer-ineligible, while preserving eligible exact-match precedence and issuer ambiguity rejection (PR #1326).
+
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use indexed BreakglassSession lookups for DebugSession grant checks while retaining a fresh-reader fallback when the cache has no eligible exact grant (PR #1326).
 
+- Revalidate positive cached DebugSession grants through the fresh reader, rejecting revoked or deleted sessions and stale object identities (PR #1326).
+
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Restrict webhook local-part compatibility to single-at-sign email identities and skip alias lookups for email-form requesters (PR #1326).
-
 - Filter Breakglass grants used for DebugSession creation by the request issuer unless the grant explicitly allows IDP mismatch (PR #1326).
 - Keep DebugSession creation grant matching exact to authenticated username/email claims; email local-part aliases remain limited to the issuer-scoped webhook compatibility path (PR #1326).
 - Allow the webhook's issuer-scoped email alias fallback when exact sessions are expired or issuer-ineligible, while preserving eligible exact-match precedence and issuer ambiguity rejection (PR #1326).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Filter Breakglass grants used for DebugSession creation by the request issuer unless the grant explicitly allows IDP mismatch (PR #1326).
+
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow the webhook's issuer-scoped email alias fallback when exact sessions are expired or issuer-ineligible, while preserving eligible exact-match precedence and issuer ambiguity rejection (PR #1326).
 
+- Use indexed BreakglassSession lookups for DebugSession grant checks while retaining a fresh-reader fallback when the cache has no eligible exact grant (PR #1326).
+
 - Disable trusted raw field output for a complete debug template set when Sprig
   mutation functions can modify requester-visible maps during rendering.
 

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -734,6 +734,12 @@ When a spoke cluster performs OIDC authentication, it extracts the username from
 
 For the breakglass authorization webhook to correctly match sessions to SAR requests, the session's `spec.user` must contain the same identifier that the spoke cluster extracts from the JWT.
 
+If an exact `spec.user` lookup returns no eligible session, the webhook may use
+the email local-part as a compatibility alias. Alias matching remains scoped to
+the SAR issuer; an eligible exact match takes precedence, expired or
+issuer-ineligible exact matches do not suppress a valid alias, and aliases from
+multiple issuers are rejected when the SAR does not provide an issuer.
+
 Use `userIdentifierClaim` to specify which OIDC claim the spoke cluster uses:
 
 ```yaml

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -740,6 +740,10 @@ the SAR issuer; an eligible exact match takes precedence, expired or
 issuer-ineligible exact matches do not suppress a valid alias, and aliases from
 multiple issuers are rejected when the SAR does not provide an issuer.
 
+Webhook local-part compatibility accepts only a nonempty local part and domain
+separated by one `@`. Requesters already expressed as email addresses use exact
+identity matching and do not trigger the local-part alias lookup.
+
 Use `userIdentifierClaim` to specify which OIDC claim the spoke cluster uses:
 
 ```yaml

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1465,6 +1465,14 @@ debug session when they are the requester, an active participant, an invited
 participant, a configured approver, or a recorded approver/rejector for that
 session.
 
+When creating a session, active Breakglass grants are added only when the
+authenticated username or email claim exactly matches `BreakglassSession.spec.user`
+and the issuer matches unless `allowIDPMismatch` is enabled. The API does not
+infer an email address from a username's local part, because the same local part
+can belong to different domains. The authorization webhook has a separate,
+issuer-scoped email-alias compatibility path for SubjectAccessReviews; that path
+does not broaden the DebugSession creation check.
+
 Mutating DebugSession endpoints that accept JSON bodies use strict decoding:
 unknown fields, malformed JSON, and trailing JSON values return `400 Bad
 Request`. The join endpoint may omit its body and defaults to the `viewer` role;

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -793,7 +793,7 @@ When a user creates a debug session:
    - `selectorTerms` on either the allow or the deny side are evaluated against **live namespace labels** read from the target cluster. If those labels cannot be read (spoke API error, namespace missing, no client configured), the request is **rejected** with an error naming the namespace and the offending filter — a selector-based policy is never silently skipped.
    - If a `DebugSessionClusterBinding` is selected, the namespace must satisfy both the template constraints and the binding constraints
 4. **Namespace doesn't exist**: 
-   - `createIfNotExists: true`: Creates namespace with `namespaceLabels`
+   - `createIfNotExists: true`: Creates namespace with `namespaceLabels` from the effective constraints; a binding's namespace constraints take precedence when present
    - `createIfNotExists: false`: Session fails or uses fail-open mode
 
 The web UI validates Kubernetes namespace syntax and glob-style allowed/denied patterns before submitting a debug session request. The API and controller remain the authoritative enforcement points for namespace constraints and cluster state.

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1471,7 +1471,10 @@ and the issuer matches unless `allowIDPMismatch` is enabled. The API does not
 infer an email address from a username's local part, because the same local part
 can belong to different domains. The authorization webhook has a separate,
 issuer-scoped email-alias compatibility path for SubjectAccessReviews; that path
-does not broaden the DebugSession creation check.
+does not broaden the DebugSession creation check. Grant lookup uses the cached
+cluster index when available and performs a fresh reader fallback when the cache
+has no eligible exact grant, so newly approved grants are not hidden by cache
+propagation delay.
 
 Mutating DebugSession endpoints that accept JSON bodies use strict decoding:
 unknown fields, malformed JSON, and trailing JSON values return `400 Bad

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1472,9 +1472,10 @@ infer an email address from a username's local part, because the same local part
 can belong to different domains. The authorization webhook has a separate,
 issuer-scoped email-alias compatibility path for SubjectAccessReviews; that path
 does not broaden the DebugSession creation check. Grant lookup uses the cached
-cluster index when available and performs a fresh reader fallback when the cache
-has no eligible exact grant, so newly approved grants are not hidden by cache
-propagation delay.
+cluster index when available and re-reads positive candidates through the fresh
+reader. If no eligible exact grant remains, it performs a fresh full-reader
+fallback, so newly approved grants are not hidden by cache propagation delay and
+revoked or deleted cached grants are not trusted.
 
 Mutating DebugSession endpoints that accept JSON bodies use strict decoding:
 unknown fields, malformed JSON, and trailing JSON values return `400 Bad

--- a/docs/debug-session.md
+++ b/docs/debug-session.md
@@ -1472,10 +1472,11 @@ infer an email address from a username's local part, because the same local part
 can belong to different domains. The authorization webhook has a separate,
 issuer-scoped email-alias compatibility path for SubjectAccessReviews; that path
 does not broaden the DebugSession creation check. Grant lookup uses the cached
-cluster index when available and re-reads positive candidates through the fresh
-reader. If no eligible exact grant remains, it performs a fresh full-reader
-fallback, so newly approved grants are not hidden by cache propagation delay and
-revoked or deleted cached grants are not trusted.
+`spec.cluster` and `spec.user` field indexes when available and re-reads positive
+candidates through the fresh reader. If the indexes are unavailable, it performs
+one full-list fallback. If no eligible exact grant remains, it performs a fresh
+full-reader fallback, so newly approved grants are not hidden by cache
+propagation delay and revoked or deleted cached grants are not trusted.
 
 Mutating DebugSession endpoints that accept JSON bodies use strict decoding:
 unknown fields, malformed JSON, and trailing JSON values return `400 Bad

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -821,6 +821,13 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
 	authorizationReader := c.reader()
+	sessionGroups, err := c.activeBreakglassGroups(apiCtx, authorizationReader, req.Cluster, currentUserStr, userEmail)
+	if err != nil {
+		reqLog.Errorw("Failed to load active Breakglass session groups", "error", err)
+		apiresponses.RespondInternalErrorSimple(ctx, "failed to validate Breakglass access")
+		return
+	}
+	userGroups = append(userGroups, sessionGroups...)
 
 	if err := authorizationReader.Get(apiCtx, ctrlclient.ObjectKey{Name: req.TemplateRef}, template); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -1378,6 +1385,26 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 		reqLog.Infow("Session created with warnings", "warnings", warnings)
 	}
 	ctx.JSON(http.StatusCreated, response)
+}
+
+func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, reader ctrlclient.Reader, cluster, username, email string) ([]string, error) {
+	var sessions breakglassv1alpha1.BreakglassSessionList
+	if err := reader.List(ctx, &sessions); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	groups := make([]string, 0)
+	for _, session := range sessions.Items {
+		if session.Spec.Cluster != cluster ||
+			session.Status.State != breakglassv1alpha1.SessionStateApproved ||
+			session.Status.ExpiresAt.IsZero() ||
+			!session.Status.ExpiresAt.After(now) ||
+			(session.Spec.User != username && session.Spec.User != email) {
+			continue
+		}
+		groups = append(groups, session.Spec.GrantedGroup)
+	}
+	return groups, nil
 }
 
 // admitCreatedDebugSession retries only the bounded resource-version race

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1388,8 +1388,12 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 }
 
 func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, reader ctrlclient.Reader, cluster, username, email, issuer string) ([]string, error) {
+	indexedReader := reader
+	if c.client != nil {
+		indexedReader = c.client
+	}
 	var sessions breakglassv1alpha1.BreakglassSessionList
-	if err := reader.List(ctx, &sessions, ctrlclient.MatchingFields{"spec.cluster": cluster}); err != nil {
+	if err := indexedReader.List(ctx, &sessions, ctrlclient.MatchingFields{"spec.cluster": cluster}); err != nil {
 		if !breakglass.IsFieldIndexError(err) {
 			return nil, err
 		}
@@ -1405,20 +1409,37 @@ func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, 
 		}
 	}
 	now := time.Now()
-	groups := make([]string, 0, len(sessions.Items))
-	seen := make(map[string]struct{}, len(sessions.Items))
-	for _, session := range sessions.Items {
-		if !breakglass.IsSessionAuthorizationEligible(session, now) ||
-			(session.Spec.User != username && session.Spec.User != email) ||
-			(issuer != "" && !session.Spec.AllowIDPMismatch &&
-				strings.TrimRight(session.Spec.IdentityProviderIssuer, "/") != strings.TrimRight(issuer, "/")) {
-			continue
+	collectGroups := func(items []breakglassv1alpha1.BreakglassSession) []string {
+		groups := make([]string, 0, len(items))
+		seen := make(map[string]struct{}, len(items))
+		for _, session := range items {
+			if !breakglass.IsSessionAuthorizationEligible(session, now) ||
+				(session.Spec.User != username && session.Spec.User != email) ||
+				(issuer != "" && !session.Spec.AllowIDPMismatch &&
+					strings.TrimRight(session.Spec.IdentityProviderIssuer, "/") != strings.TrimRight(issuer, "/")) {
+				continue
+			}
+			if _, ok := seen[session.Spec.GrantedGroup]; ok {
+				continue
+			}
+			seen[session.Spec.GrantedGroup] = struct{}{}
+			groups = append(groups, session.Spec.GrantedGroup)
 		}
-		if _, ok := seen[session.Spec.GrantedGroup]; ok {
-			continue
+		return groups
+	}
+	groups := collectGroups(sessions.Items)
+	if c.client != nil && c.apiReader != nil && len(groups) == 0 {
+		var fresh breakglassv1alpha1.BreakglassSessionList
+		if err := reader.List(ctx, &fresh); err != nil {
+			return nil, err
 		}
-		seen[session.Spec.GrantedGroup] = struct{}{}
-		groups = append(groups, session.Spec.GrantedGroup)
+		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(fresh.Items))
+		for _, session := range fresh.Items {
+			if session.Spec.Cluster == cluster {
+				filtered = append(filtered, session)
+			}
+		}
+		groups = collectGroups(filtered)
 	}
 	return groups, nil
 }

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -821,7 +821,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	apiCtx, cancel := context.WithTimeout(ctx.Request.Context(), breakglass.APIContextTimeout)
 	defer cancel()
 	authorizationReader := c.reader()
-	sessionGroups, err := c.activeBreakglassGroups(apiCtx, authorizationReader, req.Cluster, currentUserStr, userEmail)
+	sessionGroups, err := c.activeBreakglassGroups(apiCtx, authorizationReader, req.Cluster, currentUserStr, userEmail, ctx.GetString("issuer"))
 	if err != nil {
 		reqLog.Errorw("Failed to load active Breakglass session groups", "error", err)
 		apiresponses.RespondInternalErrorSimple(ctx, "failed to validate Breakglass access")
@@ -1387,7 +1387,7 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 	ctx.JSON(http.StatusCreated, response)
 }
 
-func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, reader ctrlclient.Reader, cluster, username, email string) ([]string, error) {
+func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, reader ctrlclient.Reader, cluster, username, email, issuer string) ([]string, error) {
 	var sessions breakglassv1alpha1.BreakglassSessionList
 	if err := reader.List(ctx, &sessions); err != nil {
 		return nil, err
@@ -1396,10 +1396,10 @@ func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, 
 	groups := make([]string, 0)
 	for _, session := range sessions.Items {
 		if session.Spec.Cluster != cluster ||
-			session.Status.State != breakglassv1alpha1.SessionStateApproved ||
-			session.Status.ExpiresAt.IsZero() ||
-			!session.Status.ExpiresAt.After(now) ||
-			(session.Spec.User != username && session.Spec.User != email) {
+			!breakglass.IsSessionAuthorizationEligible(session, now) ||
+			(session.Spec.User != username && session.Spec.User != email) ||
+			(issuer != "" && !session.Spec.AllowIDPMismatch &&
+				strings.TrimRight(session.Spec.IdentityProviderIssuer, "/") != strings.TrimRight(issuer, "/")) {
 			continue
 		}
 		groups = append(groups, session.Spec.GrantedGroup)

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1393,19 +1393,66 @@ func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, 
 		indexedReader = c.client
 	}
 	var sessions breakglassv1alpha1.BreakglassSessionList
-	if err := indexedReader.List(ctx, &sessions, ctrlclient.MatchingFields{"spec.cluster": cluster}); err != nil {
-		if !breakglass.IsFieldIndexError(err) {
-			return nil, err
+	identities := make([]string, 0, 2)
+	seenIdentities := make(map[string]struct{}, 2)
+	for _, identity := range []string{username, email} {
+		if identity == "" {
+			continue
 		}
+		if _, seen := seenIdentities[identity]; seen {
+			continue
+		}
+		seenIdentities[identity] = struct{}{}
+		identities = append(identities, identity)
+	}
+	appendSession := func(session breakglassv1alpha1.BreakglassSession, seen map[string]struct{}) {
+		key := session.Namespace + "\x00" + session.Name
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		sessions.Items = append(sessions.Items, session)
+	}
+	seenSessions := make(map[string]struct{})
+	if len(identities) == 0 {
 		var all breakglassv1alpha1.BreakglassSessionList
 		if err := reader.List(ctx, &all); err != nil {
 			return nil, err
 		}
-		sessions.Items = make([]breakglassv1alpha1.BreakglassSession, 0, len(all.Items))
 		for _, session := range all.Items {
 			if session.Spec.Cluster == cluster {
-				sessions.Items = append(sessions.Items, session)
+				appendSession(session, seenSessions)
 			}
+		}
+	} else {
+		for _, identity := range identities {
+			var matches breakglassv1alpha1.BreakglassSessionList
+			err := indexedReader.List(ctx, &matches, ctrlclient.MatchingFields{
+				"spec.cluster": cluster,
+				"spec.user":    identity,
+			})
+			if err == nil {
+				for _, session := range matches.Items {
+					appendSession(session, seenSessions)
+				}
+				continue
+			}
+			if !breakglass.IsFieldIndexError(err) {
+				return nil, err
+			}
+			// A missing index invalidates all identity-specific queries. Do one
+			// full read and apply the same cluster filter instead of issuing a
+			// second indexed query for the other identity.
+			var all breakglassv1alpha1.BreakglassSessionList
+			if err := reader.List(ctx, &all); err != nil {
+				return nil, err
+			}
+			for _, session := range all.Items {
+				if session.Spec.Cluster == cluster {
+					appendSession(session, seenSessions)
+				}
+			}
+			break
 		}
 	}
 	now := time.Now()

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1409,6 +1409,30 @@ func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, 
 		}
 	}
 	now := time.Now()
+	if c.client != nil && c.apiReader != nil {
+		freshCandidates := make([]breakglassv1alpha1.BreakglassSession, 0, len(sessions.Items))
+		for i := range sessions.Items {
+			candidate := sessions.Items[i]
+			if !breakglass.IsSessionAuthorizationEligible(candidate, now) ||
+				(candidate.Spec.User != username && candidate.Spec.User != email) ||
+				(issuer != "" && !candidate.Spec.AllowIDPMismatch &&
+					strings.TrimRight(candidate.Spec.IdentityProviderIssuer, "/") != strings.TrimRight(issuer, "/")) {
+				continue
+			}
+			fresh := &breakglassv1alpha1.BreakglassSession{}
+			if err := reader.Get(ctx, ctrlclient.ObjectKeyFromObject(&candidate), fresh); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return nil, err
+			}
+			if candidate.UID != "" && fresh.UID != candidate.UID {
+				continue
+			}
+			freshCandidates = append(freshCandidates, *fresh)
+		}
+		sessions.Items = freshCandidates
+	}
 	collectGroups := func(items []breakglassv1alpha1.BreakglassSession) []string {
 		groups := make([]string, 0, len(items))
 		seen := make(map[string]struct{}, len(items))

--- a/pkg/breakglass/debug/debug_session_api.go
+++ b/pkg/breakglass/debug/debug_session_api.go
@@ -1389,19 +1389,35 @@ func (c *DebugSessionAPIController) handleCreateDebugSession(ctx *gin.Context) {
 
 func (c *DebugSessionAPIController) activeBreakglassGroups(ctx context.Context, reader ctrlclient.Reader, cluster, username, email, issuer string) ([]string, error) {
 	var sessions breakglassv1alpha1.BreakglassSessionList
-	if err := reader.List(ctx, &sessions); err != nil {
-		return nil, err
+	if err := reader.List(ctx, &sessions, ctrlclient.MatchingFields{"spec.cluster": cluster}); err != nil {
+		if !breakglass.IsFieldIndexError(err) {
+			return nil, err
+		}
+		var all breakglassv1alpha1.BreakglassSessionList
+		if err := reader.List(ctx, &all); err != nil {
+			return nil, err
+		}
+		sessions.Items = make([]breakglassv1alpha1.BreakglassSession, 0, len(all.Items))
+		for _, session := range all.Items {
+			if session.Spec.Cluster == cluster {
+				sessions.Items = append(sessions.Items, session)
+			}
+		}
 	}
 	now := time.Now()
-	groups := make([]string, 0)
+	groups := make([]string, 0, len(sessions.Items))
+	seen := make(map[string]struct{}, len(sessions.Items))
 	for _, session := range sessions.Items {
-		if session.Spec.Cluster != cluster ||
-			!breakglass.IsSessionAuthorizationEligible(session, now) ||
+		if !breakglass.IsSessionAuthorizationEligible(session, now) ||
 			(session.Spec.User != username && session.Spec.User != email) ||
 			(issuer != "" && !session.Spec.AllowIDPMismatch &&
 				strings.TrimRight(session.Spec.IdentityProviderIssuer, "/") != strings.TrimRight(issuer, "/")) {
 			continue
 		}
+		if _, ok := seen[session.Spec.GrantedGroup]; ok {
+			continue
+		}
+		seen[session.Spec.GrantedGroup] = struct{}{}
 		groups = append(groups, session.Spec.GrantedGroup)
 	}
 	return groups, nil

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -48,6 +48,95 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing.T) {
+	now := time.Now()
+	future := metav1.NewTime(now.Add(time.Hour))
+	past := metav1.NewTime(now.Add(-time.Minute))
+	client := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "username-match"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-a",
+				User:         "platform-requester",
+				GrantedGroup: "breakglass:platform:debugsession",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "email-match"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-a",
+				User:         "platform-requester@example.test",
+				GrantedGroup: "breakglass:platform:diagnostics",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "expired"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-a",
+				User:         "platform-requester@example.test",
+				GrantedGroup: "expired",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: past,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-a",
+				User:         "platform-requester@example.test",
+				GrantedGroup: "pending",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStatePending,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-cluster"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-b",
+				User:         "platform-requester@example.test",
+				GrantedGroup: "wrong-cluster",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-user"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:      "tenant-a",
+				User:         "other@example.test",
+				GrantedGroup: "wrong-user",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+	).Build()
+
+	controller := &DebugSessionAPIController{}
+	groups, err := controller.activeBreakglassGroups(context.Background(), client, "tenant-a", "platform-requester", "platform-requester@example.test")
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"breakglass:platform:debugsession",
+		"breakglass:platform:diagnostics",
+	}, groups)
+}
+
 func debugSessionAPITestRouter(t *testing.T, ctrl *DebugSessionAPIController, username, email string, groups []string) *gin.Engine {
 	t.Helper()
 	router := gin.New()

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -210,6 +210,70 @@ func TestActiveBreakglassGroupsDoesNotInferEmailFromUsername(t *testing.T) {
 	assert.Empty(t, groups, "the API must require an exact authenticated username or email claim")
 }
 
+func TestActiveBreakglassGroupsUsesCachedIndexWhenFreshReaderIsConfigured(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "indexed"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:                "tenant-a",
+			User:                   "alice",
+			GrantedGroup:           "breakglass:debug",
+			IdentityProviderIssuer: "https://idp-a.example",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: future,
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(session).WithIndex(
+		&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		},
+	).Build()
+	cached := &debugSessionRecordingListClient{Client: base}
+	controller := &DebugSessionAPIController{client: cached}
+
+	groups, err := controller.activeBreakglassGroups(context.Background(), base, "tenant-a", "alice", "", "https://idp-a.example")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"breakglass:debug"}, groups)
+	assert.Equal(t, []string{"tenant-a"}, debugSessionRecordedFieldValues(cached.calls, "spec.cluster"))
+}
+
+func TestActiveBreakglassGroupsRefreshesFreshReaderWhenCacheHasNoGrant(t *testing.T) {
+	cachedSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approval"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:                "tenant-a",
+			User:                   "alice",
+			GrantedGroup:           "breakglass:debug",
+			IdentityProviderIssuer: "https://idp-a.example",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(time.Now().Add(-time.Minute)),
+		},
+	}
+	freshSession := cachedSession.DeepCopy()
+	freshSession.Status.ExpiresAt = metav1.NewTime(time.Now().Add(time.Hour))
+	cachedBase := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cachedSession).WithIndex(
+		&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		},
+	).Build()
+	freshBase := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(freshSession).Build()
+	cached := &debugSessionRecordingListClient{Client: cachedBase}
+	fresh := &debugSessionRecordingListClient{Client: freshBase}
+	controller := &DebugSessionAPIController{client: cached, apiReader: fresh}
+
+	groups, err := controller.activeBreakglassGroups(context.Background(), fresh, "tenant-a", "alice", "", "https://idp-a.example")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"breakglass:debug"}, groups)
+	assert.Equal(t, []string{"tenant-a"}, debugSessionRecordedFieldValues(cached.calls, "spec.cluster"))
+	assert.Empty(t, debugSessionRecordedFieldValues(fresh.calls, "spec.cluster"), "fresh fallback must use a full live read")
+}
+
 func debugSessionAPITestRouter(t *testing.T, ctrl *DebugSessionAPIController, username, email string, groups []string) *gin.Engine {
 	t.Helper()
 	router := gin.New()

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -184,6 +184,32 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 	}, groups)
 }
 
+func TestActiveBreakglassGroupsDoesNotInferEmailFromUsername(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "alice-other-domain"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "tenant-a",
+				User:                   "alice@other-domain.example",
+				GrantedGroup:           "breakglass:admin",
+				IdentityProviderIssuer: "https://idp-a.example",
+				AllowIDPMismatch:       true,
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+	).Build()
+
+	controller := &DebugSessionAPIController{}
+	groups, err := controller.activeBreakglassGroups(context.Background(), reader, "tenant-a", "alice", "", "https://idp-a.example")
+
+	require.NoError(t, err)
+	assert.Empty(t, groups, "the API must require an exact authenticated username or email claim")
+}
+
 func debugSessionAPITestRouter(t *testing.T, ctrl *DebugSessionAPIController, username, email string, groups []string) *gin.Engine {
 	t.Helper()
 	router := gin.New()

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -80,6 +80,19 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 			},
 		},
 		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "username-match-duplicate"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "tenant-a",
+				User:                   "platform-requester",
+				GrantedGroup:           "breakglass:platform:debugsession",
+				IdentityProviderIssuer: "https://idp-a.example",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "expired"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
 				Cluster:                "tenant-a",

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -230,6 +230,10 @@ func TestActiveBreakglassGroupsUsesCachedIndexWhenFreshReaderIsConfigured(t *tes
 		&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
 			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
 		},
+	).WithIndex(
+		&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		},
 	).Build()
 	cached := &debugSessionRecordingListClient{Client: base}
 	controller := &DebugSessionAPIController{client: cached}
@@ -238,7 +242,63 @@ func TestActiveBreakglassGroupsUsesCachedIndexWhenFreshReaderIsConfigured(t *tes
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"breakglass:debug"}, groups)
+	require.Len(t, cached.calls, 1)
 	assert.Equal(t, []string{"tenant-a"}, debugSessionRecordedFieldValues(cached.calls, "spec.cluster"))
+	assert.Equal(t, []string{"alice"}, debugSessionRecordedFieldValues(cached.calls, "spec.user"))
+}
+
+func TestActiveBreakglassGroupsQueriesEachUniqueIdentityWithCompoundIndex(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	usernameSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "username-grant"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "tenant-a", User: "alice", GrantedGroup: "breakglass:username", IdentityProviderIssuer: "https://idp.example"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved, ExpiresAt: future},
+	}
+	emailSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "email-grant"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "tenant-a", User: "alice@example.test", GrantedGroup: "breakglass:email", IdentityProviderIssuer: "https://idp.example"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved, ExpiresAt: future},
+	}
+	base := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(usernameSession, emailSession).
+		WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		}).WithIndex(&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+		return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+	}).Build()
+	cached := &debugSessionRecordingListClient{Client: base}
+	controller := &DebugSessionAPIController{client: cached}
+
+	groups, err := controller.activeBreakglassGroups(context.Background(), base, "tenant-a", "alice", "alice@example.test", "https://idp.example")
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"breakglass:username", "breakglass:email"}, groups)
+	require.Len(t, cached.calls, 2)
+	assert.ElementsMatch(t, []string{"alice", "alice@example.test"}, debugSessionRecordedFieldValues(cached.calls, "spec.user"))
+	for _, call := range cached.calls {
+		value, found := call.FieldSelector.RequiresExactMatch("spec.cluster")
+		require.True(t, found)
+		assert.Equal(t, "tenant-a", value)
+	}
+}
+
+func TestActiveBreakglassGroupsFallsBackToOneFullListWhenIdentityIndexMissing(t *testing.T) {
+	future := metav1.NewTime(time.Now().Add(time.Hour))
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "email-grant"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "tenant-a", User: "alice@example.test", GrantedGroup: "breakglass:email", IdentityProviderIssuer: "https://idp.example"},
+		Status:     breakglassv1alpha1.BreakglassSessionStatus{State: breakglassv1alpha1.SessionStateApproved, ExpiresAt: future},
+	}
+	base := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(session).Build()
+	missingIndex := &debugSessionMissingIndexClient{Client: base}
+	controller := &DebugSessionAPIController{client: missingIndex}
+
+	groups, err := controller.activeBreakglassGroups(context.Background(), base, "tenant-a", "alice", "alice@example.test", "https://idp.example")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"breakglass:email"}, groups)
+	require.Len(t, missingIndex.calls, 1, "one failed indexed query must trigger one full-list fallback")
+	assert.Equal(t, []string{"tenant-a"}, debugSessionRecordedFieldValues(missingIndex.calls, "spec.cluster"))
+	assert.Equal(t, []string{"alice"}, debugSessionRecordedFieldValues(missingIndex.calls, "spec.user"))
 }
 
 func TestActiveBreakglassGroupsRefreshesFreshReaderWhenCacheHasNoGrant(t *testing.T) {
@@ -261,6 +321,10 @@ func TestActiveBreakglassGroupsRefreshesFreshReaderWhenCacheHasNoGrant(t *testin
 		&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
 			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
 		},
+	).WithIndex(
+		&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
+		},
 	).Build()
 	freshBase := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(freshSession).Build()
 	cached := &debugSessionRecordingListClient{Client: cachedBase}
@@ -271,7 +335,9 @@ func TestActiveBreakglassGroupsRefreshesFreshReaderWhenCacheHasNoGrant(t *testin
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"breakglass:debug"}, groups)
+	require.Len(t, cached.calls, 1)
 	assert.Equal(t, []string{"tenant-a"}, debugSessionRecordedFieldValues(cached.calls, "spec.cluster"))
+	assert.Equal(t, []string{"alice"}, debugSessionRecordedFieldValues(cached.calls, "spec.user"))
 	assert.Empty(t, debugSessionRecordedFieldValues(fresh.calls, "spec.cluster"), "fresh fallback must use a full live read")
 }
 
@@ -315,6 +381,10 @@ func TestActiveBreakglassGroupsRejectsStaleCachedGrant(t *testing.T) {
 			cachedBase := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cachedSession).WithIndex(
 				&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
 					return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+				},
+			).WithIndex(
+				&breakglassv1alpha1.BreakglassSession{}, "spec.user", func(obj client.Object) []string {
+					return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.User}
 				},
 			).Build()
 			fresh := &debugSessionRecordingGetClient{Client: tt.freshSetup(testScheme())}

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -35,6 +35,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -274,6 +275,60 @@ func TestActiveBreakglassGroupsRefreshesFreshReaderWhenCacheHasNoGrant(t *testin
 	assert.Empty(t, debugSessionRecordedFieldValues(fresh.calls, "spec.cluster"), "fresh fallback must use a full live read")
 }
 
+func TestActiveBreakglassGroupsRejectsStaleCachedGrant(t *testing.T) {
+	cachedSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approval", Namespace: "breakglass", UID: "cached-uid"},
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			Cluster:                "tenant-a",
+			User:                   "alice",
+			GrantedGroup:           "breakglass:debug",
+			IdentityProviderIssuer: "https://idp-a.example",
+		},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
+		},
+	}
+
+	tests := []struct {
+		name       string
+		freshSetup func(*runtime.Scheme) client.Client
+	}{
+		{
+			name: "revoked",
+			freshSetup: func(scheme *runtime.Scheme) client.Client {
+				revoked := cachedSession.DeepCopy()
+				revoked.Status.State = breakglassv1alpha1.SessionStateExpired
+				return fake.NewClientBuilder().WithScheme(scheme).WithObjects(revoked).Build()
+			},
+		},
+		{
+			name: "deleted",
+			freshSetup: func(scheme *runtime.Scheme) client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).Build()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cachedBase := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(cachedSession).WithIndex(
+				&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+					return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+				},
+			).Build()
+			fresh := &debugSessionRecordingGetClient{Client: tt.freshSetup(testScheme())}
+			controller := &DebugSessionAPIController{client: cachedBase, apiReader: fresh}
+
+			groups, err := controller.activeBreakglassGroups(context.Background(), fresh, "tenant-a", "alice", "", "https://idp-a.example")
+
+			require.NoError(t, err)
+			assert.Empty(t, groups)
+			assert.Len(t, fresh.gets, 1)
+		})
+	}
+}
+
 func debugSessionAPITestRouter(t *testing.T, ctrl *DebugSessionAPIController, username, email string, groups []string) *gin.Engine {
 	t.Helper()
 	router := gin.New()
@@ -308,6 +363,16 @@ func (c *debugSessionRecordingListClient) List(ctx context.Context, list client.
 	}
 	c.calls = append(c.calls, listOpts)
 	return c.Client.List(ctx, list, opts...)
+}
+
+type debugSessionRecordingGetClient struct {
+	client.Client
+	gets []client.ObjectKey
+}
+
+func (c *debugSessionRecordingGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.gets = append(c.gets, key)
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 func debugSessionRecordedFieldValues(calls []client.ListOptions, field string) []string {

--- a/pkg/breakglass/debug/debug_session_api_test.go
+++ b/pkg/breakglass/debug/debug_session_api_test.go
@@ -56,9 +56,10 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "username-match"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-a",
-				User:         "platform-requester",
-				GrantedGroup: "breakglass:platform:debugsession",
+				Cluster:                "tenant-a",
+				User:                   "platform-requester",
+				GrantedGroup:           "breakglass:platform:debugsession",
+				IdentityProviderIssuer: "https://idp-a.example/",
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStateApproved,
@@ -68,9 +69,10 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "email-match"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-a",
-				User:         "platform-requester@example.test",
-				GrantedGroup: "breakglass:platform:diagnostics",
+				Cluster:                "tenant-a",
+				User:                   "platform-requester@example.test",
+				GrantedGroup:           "breakglass:platform:diagnostics",
+				IdentityProviderIssuer: "https://idp-a.example",
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStateApproved,
@@ -80,9 +82,10 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "expired"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-a",
-				User:         "platform-requester@example.test",
-				GrantedGroup: "expired",
+				Cluster:                "tenant-a",
+				User:                   "platform-requester@example.test",
+				GrantedGroup:           "expired",
+				IdentityProviderIssuer: "https://idp-a.example",
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStateApproved,
@@ -92,9 +95,10 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "pending"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-a",
-				User:         "platform-requester@example.test",
-				GrantedGroup: "pending",
+				Cluster:                "tenant-a",
+				User:                   "platform-requester@example.test",
+				GrantedGroup:           "pending",
+				IdentityProviderIssuer: "https://idp-a.example",
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStatePending,
@@ -104,9 +108,10 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "wrong-cluster"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-b",
-				User:         "platform-requester@example.test",
-				GrantedGroup: "wrong-cluster",
+				Cluster:                "tenant-b",
+				User:                   "platform-requester@example.test",
+				GrantedGroup:           "wrong-cluster",
+				IdentityProviderIssuer: "https://idp-a.example",
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStateApproved,
@@ -116,9 +121,37 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 		&breakglassv1alpha1.BreakglassSession{
 			ObjectMeta: metav1.ObjectMeta{Name: "wrong-user"},
 			Spec: breakglassv1alpha1.BreakglassSessionSpec{
-				Cluster:      "tenant-a",
-				User:         "other@example.test",
-				GrantedGroup: "wrong-user",
+				Cluster:                "tenant-a",
+				User:                   "other@example.test",
+				GrantedGroup:           "wrong-user",
+				IdentityProviderIssuer: "https://idp-a.example",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-issuer"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "tenant-a",
+				User:                   "platform-requester",
+				GrantedGroup:           "wrong-issuer",
+				IdentityProviderIssuer: "https://idp-b.example",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: future,
+			},
+		},
+		&breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "mismatch-allowed"},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "tenant-a",
+				User:                   "platform-requester",
+				GrantedGroup:           "breakglass:platform:legacy",
+				IdentityProviderIssuer: "https://idp-b.example",
+				AllowIDPMismatch:       true,
 			},
 			Status: breakglassv1alpha1.BreakglassSessionStatus{
 				State:     breakglassv1alpha1.SessionStateApproved,
@@ -128,12 +161,13 @@ func TestActiveBreakglassGroupsFiltersByClusterIdentityStateAndExpiry(t *testing
 	).Build()
 
 	controller := &DebugSessionAPIController{}
-	groups, err := controller.activeBreakglassGroups(context.Background(), client, "tenant-a", "platform-requester", "platform-requester@example.test")
+	groups, err := controller.activeBreakglassGroups(context.Background(), client, "tenant-a", "platform-requester", "platform-requester@example.test", "https://idp-a.example")
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
 		"breakglass:platform:debugsession",
 		"breakglass:platform:diagnostics",
+		"breakglass:platform:legacy",
 	}, groups)
 }
 

--- a/pkg/breakglass/debug/debug_session_quota_test.go
+++ b/pkg/breakglass/debug/debug_session_quota_test.go
@@ -5,21 +5,116 @@ package debug
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 	"github.com/telekom/k8s-breakglass/pkg/breakglass"
+	"github.com/telekom/k8s-breakglass/pkg/cluster"
 	"github.com/telekom/k8s-breakglass/pkg/quotas"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestEnsureTargetNamespaceHonorsCreationAndFailMode(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		failMode    string
+		constraints *breakglassv1alpha1.NamespaceConstraints
+		wantError   bool
+		wantCreate  bool
+		wantReady   bool
+	}{
+		{name: "creates missing namespace", constraints: &breakglassv1alpha1.NamespaceConstraints{CreateIfNotExists: true, NamespaceLabels: map[string]string{"owner": "breakglass"}}, wantCreate: true, wantReady: true},
+		{name: "fail open skips missing namespace", failMode: "open"},
+		{name: "fail closed rejects missing namespace", wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(Scheme).Build()
+			controller := NewDebugSessionController(zap.NewNop().Sugar(), cli, nil)
+			ready, err := controller.ensureTargetNamespace(t.Context(), cli, "debug-target", tt.failMode, tt.constraints)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantReady, ready)
+
+			ns := &corev1.Namespace{}
+			err = cli.Get(t.Context(), client.ObjectKey{Name: "debug-target"}, ns)
+			if tt.wantCreate {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]string{"owner": "breakglass"}, ns.Labels)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestEffectiveNamespaceConstraintsBindingOverridesTemplate(t *testing.T) {
+	templateConstraints := &breakglassv1alpha1.NamespaceConstraints{DefaultNamespace: "template-debug", NamespaceLabels: map[string]string{"source": "template"}}
+	bindingConstraints := &breakglassv1alpha1.NamespaceConstraints{DefaultNamespace: "binding-debug", CreateIfNotExists: true, NamespaceLabels: map[string]string{"source": "binding"}}
+	template := &breakglassv1alpha1.DebugSessionTemplate{Spec: breakglassv1alpha1.DebugSessionTemplateSpec{NamespaceConstraints: templateConstraints}}
+	binding := &breakglassv1alpha1.DebugSessionClusterBinding{Spec: breakglassv1alpha1.DebugSessionClusterBindingSpec{NamespaceConstraints: bindingConstraints}}
+
+	assert.Same(t, bindingConstraints, effectiveNamespaceConstraints(template, binding))
+	assert.Same(t, templateConstraints, effectiveNamespaceConstraints(template, nil))
+	assert.Same(t, templateConstraints, effectiveNamespaceConstraints(template, &breakglassv1alpha1.DebugSessionClusterBinding{}))
+}
+
+func TestDeployDebugResourcesFailOpenSkipsSpokeWrites(t *testing.T) {
+	var writes int
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writes++
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/namespaces/missing-debug" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(metav1.Status{TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"}, Status: metav1.StatusFailure, Reason: metav1.StatusReasonNotFound, Code: http.StatusNotFound})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := &httptest.Server{Listener: listener, Config: &http.Server{Handler: handler}}
+	server.Start()
+	defer server.Close()
+	t.Setenv("BREAKGLASS_DISABLE_LOOPBACK_REWRITE", "true")
+
+	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{
+		APIVersion: "v1", Kind: "Config",
+		Clusters:       map[string]*clientcmdapi.Cluster{"spoke": {Server: server.URL}},
+		AuthInfos:      map[string]*clientcmdapi.AuthInfo{"controller": {}},
+		Contexts:       map[string]*clientcmdapi.Context{"default": {Cluster: "spoke", AuthInfo: "controller"}},
+		CurrentContext: "default",
+	})
+	require.NoError(t, err)
+	clusterConfig := &breakglassv1alpha1.ClusterConfig{ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "default"}, Spec: breakglassv1alpha1.ClusterConfigSpec{KubeconfigSecretRef: &breakglassv1alpha1.SecretKeyReference{Name: "spoke-kubeconfig", Namespace: "default"}}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "spoke-kubeconfig", Namespace: "default"}, Data: map[string][]byte{"value": kubeconfig}}
+	template := &breakglassv1alpha1.DebugSessionTemplate{ObjectMeta: metav1.ObjectMeta{Name: "template"}, Spec: breakglassv1alpha1.DebugSessionTemplateSpec{FailMode: "open", TargetNamespace: "missing-debug", ResourceQuota: &breakglassv1alpha1.DebugResourceQuotaConfig{MaxPods: int32Ptr(1)}}}
+	session := newTestDebugSession("fail-open", template.Name, clusterConfig.Name, "user@example.com")
+	hub := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(clusterConfig, secret, template).Build()
+	controller := NewDebugSessionController(zap.NewNop().Sugar(), hub, cluster.NewClientProvider(hub, zap.NewNop().Sugar())).WithAPIReader(hub)
+
+	require.NoError(t, controller.deployDebugResources(t.Context(), session, template))
+	assert.Zero(t, writes, "fail-open must stop deployment after a missing namespace")
+}
 
 func TestDebugQuotaScopesAcrossNamespacesAndBindings(t *testing.T) {
 	one := int32(1)

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -70,6 +70,10 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	// Get target cluster client (with or without impersonation)
 	var targetClient ctrlclient.Client
 	var err error
+	namespaceConstraints := template.Spec.NamespaceConstraints
+	if binding != nil && binding.Spec.NamespaceConstraints != nil {
+		namespaceConstraints = binding.Spec.NamespaceConstraints
+	}
 
 	// First, resolve the target namespace (needed for per-session SA creation)
 	targetNs := ds.Spec.TargetNamespace
@@ -78,8 +82,8 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	}
 	if targetNs == "" {
 		// Check namespaceConstraints for default
-		if template.Spec.NamespaceConstraints != nil && template.Spec.NamespaceConstraints.DefaultNamespace != "" {
-			targetNs = template.Spec.NamespaceConstraints.DefaultNamespace
+		if namespaceConstraints != nil && namespaceConstraints.DefaultNamespace != "" {
+			targetNs = namespaceConstraints.DefaultNamespace
 		}
 	}
 	if targetNs == "" {
@@ -122,13 +126,24 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	ns := &corev1.Namespace{}
 	if err := targetClient.Get(ctx, ctrlclient.ObjectKey{Name: targetNs}, ns); err != nil {
 		if apierrors.IsNotFound(err) {
-			if template.Spec.FailMode == "open" {
+			if namespaceConstraints != nil && namespaceConstraints.CreateIfNotExists {
+				ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:   targetNs,
+					Labels: namespaceConstraints.NamespaceLabels,
+				}}
+				if err := targetClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+					return fmt.Errorf("failed to create target namespace %s: %w", targetNs, err)
+				}
+			} else if template.Spec.FailMode == "open" {
 				log.Warnw("Target namespace does not exist, fail-open mode", "namespace", targetNs)
 				return nil
+			} else {
+				return fmt.Errorf("target namespace %s does not exist", targetNs)
 			}
-			return fmt.Errorf("target namespace %s does not exist", targetNs)
 		}
-		return fmt.Errorf("failed to check namespace: %w", err)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to check namespace: %w", err)
+		}
 	}
 
 	// Deploy ResourceQuota if configured

--- a/pkg/breakglass/debug/debug_session_reconciler_workload.go
+++ b/pkg/breakglass/debug/debug_session_reconciler_workload.go
@@ -70,10 +70,7 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	// Get target cluster client (with or without impersonation)
 	var targetClient ctrlclient.Client
 	var err error
-	namespaceConstraints := template.Spec.NamespaceConstraints
-	if binding != nil && binding.Spec.NamespaceConstraints != nil {
-		namespaceConstraints = binding.Spec.NamespaceConstraints
-	}
+	namespaceConstraints := effectiveNamespaceConstraints(template, binding)
 
 	// First, resolve the target namespace (needed for per-session SA creation)
 	targetNs := ds.Spec.TargetNamespace
@@ -123,27 +120,12 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	}
 
 	// Ensure target namespace exists
-	ns := &corev1.Namespace{}
-	if err := targetClient.Get(ctx, ctrlclient.ObjectKey{Name: targetNs}, ns); err != nil {
-		if apierrors.IsNotFound(err) {
-			if namespaceConstraints != nil && namespaceConstraints.CreateIfNotExists {
-				ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-					Name:   targetNs,
-					Labels: namespaceConstraints.NamespaceLabels,
-				}}
-				if err := targetClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
-					return fmt.Errorf("failed to create target namespace %s: %w", targetNs, err)
-				}
-			} else if template.Spec.FailMode == "open" {
-				log.Warnw("Target namespace does not exist, fail-open mode", "namespace", targetNs)
-				return nil
-			} else {
-				return fmt.Errorf("target namespace %s does not exist", targetNs)
-			}
-		}
-		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check namespace: %w", err)
-		}
+	ready, err := c.ensureTargetNamespace(ctx, targetClient, targetNs, template.Spec.FailMode, namespaceConstraints)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return nil
 	}
 
 	// Deploy ResourceQuota if configured
@@ -255,6 +237,38 @@ func (c *DebugSessionController) deployDebugResources(ctx context.Context, ds *b
 	}
 
 	return nil
+}
+
+func effectiveNamespaceConstraints(template *breakglassv1alpha1.DebugSessionTemplate, binding *breakglassv1alpha1.DebugSessionClusterBinding) *breakglassv1alpha1.NamespaceConstraints {
+	if binding != nil && binding.Spec.NamespaceConstraints != nil {
+		return binding.Spec.NamespaceConstraints
+	}
+	return template.Spec.NamespaceConstraints
+}
+
+func (c *DebugSessionController) ensureTargetNamespace(ctx context.Context, targetClient ctrlclient.Client, targetNs, failMode string, constraints *breakglassv1alpha1.NamespaceConstraints) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := targetClient.Get(ctx, ctrlclient.ObjectKey{Name: targetNs}, ns); err == nil {
+		return true, nil
+	} else if !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to check namespace: %w", err)
+	}
+
+	if constraints != nil && constraints.CreateIfNotExists {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   targetNs,
+			Labels: constraints.NamespaceLabels,
+		}}
+		if err := targetClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			return false, fmt.Errorf("failed to create target namespace %s: %w", targetNs, err)
+		}
+		return true, nil
+	}
+	if failMode == "open" {
+		c.log.Warnw("Target namespace does not exist, fail-open mode", "namespace", targetNs)
+		return false, nil
+	}
+	return false, fmt.Errorf("target namespace %s does not exist", targetNs)
 }
 
 func startAuxiliaryStatusTracking(ds *breakglassv1alpha1.DebugSession, auxiliaryResourcesConfigured bool) []breakglassv1alpha1.AuxiliaryResourceStatus {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -415,12 +415,39 @@ func (c *SessionManager) GetClusterUserBreakglassSessions(ctx context.Context,
 		if !refreshed || len(fallback) == 0 {
 			return bsl.Items, nil
 		}
+
 		result := mergeSessionResults(bsl.Items, fallback)
 		log.Infow("Fetched BreakglassSessions from live reader after cache lookup found no eligible session",
 			"count", len(result), "cluster", cluster, "user", user)
 		return result, nil
 	}
 	log.Infow("Fetched BreakglassSessions (indexed)", "count", len(bsl.Items), "cluster", cluster, "user", user)
+	return bsl.Items, nil
+}
+
+// GetClusterBreakglassSessions lists sessions for a cluster when the caller
+// needs to resolve an identity alias that cannot be represented by the
+// spec.user field index.
+func (c *SessionManager) GetClusterBreakglassSessions(ctx context.Context,
+	cluster string,
+) ([]breakglassv1alpha1.BreakglassSession, error) {
+	bsl := breakglassv1alpha1.BreakglassSessionList{}
+	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"spec.cluster": cluster}); err != nil {
+		if !IsFieldIndexError(err) {
+			return nil, fmt.Errorf("failed to list BreakglassSessions for cluster: %w", err)
+		}
+		all, err := c.GetAllBreakglassSessions(ctx)
+		if err != nil {
+			return nil, err
+		}
+		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(all))
+		for _, s := range all {
+			if s.Spec.Cluster == cluster {
+				filtered = append(filtered, s)
+			}
+		}
+		return filtered, nil
+	}
 	return bsl.Items, nil
 }
 

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -455,11 +455,22 @@ func (c *SessionManager) GetClusterBreakglassSessions(ctx context.Context,
 		}
 
 		result := mergeSessionResults(bsl.Items, fallback)
-		c.getLogger().Infow("Fetched BreakglassSessions from live reader after cluster cache lookup found no eligible session",
+		c.getLogger().Infow("Fetched BreakglassSessions from live reader after cluster cache lookup",
 			"count", len(result), "cluster", cluster)
 		return result, nil
 	}
 	return bsl.Items, nil
+}
+
+// RefreshClusterBreakglassSessions refreshes the live cluster list when an
+// alias lookup found no eligible cached session.
+func (c *SessionManager) RefreshClusterBreakglassSessions(ctx context.Context,
+	cluster string,
+) ([]breakglassv1alpha1.BreakglassSession, bool) {
+	if c.liveReader == nil {
+		return nil, false
+	}
+	return c.fetchLiveClusterBreakglassSessions(ctx, cluster, "\x00cluster\x00"+cluster, c.getLogger())
 }
 
 // RefreshClusterUserBreakglassSessions refreshes a cached cluster/user lookup

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -434,7 +434,7 @@ func (c *SessionManager) GetClusterBreakglassSessions(ctx context.Context,
 	bsl := breakglassv1alpha1.BreakglassSessionList{}
 	if err := c.Client.List(ctx, &bsl, client.MatchingFields{"spec.cluster": cluster}); err != nil {
 		if !IsFieldIndexError(err) {
-			return nil, fmt.Errorf("failed to list BreakglassSessions for cluster: %w", err)
+			return nil, fmt.Errorf("failed to list BreakglassSessions for cluster %q: %w", cluster, err)
 		}
 		all, err := c.GetAllBreakglassSessions(ctx)
 		if err != nil {

--- a/pkg/breakglass/session_manager.go
+++ b/pkg/breakglass/session_manager.go
@@ -448,6 +448,17 @@ func (c *SessionManager) GetClusterBreakglassSessions(ctx context.Context,
 		}
 		return filtered, nil
 	}
+	if c.liveReader != nil && !hasAuthorizationEligibleSession(bsl.Items, time.Now()) {
+		fallback, refreshed := c.fetchLiveClusterBreakglassSessions(ctx, cluster, "\x00cluster\x00"+cluster, c.getLogger())
+		if !refreshed || len(fallback) == 0 {
+			return bsl.Items, nil
+		}
+
+		result := mergeSessionResults(bsl.Items, fallback)
+		c.getLogger().Infow("Fetched BreakglassSessions from live reader after cluster cache lookup found no eligible session",
+			"count", len(result), "cluster", cluster)
+		return result, nil
+	}
 	return bsl.Items, nil
 }
 
@@ -518,6 +529,53 @@ func (c *SessionManager) fetchLiveClusterUserBreakglassSessions(ctx context.Cont
 		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
 		for _, s := range liveList.Items {
 			if s.Spec.Cluster == cluster && s.Spec.User == user {
+				filtered = append(filtered, s)
+			}
+		}
+		if hasAuthorizationEligibleSession(filtered, time.Now()) {
+			return liveFallbackResult{sessions: filtered, success: true}, nil
+		}
+		c.recordLiveReaderFallback(fallbackKey, time.Now())
+		return liveFallbackResult{sessions: filtered, success: true}, nil
+	})
+	var value interface{}
+	select {
+	case result := <-resultCh:
+		value = result.Val
+	case <-ctx.Done():
+		return nil, false
+	}
+	fallback, ok := value.(liveFallbackResult)
+	if !ok || !fallback.success {
+		return nil, false
+	}
+	return fallback.sessions, true
+}
+
+func (c *SessionManager) fetchLiveClusterBreakglassSessions(ctx context.Context,
+	cluster string,
+	fallbackKey string,
+	log *zap.SugaredLogger,
+) ([]breakglassv1alpha1.BreakglassSession, bool) {
+	if c.liveReaderFallbackSuppressed(fallbackKey, time.Now()) {
+		return nil, false
+	}
+	resultCh := c.liveFallbackFlight.DoChan(fallbackKey, func() (interface{}, error) {
+		opCtx, cancel := context.WithTimeout(context.Background(), liveReaderRefreshTimeout)
+		defer cancel()
+		var liveList breakglassv1alpha1.BreakglassSessionList
+		err := c.liveReader.List(opCtx, &liveList, client.MatchingFields{"spec.cluster": cluster})
+		if err != nil && IsFieldIndexError(err) {
+			err = c.liveReader.List(opCtx, &liveList)
+		}
+		if err != nil {
+			log.Warnw("Failed to refresh BreakglassSessions from live reader after cluster cache lookup found no eligible session",
+				"cluster", cluster, "error", err)
+			return liveFallbackResult{}, nil
+		}
+		filtered := make([]breakglassv1alpha1.BreakglassSession, 0, len(liveList.Items))
+		for _, s := range liveList.Items {
+			if s.Spec.Cluster == cluster {
 				filtered = append(filtered, s)
 			}
 		}

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	breakglassv1alpha1 "github.com/telekom/k8s-breakglass/api/v1alpha1"
 )
@@ -86,6 +87,20 @@ func TestSessionManager_LiveFallbackSelectorsAndErrors(t *testing.T) {
 		assert.False(t, refreshed)
 		assert.Equal(t, 1, calls)
 	})
+}
+
+func TestSessionManager_GetClusterBreakglassSessionsIncludesClusterOnListError(t *testing.T) {
+	listErr := fmt.Errorf("forbidden")
+	cli := fake.NewClientBuilder().WithScheme(Scheme).WithInterceptorFuncs(interceptor.Funcs{
+		List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+			return listErr
+		},
+	}).Build()
+
+	_, err := (&SessionManager{Client: cli}).GetClusterBreakglassSessions(context.Background(), "tenant-a")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `failed to list BreakglassSessions for cluster "tenant-a"`)
+	assert.ErrorIs(t, err, listErr)
 }
 
 func TestSessionManager_Simple(t *testing.T) {

--- a/pkg/breakglass/session_manager_simple_test.go
+++ b/pkg/breakglass/session_manager_simple_test.go
@@ -89,6 +89,39 @@ func TestSessionManager_LiveFallbackSelectorsAndErrors(t *testing.T) {
 	})
 }
 
+func TestSessionManager_GetClusterBreakglassSessionsRefreshesStaleCache(t *testing.T) {
+	now := time.Now()
+	cachedSession := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "approval"},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{Cluster: "cluster-a", User: "alice"},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(now.Add(-time.Minute)),
+		},
+	}
+	liveSession := cachedSession.DeepCopy()
+	liveSession.Status.ExpiresAt = metav1.NewTime(now.Add(time.Hour))
+	liveCalls := 0
+	liveReader := stubReader{listFnWithOpts: func(list client.ObjectList, _ []client.ListOption) error {
+		liveCalls++
+		list.(*breakglassv1alpha1.BreakglassSessionList).Items = []breakglassv1alpha1.BreakglassSession{*liveSession}
+		return nil
+	}}
+	cachedClient := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(cachedSession).WithIndex(
+		&breakglassv1alpha1.BreakglassSession{}, "spec.cluster", func(obj client.Object) []string {
+			return []string{obj.(*breakglassv1alpha1.BreakglassSession).Spec.Cluster}
+		},
+	).Build()
+	manager := NewSessionManagerWithClientAndReader(cachedClient, liveReader)
+
+	sessions, err := manager.GetClusterBreakglassSessions(context.Background(), "cluster-a")
+
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.True(t, sessions[0].Status.ExpiresAt.After(now))
+	assert.Equal(t, 1, liveCalls)
+}
+
 func TestSessionManager_GetClusterBreakglassSessionsIncludesClusterOnListError(t *testing.T) {
 	listErr := fmt.Errorf("forbidden")
 	cli := fake.NewClientBuilder().WithScheme(Scheme).WithInterceptorFuncs(interceptor.Funcs{

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -943,8 +943,28 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
+	if len(all) == 0 && username != "" && issuer != "" {
+		clusterSessions, listErr := wc.sesManager.GetClusterBreakglassSessions(ctx, clustername)
+		if listErr != nil {
+			return nil, nil, listErr
+		}
+		for _, session := range clusterSessions {
+			if session.Spec.IdentityProviderIssuer == issuer &&
+				sessionUserAliasMatches(username, session.Spec.User) {
+				all = append(all, session)
+			}
+		}
+	}
 	out, idpMismatches := filterSessionsForAuthorization(all, issuer, time.Now())
 	return out, idpMismatches, nil
+}
+
+func sessionUserAliasMatches(username, sessionUser string) bool {
+	if username == "" || sessionUser == "" {
+		return false
+	}
+	at := strings.LastIndexByte(sessionUser, '@')
+	return at > 0 && strings.EqualFold(username, sessionUser[:at])
 }
 
 func grantedGroupsFromSessions(sessions []breakglassv1alpha1.BreakglassSession) []string {

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -943,17 +943,12 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(all) == 0 && username != "" && issuer != "" {
+	if len(all) == 0 && username != "" {
 		clusterSessions, listErr := wc.sesManager.GetClusterBreakglassSessions(ctx, clustername)
 		if listErr != nil {
 			return nil, nil, listErr
 		}
-		for _, session := range clusterSessions {
-			if session.Spec.IdentityProviderIssuer == issuer &&
-				sessionUserAliasMatches(username, session.Spec.User) {
-				all = append(all, session)
-			}
-		}
+		all = sessionsMatchingIdentityAlias(clusterSessions, username, issuer)
 	}
 	out, idpMismatches := filterSessionsForAuthorization(all, issuer, time.Now())
 	return out, idpMismatches, nil
@@ -965,6 +960,26 @@ func sessionUserAliasMatches(username, sessionUser string) bool {
 	}
 	at := strings.LastIndexByte(sessionUser, '@')
 	return at > 0 && strings.EqualFold(username, sessionUser[:at])
+}
+
+func sessionsMatchingIdentityAlias(sessions []breakglassv1alpha1.BreakglassSession, username, issuer string) []breakglassv1alpha1.BreakglassSession {
+	matches := make([]breakglassv1alpha1.BreakglassSession, 0)
+	issuers := map[string]struct{}{}
+	for _, session := range sessions {
+		if !sessionUserAliasMatches(username, session.Spec.User) ||
+			session.Spec.IdentityProviderIssuer == "" {
+			continue
+		}
+		if issuer != "" && session.Spec.IdentityProviderIssuer != issuer {
+			continue
+		}
+		matches = append(matches, session)
+		issuers[session.Spec.IdentityProviderIssuer] = struct{}{}
+	}
+	if issuer == "" && len(issuers) != 1 {
+		return nil
+	}
+	return matches
 }
 
 func grantedGroupsFromSessions(sessions []breakglassv1alpha1.BreakglassSession) []string {

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -944,14 +944,19 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(all) == 0 && username != "" {
+	now := time.Now()
+	out, idpMismatches := filterSessionsForAuthorization(all, issuer, now)
+	if len(out) == 0 && username != "" {
 		clusterSessions, listErr := wc.sesManager.GetClusterBreakglassSessions(ctx, clustername)
 		if listErr != nil {
 			return nil, nil, listErr
 		}
-		all = sessionsMatchingIdentityAlias(clusterSessions, username, issuer)
+		aliasSessions := sessionsMatchingIdentityAlias(clusterSessions, username, issuer)
+		aliasOut, _ := filterSessionsForAuthorization(aliasSessions, issuer, now)
+		if len(aliasOut) > 0 {
+			out = aliasOut
+		}
 	}
-	out, idpMismatches := filterSessionsForAuthorization(all, issuer, time.Now())
 	return out, idpMismatches, nil
 }
 

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -939,6 +939,7 @@ func (wc *WebhookController) getUserGroupsAndSessionsWithIDPInfo(ctx context.Con
 // If issuer is empty, returns all sessions (single-IDP or backward compatibility mode)
 // Also returns a list of sessions that were filtered out due to IDP issuer mismatch
 func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context, username, clustername, issuer string) ([]breakglassv1alpha1.BreakglassSession, []breakglassv1alpha1.BreakglassSession, error) {
+	issuer = canonicalIssuer(issuer)
 	all, err := wc.sesManager.GetClusterUserBreakglassSessions(ctx, clustername, username)
 	if err != nil {
 		return nil, nil, err
@@ -962,7 +963,12 @@ func sessionUserAliasMatches(username, sessionUser string) bool {
 	return at > 0 && strings.EqualFold(username, sessionUser[:at])
 }
 
+func canonicalIssuer(issuer string) string {
+	return strings.TrimRight(issuer, "/")
+}
+
 func sessionsMatchingIdentityAlias(sessions []breakglassv1alpha1.BreakglassSession, username, issuer string) []breakglassv1alpha1.BreakglassSession {
+	issuer = canonicalIssuer(issuer)
 	matches := make([]breakglassv1alpha1.BreakglassSession, 0)
 	issuers := map[string]struct{}{}
 	for _, session := range sessions {
@@ -970,11 +976,11 @@ func sessionsMatchingIdentityAlias(sessions []breakglassv1alpha1.BreakglassSessi
 			session.Spec.IdentityProviderIssuer == "" {
 			continue
 		}
-		if issuer != "" && session.Spec.IdentityProviderIssuer != issuer {
+		if issuer != "" && canonicalIssuer(session.Spec.IdentityProviderIssuer) != issuer {
 			continue
 		}
 		matches = append(matches, session)
-		issuers[session.Spec.IdentityProviderIssuer] = struct{}{}
+		issuers[canonicalIssuer(session.Spec.IdentityProviderIssuer)] = struct{}{}
 	}
 	if issuer == "" && len(issuers) != 1 {
 		return nil
@@ -994,13 +1000,14 @@ func filterSessionsForAuthorization(sessions []breakglassv1alpha1.BreakglassSess
 	issuer string,
 	now time.Time,
 ) ([]breakglassv1alpha1.BreakglassSession, []breakglassv1alpha1.BreakglassSession) {
+	issuer = canonicalIssuer(issuer)
 	out := make([]breakglassv1alpha1.BreakglassSession, 0, len(sessions))
 	idpMismatches := make([]breakglassv1alpha1.BreakglassSession, 0)
 	for _, session := range sessions {
 		if !breakglass.IsSessionAuthorizationEligible(session, now) {
 			continue
 		}
-		if issuer != "" && !session.Spec.AllowIDPMismatch && session.Spec.IdentityProviderIssuer != issuer {
+		if issuer != "" && !session.Spec.AllowIDPMismatch && canonicalIssuer(session.Spec.IdentityProviderIssuer) != issuer {
 			idpMismatches = append(idpMismatches, session)
 			continue
 		}

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -946,7 +946,7 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 	}
 	now := time.Now()
 	out, idpMismatches := filterSessionsForAuthorization(all, issuer, now)
-	if len(out) == 0 && username != "" {
+	if len(out) == 0 && username != "" && !strings.ContainsRune(username, '@') {
 		clusterSessions, listErr := wc.sesManager.GetClusterBreakglassSessions(ctx, clustername)
 		if listErr != nil {
 			return nil, nil, listErr
@@ -967,11 +967,11 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 }
 
 func sessionUserAliasMatches(username, sessionUser string) bool {
-	if username == "" || sessionUser == "" {
+	if username == "" || strings.ContainsRune(username, '@') || strings.Count(sessionUser, "@") != 1 {
 		return false
 	}
 	at := strings.LastIndexByte(sessionUser, '@')
-	return at > 0 && strings.EqualFold(username, sessionUser[:at])
+	return at > 0 && at < len(sessionUser)-1 && strings.EqualFold(username, sessionUser[:at])
 }
 
 func canonicalIssuer(issuer string) string {

--- a/pkg/webhook/controller.go
+++ b/pkg/webhook/controller.go
@@ -953,6 +953,12 @@ func (wc *WebhookController) getSessionsWithIDPMismatchInfo(ctx context.Context,
 		}
 		aliasSessions := sessionsMatchingIdentityAlias(clusterSessions, username, issuer)
 		aliasOut, _ := filterSessionsForAuthorization(aliasSessions, issuer, now)
+		if len(aliasOut) == 0 {
+			if liveSessions, refreshed := wc.sesManager.RefreshClusterBreakglassSessions(ctx, clustername); refreshed {
+				aliasSessions = sessionsMatchingIdentityAlias(liveSessions, username, issuer)
+				aliasOut, _ = filterSessionsForAuthorization(aliasSessions, issuer, now)
+			}
+		}
 		if len(aliasOut) > 0 {
 			out = aliasOut
 		}

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -46,6 +46,24 @@ var sessionIndexFnsWebhook = map[string]client.IndexerFunc{
 	},
 }
 
+func TestSessionUserAliasMatches(t *testing.T) {
+	tests := []struct {
+		name, username, sessionUser string
+		want                        bool
+	}{
+		{"same local part", "platform-requester", "platform-requester@example.test", true},
+		{"case insensitive", "Platform-Requester", "platform-requester@example.test", true},
+		{"different local part", "other", "platform-requester@example.test", false},
+		{"session is not email", "platform-requester", "platform-requester", false},
+		{"empty username", "", "platform-requester@example.test", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sessionUserAliasMatches(tt.username, tt.sessionUser))
+		})
+	}
+}
+
 var debugSessionIndexFnsWebhook = map[string]client.IndexerFunc{
 	"spec.cluster": func(o client.Object) []string {
 		ds := o.(*breakglassv1alpha1.DebugSession)

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -64,6 +64,21 @@ func TestSessionUserAliasMatches(t *testing.T) {
 	}
 }
 
+func TestSessionsMatchingIdentityAlias(t *testing.T) {
+	sessions := []breakglassv1alpha1.BreakglassSession{
+		{Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User: "platform-requester@example.test", IdentityProviderIssuer: "https://idp-a.example",
+		}},
+		{Spec: breakglassv1alpha1.BreakglassSessionSpec{
+			User: "platform-requester@example.test", IdentityProviderIssuer: "https://idp-b.example",
+		}},
+	}
+	assert.Len(t, sessionsMatchingIdentityAlias(sessions[:1], "platform-requester", "https://idp-a.example"), 1)
+	assert.Len(t, sessionsMatchingIdentityAlias(sessions, "platform-requester", "https://idp-a.example"), 1)
+	assert.Empty(t, sessionsMatchingIdentityAlias(sessions, "platform-requester", ""))
+	assert.Empty(t, sessionsMatchingIdentityAlias(sessions[:1], "platform-requester", "https://other.example"))
+}
+
 var debugSessionIndexFnsWebhook = map[string]client.IndexerFunc{
 	"spec.cluster": func(o client.Object) []string {
 		ds := o.(*breakglassv1alpha1.DebugSession)

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -219,6 +219,39 @@ func TestGetSessionsWithIDPMismatchInfoFailsClosedOnDirectListError(t *testing.T
 	assert.Error(t, err)
 }
 
+func TestGetSessionsWithIDPMismatchInfoRefreshesAliasWhenOtherCachedGrantIsEligible(t *testing.T) {
+	now := time.Now()
+	newSession := func(name, user string) *breakglassv1alpha1.BreakglassSession {
+		return &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "test-cluster",
+				User:                   user,
+				GrantedGroup:           name,
+				IdentityProviderIssuer: "https://idp-a.example",
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: metav1.NewTime(now.Add(time.Hour)),
+			},
+		}
+	}
+	bob := newSession("bob", "bob")
+	aliceAlias := newSession("alice-alias", "alice@example.com")
+	cached := fake.NewClientBuilder().WithScheme(breakglass.Scheme).WithObjects(bob)
+	for name, fn := range sessionIndexFnsWebhook {
+		cached = cached.WithIndex(&breakglassv1alpha1.BreakglassSession{}, name, fn)
+	}
+	manager := breakglass.NewSessionManagerWithClientAndReader(cached.Build(), fake.NewClientBuilder().WithScheme(breakglass.Scheme).WithObjects(bob, aliceAlias).Build())
+	controller := &WebhookController{sesManager: manager}
+
+	groups, mismatches, err := controller.getSessionsWithIDPMismatchInfo(context.Background(), "alice", "test-cluster", "https://idp-a.example")
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"alice-alias"}, grantedGroupsFromSessions(groups))
+	assert.Empty(t, mismatches)
+}
+
 var debugSessionIndexFnsWebhook = map[string]client.IndexerFunc{
 	"spec.cluster": func(o client.Object) []string {
 		ds := o.(*breakglassv1alpha1.DebugSession)

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -74,9 +74,24 @@ func TestSessionsMatchingIdentityAlias(t *testing.T) {
 		}},
 	}
 	assert.Len(t, sessionsMatchingIdentityAlias(sessions[:1], "platform-requester", "https://idp-a.example"), 1)
+	assert.Len(t, sessionsMatchingIdentityAlias(sessions[:1], "platform-requester", "https://idp-a.example/"), 1)
 	assert.Len(t, sessionsMatchingIdentityAlias(sessions, "platform-requester", "https://idp-a.example"), 1)
 	assert.Empty(t, sessionsMatchingIdentityAlias(sessions, "platform-requester", ""))
 	assert.Empty(t, sessionsMatchingIdentityAlias(sessions[:1], "platform-requester", "https://other.example"))
+}
+
+func TestFilterSessionsForAuthorizationCanonicalizesIssuer(t *testing.T) {
+	session := breakglassv1alpha1.BreakglassSession{
+		Spec: breakglassv1alpha1.BreakglassSessionSpec{IdentityProviderIssuer: "https://idp-a.example/"},
+		Status: breakglassv1alpha1.BreakglassSessionStatus{
+			State:     breakglassv1alpha1.SessionStateApproved,
+			ExpiresAt: metav1.NewTime(time.Now().Add(time.Hour)),
+		},
+	}
+
+	out, mismatches := filterSessionsForAuthorization([]breakglassv1alpha1.BreakglassSession{session}, "https://idp-a.example", time.Now())
+	assert.Len(t, out, 1)
+	assert.Empty(t, mismatches)
 }
 
 var debugSessionIndexFnsWebhook = map[string]client.IndexerFunc{

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -94,6 +94,131 @@ func TestFilterSessionsForAuthorizationCanonicalizesIssuer(t *testing.T) {
 	assert.Empty(t, mismatches)
 }
 
+type countingListClient struct {
+	client.Client
+	listCalls int
+}
+
+func (c *countingListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.listCalls++
+	return c.Client.List(ctx, list, opts...)
+}
+
+func TestGetSessionsWithIDPMismatchInfoUsesAliasOnlyWithoutEligibleDirectMatch(t *testing.T) {
+	now := time.Now()
+	newSession := func(name, user, issuer string, expiresAt time.Time) *breakglassv1alpha1.BreakglassSession {
+		return &breakglassv1alpha1.BreakglassSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: breakglassv1alpha1.BreakglassSessionSpec{
+				Cluster:                "test-cluster",
+				User:                   user,
+				GrantedGroup:           name,
+				IdentityProviderIssuer: issuer,
+			},
+			Status: breakglassv1alpha1.BreakglassSessionStatus{
+				State:     breakglassv1alpha1.SessionStateApproved,
+				ExpiresAt: metav1.NewTime(expiresAt),
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		direct         *breakglassv1alpha1.BreakglassSession
+		aliases        []*breakglassv1alpha1.BreakglassSession
+		issuer         string
+		wantGroups     []string
+		wantMismatches int
+		wantListCalls  int
+	}{
+		{
+			name:   "expired direct match allows active alias",
+			direct: newSession("expired-direct", "alice", "https://idp-a.example", now.Add(-time.Minute)),
+			aliases: []*breakglassv1alpha1.BreakglassSession{
+				newSession("alice-alias", "alice@example.com", "https://idp-a.example", now.Add(time.Hour)),
+			},
+			issuer:        "https://idp-a.example",
+			wantGroups:    []string{"alice-alias"},
+			wantListCalls: 2,
+		},
+		{
+			name:   "wrong issuer direct match preserves mismatch and allows alias",
+			direct: newSession("wrong-issuer-direct", "alice", "https://idp-b.example", now.Add(time.Hour)),
+			aliases: []*breakglassv1alpha1.BreakglassSession{
+				newSession("alice-alias", "alice@example.com", "https://idp-a.example", now.Add(time.Hour)),
+			},
+			issuer:         "https://idp-a.example",
+			wantGroups:     []string{"alice-alias"},
+			wantMismatches: 1,
+			wantListCalls:  2,
+		},
+		{
+			name:   "eligible direct match suppresses alias scan",
+			direct: newSession("direct", "alice", "https://idp-a.example", now.Add(time.Hour)),
+			aliases: []*breakglassv1alpha1.BreakglassSession{
+				newSession("alice-alias", "alice@example.com", "https://idp-a.example", now.Add(time.Hour)),
+			},
+			issuer:        "https://idp-a.example",
+			wantGroups:    []string{"direct"},
+			wantListCalls: 1,
+		},
+		{
+			name: "wrong issuer alias is denied",
+			aliases: []*breakglassv1alpha1.BreakglassSession{
+				newSession("wrong-issuer-alias", "alice@example.com", "https://idp-b.example", now.Add(time.Hour)),
+			},
+			issuer:        "https://idp-a.example",
+			wantListCalls: 2,
+		},
+		{
+			name: "issuerless aliases from multiple issuers are ambiguous",
+			aliases: []*breakglassv1alpha1.BreakglassSession{
+				newSession("alias-a", "alice@example.com", "https://idp-a.example", now.Add(time.Hour)),
+				newSession("alias-b", "alice@example.com", "https://idp-b.example", now.Add(time.Hour)),
+			},
+			wantListCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]client.Object, 0, 1+len(tt.aliases))
+			if tt.direct != nil {
+				objects = append(objects, tt.direct)
+			}
+			for _, alias := range tt.aliases {
+				objects = append(objects, alias)
+			}
+			builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme).WithObjects(objects...)
+			for name, fn := range sessionIndexFnsWebhook {
+				builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, name, fn)
+			}
+			countingClient := &countingListClient{Client: builder.Build()}
+			manager := breakglass.NewSessionManagerWithClient(countingClient)
+			controller := &WebhookController{sesManager: manager}
+
+			groups, mismatches, err := controller.getSessionsWithIDPMismatchInfo(context.Background(), "alice", "test-cluster", tt.issuer)
+
+			if assert.NoError(t, err) {
+				assert.Len(t, groups, len(tt.wantGroups))
+				if len(tt.wantGroups) > 0 {
+					assert.Equal(t, tt.wantGroups, grantedGroupsFromSessions(groups))
+				}
+				assert.Len(t, mismatches, tt.wantMismatches)
+				assert.Equal(t, tt.wantListCalls, countingClient.listCalls)
+			}
+		})
+	}
+}
+
+func TestGetSessionsWithIDPMismatchInfoFailsClosedOnDirectListError(t *testing.T) {
+	controller := &WebhookController{sesManager: &breakglass.SessionManager{Client: &listErrorClient{}}}
+
+	_, _, err := controller.getSessionsWithIDPMismatchInfo(context.Background(), "alice", "test-cluster", "https://idp-a.example")
+
+	assert.Error(t, err)
+}
+
 var debugSessionIndexFnsWebhook = map[string]client.IndexerFunc{
 	"spec.cluster": func(o client.Object) []string {
 		ds := o.(*breakglassv1alpha1.DebugSession)

--- a/pkg/webhook/controller_test.go
+++ b/pkg/webhook/controller_test.go
@@ -56,6 +56,9 @@ func TestSessionUserAliasMatches(t *testing.T) {
 		{"different local part", "other", "platform-requester@example.test", false},
 		{"session is not email", "platform-requester", "platform-requester", false},
 		{"empty username", "", "platform-requester@example.test", false},
+		{"multiple at signs", "alice@corp", "alice@corp@domain", false},
+		{"email requester is exact only", "alice@corp", "alice@corp", false},
+		{"empty domain", "alice", "alice@", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -4012,4 +4015,18 @@ func TestAuditTargetFromSARSkipsNamespaceLabelsForNonResource(t *testing.T) {
 	assert.Equal(t, "get", verb)
 	assert.Empty(t, subresource)
 	assert.Empty(t, apiGroup)
+}
+
+func TestEmailRequesterSkipsIdentityAliasList(t *testing.T) {
+	builder := fake.NewClientBuilder().WithScheme(breakglass.Scheme)
+	for name, fn := range sessionIndexFnsWebhook {
+		builder = builder.WithIndex(&breakglassv1alpha1.BreakglassSession{}, name, fn)
+	}
+	counted := &countingListClient{Client: builder.Build()}
+	controller := &WebhookController{sesManager: breakglass.NewSessionManagerWithClient(counted)}
+	sessions, mismatches, err := controller.getSessionsWithIDPMismatchInfo(context.Background(), "alice@corp", "cluster", "https://issuer")
+	assert.NoError(t, err)
+	assert.Empty(t, sessions)
+	assert.Empty(t, mismatches)
+	assert.Equal(t, 1, counted.listCalls, "only the indexed exact identity lookup is needed")
 }


### PR DESCRIPTION
## Summary
- preserve issuer-safe Breakglass identity alias matching
- include active approved, unexpired matching Breakglass grants in DebugSession requester groups
- reject grants from other clusters, identities, or terminal/expired sessions

## Validation
- `go test ./pkg/breakglass/debug ./pkg/breakglass ./pkg/webhook`
- live retained-lab acceptance pending candidate rollout

No merge or release requested.