### PR TITLE
ci: publish all seven generic debug utility images

### DIFF
--- a/.github/workflows/catalogue-utility-integration.yml
+++ b/.github/workflows/catalogue-utility-integration.yml
@@ -23,6 +23,9 @@ on:
       - "utils/images/dump-reader/**"
       - "utils/images/tests/**"
       - "utils/images/Makefile"
+      - "hack/utility-image-matrix.json"
+      - ".github/workflows/utility-release.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/catalogue-utility-integration.yml"
   push:
     branches: [main, deployment-testing]
@@ -37,6 +40,9 @@ on:
       - "utils/images/dump-reader/**"
       - "utils/images/tests/**"
       - "utils/images/Makefile"
+      - "hack/utility-image-matrix.json"
+      - ".github/workflows/utility-release.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/catalogue-utility-integration.yml"
 
 permissions:

--- a/.github/workflows/catalogue-utility-integration.yml
+++ b/.github/workflows/catalogue-utility-integration.yml
@@ -29,21 +29,6 @@ on:
       - ".github/workflows/catalogue-utility-integration.yml"
   push:
     branches: [main, deployment-testing]
-    paths:
-      - "charts/debug-session-catalogue/**"
-      - "cmd/cluster-validator/**"
-      - "pkg/clustervalidator/**"
-      - "hack/cluster-validator-**"
-      - "Dockerfile.validator"
-      - "utils/cluster-validator/**"
-      # Dump-reader has no dedicated workflow; retain its shared runtime gate.
-      - "utils/images/dump-reader/**"
-      - "utils/images/tests/**"
-      - "utils/images/Makefile"
-      - "hack/utility-image-matrix.json"
-      - ".github/workflows/utility-release.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/catalogue-utility-integration.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,11 @@ jobs:
             context: utils/node-maintenance
           - name: diagnostic-artifact-collector
             context: utils/images/diagnostic-artifact-collector
+          - name: dump-reader
+            context: utils/images/dump-reader
+          - name: cluster-validator
+            context: utils/cluster-validator
+            buildContext: .
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -103,7 +108,8 @@ jobs:
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
+          context: ${{ matrix.buildContext || matrix.context }}
+          file: ${{ matrix.file || format('{0}/Dockerfile', matrix.context) }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/utils/${{ matrix.name }}:${{ github.ref_name }}
@@ -112,6 +118,7 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
             VCS_REF=${{ github.sha }}
+            GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.buildContext || matrix.context }}
-          file: ${{ matrix.file || format('{0}/Dockerfile', matrix.context) }}
+          file: ${{ format('{0}/Dockerfile', matrix.context) }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/utils/${{ matrix.name }}:${{ github.ref_name }}

--- a/.github/workflows/utility-image-security.yml
+++ b/.github/workflows/utility-image-security.yml
@@ -20,6 +20,7 @@ on:
       - "hack/test-utility-image-security-contract.sh"
       - "hack/release-required-checks.json"
       - ".github/workflows/utility-image-security.yml"
+      - ".github/workflows/release.yml"
   push:
     # This intentionally has no path filter. Release tags require this exact
     # check on the exact main commit, including when only controller code

--- a/.github/workflows/utility-image-security.yml
+++ b/.github/workflows/utility-image-security.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Build exact platform image for scanning
         id: build
         env:
-          CONTEXT: ${{ matrix.image.context }}
+          CONTEXT: ${{ matrix.image.buildContext || matrix.image.context }}
           DOCKERFILE: ${{ matrix.image.file }}
           PLATFORM: ${{ matrix.platform }}
         run: |

--- a/.github/workflows/utility-release.yml
+++ b/.github/workflows/utility-release.yml
@@ -112,7 +112,7 @@ jobs:
           tag="utility-contract-${name}:${PLATFORM##*/}"
           timeout 45m docker buildx build --platform "${PLATFORM}" --load \
             --file "$(jq -r .file <<<"${ENTRY}")" --tag "${tag}" \
-            "$(jq -r .context <<<"${ENTRY}")"
+            "$(jq -r '.buildContext // .context' <<<"${ENTRY}")"
           test "$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "${tag}")" = "${PLATFORM}"
           smoke_command=()
           while IFS= read -r -d '' argument; do smoke_command+=("${argument}"); done < <(jq -j '.smokeCommand[] + "\u0000"' <<<"${ENTRY}")
@@ -223,7 +223,7 @@ jobs:
           IMAGE: ${{ matrix.image }}
           TAG: ${{ needs.discover.outputs.tag }}
           PUBLICATION_TAG: ${{ needs.discover.outputs.publication_tag }}
-          CONTEXT: ${{ matrix.context }}
+          CONTEXT: ${{ matrix.buildContext || matrix.context }}
           DOCKERFILE: ${{ matrix.file }}
           SOURCE_SHA: ${{ github.sha }}
         run: |

--- a/.github/workflows/utility-release.yml
+++ b/.github/workflows/utility-release.yml
@@ -38,6 +38,7 @@ on:
       - ".github/workflows/node-maintenance.yml"
       - ".github/workflows/network-debug-pod-capture-integration.yml"
       - ".github/workflows/diagnostic-artifact-collector-image.yml"
+      - ".github/workflows/release.yml"
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Publish the generic `dump-reader` and provider-neutral `cluster-validator`
+  images through the signed utility-image release matrix, with their existing
+  runtime behavior gates and multi-architecture build contexts.
+
 - The debug-session-catalogue Helm chart provides administrator-authored,
   restricted DebugSession profiles for workload, network, storage, dump-access,
   and cluster-validation diagnostics.

--- a/docs/debug-session-catalogue-interface.md
+++ b/docs/debug-session-catalogue-interface.md
@@ -99,10 +99,11 @@ and target-cluster permissions before enabling any elevated profile.
 
 Each profile selects `images.<profile imageKey>` or supplies a direct `image`
 reference and runs its `command`/`args`. The chart's checked-in image values
-are non-runnable zero-digest placeholders. The five public utility names use
-the canonical `ghcr.io/telekom/k8s-breakglass/utils/<intent-image>` path;
-dump-access and internal cluster-validation remain non-public placeholders
-until separately approved. Replace public images with independently verified
+are non-runnable zero-digest placeholders. The seven generic utility names use
+the canonical `ghcr.io/telekom/k8s-breakglass/utils/<intent-image>` path, including
+`dump-reader` and the provider-neutral `cluster-validator`. Catalogue image
+values remain non-runnable zero-digest placeholders until independently
+verified release digests are injected. Replace public images with independently verified
 release digests before enabling access; release packaging injects validated
 values from `release-refs/*.ref`. Mutable tags are not release inputs. The
 storage and dump mounts match the
@@ -114,8 +115,10 @@ opt-in flag is set because the catalogue contract does not carry the
 controller-issued immutable approval tuple required by node-maintenance; the
 example logs that limitation and does not attempt to bypass the chart gate.
 The restricted `dump-access` profile is also disabled by default, but does not
-require elevation; it remains a non-public placeholder until its image and
-reviewed source-volume contract are approved.
+require elevation. It still needs a separately approved source-volume and
+retention contract before catalogue enablement. Internal cluster-validation
+adapters remain downstream-owned and gated by their own approval; the generic
+upstream validator does not make that internal support claim.
 
 Profile items are concise: shared authorization, lifecycle, audit, image
 resolution, workload wiring, pod hardening, and resource defaults are named

--- a/hack/test-utility-matrix-expansion.sh
+++ b/hack/test-utility-matrix-expansion.sh
@@ -26,7 +26,7 @@ workflow_path = ARGV.fetch(0)
 workflow = YAML.safe_load(File.read(workflow_path), aliases: false)
 matrix = JSON.parse(ENV.fetch("UTILITY_MATRIX_JSON"))
 
-abort "utility matrix expansion: contract matrix must contain exactly five images" unless matrix.is_a?(Array) && matrix.length == 5
+abort "utility matrix expansion: contract matrix must contain exactly seven images" unless matrix.is_a?(Array) && matrix.length == 7
 
 scan = workflow.fetch("jobs").fetch("scan")
 strategy_matrix = scan.fetch("strategy").fetch("matrix")
@@ -79,8 +79,8 @@ end
 expected_labels = matrix.flat_map do |image|
   platforms.map { |platform| "Utility image vulnerability (#{image.fetch("name")} / #{platform})" }
 end
-abort "utility matrix expansion: expected ten rendered labels" unless labels.length == 10 && labels.sort == expected_labels.sort
+abort "utility matrix expansion: expected fourteen rendered labels" unless labels.length == 14 && labels.sort == expected_labels.sort
 abort "utility matrix expansion: rendered labels are not unique" unless labels.uniq.length == labels.length
 RUBY
 
-printf '%s\n' 'utility matrix expansion behavioral proof passed (5 images x 2 platforms)'
+printf '%s\n' 'utility matrix expansion behavioral proof passed (7 images x 2 platforms)'

--- a/hack/test-utility-matrix-expansion.sh
+++ b/hack/test-utility-matrix-expansion.sh
@@ -47,6 +47,8 @@ def resolve_field(expression, image, platform)
     image.fetch("name")
   when "${{ matrix.image.context }}"
     image.fetch("context")
+  when "${{ matrix.image.buildContext || matrix.image.context }}"
+    image.fetch("buildContext", image.fetch("context"))
   when "${{ matrix.image.file }}"
     image.fetch("file")
   when "${{ matrix.platform }}"

--- a/hack/test-utility-matrix-expansion.sh
+++ b/hack/test-utility-matrix-expansion.sh
@@ -71,7 +71,8 @@ end
 labels = []
 matrix.each do |image|
   platforms.each do |platform|
-    abort "utility matrix expansion: context mapping does not resolve" unless resolve_field(build_env.fetch("CONTEXT"), image, platform) == image.fetch("context")
+    expected_context = image.fetch("buildContext", image.fetch("context"))
+    abort "utility matrix expansion: context mapping does not resolve" unless resolve_field(build_env.fetch("CONTEXT"), image, platform) == expected_context
     abort "utility matrix expansion: Dockerfile mapping does not resolve" unless resolve_field(build_env.fetch("DOCKERFILE"), image, platform) == image.fetch("file")
     abort "utility matrix expansion: platform mapping does not resolve" unless resolve_field(build_env.fetch("PLATFORM"), image, platform) == platform
     labels << render_label(scan.fetch("name"), image, platform)

--- a/hack/test-utility-release-contract.sh
+++ b/hack/test-utility-release-contract.sh
@@ -80,5 +80,9 @@ jq -e 'sort == ["Core CI","Future behavior"]' <<<"${checks}" >/dev/null
 printf '%s\n' '{"schemaVersion":1,"images":[{"name":"future-tool","context":"utils/images/future-tool","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]},{"name":"future-tool","context":"utils/images/future-tool","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future duplicate behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]}]}' >"${fixture}/hack/utility-image-matrix.json"
 expect_fail "${contract}" matrix "${fixture}"
 expect_fail env UTILITY_IMAGE_PREFIX=ghcr.io/example/acme/other-utils "${contract}" matrix "${fixture}"
+printf '%s\n' '{"schemaVersion":1,"images":[{"name":"future-tool","context":"utils/images/future-tool","buildContext":"utils/images/missing","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]}]}' >"${fixture}/hack/utility-image-matrix.json"
+expect_fail "${contract}" matrix "${fixture}"
+printf '%s\n' '{"schemaVersion":1,"images":[{"name":"future-tool","context":"utils/images/future-tool","buildContext":".","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]}]}' >"${fixture}/hack/utility-image-matrix.json"
+expect_fail "${contract}" matrix "${fixture}"
 
 printf '%s\n' 'utility release contract behavioral tests passed'

--- a/hack/test-utility-release-contract.sh
+++ b/hack/test-utility-release-contract.sh
@@ -84,5 +84,7 @@ printf '%s\n' '{"schemaVersion":1,"images":[{"name":"future-tool","context":"uti
 expect_fail "${contract}" matrix "${fixture}"
 printf '%s\n' '{"schemaVersion":1,"images":[{"name":"future-tool","context":"utils/images/future-tool","buildContext":".","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]}]}' >"${fixture}/hack/utility-image-matrix.json"
 expect_fail "${contract}" matrix "${fixture}"
+printf '%s\n' '{"schemaVersion":1,"images":[{"name":"cluster-validator","context":"utils/images/future-tool","file":"utils/images/future-tool/Dockerfile","smokeCommand":["help"],"smokeOutput":"future help","requiredChecks":["Future behavior"],"behaviorWorkflows":[".github/workflows/future-tool.yml"]}]}' >"${fixture}/hack/utility-image-matrix.json"
+expect_fail "${contract}" matrix "${fixture}"
 
 printf '%s\n' 'utility release contract behavioral tests passed'

--- a/hack/test-utility-workflow-paths.sh
+++ b/hack/test-utility-workflow-paths.sh
@@ -62,6 +62,11 @@ expected_helpers.each do |workflow_name, required|
   unexpected = (paths & all_helpers) - required
   abort "#{workflow_name} has unrelated shared-helper path filters: #{unexpected.join(', ')}" unless unexpected.empty?
 end
+
+catalogue = YAML.safe_load(File.read(File.join(root, ".github/workflows/catalogue-utility-integration.yml")), aliases: false)
+push = catalogue.fetch(true).fetch("push")
+abort "catalogue utility behavior must run on every main push" unless push.fetch("branches").sort == %w[deployment-testing main]
+abort "catalogue utility behavior push must not be path filtered" if push.key?("paths")
 RUBY
 
 printf '%s\n' 'utility workflow path filters cover shared ownership and security contracts'

--- a/hack/test-utility-workflow-paths.sh
+++ b/hack/test-utility-workflow-paths.sh
@@ -53,9 +53,15 @@ expected_helpers = {
   ]
 }
 
+def workflow_triggers(workflow, name)
+  keys = ["on", true].select { |key| workflow.is_a?(Hash) && workflow.key?(key) }
+  abort "#{name} must define exactly one workflow trigger key (on/true)" unless keys.length == 1
+  workflow.fetch(keys.fetch(0))
+end
+
 expected_helpers.each do |workflow_name, required|
   workflow = YAML.safe_load(File.read(File.join(root, ".github/workflows", workflow_name)), aliases: false)
-  trigger = workflow.fetch(true).fetch("pull_request")
+  trigger = workflow_triggers(workflow, workflow_name).fetch("pull_request")
   paths = trigger.fetch("paths")
   missing = required.reject { |path| paths.include?(path) }
   abort "#{workflow_name} is missing release-gate path filters: #{missing.join(', ')}" unless missing.empty?
@@ -64,7 +70,7 @@ expected_helpers.each do |workflow_name, required|
 end
 
 catalogue = YAML.safe_load(File.read(File.join(root, ".github/workflows/catalogue-utility-integration.yml")), aliases: false)
-push = catalogue.fetch(true).fetch("push")
+push = workflow_triggers(catalogue, "catalogue-utility-integration.yml").fetch("push")
 abort "catalogue utility behavior must run on every main push" unless push.fetch("branches").sort == %w[deployment-testing main]
 abort "catalogue utility behavior push must not be path filtered" if push.key?("paths")
 RUBY

--- a/hack/utility-image-matrix.json
+++ b/hack/utility-image-matrix.json
@@ -55,7 +55,7 @@
       "context": "utils/images/dump-reader",
       "file": "utils/images/dump-reader/Dockerfile",
       "smokeCommand": ["help"],
-      "smokeOutput": "dump-reader: inspect existing dump artifacts",
+      "smokeOutput": "dump-reader: inspect existing dump files without generating or modifying them",
       "requiredChecks": ["Intent / storage-diagnostics and dump-access behavior"],
       "behaviorWorkflows": [".github/workflows/catalogue-utility-integration.yml"]
     },

--- a/hack/utility-image-matrix.json
+++ b/hack/utility-image-matrix.json
@@ -49,6 +49,25 @@
       "smokeOutput": "diagnostic-artifact-collector: bounded, immutable diagnostic recipes",
       "requiredChecks": ["Utility image checks (diagnostic-artifact-collection)"],
       "behaviorWorkflows": [".github/workflows/diagnostic-artifact-collector-image.yml"]
+    },
+    {
+      "name": "dump-reader",
+      "context": "utils/images/dump-reader",
+      "file": "utils/images/dump-reader/Dockerfile",
+      "smokeCommand": ["help"],
+      "smokeOutput": "dump-reader: inspect existing dump artifacts",
+      "requiredChecks": ["Storage and dump access behavior"],
+      "behaviorWorkflows": [".github/workflows/catalogue-utility-integration.yml"]
+    },
+    {
+      "name": "cluster-validator",
+      "context": "utils/cluster-validator",
+      "buildContext": ".",
+      "file": "utils/cluster-validator/Dockerfile",
+      "smokeCommand": ["--help"],
+      "smokeOutput": "Usage of cluster-validator",
+      "requiredChecks": ["Cluster validation behavior"],
+      "behaviorWorkflows": [".github/workflows/catalogue-utility-integration.yml"]
     }
   ]
 }

--- a/hack/utility-image-matrix.json
+++ b/hack/utility-image-matrix.json
@@ -56,7 +56,7 @@
       "file": "utils/images/dump-reader/Dockerfile",
       "smokeCommand": ["help"],
       "smokeOutput": "dump-reader: inspect existing dump artifacts",
-      "requiredChecks": ["Storage and dump access behavior"],
+      "requiredChecks": ["Intent / storage-diagnostics and dump-access behavior"],
       "behaviorWorkflows": [".github/workflows/catalogue-utility-integration.yml"]
     },
     {
@@ -66,7 +66,7 @@
       "file": "utils/cluster-validator/Dockerfile",
       "smokeCommand": ["--help"],
       "smokeOutput": "Usage of cluster-validator",
-      "requiredChecks": ["Cluster validation behavior"],
+      "requiredChecks": ["Intent / cluster-validation behavior"],
       "behaviorWorkflows": [".github/workflows/catalogue-utility-integration.yml"]
     }
   ]

--- a/hack/utility-release-contract.sh
+++ b/hack/utility-release-contract.sh
@@ -53,6 +53,7 @@ matrix() {
 		(.context|contains("..")|not) and (.context|contains("//")|not) and
 		($buildContext|test("^(\\.|utils/[A-Za-z0-9._/-]+)$")) and
 		($buildContext|contains("..")|not) and ($buildContext|contains("//")|not) and
+		((.buildContext == null) or (.name == "cluster-validator" and .buildContext == ".")) and
         (.file == (.context + "/Dockerfile")) and
 		(.smokeCommand|type=="array" and length>0 and all(.[]; type=="string" and length>0)) and
 		(.smokeOutput|type=="string" and length>0) and
@@ -60,6 +61,7 @@ matrix() {
 		(.behaviorWorkflows|type=="array" and length>0 and all(.[]; type=="string" and test("^\\.github/workflows/[A-Za-z0-9._-]+\\.yml$")))) and
 		(([.images[].requiredChecks[]]|length) == ([.images[].requiredChecks[]]|unique|length))' "${manifest}" >/dev/null || die 'invalid utility image manifest'
 	while IFS= read -r path; do [[ -d "${root}/${path}" ]] || die "manifest context does not exist: ${path}"; done < <(jq -r '.images[].context' "${manifest}")
+	while IFS= read -r path; do [[ -d "${root}/${path}" ]] || die "manifest build context does not exist: ${path}"; done < <(jq -r '.images[] | (.buildContext // .context)' "${manifest}")
 	while IFS= read -r path; do [[ -f "${root}/${path}" ]] || die "manifest Dockerfile does not exist: ${path}"; done < <(jq -r '.images[].file' "${manifest}")
 	while IFS= read -r path; do [[ -f "${root}/${path}" ]] || die "behavior workflow does not exist: ${path}"; done < <(jq -r '.images[].behaviorWorkflows[]' "${manifest}")
 	jq -cS --arg prefix "${prefix}" '[.images[] | . + {image:($prefix+"/"+.name)}] | sort_by(.name)' "${manifest}"

--- a/hack/utility-release-contract.sh
+++ b/hack/utility-release-contract.sh
@@ -47,10 +47,13 @@ matrix() {
 	jq -e '(.schemaVersion == 1) and (.images|type=="array" and length>0) and
 		(([.images[].name]|length) == ([.images[].name]|unique|length)) and
 		(([.images[].file]|length) == ([.images[].file]|unique|length)) and
-		all(.images[]; (.name|test("^[a-z0-9]+([.-][a-z0-9]+)*$")) and
+		all(.images[]; (.buildContext // .context) as $buildContext |
+		(.name|test("^[a-z0-9]+([.-][a-z0-9]+)*$")) and
 		(.context|test("^utils/[A-Za-z0-9._/-]+$")) and
 		(.context|contains("..")|not) and (.context|contains("//")|not) and
-		(.file == (.context + "/Dockerfile")) and
+		($buildContext|test("^(\\.|utils/[A-Za-z0-9._/-]+)$")) and
+		($buildContext|contains("..")|not) and ($buildContext|contains("//")|not) and
+        (.file == (.context + "/Dockerfile")) and
 		(.smokeCommand|type=="array" and length>0 and all(.[]; type=="string" and length>0)) and
 		(.smokeOutput|type=="string" and length>0) and
 		(.requiredChecks|type=="array" and length>0 and all(.[]; type=="string" and length>0)) and

--- a/hack/utility-release-contract.sh
+++ b/hack/utility-release-contract.sh
@@ -53,7 +53,8 @@ matrix() {
 		(.context|contains("..")|not) and (.context|contains("//")|not) and
 		($buildContext|test("^(\\.|utils/[A-Za-z0-9._/-]+)$")) and
 		($buildContext|contains("..")|not) and ($buildContext|contains("//")|not) and
-		((.buildContext == null) or (.name == "cluster-validator" and .buildContext == ".")) and
+		((.name == "cluster-validator" and .buildContext == ".") or
+		 (.name != "cluster-validator" and .buildContext == null)) and
         (.file == (.context + "/Dockerfile")) and
 		(.smokeCommand|type=="array" and length>0 and all(.[]; type=="string" and length>0)) and
 		(.smokeOutput|type=="string" and length>0) and


### PR DESCRIPTION
Add the existing generic `dump-reader` and `cluster-validator` images to the signed utility publication matrix. Carry the validator build context through release publication and require their behavioral CI checks before publishing.

The matrix now covers seven images on amd64 and arm64. Catalogue profiles remain disabled with placeholder references until verified release digests and required source-volume approvals are available.

Validation: matrix expansion and release contract checks passed; independent Astra review approved commit `5751987123e8069a3d47c01b5905c7bc85d6f511`. Full CI and Copilot review remain required before merge; registry publication will be verified separately after green main CI.
