### PR TITLE
fix: retry quota admission completion conflicts safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retry final quota-admission completion after same-UID resource-version
+  conflicts, while refusing terminal or replacement sessions.
+
 - Recover tracked resources after bounded create timeouts when session and
   operation markers and requested content match the persisted object.
 

--- a/docs/security-defender-quotas.md
+++ b/docs/security-defender-quotas.md
@@ -14,6 +14,8 @@ or request notifications. Provisional objects are visible but cannot grant
 breakglass access or progress to debug workloads without admission; this guard
 is applied in the shared clock-injected validity and token checks used by the
 authorization webhook as well as the ordinary wrappers.
+If an unrelated same-UID update wins the final annotation race, completion
+re-reads and retries; replacement or terminal sessions are never promoted.
 
 The ledger covers regular-session tuple uniqueness (user, cluster, granted
 group), global per-user limits, escalation-UID totals, debug template-UID totals,

--- a/pkg/breakglass/session_admission.go
+++ b/pkg/breakglass/session_admission.go
@@ -15,6 +15,7 @@ import (
 	"github.com/telekom/k8s-breakglass/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -216,15 +217,42 @@ func (c *SessionManager) admitSession(ctx context.Context, s *breakglassv1alpha1
 	if !c.quotaEnabled || s.Annotations[quotas.AdmissionAnnotation] == quotas.Ready {
 		return nil
 	}
-	before := s.DeepCopy()
-	if s.Annotations == nil {
-		s.Annotations = map[string]string{}
-	}
-	s.Annotations[quotas.AdmissionAnnotation] = quotas.Ready
-	if err := c.Client.Patch(ctx, s, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
+	if err := c.completeSessionAdmission(ctx, s); err != nil {
 		return fmt.Errorf("complete session admission: %w", err)
 	}
 	return nil
+}
+
+// completeSessionAdmission publishes quota readiness from a fresh same-UID
+// object. Reservation is already durable, so an unrelated update must retry
+// the annotation write instead of leaving a permanently provisional session.
+func (c *SessionManager) completeSessionAdmission(ctx context.Context, session *breakglassv1alpha1.BreakglassSession) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &breakglassv1alpha1.BreakglassSession{}
+		if err := c.Reader().Get(ctx, client.ObjectKeyFromObject(session), current); err != nil {
+			return err
+		}
+		if session.UID != "" && current.UID != session.UID {
+			return fmt.Errorf("session UID changed while completing admission")
+		}
+		if IsSessionTerminalState(current.Status.State) {
+			return fmt.Errorf("refusing to admit terminal session")
+		}
+		if current.Annotations[quotas.AdmissionAnnotation] == quotas.Ready {
+			*session = *current
+			return nil
+		}
+		before := current.DeepCopy()
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		current.Annotations[quotas.AdmissionAnnotation] = quotas.Ready
+		if err := c.Client.Patch(ctx, current, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
+			return err
+		}
+		*session = *current
+		return nil
+	})
 }
 
 // recoverSessionAdmissions finishes durable provisional admissions after an API

--- a/pkg/breakglass/session_admission_test.go
+++ b/pkg/breakglass/session_admission_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestSessionAdmissionGlobalScopesAndCrashRecovery(t *testing.T) {
@@ -139,6 +140,99 @@ func TestQuotaReservationSurvivesInitialStatusFailure(t *testing.T) {
 	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(s), s))
 	assert.Equal(t, breakglassv1alpha1.SessionStatePending, s.Status.State)
 	assert.Equal(t, quotas.Ready, s.Annotations[quotas.AdmissionAnnotation])
+}
+
+func TestQuotaAdmissionCompletionRetriesSameUIDConflict(t *testing.T) {
+	esc := &breakglassv1alpha1.BreakglassEscalation{ObjectMeta: metav1.ObjectMeta{Name: "escalation", Namespace: "ns", UID: "esc"}}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "ns", UID: "session", Annotations: map[string]string{quotas.AdmissionAnnotation: quotas.Pending}, OwnerReferences: []metav1.OwnerReference{{APIVersion: breakglassv1alpha1.GroupVersion.String(), Kind: "BreakglassEscalation", Name: esc.Name, UID: esc.UID, Controller: ptrBool(true)}}},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{User: "user", Cluster: "cluster", GrantedGroup: "admin"},
+	}
+	injected := false
+	cli := fake.NewClientBuilder().WithScheme(Scheme).WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).
+		WithObjects(esc, session).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, underlying client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			candidate, ok := obj.(*breakglassv1alpha1.BreakglassSession)
+			if !injected && ok && candidate.Annotations[quotas.AdmissionAnnotation] == quotas.Ready {
+				injected = true
+				var concurrent breakglassv1alpha1.BreakglassSession
+				require.NoError(t, underlying.Get(ctx, client.ObjectKeyFromObject(session), &concurrent))
+				concurrent.Labels = map[string]string{"concurrent": "update"}
+				require.NoError(t, underlying.Update(ctx, &concurrent))
+			}
+			return underlying.Patch(ctx, obj, patch, opts...)
+		},
+	}).Build()
+	manager := NewSessionManagerWithClientAndReader(cli, cli, WithQuotaNamespace("controller"))
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), session))
+	require.NoError(t, manager.admitSession(t.Context(), session))
+	var stored breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), &stored))
+	assert.Equal(t, quotas.Ready, stored.Annotations[quotas.AdmissionAnnotation])
+	assert.Equal(t, "update", stored.Labels["concurrent"])
+	assert.True(t, injected)
+}
+
+func TestQuotaAdmissionCompletionRejectsUIDReplacement(t *testing.T) {
+	esc := &breakglassv1alpha1.BreakglassEscalation{ObjectMeta: metav1.ObjectMeta{Name: "escalation", Namespace: "ns", UID: "esc"}}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "ns", UID: "session", Annotations: map[string]string{quotas.AdmissionAnnotation: quotas.Pending}},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{User: "user", Cluster: "cluster", GrantedGroup: "admin"},
+	}
+	controller := true
+	session.OwnerReferences = []metav1.OwnerReference{{APIVersion: breakglassv1alpha1.GroupVersion.String(), Kind: "BreakglassEscalation", Name: esc.Name, UID: esc.UID, Controller: &controller}}
+	cli := fake.NewClientBuilder().WithScheme(Scheme).WithObjects(esc, session).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, underlying client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			candidate, ok := obj.(*breakglassv1alpha1.BreakglassSession)
+			if ok && candidate.Annotations[quotas.AdmissionAnnotation] == quotas.Ready {
+				var replacement breakglassv1alpha1.BreakglassSession
+				require.NoError(t, underlying.Get(ctx, client.ObjectKeyFromObject(session), &replacement))
+				replacement.UID = "replacement"
+				replacement.Labels = map[string]string{"replacement": "true"}
+				require.NoError(t, underlying.Update(ctx, &replacement))
+			}
+			return underlying.Patch(ctx, obj, patch, opts...)
+		},
+	}).Build()
+	manager := NewSessionManagerWithClientAndReader(cli, cli, WithQuotaNamespace("controller"))
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), session))
+	require.Error(t, manager.admitSession(t.Context(), session))
+	var stored breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), &stored))
+	assert.Equal(t, types.UID("replacement"), stored.UID)
+	assert.Equal(t, "true", stored.Labels["replacement"])
+	assert.Equal(t, quotas.Pending, stored.Annotations[quotas.AdmissionAnnotation])
+}
+
+func TestQuotaAdmissionCompletionRejectsTerminalTransition(t *testing.T) {
+	esc := &breakglassv1alpha1.BreakglassEscalation{ObjectMeta: metav1.ObjectMeta{Name: "escalation", Namespace: "ns", UID: "esc"}}
+	session := &breakglassv1alpha1.BreakglassSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session", Namespace: "ns", UID: "session", Annotations: map[string]string{quotas.AdmissionAnnotation: quotas.Pending}},
+		Spec:       breakglassv1alpha1.BreakglassSessionSpec{User: "user", Cluster: "cluster", GrantedGroup: "admin"},
+	}
+	controller := true
+	session.OwnerReferences = []metav1.OwnerReference{{APIVersion: breakglassv1alpha1.GroupVersion.String(), Kind: "BreakglassEscalation", Name: esc.Name, UID: esc.UID, Controller: &controller}}
+	cli := fake.NewClientBuilder().WithScheme(Scheme).WithStatusSubresource(&breakglassv1alpha1.BreakglassSession{}).WithObjects(esc, session).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, underlying client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			candidate, ok := obj.(*breakglassv1alpha1.BreakglassSession)
+			if ok && candidate.Annotations[quotas.AdmissionAnnotation] == quotas.Ready {
+				var terminal breakglassv1alpha1.BreakglassSession
+				require.NoError(t, underlying.Get(ctx, client.ObjectKeyFromObject(session), &terminal))
+				terminal.Status.State = breakglassv1alpha1.SessionStateRejected
+				terminal.Status.ReasonEnded = "concurrent rejection"
+				require.NoError(t, underlying.Status().Update(ctx, &terminal))
+			}
+			return underlying.Patch(ctx, obj, patch, opts...)
+		},
+	}).Build()
+	manager := NewSessionManagerWithClientAndReader(cli, cli, WithQuotaNamespace("controller"))
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), session))
+	require.Error(t, manager.admitSession(t.Context(), session))
+	var stored breakglassv1alpha1.BreakglassSession
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(session), &stored))
+	assert.Equal(t, breakglassv1alpha1.SessionStateRejected, stored.Status.State)
+	assert.Equal(t, "concurrent rejection", stored.Status.ReasonEnded)
+	assert.Equal(t, quotas.Pending, stored.Annotations[quotas.AdmissionAnnotation])
 }
 
 func TestDurableQuotaLimitPrecedence(t *testing.T) {


### PR DESCRIPTION
A concurrent session status update could make quota admission completion return HTTP 500 after reserving quota. Retry the readiness annotation patch on a fresh resource version while preserving the original session UID and refusing sessions that became terminal.

Validation: focused behavioral tests cover successful conflict recovery, UID replacement, and concurrent terminal transition; all passed. Independent Astra review approved commit `1fadd5a982000439bbe0ab49c01c13d0d7cdec63`. Full CI and Copilot review remain required before merge.
